### PR TITLE
feat(legal): add privacy policy, terms of service and deployment guide

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,9 @@
 VITE_GOOGLE_CLIENT_ID=
 
+# The public URL where the app is hosted (e.g., https://codex-arcana.web.app)
+# Required for correct OAuth redirect calculation in production.
+VITE_PUBLIC_APP_URL=
+
 # Optional: Google Gemini API Key for image generation (Nano Banana)
 VITE_GOOGLE_IMAGEN_KEY=
 

--- a/apps/web/src/lib/components/settings/CloudStatus.svelte
+++ b/apps/web/src/lib/components/settings/CloudStatus.svelte
@@ -6,6 +6,7 @@
 
     import { uiStore } from "$stores/ui.svelte";
     import AISettings from "./AISettings.svelte";
+    import { base } from "$app/paths";
 
     let adapter = new GoogleDriveAdapter();
     let isLoading = $state(false);
@@ -312,6 +313,12 @@
                                 <span class="icon-[lucide--tags] w-3 h-3"></span>
                                 MANAGE CATEGORIES
                             </button>
+                        </div>
+
+                        <div class="pt-2 flex justify-center gap-4 text-[9px] text-gray-700 uppercase tracking-tighter">
+                            <a href="{base}/privacy" class="hover:text-green-900 transition-colors">Privacy Policy</a>
+                            <span>•</span>
+                            <a href="{base}/terms" class="hover:text-green-900 transition-colors">Terms of Service</a>
                         </div>
                     </div>
                 {/if}

--- a/apps/web/src/routes/privacy/+page.svelte
+++ b/apps/web/src/routes/privacy/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { parse } from 'marked';
+  import { base } from '$app/paths';
+
+  let content = $state('');
+
+  onMount(async () => {
+    const res = await fetch(`${base}/PRIVACY.md`);
+    const text = await res.text();
+    content = await parse(text);
+  });
+</script>
+
+<div class="max-w-3xl mx-auto px-6 py-12 bg-black min-h-screen">
+  <div class="mb-8 border-b border-green-900/30 pb-4">
+    <a href="{base}/" class="text-green-500 hover:text-green-400 font-mono text-sm flex items-center gap-2">
+      <span class="icon-[lucide--arrow-left] w-4 h-4"></span>
+      BACK TO SYSTEM
+    </a>
+  </div>
+
+  <div class="prose prose-invert prose-green max-w-none font-mono text-green-100/90
+    prose-headings:text-green-400 prose-headings:font-bold prose-headings:uppercase prose-headings:tracking-wider
+    prose-p:leading-relaxed prose-strong:text-green-300 prose-a:text-green-400 prose-a:underline hover:prose-a:text-green-300">
+    {@html content}
+  </div>
+</div>

--- a/apps/web/src/routes/terms/+page.svelte
+++ b/apps/web/src/routes/terms/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { parse } from 'marked';
+  import { base } from '$app/paths';
+
+  let content = $state('');
+
+  onMount(async () => {
+    const res = await fetch(`${base}/TERMS.md`);
+    const text = await res.text();
+    content = await parse(text);
+  });
+</script>
+
+<div class="max-w-3xl mx-auto px-6 py-12 bg-black min-h-screen">
+  <div class="mb-8 border-b border-green-900/30 pb-4">
+    <a href="{base}/" class="text-green-500 hover:text-green-400 font-mono text-sm flex items-center gap-2">
+      <span class="icon-[lucide--arrow-left] w-4 h-4"></span>
+      BACK TO SYSTEM
+    </a>
+  </div>
+
+  <div class="prose prose-invert prose-green max-w-none font-mono text-green-100/90
+    prose-headings:text-green-400 prose-headings:font-bold prose-headings:uppercase prose-headings:tracking-wider
+    prose-p:leading-relaxed prose-strong:text-green-300 prose-a:text-green-400 prose-a:underline hover:prose-a:text-green-300">
+    {@html content}
+  </div>
+</div>

--- a/apps/web/static/PRIVACY.md
+++ b/apps/web/static/PRIVACY.md
@@ -1,0 +1,30 @@
+# Privacy Policy for Codex Arcana
+
+**Last Updated: 2026-01-29**
+
+Codex Arcana is a local-first application designed to help creators manage lore and world-building data. We respect your privacy and provide this policy to explain how your data is handled.
+
+## 1. Local-First Data Sovereignty
+Your data is yours. By default, all "Vaults," entities, notes, and images are stored locally on your device using browser technologies (Origin Private File System and IndexedDB).
+- We do not have access to your local files.
+- We do not store your data on our own servers.
+
+## 2. Google Drive Integration (Optional)
+If you choose to enable Cloud Sync, Codex Arcana will request access to your Google Drive.
+- **Scope**: The application uses the `https://www.googleapis.com/auth/drive.file` scope. This allows the app to only see and manage files that it has created or that you have specifically opened with it.
+- **Usage**: The app mirrors your local vault to a folder in your Google Drive to provide backup and multi-device synchronization.
+- **Data Sharing**: We do not share your Google Drive data with any third parties.
+
+## 3. Google Gemini AI Usage
+Codex Arcana integrates with Google Gemini API for features like "Lore Oracle" (AI analysis) and Image Generation.
+- **Data Transfer**: When you use these features, specific content from your vault (text for analysis or prompts for images) is sent to Google's servers.
+- **Google's Privacy**: The processing of this data is subject to [Google's Privacy Policy](https://policies.google.com/privacy) and [Generative AI Terms](https://ai.google.dev/terms).
+
+## 4. No Tracking or Cookies
+Codex Arcana does not use advertising cookies, tracking scripts, or analytics packages. The only data collected is standard server-side logs if the application is accessed via a public URL, which are used solely for troubleshooting and security.
+
+## 5. Changes to This Policy
+We may update this policy occasionally. Continued use of the application after changes constitutes acceptance of the new terms.
+
+## 6. Contact
+For questions regarding this policy, please contact the developer at [Your Contact Info].

--- a/apps/web/static/TERMS.md
+++ b/apps/web/static/TERMS.md
@@ -1,0 +1,33 @@
+# Terms of Service for Codex Arcana
+
+**Last Updated: 2026-01-29**
+
+By using Codex Arcana, you agree to the following terms and conditions.
+
+## 1. Description of Service
+Codex Arcana is a creative writing and lore management tool. It provides local storage, optional cloud synchronization via Google Drive, and AI-assisted content generation via Google Gemini.
+
+## 2. User Content and Ownership
+- You retain full ownership and copyright of all content you create in Codex Arcana.
+- We claim no rights to your "Vaults," notes, or generated images.
+
+## 3. Data Responsibility
+- Codex Arcana is a local-first application. You are solely responsible for backing up your data.
+- While we provide Google Drive synchronization as a convenience, we are not liable for any data loss resulting from sync errors, browser cache clearing, or service interruptions.
+
+## 4. AI Usage and Compliance
+When using the AI features (Lore Oracle, Image Generation):
+- You must comply with [Google’s Generative AI Prohibited Use Policy](https://policies.google.com/terms/generative-ai/use-policy).
+- You agree not to use the service to generate illegal, harmful, or copyright-infringing content.
+
+## 5. Disclaimer of Warranties
+The application is provided "as is" and "as available" without any warranties of any kind, express or implied. Use of the application is at your own risk.
+
+## 6. Limitation of Liability
+In no event shall the developer be liable for any indirect, incidental, special, or consequential damages arising out of or in connection with your use of the application.
+
+## 7. Termination
+We reserve the right to discontinue the application or restrict access at any time without notice.
+
+## 8. Governing Law
+These terms are governed by the laws of [Your Jurisdiction].

--- a/specs/015-legal-and-deployment-prep/deployment-guide.md
+++ b/specs/015-legal-and-deployment-prep/deployment-guide.md
@@ -1,0 +1,43 @@
+# Deployment Guide: GitHub Pages & Google Cloud
+
+This guide outlines the steps to deploy **Codex Arcana** to GitHub Pages and configure the Google Cloud Project (GCP) for public access.
+
+## 1. Prerequisites
+- A Google Cloud Project (GCP).
+- Deployment URL: `https://eserlan.github.io/Codex-Arcana/`
+
+## 2. GCP OAuth Configuration (CRITICAL)
+To allow public users to sync with Google Drive, you must configure the OAuth Consent Screen:
+
+1.  **User Type**: Set to `External`.
+2.  **App Information**: Provide the App Name and User Support Email.
+3.  **App Domain**:
+    - **Homepage**: `https://eserlan.github.io/Codex-Arcana/`
+    - **Privacy Policy**: `https://eserlan.github.io/Codex-Arcana/privacy`
+    - **Terms of Service**: `https://eserlan.github.io/Codex-Arcana/terms`
+4.  **Scopes**: Add `https://www.googleapis.com/auth/drive.file`.
+5.  **Authorized Domains**: Add `github.io`.
+
+### Credentials
+Update your OAuth 2.0 Client ID:
+- **Authorized JavaScript Origins**: Add `https://eserlan.github.io`.
+- **Authorized Redirect URIs**: Add `https://eserlan.github.io/Codex-Arcana/`.
+
+## 3. Deployment Steps (GitHub Pages)
+The app is configured for GitHub Pages using `adapter-static` and a base path of `/Codex-Arcana`.
+
+1.  **Build**:
+    ```bash
+    cd apps/web
+    npm run build
+    ```
+2.  **Deploy**: Push the `build` folder content to the `gh-pages` branch or use the existing GitHub Action.
+
+## 4. Environment Variables
+Ensure your GitHub Actions secrets or `.env.production` has:
+- `VITE_GOOGLE_CLIENT_ID`: Your GCP Client ID.
+- `VITE_PUBLIC_APP_URL`: `https://eserlan.github.io/Codex-Arcana`
+- `VITE_SHARED_GEMINI_KEY`: (Optional) Restricted to the domain.
+
+## 5. Security Note
+Always restrict your Google API Keys in the GCP Console to only allow requests from your production domain to prevent quota theft.

--- a/specs/015-legal-and-deployment-prep/plan.md
+++ b/specs/015-legal-and-deployment-prep/plan.md
@@ -1,0 +1,17 @@
+# Plan: Legal Compliance & Deployment Preparation
+
+**Feature**: Legal and Deployment (015-legal-and-deployment-prep)
+
+## Phase 1: Document Drafting
+1. **Draft Privacy Policy**: Create a comprehensive policy covering Local Storage, Google Drive Sync, and Gemini AI usage.
+2. **Draft Terms of Service**: Create terms focusing on user ownership and service limitations.
+3. **Draft Deployment Checklist**: Define steps for GCP project configuration.
+
+## Phase 2: Implementation
+1. **Host Documents**: Place Markdown/HTML versions of legal documents in `apps/web/src/routes/(legal)`.
+2. **UI Integration**: Add a footer to the main layout or a link in the Settings panel for "Legal & Privacy".
+3. **Configuration Update**: Ensure the app can handle a production URL for OAuth redirects.
+
+## Phase 3: Verification
+1. Verify routes `/privacy` and `/terms` load correctly.
+2. Check that all mandatory Google Cloud "OAuth Verification" fields are addressed by the documents.

--- a/specs/015-legal-and-deployment-prep/spec.md
+++ b/specs/015-legal-and-deployment-prep/spec.md
@@ -1,0 +1,40 @@
+# Specification: Legal Compliance & Deployment Preparation
+
+**Feature**: Legal and Deployment (015-legal-and-deployment-prep)
+**Status**: Draft
+**Date**: 2026-01-29
+
+## 1. Goal
+Provide the necessary legal documentation (Privacy Policy, Terms of Service) and technical groundwork required to publish Codex Arcana as a public application on Google Cloud, ensuring compliance with Google Cloud Project (GCP) requirements for OAuth and AI usage.
+
+## 2. User Stories
+- **As a Developer**, I want to have a clear Privacy Policy so that I can complete the OAuth Consent Screen for Google Drive integration.
+- **As a User**, I want to understand how my data is handled (local-first vs. cloud sync) before I use the app on a public URL.
+- **As a Developer**, I want the app to be deployable to a public URL (e.g., Firebase Hosting or Cloud Run) to fulfill Google's requirement for a live homepage.
+
+## 3. Requirements
+
+### 3.1 Privacy Policy (PRIVACY.md)
+- **Data Sovereignty**: Explicitly state that user vaults are stored locally (OPFS/IndexedDB).
+- **Google Drive Integration**: Describe how the app interacts with the user's Google Drive (restricted scope for mirroring only).
+- **AI Processing**: Disclose that content is sent to Google Gemini API for Lore Oracle and Image Generation.
+- **No Third-Party Tracking**: State that the app does not use cookies or tracking scripts (other than GCP essential logs if applicable).
+
+### 3.2 Terms of Service (TERMS.md)
+- **User Ownership**: Users retain all rights to the lore and images generated.
+- **Liability**: The app is provided "as is" with no guarantee of data persistence (users are responsible for vault backups).
+- **AI Usage**: Users must comply with Google's Generative AI Prohibited Use Policy.
+
+### 3.3 Technical Implementation
+- **Static Asset Hosting**: Legal documents must be served at predictable URLs (e.g., `/privacy` and `/terms`).
+- **Footer Links**: The application UI must include links to these documents.
+
+## 4. Deployment Strategy
+- **Platform**: Google Cloud (Cloud Run or Firebase Hosting).
+- **Authentication**: Update GCP OAuth Consent Screen with the public domain.
+- **CORS/Redirects**: Ensure redirect URIs match the production domain.
+
+## 5. Success Criteria
+- [ ] `PRIVACY.md` and `TERMS.md` are accessible via the app.
+- [ ] UI contains visible links to legal documents.
+- [ ] Deployment plan for Google Cloud is documented.

--- a/specs/015-legal-and-deployment-prep/tasks.md
+++ b/specs/015-legal-and-deployment-prep/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: Legal Compliance & Deployment Preparation
+
+**Feature**: Legal and Deployment (015-legal-and-deployment-prep)
+
+## 1. Documentation
+- [x] Create `apps/web/static/PRIVACY.md` with GCP-compliant language. <!-- id: 0 -->
+- [x] Create `apps/web/static/TERMS.md`. <!-- id: 1 -->
+- [x] Create a "Deployment Guide" in the spec folder for Cloud Run/Firebase. <!-- id: 2 -->
+
+## 2. Implementation
+- [x] Create `apps/web/src/routes/privacy/+page.svelte` to render the privacy policy. <!-- id: 3 -->
+- [x] Create `apps/web/src/routes/terms/+page.svelte` to render the terms of service. <!-- id: 4 -->
+- [x] Add links to Privacy/Terms in the `VaultControls.svelte` or a new Footer component. <!-- id: 5 -->
+
+## 3. Configuration
+- [x] Update `.env.example` with placeholders for `PUBLIC_APP_URL`. <!-- id: 6 -->
+- [x] Document the required Redirect URIs for the GCP OAuth Console. <!-- id: 7 -->


### PR DESCRIPTION
- Drafted PRIVACY.md and TERMS.md for GCP/GitHub Pages compliance.
- Implemented /privacy and /terms routes with dynamic markdown rendering.
- Added links to legal documents in the Cloud Sync menu.
- Added VITE_PUBLIC_APP_URL to .env.example.
- Created deployment-guide.md for GCP OAuth configuration on GitHub Pages.