### PR TITLE
fix(020): refine tour overlay dimming and z-index

### DIFF
--- a/apps/web/src/lib/components/help/TourOverlay.svelte
+++ b/apps/web/src/lib/components/help/TourOverlay.svelte
@@ -46,7 +46,7 @@
 
     const handleKeydown = (e: KeyboardEvent) => {
         if (!helpStore.activeTour) return;
-        
+
         if (e.key === "Escape") {
             helpStore.skipTour();
         } else if (e.key === "ArrowRight") {
@@ -64,7 +64,7 @@
 
     let maskStyle = $derived.by(() => {
         if (!targetRect) return "";
-        
+
         const padding = 8;
         const x = targetRect.left - padding;
         const y = targetRect.top - padding;
@@ -112,18 +112,21 @@
 </script>
 
 {#if helpStore.activeTour && !isDisabled}
-    <div
-        class="fixed inset-0 z-[900] bg-black/60 backdrop-blur-[2px] transition-all duration-300"
-        style={maskStyle}
-        transition:fade
-        role="presentation"
-    ></div>
+    {#if targetRect}
+        <div
+            class="fixed inset-0 z-[80] bg-black/60 backdrop-blur-[2px] transition-all duration-300"
+            style={maskStyle}
+            transition:fade
+            role="presentation"
+        ></div>
+    {/if}
 
     {#if helpStore.currentStep}
-        <GuideTooltip 
-            step={helpStore.currentStep} 
-            {targetRect} 
-            isLast={helpStore.activeTour.currentStepIndex === helpStore.activeTour.steps.length - 1}
+        <GuideTooltip
+            step={helpStore.currentStep}
+            {targetRect}
+            isLast={helpStore.activeTour.currentStepIndex ===
+                helpStore.activeTour.steps.length - 1}
             current={helpStore.activeTour.currentStepIndex + 1}
             total={helpStore.activeTour.steps.length}
         />

--- a/apps/web/tests/help-onboarding.spec.ts
+++ b/apps/web/tests/help-onboarding.spec.ts
@@ -13,40 +13,56 @@ test.describe("Help Onboarding Walkthrough", () => {
     test("should automatically start onboarding for new users", async ({ page }) => {
         // 1. Check if welcome modal appears
         await expect(page.getByText("Welcome to Codex Cryptica")).toBeVisible();
-        
+
         // 2. Click Next
         await page.getByRole("button", { name: "Next" }).click();
-        
+
         // 3. Check if Vault step is highlighted (Vault info should be visible)
         await expect(page.getByText("Your Archive")).toBeVisible();
-        
+
         // 4. Navigate through all steps
         await page.getByRole("button", { name: "Next" }).click(); // Search
         await expect(page.getByText("Omni-Search")).toBeVisible();
-        
+
         await page.getByRole("button", { name: "Next" }).click(); // Graph
         await expect(page.getByText("Knowledge Graph")).toBeVisible();
-        
+
         await page.getByRole("button", { name: "Next" }).click(); // Oracle
         await expect(page.getByText("Lore Oracle")).toBeVisible();
-        
+
         await page.getByRole("button", { name: "Next" }).click(); // Settings
         await expect(page.getByText("Configuration")).toBeVisible();
-        
+
         // 5. Finish tour
         await page.getByRole("button", { name: "Finish" }).click();
-        
+
         // 6. Verify tour is gone and doesn't reappear
         await expect(page.getByText("Configuration")).not.toBeVisible();
         await page.reload();
         await expect(page.getByText("Welcome to Codex Cryptica")).not.toBeVisible();
     });
 
+    test("should NOT dim the screen on welcome step (body target)", async ({ page }) => {
+        // Welcome step targets "body" so should NOT show dimming overlay
+        await expect(page.getByText("Welcome to Codex Cryptica")).toBeVisible();
+
+        // The dimming overlay has role="presentation" and a specific class
+        const dimmingOverlay = page.locator('[role="presentation"].bg-black\\/60');
+        await expect(dimmingOverlay).not.toBeVisible();
+
+        // Click Next to go to Vault step which HAS a specific target
+        await page.getByRole("button", { name: "Next" }).click();
+        await expect(page.getByText("Your Archive")).toBeVisible();
+
+        // Now the dimming overlay SHOULD be visible (spotlight on vault button)
+        await expect(dimmingOverlay).toBeVisible();
+    });
+
     test("should allow skipping the tour", async ({ page }) => {
         await expect(page.getByText("Welcome to Codex Cryptica")).toBeVisible();
         await page.getByRole("button", { name: "Dismiss" }).click();
         await expect(page.getByText("Welcome to Codex Cryptica")).not.toBeVisible();
-        
+
         // Verify it doesn't reappear
         await page.reload();
         await expect(page.getByText("Welcome to Codex Cryptica")).not.toBeVisible();
@@ -59,16 +75,16 @@ test.describe("Help Onboarding Walkthrough", () => {
 
         // 1. Activate Connect Mode (press C)
         await page.keyboard.press("c");
-        
+
         // 2. Verify hint appears
         await expect(page.getByText("CONNECT MODE")).toBeVisible();
-        
+
         // 3. Dismiss hint
         await page.getByTestId("dismiss-hint-button").click();
-        
+
         // Wait for removal of the hint UI
         await expect(page.getByTestId("dismiss-hint-button")).not.toBeVisible();
-        
+
         // 4. Verify it stays dismissed when toggling Connect Mode again
         await page.keyboard.press("c"); // toggle off
         await page.keyboard.press("c"); // toggle on


### PR DESCRIPTION
## Description
This PR addresses a bug found in the Help System overlay after deployment. The overlay was incorrectly dimming the screen during the "Welcome" step (which has no specific target element), making the initial introduction less welcoming.

## Changes
- **TourOverlay.svelte**: Added a conditional check to only render the dimming backdrop when a `targetRect` is present. This ensures the first step (targeting `body`) does not dim the screen.
- **TourOverlay.svelte**: Reverted the z-index from `900` to `80` based on production testing feedback.
- **help-onboarding.spec.ts**: Added a new E2E test to verify that the screen is NOT dimmed on the welcome step but correctly dims on subsequent steps with specific targets.

## Verification
- [x] Verified with new E2E test `should NOT dim the screen on welcome step`.
- [x] Manual verification of the tour flow.