### PR TITLE
fix(graph): improve minimap visibility and coloring

### DIFF
--- a/apps/web/src/lib/components/graph/Minimap.svelte
+++ b/apps/web/src/lib/components/graph/Minimap.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Core } from "cytoscape";
   import { onMount, onDestroy } from "svelte";
+  import { isTransparent } from "$lib/utils/color";
 
   interface Props {
     cy: Core;
@@ -44,16 +45,6 @@
   // Toggle Visibility (US4)
   let collapsed = $state(false); // Default to expanded for visibility
   const toggleMinimap = () => (collapsed = !collapsed);
-
-  const isTransparent = (color: string) => {
-    if (!color || color === "transparent") return true;
-    const normalized = color.replace(/\s+/g, "").toLowerCase();
-    return (
-      normalized.includes("rgba(0,0,0,0)") ||
-      normalized.includes(",0)") ||
-      normalized === "transparent"
-    );
-  };
 
   const updateProjection = () => {
     if (!cy) return;

--- a/apps/web/src/lib/utils/color.test.ts
+++ b/apps/web/src/lib/utils/color.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { isTransparent } from "./color";
+
+describe("isTransparent", () => {
+  it("should return true for empty or null-ish values", () => {
+    expect(isTransparent("")).toBe(true);
+    expect(isTransparent(null as any)).toBe(true);
+    expect(isTransparent(undefined as any)).toBe(true);
+  });
+
+  it("should return true for 'transparent' keyword", () => {
+    expect(isTransparent("transparent")).toBe(true);
+    expect(isTransparent("TRANSPARENT")).toBe(true);
+  });
+
+  it("should return true for rgba with zero alpha", () => {
+    expect(isTransparent("rgba(0, 0, 0, 0)")).toBe(true);
+    expect(isTransparent("rgba(255, 255, 255, 0)")).toBe(true);
+    expect(isTransparent("rgba(0,0,0,0)")).toBe(true);
+    expect(isTransparent("RGBA(0,0,0,0)")).toBe(true);
+  });
+
+  it("should return true for any color with 0 alpha in rgba", () => {
+    expect(isTransparent("rgba(10, 20, 30, 0)")).toBe(true);
+    expect(isTransparent("rgba(10,20,30,0)")).toBe(true);
+  });
+
+  it("should return false for opaque colors", () => {
+    expect(isTransparent("#ff0000")).toBe(false);
+    expect(isTransparent("rgb(255, 0, 0)")).toBe(false);
+    expect(isTransparent("rgba(0, 0, 0, 1)")).toBe(false);
+    expect(isTransparent("rgba(0, 0, 0, 0.5)")).toBe(false);
+    expect(isTransparent("green")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/utils/color.ts
+++ b/apps/web/src/lib/utils/color.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks if a CSS color string represents a transparent color.
+ * Handles various formats returned by browsers and Cytoscape.
+ */
+export const isTransparent = (color: string): boolean => {
+  if (!color || color === "transparent") return true;
+  const normalized = color.replace(/\s+/g, "").toLowerCase();
+  
+  // rgba(r,g,b,0) or rgba(r,g,b,0.0)
+  if (normalized.includes("rgba(")) {
+    return normalized.endsWith(",0)") || normalized.endsWith(",0.0)");
+  }
+
+  return normalized === "transparent";
+};


### PR DESCRIPTION
This PR fixes the issue where the minimap appeared empty or barely visible.\n\n### Improvements:\n- **Visibility**: Defaulted to expanded state so users don't miss it.\n- **Styling**: Switched to category-aware coloring (extracted from node borders) to match the main canvas.\n- **Contrast**: Added a subtle glow and dark strokes to the node dots for better definition against the background.\n- **Reliability**: Added listeners for `data` and `layoutstop` to ensure the map updates when entity properties change or layout stabilizes.