### PR TITLE
feat: add visual indicator for revealed nodes in graph

### DIFF
--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -6,4 +6,4 @@ export const VERSION = import.meta.env.VITE_APP_VERSION ?? "0.8.4";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";
-export const PATREON_URL = "https://patreon.com/";
+export const PATREON_URL = "https://patreon.com/EspenE";

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -58,6 +58,11 @@ export class GraphTransformer {
 
       const dateLabel = formatDate(entity.date || entity.start_date || entity.end_date);
 
+      // Visibility markers for Admin visual cues
+      const markers = [...(entity.tags || []), ...(entity.labels || [])].map(m => m.toLowerCase());
+      const isRevealed = markers.includes("revealed") || markers.includes("visible");
+      const _isHidden = markers.includes("hidden");
+
       // Create Node
       const nodeData: GraphNode["data"] = {
         id: entity.id,
@@ -71,6 +76,7 @@ export class GraphTransformer {
       };
       if (entity.image) nodeData.image = entity.image;
       if (entity.thumbnail) nodeData.thumbnail = entity.thumbnail;
+      if (isRevealed) (nodeData as any).isRevealed = true;
 
       elements.push({
         group: "nodes",
@@ -151,6 +157,17 @@ export const getGraphStyle = (template: StylingTemplate, categories: Category[])
         height: "data(height)",
         "border-width": graph.nodeBorderWidth + 1,
         "border-color": tokens.primary,
+      },
+    },
+    {
+      // Revealed indicator - subtle white shine effect (doesn't override background-image)
+      selector: "node[isRevealed]",
+      style: {
+        "overlay-color": "#ffffff",
+        "overlay-opacity": 0.3,
+        "overlay-padding": 8,
+        "border-color": "#d4d4d4",
+        "border-width": graph.nodeBorderWidth + 3,
       },
     },
     {


### PR DESCRIPTION
- Add white glow overlay effect for nodes with 'revealed' or 'visible' tag
- Uses Cytoscape overlay system (30% opacity white, 8px padding)
- Adds light grey border to distinguish revealed nodes
- Fixes fog-of-war visual feedback for admin/world builder view