### PR TITLE
🧪 add tests for HTML to Markdown conversion

### DIFF
--- a/packages/importer/tests/utils.spec.ts
+++ b/packages/importer/tests/utils.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { htmlToMarkdown } from "../src/utils";
+
+describe("htmlToMarkdown", () => {
+  it("converts basic HTML to markdown", () => {
+    const html = "<p>Hello <strong>World</strong>!</p>";
+    expect(htmlToMarkdown(html)).toBe("Hello **World**!");
+  });
+
+  it("uses ATX style headings", () => {
+    const h1 = "<h1>Heading 1</h1>";
+    const h2 = "<h2>Heading 2</h2>";
+    expect(htmlToMarkdown(h1)).toBe("# Heading 1");
+    expect(htmlToMarkdown(h2)).toBe("## Heading 2");
+  });
+
+  it("uses fenced code blocks", () => {
+    const code = "<pre><code>const x = 1;</code></pre>";
+    const result = htmlToMarkdown(code);
+    expect(result).toContain("```");
+    expect(result).toContain("const x = 1;");
+  });
+
+  it("handles links and images", () => {
+    const html = '<a href="https://example.com">Link</a><img src="img.png" alt="Alt text">';
+    const result = htmlToMarkdown(html);
+    expect(result).toContain("[Link](https://example.com)");
+    expect(result).toContain("![Alt text](img.png)");
+  });
+
+  it("handles lists", () => {
+    const ul = "<ul><li>Item 1</li><li>Item 2</li></ul>";
+    const ol = "<ol><li>First</li><li>Second</li></ol>";
+
+    const ulResult = htmlToMarkdown(ul);
+    expect(ulResult).toContain("Item 1");
+    expect(ulResult).toContain("Item 2");
+    expect(ulResult).toMatch(/^\*\s+/m);
+
+    const olResult = htmlToMarkdown(ol);
+    expect(olResult).toContain("First");
+    expect(olResult).toContain("Second");
+    expect(olResult).toMatch(/^1\.\s+/m);
+  });
+
+  it("handles empty strings", () => {
+    expect(htmlToMarkdown("")).toBe("");
+  });
+
+  it("handles nested elements", () => {
+    const html = "<div><p>Paragraph with <em>italic <strong>bold</strong></em></p></div>";
+    expect(htmlToMarkdown(html)).toBe("Paragraph with *italic **bold***");
+  });
+});


### PR DESCRIPTION
This PR adds a comprehensive set of unit tests for the `htmlToMarkdown` utility function in `packages/importer`.

### 🎯 What:
The testing gap addressed is the lack of direct verification for the `htmlToMarkdown` wrapper. These tests ensure that the conversion logic and its specific configuration (ATX headings, fenced code blocks) are correct and protected against regressions.

### 📊 Coverage:
The following scenarios are now tested:
- **Headers:** Verified use of ATX-style headings (# Heading).
- **Code Blocks:** Verified use of fenced code blocks (```).
- **Basic Formatting:** Paragraphs, bold, and italic text.
- **Lists:** Ordered and unordered lists.
- **Media/Links:** Hyperlinks and images with alt text.
- **Nesting:** Nested elements like `div > p > em > strong`.
- **Edge Cases:** Empty string input.

### ✨ Result:
Improved test coverage and reliability for the importer's utility functions. Future changes to Turndown configuration or library updates can now be verified against these expected outputs.

*Note: Due to environment limitations in the sandbox (missing dependencies in node_modules and restricted network), tests could not be executed during verification, but the logic has been manually verified against the implementation and standard Turndown behavior.*

---
*PR created automatically by Jules for task [5114651550202493318](https://jules.google.com/task/5114651550202493318) started by @eserlan*