### PR TITLE
⚡ Bolt: Optimize tooltip rendering in GraphView

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -766,6 +766,13 @@
   let hoveredEntity = $derived(
     hoveredEntityId ? vault.entities[hoveredEntityId] : null,
   );
+
+  // Memoize markdown parsing to prevent re-computation on every render (e.g. tooltip position updates)
+  let tooltipContent = $derived(
+    hoveredEntity?.content
+      ? DOMPurify.sanitize(marked.parse(hoveredEntity.content) as string)
+      : '<span class="italic text-theme-muted">No data available</span>',
+  );
 </script>
 
 <div
@@ -935,9 +942,7 @@
         <div
           class="text-sm text-theme-text/90 font-mono leading-relaxed prose prose-p:my-1 prose-headings:text-theme-primary prose-headings:text-xs prose-strong:text-theme-primary prose-em:text-theme-secondary"
         >
-          {@html hoveredEntity.content
-            ? DOMPurify.sanitize(marked.parse(hoveredEntity.content) as string)
-            : '<span class="italic text-theme-muted">No data available</span>'}
+          {@html tooltipContent}
         </div>
 
         <!-- Decorative corner bits -->


### PR DESCRIPTION
💡 What: The optimization implemented
Memoized the result of `marked.parse` and `DOMPurify.sanitize` in `GraphView.svelte` using a `$derived` rune (`tooltipContent`).

🎯 Why: The performance problem it solves
Previously, the markdown parsing and HTML sanitization were executed inline within the template expression. This meant that every time the component re-rendered (which happens on every mouse move when the tooltip is active, due to `hoverPosition` updates), the expensive parsing logic would re-run, potentially causing jank on lower-end devices or with large content.

📊 Impact: Expected performance improvement
Eliminates redundant parsing operations during tooltip movement. Parsing now only occurs when the `hoveredEntity.content` actually changes.

🔬 Measurement: How to verify the improvement
- Verified visually via Playwright script that the tooltip still renders correctly.
- Verified that `npm run check` and `npm test` pass.

---
*PR created automatically by Jules for task [1997737090660973044](https://jules.google.com/task/1997737090660973044) started by @eserlan*