### PR TITLE
fix: correct path in git add for version bump workflow

### DIFF
--- a/.github/workflows/auto-bump-web-version.yml
+++ b/.github/workflows/auto-bump-web-version.yml
@@ -40,6 +40,6 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add apps/web/package.json apps/web/src/lib/config.ts apps/web/src/service-worker.ts
+          git add apps/web/package.json apps/web/src/lib/config/index.ts apps/web/src/service-worker.ts
           git commit -m "chore(web): auto-bump version after merge #${{ github.event.pull_request.number }} [skip ci]"
           git push


### PR DESCRIPTION
Fixes the 'pathspec did not match' error in the automated version bump workflow by correcting the file path in the 'git add' command.

### Changes
- Updated `.github/workflows/auto-bump-web-version.yml` to stage `apps/web/src/lib/config/index.ts` instead of the non-existent `apps/web/src/lib/config.ts`.