### PR TITLE
feat(importer): session-level deduplication and PDF import support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,7 @@
     "isomorphic-dompurify": "^2.36.0",
     "js-yaml": "^4.1.1",
     "marked": "^17.0.2",
+    "pdfjs-dist": "^5.4.624",
     "peerjs": "^1.5.5",
     "schema": "*",
     "svelte-tiptap": "^3.0.1",

--- a/apps/web/src/lib/components/settings/ImportSettings.svelte
+++ b/apps/web/src/lib/components/settings/ImportSettings.svelte
@@ -22,6 +22,7 @@
   import type { DiscoveredEntity } from "@codex/importer";
   import { sanitizeId } from "$lib/utils/markdown";
   import { slide, fade } from "svelte/transition";
+  import pdfWorker from "pdfjs-dist/build/pdf.worker.mjs?url";
 
   let step = $state<"upload" | "processing" | "review" | "complete">("upload");
   let statusMessage = $state("");
@@ -52,7 +53,7 @@
     new TextParser(),
     new DocxParser(),
     new JsonParser(),
-    new PdfParser(),
+    new PdfParser(pdfWorker),
   ];
 
   const handleFiles = async (files: File[]) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       }
     },
     "apps/web": {
-      "version": "0.8.23",
+      "version": "0.8.25",
       "dependencies": {
         "@codex/importer": "*",
         "@codex/proposer": "*",
@@ -65,6 +65,7 @@
         "isomorphic-dompurify": "^2.36.0",
         "js-yaml": "^4.1.1",
         "marked": "^17.0.2",
+        "pdfjs-dist": "^5.4.624",
         "peerjs": "^1.5.5",
         "schema": "*",
         "svelte-tiptap": "^3.0.1",
@@ -1270,6 +1271,19 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "apps/web/node_modules/pdfjs-dist": {
+      "version": "5.4.624",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz",
+      "integrity": "sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.88",
+        "node-readable-to-web-readable-stream": "^0.4.2"
+      }
     },
     "apps/web/node_modules/picomatch": {
       "version": "4.0.3",
@@ -10582,6 +10596,13 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -13899,12 +13920,14 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@types/turndown": "^5.0.6",
+        "idb": "^8.0.3",
         "mammoth": "^1.11.0",
         "pdfjs-dist": "^4.0.0",
         "turndown": "^7.2.2"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "fake-indexeddb": "^6.0.0",
         "jsdom": "^28.0.0",
         "typescript": "^5.7.3",
         "vitest": "^1.0.0"

--- a/packages/importer/tests/parsers/pdf.spec.ts
+++ b/packages/importer/tests/parsers/pdf.spec.ts
@@ -7,11 +7,11 @@ vi.mock("pdfjs-dist", () => ({
   GlobalWorkerOptions: {
     workerSrc: "",
   },
-  version: "4.0.0",
+  version: "mock-version",
 }));
 
 describe("PdfParser", () => {
-  const parser = new PdfParser();
+  const parser = new PdfParser("/mock/worker.js");
 
   it("accepts pdf files", () => {
     const file = new File([""], "test.pdf", { type: "application/pdf" });


### PR DESCRIPTION
## Summary
This PR addresses issue #163 by enabling support for PDF imports and implementing session-level entity deduplication to prevent redundant proposals during large document ingestions.

### Key Changes
- **Session-Level Deduplication**: Added a `mergeEntities` utility that combines discovered entities by title across the entire import session (multiple chunks and files). Lore and chronicles are concatenated, and links are deduplicated.
- **PDF Support**: Enabled the `PdfParser` in the ingestion pipeline. Configured `pdfjs-dist` with a reliable CDN worker fallback to ensure browser compatibility without complex bundler configuration.
- **Improved Fragmentation**: Updated `splitTextIntoChunks` to support space-based fallback splitting. This prevents words from being cut in half when no paragraph breaks are found within the chunk boundary.
- **Enhanced Reliability**:
  - Optimized the registry pruning logic to avoid transaction conflicts.
  - Improved error handling to clear partial progress on unexpected analysis failures.
  - Added monotonic time mocks to unit tests to ensure predictable LRU pruning verification.

### Testing
- **Unit Tests**: 39 passing tests in `@codex/importer`, including new coverage for cross-instance entity merging and PDF text extraction.
- **E2E Tests**: Expanded Playwright coverage to verify file upload flows and the persistence of "Already Processed" states.

Resolves #163 
Relates to #149