### PR TITLE
:bug: fix(ci): make auto-bump script resilient to version drift

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.8.26",
+  "version": "0.8.27",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/src/service-worker.ts
+++ b/apps/web/src/service-worker.ts
@@ -5,7 +5,7 @@
 
 import { build, files, version } from "$service-worker";
 
-const CACHE_VERSION = "23";
+const CACHE_VERSION = "24";
 const CACHE = `cache-${version}-${CACHE_VERSION}`;
 
 const ASSETS = [

--- a/scripts/bump-web-version.mjs
+++ b/scripts/bump-web-version.mjs
@@ -20,14 +20,20 @@ pkg.version = nextVersion;
 writeFileSync(webPackagePath, `${JSON.stringify(pkg, null, 2)}\n`);
 
 const config = readFileSync(configPath, 'utf8');
+const configRegex = /versionFromBuild \?\? "\d+\.\d+\.\d+"/;
+
+if (!configRegex.test(config)) {
+  throw new Error('Could not find VERSION fallback pattern in apps/web/src/lib/config/index.ts');
+}
+
 const updatedConfig = config.replace(
-  /versionFromBuild \?\? "\d+\.\d+\.\d+"/,
+  configRegex,
   `versionFromBuild ?? "${nextVersion}"`,
 );
-if (updatedConfig === config) {
-  throw new Error('Failed to update VERSION fallback in apps/web/src/lib/config/index.ts');
+
+if (updatedConfig !== config) {
+  writeFileSync(configPath, updatedConfig);
 }
-writeFileSync(configPath, updatedConfig);
 
 const sw = readFileSync(serviceWorkerPath, 'utf8');
 const swMatch = /const CACHE_VERSION = "(\d+)";/.exec(sw);


### PR DESCRIPTION
This PR fixes the recurring failure in the `Auto Bump Web Version After Merge` workflow.

### Root Cause
The `bump-web-version.mjs` script was designed to throw an error if the regex replacement in `apps/web/src/lib/config/index.ts` resulted in no changes. However, if a manual version update or a previous partial failure left the config file already matching the *next* intended version, the script would crash, blocking the entire pipeline.

### Improvements
- **Resilient Logic**: The script now checks for the existence of the version pattern *before* attempting replacement. If the file is already in sync with the next version, it proceeds gracefully instead of erroring out.
- **Explicit Checks**: Added a pre-emptive `.test()` call on the config content to provide a clearer error message if the file structure ever deviates from the expected format.
- **Version Sync**: Manually synchronized `package.json`, `config/index.ts`, and `service-worker.ts` to `0.8.27` / `24` to resolve the current drift in `main`.

---
*PR created by Gemini CLI*