### PR TITLE
:lipstick: fix(themes): improve Blood & Noir readability with high-contrast tokens

### DIFF
--- a/apps/web/tests/themes.spec.ts
+++ b/apps/web/tests/themes.spec.ts
@@ -119,7 +119,7 @@ test.describe("Visual Styling Templates", () => {
         .getPropertyValue("--color-accent-primary")
         .trim(),
     );
-    expect(primaryColor).toBe("#991b1b");
+    expect(primaryColor).toBe("#dc2626");
   });
 
   test("Theme selection persists across reloads", async ({ page }) => {

--- a/packages/schema/src/theme.ts
+++ b/packages/schema/src/theme.ts
@@ -151,13 +151,13 @@ export const THEMES: Record<string, StylingTemplate> = {
     id: "horror",
     name: "Blood & Noir",
     tokens: {
-      primary: "#991b1b",
-      secondary: "#7f1d1d",
+      primary: "#dc2626", // Blood Red (Vibrant)
+      secondary: "#d1d5db", // Light Grey (Muted labels)
       background: "#050505",
-      surface: "#171717",
-      text: "#e5e5e5",
-      border: "rgba(153, 27, 27, 0.4)",
-      accent: "#a3a3a3",
+      surface: "#121212",
+      text: "#f3f4f6", // Off-white (Body)
+      border: "rgba(220, 38, 38, 0.3)",
+      accent: "#991b1b", // Crimson (Deep accent)
       fontHeader: "'Spectral', serif",
       fontBody: "'Inter', sans-serif",
     },
@@ -166,7 +166,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       edgeStyle: "solid",
       nodeBorderWidth: 2,
       edgeWidth: 1,
-      edgeColor: "#7f1d1d",
+      edgeColor: "#991b1b",
     },
   },
 };


### PR DESCRIPTION
This PR improves the readability of the **Blood & Noir** (Horror) theme by adjusting its color tokens for higher contrast against the dark background.

### Changes
- **Primary Color**: Brightened from `#991b1b` to `#dc2626` (Vibrant Blood Red) to ensure headers and titles are easily readable.
- **Secondary Color**: Switched from a dark red to a light grey `#d1d5db` for metadata and muted UI labels.
- **Body Text**: Updated to an off-white `#f3f4f6` for better long-form reading comfort.
- **Surface**: Adjusted surface color to `#121212` for better depth perception.
- **Graph Edges**: Updated to use the deep crimson `#991b1b` for a thematic, non-distracting look.

### Verification
- Updated Playwright E2E tests to match the new primary color token.
- Verified visual contrast ratios manually against the pitch-black background.
- All existing tests and linting passed.

---
*PR created by Gemini CLI*