### PR TITLE
🐛 fix(build): use base path for sitemap link

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -323,7 +323,7 @@
     rel="sitemap"
     type="application/xml"
     title="Sitemap"
-    href="/sitemap.xml"
+    href="{base}/sitemap.xml"
   />
 </svelte:head>
 


### PR DESCRIPTION
Fixes a build error in the staging environment where `/sitemap.xml` was being referenced as an absolute path, causing a 404 because the staging app lives under `/staging`.

### Fix
- Updated `apps/web/src/routes/+layout.svelte` to use `{base}/sitemap.xml` instead of `/sitemap.xml`.
- This ensures the link correctly respects the configured `base` path during build and runtime.

### Verification
- CI build should now succeed for both root and staging paths.