### PR TITLE
:bug: fix(web): ensure legal docs render during SSR/prerender

### DIFF
--- a/apps/web/src/lib/components/LegalDocument.svelte
+++ b/apps/web/src/lib/components/LegalDocument.svelte
@@ -8,18 +8,20 @@
     title,
     initialContent = "",
   } = $props<{ fileName: string; title: string; initialContent?: string }>();
-  let content = $state("");
+
+  // Local state for client-side fetching fallback
+  let fetchedContent = $state("");
+
+  // Derived content: prefers prop (SSR/Hydration), falls back to fetched, defaults to empty
+  let content = $derived.by(() => {
+    if (initialContent) return parse(initialContent) as string;
+    if (fetchedContent) return parse(fetchedContent) as string;
+    return "";
+  });
 
   function updateContent(text: string) {
-    content = parse(text) as string;
+    fetchedContent = text;
   }
-
-  // Pre-parse if initial content is provided (for SSR/Prerender)
-  $effect.pre(() => {
-    if (initialContent && !content) {
-      updateContent(initialContent);
-    }
-  });
 
   onMount(async () => {
     // If no initial content (e.g. client-side navigation or hydration mismatch), fetch it


### PR DESCRIPTION
Fixes an issue where legal pages (Terms, Privacy) rendered as empty during pre-rendering/SSR.

- **Cause:** `LegalDocument.svelte` was initializing content inside `$effect.pre`, which only runs on the client.
- **Fix:** Content is now initialized synchronously from `initialContent` prop during component creation, ensuring it is present in the server-rendered HTML.