### PR TITLE
🐛 fix: parse markdown synchronously in LegalDocument for SSR/prerender

### DIFF
--- a/apps/web/src/lib/components/LegalDocument.svelte
+++ b/apps/web/src/lib/components/LegalDocument.svelte
@@ -8,35 +8,34 @@
     title,
     initialContent = "",
   } = $props<{ fileName: string; title: string; initialContent?: string }>();
-  let content = $state("");
 
-  function updateContent(text: string) {
-    content = parse(text) as string;
-  }
+  // Parse synchronously so SSR/prerender emits real HTML (not an empty string).
+  // $derived re-runs whenever initialContent changes (e.g. client-side navigation).
+  let parsedInitial = $derived(
+    initialContent ? (parse(initialContent) as string) : "",
+  );
 
-  // Pre-parse if initial content is provided (for SSR/Prerender)
-  $effect.pre(() => {
-    if (initialContent && !content) {
-      updateContent(initialContent);
-    }
-  });
+  // Client-side fallback content (used only when there was no initialContent).
+  let fetchedContent = $state("");
+
+  // The final rendered HTML: prefer the synchronously-derived value.
+  let content = $derived(parsedInitial || fetchedContent);
 
   onMount(async () => {
-    // If no initial content (e.g. client-side navigation or hydration mismatch), fetch it
-    if (!initialContent) {
-      try {
-        const res = await fetch(`${base}/${fileName}`);
-        if (!res.ok)
-          throw new Error(`Failed to fetch ${fileName}: ${res.statusText}`);
-        const text = await res.text();
-        updateContent(text);
-      } catch (err) {
-        console.error("LegalDocument error:", err);
-        content = `<div class="p-4 border border-red-900/50 bg-red-900/10 text-red-400 font-mono">
+    // Only fetch client-side when there was no server-provided content.
+    if (initialContent) return;
+    try {
+      const res = await fetch(`${base}/${fileName}`);
+      if (!res.ok)
+        throw new Error(`Failed to fetch ${fileName}: ${res.statusText}`);
+      const text = await res.text();
+      fetchedContent = parse(text) as string;
+    } catch (err) {
+      console.error("LegalDocument error:", err);
+      fetchedContent = `<div class="p-4 border border-red-900/50 bg-red-900/10 text-red-400 font-mono">
                 <h3 class="text-red-500! mt-0!">OFFLINE ERROR</h3>
                 <p class="mb-0!">Could not retrieve document. Please check your connection.</p>
             </div>`;
-      }
     }
   });
 </script>


### PR DESCRIPTION
## Problem

The `/terms` and `/privacy` prerendered pages were shipping with **empty content** because `$effect.pre` (used to parse the markdown) **does not run during SSR/prerendering in Svelte 5**. The flow was broken as follows:

1. `+page.ts` fetches the markdown at prerender time ✅
2. `initialContent` prop is passed to `LegalDocument.svelte` ✅
3. `$effect.pre` was supposed to parse the markdown → **skipped during SSR** ❌
4. The page HTML ships with `{@html content}` resolving to an empty string ❌
5. Client-side `onMount` sees `initialContent` is truthy and **skips re-fetching**, so content stays empty ❌

## Fix

Replace `$effect.pre` with `$derived` so `marked.parse()` is evaluated **synchronously at render time**, including during SSR/prerender:

```diff
- $effect.pre(() => {
-   if (initialContent && !content) {
-     updateContent(initialContent);
-   }
- });
+ let parsedInitial = $derived(initialContent ? (parse(initialContent) as string) : "");
+ let fetchedContent = $state("");
+ let content = $derived(parsedInitial || fetchedContent);
```

The `onMount` fallback is preserved for client-side-only navigation where no `initialContent` arrives from the server.

## Testing

- `npm run lint` → 0 errors
- `npm test` → 144 passed, 0 failed
