### PR TITLE
✨ feat: add discord link to footer

### DIFF
--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -13,3 +13,4 @@ export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";
 export const PATREON_URL = "https://patreon.com/EspenE";
+export const DISCORD_URL = "https://discord.gg/5UUMCChF2u";

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -27,7 +27,7 @@
   import { page } from "$app/state";
   import { base } from "$app/paths";
   import { browser } from "$app/environment";
-  import { PATREON_URL, APP_NAME, VERSION } from "$lib/config";
+  import { PATREON_URL, DISCORD_URL, APP_NAME, VERSION } from "$lib/config";
 
   let { children } = $props();
 
@@ -462,6 +462,15 @@
             rel="noopener noreferrer"
             class="text-[10px] font-mono text-theme-secondary hover:text-theme-primary transition-colors uppercase tracking-widest"
             >Support on Patreon</a
+          >
+        {/if}
+        {#if DISCORD_URL}
+          <a
+            href={DISCORD_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-[10px] font-mono text-theme-secondary hover:text-theme-primary transition-colors uppercase tracking-widest"
+            >Discord</a
           >
         {/if}
         <a

--- a/apps/web/tests/footer.spec.ts
+++ b/apps/web/tests/footer.spec.ts
@@ -22,6 +22,19 @@ test.describe("Footer", () => {
     await expect(patreonLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  test("should display Discord link in the footer", async ({ page }) => {
+    const footer = page.locator("footer");
+    const discordLink = footer.locator('a:has-text("Discord")');
+
+    await expect(discordLink).toBeVisible();
+    await expect(discordLink).toHaveAttribute(
+      "href",
+      "https://discord.gg/5UUMCChF2u",
+    );
+    await expect(discordLink).toHaveAttribute("target", "_blank");
+    await expect(discordLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   test("should have correct styling classes on Patreon link", async ({
     page,
   }) => {


### PR DESCRIPTION
This PR adds a link to our Discord server in the footer as requested in issue #222.

Changes:
- Added `DISCORD_URL` to `apps/web/src/lib/config/index.ts`
- Updated `apps/web/src/routes/+layout.svelte` to display the Discord link in the footer.
- Added a new E2E test in `apps/web/tests/footer.spec.ts` to verify the link's presence and attributes.

Verification:
- Ran `npm run test:e2e -- tests/footer.spec.ts` - All 4 tests passed.
- Verified manual build and lint.