### PR TITLE
✨ feat: link to features page in welcome page

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import { uiStore } from "$lib/stores/ui.svelte";
   import { fade } from "svelte/transition";
   import { themeStore } from "$lib/stores/theme.svelte";
+  import { base } from "$app/paths";
   import { demoService } from "$lib/services/demo";
   import { building, browser } from "$app/environment";
 
@@ -191,6 +192,17 @@
             >
               Try Demo
             </button>
+          </div>
+
+          <div class="mt-8 flex flex-col items-center gap-4">
+            <a
+              href="{base}/features"
+              class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
+            >
+              <span class="icon-[lucide--zap] w-3 h-3"></span>
+              View Features Overview
+            </a>
+
             <div
               class="flex items-center gap-3 bg-theme-surface/50 px-4 py-2 rounded-lg border border-theme-border/30"
             >

--- a/apps/web/tests/landing.spec.ts
+++ b/apps/web/tests/landing.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Landing Page", () => {
+  test("should have a link to the features page", async ({ page }) => {
+    await page.goto("/");
+    const featuresLink = page.locator('a:has-text("View Features Overview")');
+    await expect(featuresLink).toBeVisible();
+
+    // Test navigation
+    await featuresLink.click();
+    await expect(page).toHaveURL(/.*\/features/);
+    await expect(
+      page.getByRole("heading", { name: "Core Features" }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a "View Features Overview" link to the landing page (welcome screen) to improve discoverability of the application's core capabilities.

## Changes
- **Landing Page Link**: Added a styled text link to the Features page in `src/routes/+page.svelte`.
- **E2E Test**: Added a new test file `apps/web/tests/landing.spec.ts` to verify the link presence and navigation functionality.
- **Bug Fix**: Fixed a `ReferenceError: base is not defined` in `+page.svelte` by properly importing `base` from `$app/paths`.

## Verification
- Ran `npm run test:e2e -- tests/landing.spec.ts` - All tests passed.
- Verified manual navigation on local dev server.