### PR TITLE
feat(zen-mode): full screen Zen mode on smaller screens

### DIFF
--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -22,6 +22,7 @@
   let activeTab = $derived(uiStore.zenModeActiveTab);
   let showLightbox = $state(false);
   let scrollContainer = $state<HTMLDivElement>();
+  let mobileScroller = $state<HTMLDivElement>();
   let tabOverview = $state<HTMLButtonElement>();
   let tabInventory = $state<HTMLButtonElement>();
   let tabMap = $state<HTMLButtonElement>();
@@ -404,9 +405,7 @@
       handleClose();
     } else if (!isEditing) {
       const scroller =
-        window.innerWidth < 768
-          ? document.getElementById("panel-overview")
-          : scrollContainer;
+        window.innerWidth < 768 ? mobileScroller : scrollContainer;
       if (!scroller) return;
 
       if (e.key === "ArrowDown") {
@@ -631,6 +630,7 @@
             role="tabpanel"
             id="panel-overview"
             aria-labelledby="tab-overview"
+            bind:this={mobileScroller}
             class="flex-1 flex flex-col md:flex-row overflow-y-auto md:overflow-hidden w-full h-full custom-scrollbar"
           >
             <!-- Left Sidebar (Image & Meta) -->
@@ -937,6 +937,11 @@
   .no-scrollbar {
     -ms-overflow-style: none;
     scrollbar-width: none;
+  }
+
+  /* Add affordance for horizontal scrolling */
+  div[role="tablist"].overflow-x-auto {
+    mask-image: linear-gradient(to right, black 90%, transparent);
   }
 
   .zen-dialog {


### PR DESCRIPTION
# Feature: Full-Screen Zen Mode on Smaller Screens

This PR implements a true full-screen experience for Zen Mode on mobile and smaller screens, optimizing the layout for limited screen real estate.

## Changes

- **Full-Screen Layout**: Removed backdrop padding and set the modal height/width to 100% on screens smaller than 768px.
- **Edge-to-Edge Design**: Added a `zen-dialog` class and media query to reset `border-radius` and `border-width` to zero on mobile.
- **Header Optimization**: Reduced horizontal padding and gap in the header for mobile. Hidden the "EDIT", "SAVE", and "SAVING" labels on extra-small screens to preserve space, keeping icons visible.
- **Tab Bar Improvements**: Added horizontal scroll capability to the tab bar (`overflow-x-auto`) and removed the scrollbar visibility for a cleaner look.
- **Decorative Cleanup**: Hidden the ornate corner decorations on mobile to prevent clutter in full-screen mode.

## Verification
- Verified full-screen appearance on mobile viewport simulations.
- Verified that the ornate design and constrained layout are preserved on desktop screens.
- Confirmed that all existing functionality (editing, copying, tab switching) remains intact across screen sizes.
