### PR TITLE
chore(web): add Cloudflare Web Analytics snippet

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -54,6 +54,13 @@
 
 <body data-sveltekit-preload-data="hover">
 	<div style="display: contents">%sveltekit.body%</div>
+	<!-- Cloudflare Web Analytics -->
+	<script
+		defer
+		src="https://static.cloudflareinsights.com/beacon.min.js"
+		data-cf-beacon='{"token": "739f54f344b8409caa81df513e949d31"}'
+	></script>
+	<!-- End Cloudflare Web Analytics -->
 </body>
 
 </html>


### PR DESCRIPTION
Adds the Cloudflare Web Analytics snippet to `apps/web/src/app.html` to enable site traffic monitoring.