### PR TITLE
⚡ Bolt: Optimize GraphStore stats calculation

### DIFF
--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -68,9 +68,21 @@ class GraphStore {
 
   eras = $state<Era[]>([]);
 
-  stats = $derived({
-    nodeCount: this.elements.filter((e) => e.group === "nodes").length,
-    edgeCount: this.elements.filter((e) => e.group === "edges").length,
+  stats = $derived.by(() => {
+    // OPTIMIZATION: Use imperative loop instead of multiple .filter() calls
+    // to avoid intermediate array allocations and reduce GC pressure.
+    let nodeCount = 0;
+    let edgeCount = 0;
+    const elements = this.elements;
+    const count = elements.length;
+    for (let i = 0; i < count; i++) {
+      if (elements[i].group === "nodes") {
+        nodeCount++;
+      } else if (elements[i].group === "edges") {
+        edgeCount++;
+      }
+    }
+    return { nodeCount, edgeCount };
   });
 
   requestFit() {


### PR DESCRIPTION
💡 What: The optimization implemented
Replaced multiple `.filter()` calls with a single imperative loop in the `stats` $derived block in `GraphStore`.

🎯 Why: The performance problem it solves
In `apps/web/src/lib/stores/graph.svelte.ts`, the `stats` $derived property was calculating node and edge counts by running `.filter()` twice on the entire `elements` array. For large graphs with thousands of elements, this generated multiple intermediate arrays on every reactive update, causing unnecessary garbage collection pressure and running in 2 * O(N) time.

📊 Impact: Expected performance improvement
Reduces intermediate array allocations in this code path from 2 to 0. Reduces iteration over the elements array from 2 * O(N) to O(N). For large graph updates, this significantly cuts down on synchronous CPU time spent in Svelte reactivity cycles and avoids GC pauses.

🔬 Measurement: How to verify the improvement
Create a graph with 10k+ nodes and edges and trigger repeated state changes. You can observe reduced memory allocation and shorter execution times for the `stats` re-computation block using browser DevTools Performance profiler.

---
*PR created automatically by Jules for task [15403664663045634168](https://jules.google.com/task/15403664663045634168) started by @eserlan*