### PR TITLE
fix(canvas): resolve infinite reactivity loop

### DIFF
--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
@@ -53,18 +53,15 @@
   } | null>(null);
 
   // Modifier state passed to nodes via context or store
-  // For simplicity and reactivity, we'll use a local state here
-  let isCtrlPressed = $state(false);
-
   $effect(() => {
     const handleDown = (e: KeyboardEvent) => {
       if (e.key === "Control" || e.metaKey || e.ctrlKey) {
-        isCtrlPressed = true;
+        uiStore.isModifierPressed = true;
       }
     };
     const handleUp = (e: KeyboardEvent) => {
       if (e.key === "Control" || e.metaKey || e.ctrlKey) {
-        isCtrlPressed = false;
+        uiStore.isModifierPressed = false;
       }
     };
     window.addEventListener("keydown", handleDown);
@@ -136,7 +133,6 @@
             entityId: n.entityId,
             width: n.width,
             height: n.height,
-            isCtrlPressed,
           },
         }));
         edges = data.edges.map((e: CanvasEdge) => ({
@@ -153,18 +149,6 @@
         nodes = [];
         edges = [];
       }
-    }
-  });
-
-  $effect(() => {
-    if (nodes.length > 0) {
-      nodes = nodes.map((n) => ({
-        ...n,
-        data: {
-          ...n.data,
-          isCtrlPressed,
-        },
-      }));
     }
   });
 

--- a/apps/web/src/lib/components/canvas/EntityNode.svelte
+++ b/apps/web/src/lib/components/canvas/EntityNode.svelte
@@ -64,7 +64,7 @@
     }
   }
 
-  const isCtrlPressed = $derived(!!data.isCtrlPressed);
+  const isCtrlPressed = $derived(uiStore.isModifierPressed);
 
   function onDoubleClick() {
     if (entity) {

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -76,6 +76,9 @@ class UIStore {
     }
   }
 
+  // Interaction Modifiers
+  isModifierPressed = $state(false);
+
   // Zen Mode State
   showZenMode = $state(false);
   zenModeEntityId = $state<string | null>(null);


### PR DESCRIPTION
Resolves the 'Maximum update depth exceeded' error caused by an infinite loop in the canvas node modifier state logic.

### Fix Details
- Moved  state to  for global tracking.
- Removed the problematic  in  that was looping over nodes.
- Updated  to read from  directly via a  rune.