### PR TITLE
fix: Update canvas e2e tests to use new locators and rename modal

### DIFF
--- a/apps/web/tests/canvas.spec.ts
+++ b/apps/web/tests/canvas.spec.ts
@@ -83,13 +83,14 @@ test.describe("Spatial Canvas", () => {
     // Get source and target handles
     const sourceHandle = nodes
       .nth(0)
-      .locator('.svelte-flow__handle[data-handleid="right-source"]');
+      .locator('.source-handle-cover');
     const targetHandle = nodes
       .nth(1)
-      .locator('.svelte-flow__handle[data-handleid="left-target"]');
+      .locator('.target-handle-cover');
 
-    await expect(sourceHandle).toBeVisible();
-    await expect(targetHandle).toBeVisible();
+    // These handles use opacity-0 by default and group-hover:opacity-100, but are in the DOM
+    await expect(sourceHandle).toBeAttached();
+    await expect(targetHandle).toBeAttached();
 
     // Drag from source to target
     await sourceHandle.dragTo(targetHandle, { force: true });
@@ -161,10 +162,10 @@ test.describe("Spatial Canvas", () => {
 
     const sourceHandle = nodes
       .nth(0)
-      .locator('.svelte-flow__handle[data-handleid="right-source"]');
+      .locator('.source-handle-cover');
     const targetHandle = nodes
       .nth(1)
-      .locator('.svelte-flow__handle[data-handleid="left-target"]');
+      .locator('.target-handle-cover');
 
     await sourceHandle.dragTo(targetHandle, { force: true });
     await expect(page.locator(".svelte-flow__edge")).toHaveCount(1);
@@ -202,10 +203,10 @@ test.describe("Spatial Canvas", () => {
     const nodes = page.locator(".svelte-flow__node");
     const sourceHandle = nodes
       .nth(0)
-      .locator('.svelte-flow__handle[data-handleid="right-source"]');
+      .locator('.source-handle-cover');
     const targetHandle = nodes
       .nth(1)
-      .locator('.svelte-flow__handle[data-handleid="left-target"]');
+      .locator('.target-handle-cover');
 
     await sourceHandle.dragTo(targetHandle, { force: true });
     await expect(page.locator(".svelte-flow__edge")).toHaveCount(1);
@@ -214,12 +215,15 @@ test.describe("Spatial Canvas", () => {
     const edgePath = edge.locator("path.svelte-flow__edge-path");
 
     // Double click to rename
-    await Promise.all([
-      page
-        .waitForEvent("dialog")
-        .then((dialog) => dialog.accept("Renamed Connection")),
-      edgePath.dblclick({ force: true }),
-    ]);
+    await edgePath.dblclick({ force: true });
+
+    // Wait for the rename modal
+    const input = page.locator('input[placeholder="Enter connection label..."]');
+    await expect(input).toBeVisible();
+
+    // Type the new label and save
+    await input.fill("Renamed Connection");
+    await page.getByRole("button", { name: "Save Label" }).click();
 
     // Check if label appears
     await expect(page.locator("text=Renamed Connection")).toBeVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       }
     },
     "apps/web": {
-      "version": "0.13.2",
+      "version": "0.13.8",
       "dependencies": {
         "@codex/canvas-engine": "^0.0.0",
         "@codex/importer": "*",
@@ -17785,13 +17785,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17807,13 +17805,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17829,13 +17825,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17851,13 +17845,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17873,13 +17865,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17895,13 +17885,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17917,13 +17905,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17939,13 +17925,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17961,13 +17945,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17983,13 +17965,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -18005,13 +17985,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17785,11 +17785,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17805,11 +17807,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17825,11 +17829,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17845,11 +17851,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17865,11 +17873,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17885,11 +17895,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17905,11 +17917,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17925,11 +17939,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17945,11 +17961,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17965,11 +17983,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -17985,11 +18005,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },


### PR DESCRIPTION
Vigil Run (E2E Test Fixes):

Failed tests identified and fixed:
1. `tests/canvas.spec.ts:45:3` - `should connect two nodes together`
2. `tests/canvas.spec.ts:144:3` - `should delete an edge via context menu`
3. `tests/canvas.spec.ts:187:3` - `should rename an edge via double click`

Root Cause:
- Svelte Flow handle selectors were failing because `data-handleid` wasn't properly passed or available on the `Handle` wrappers, so the explicitly added `.source-handle-cover` and `.target-handle-cover` classes should be used instead.
- Edge handles were technically not visible because of Tailwind `opacity-0` default states, so `toBeAttached` must be used.
- The renaming flow for an edge no longer uses the native browser dialog (prompt) and now relies on a custom DOM-based `EdgeLabelModal`.

The specific test `canvas.spec.ts` now runs and passes cleanly. Due to over 10 tests failing in the broader suite (unrelated test issues or regressions), Vigil execution halted to prevent bulk/flawed fixing. A maintainer should investigate the remaining failures.

---
*PR created automatically by Jules for task [16868833912317962656](https://jules.google.com/task/16868833912317962656) started by @eserlan*