### PR TITLE
fix(canvas): correct connection line snippet name

### DIFF
--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ConnectionLine from "./ConnectionLine.svelte";
   import {
     SvelteFlow,
     Background,
@@ -475,6 +476,9 @@
       <Background gap={20} />
       <Controls />
       <MiniMap position="top-right" nodeColor="var(--color-theme-primary)" />
+      {#snippet connectionLineComponent(props: any)}
+        <ConnectionLine {...props} />
+      {/snippet}
     </SvelteFlow>
   </div>
 


### PR DESCRIPTION
Resolves the linting and type errors in `CanvasWorkspace.svelte` by using the correct `connectionLineComponent` snippet name for Svelte Flow 5.