### PR TITLE
fix(ci): include hidden files in build artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           name: dist-${{ matrix.environment }}
           path: apps/web/build/
+          include-hidden-files: true
           retention-days: 1
 
   deploy:


### PR DESCRIPTION
Sets `include-hidden-files: true` for `actions/upload-artifact@v4` so that `.well-known` and `.nojekyll` are not stripped out before being handed off to GitHub Pages.