### PR TITLE
feat(map): make GM mode the default

### DIFF
--- a/apps/web/src/lib/stores/map.svelte.ts
+++ b/apps/web/src/lib/stores/map.svelte.ts
@@ -12,7 +12,7 @@ class MapStore {
   canvasSize = $state({ width: 0, height: 0 });
   pendingPinCoords = $state<Point | null>(null);
   showFog = $state(true);
-  isGMMode = $state(false);
+  isGMMode = $state(true);
   brushRadius = $state(50);
   navigationStack = $state<string[]>([]);
   showGrid = $state(false);


### PR DESCRIPTION
Sets the map's GM mode to be on by default, as Game Masters are the primary users of this feature.