### PR TITLE
fix(ci): fetch full git history for deploy job to fix discord summaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Download Production Build
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The Discord deployment script requires access to git history to summarize the commits since the last successful production deployment. The `deploy` job was previously checking out the repository with a shallow clone (`fetch-depth: 1`), which caused `git log` to fail silently and fallback to the 'Maintenance re-deployment' message. This PR adds `fetch-depth: 0` to the checkout step in the deploy job.