### PR TITLE
feat(graph): add image toggle to the graph view

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -40,7 +40,7 @@
   let isLayoutRunning = $state(false);
 
   let graphStyle = $derived([
-    ...getGraphStyle(themeStore.activeTheme, categories.list),
+    ...getGraphStyle(themeStore.activeTheme, categories.list, graph.showImages),
     {
       selector: ".filtered-out",
       style: {
@@ -318,7 +318,6 @@
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (vault.isGuest) return;
     if (e.key.toLowerCase() === "t" && !e.ctrlKey && !e.metaKey && !e.altKey) {
       const target = document.activeElement;
       if (
@@ -331,6 +330,7 @@
       applyCurrentLayout();
     }
     if (e.key.toLowerCase() === "c" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (vault.isGuest) return;
       // Don't toggle if user is typing in an input (though we don't have many here yet)
       const target = document.activeElement;
       if (
@@ -350,6 +350,16 @@
       )
         return;
       graph.toggleLabels();
+    }
+    if (e.key.toLowerCase() === "i" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      const target = document.activeElement;
+      if (
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        (target as HTMLElement)?.isContentEditable
+      )
+        return;
+      graph.toggleImages();
     }
     if (e.key === "Escape" && connectMode) {
       toggleConnectMode();
@@ -1160,7 +1170,32 @@
         ></span>
       </button>
 
-      <!-- Connect Mode Toggle -->
+      <button
+        class="w-8 h-8 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
+        onclick={() => graph.toggleLabels()}
+        title="Toggle Labels (L)"
+        aria-label="Toggle Labels"
+      >
+        <span
+          class={graph.showLabels
+            ? "icon-[lucide--type]"
+            : "icon-[lucide--type-outline] opacity-50"}
+        ></span>
+      </button>
+      <button
+        class="w-8 h-8 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
+        onclick={() => graph.toggleImages()}
+        title="Toggle Node Images (I)"
+        aria-label="Toggle Node Images"
+      >
+        <span
+          class={graph.showImages
+            ? "icon-[lucide--image]"
+            : "icon-[lucide--image-off] opacity-50"}
+        ></span>
+      </button>
+
+      <!-- Connect Mode Toggle (Gated) -->
       {#if !vault.isGuest}
         <button
           class="w-8 h-8 flex items-center justify-center border transition {connectMode

--- a/apps/web/src/lib/components/graph/TimelineOverlay.svelte
+++ b/apps/web/src/lib/components/graph/TimelineOverlay.svelte
@@ -8,6 +8,7 @@
   } from "graph-engine";
   import type { Core, NodeSingular } from "cytoscape";
   import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
 
   let { cy } = $props<{ cy: Core }>();
 
@@ -159,39 +160,41 @@
         {/each}
 
         <!-- Node Labels (Attached to node model coordinates) -->
-        {#each timelineNodes as node}
-          <g>
-            <!-- Date (Purple) - Always above node -->
-            <foreignObject
-              x={node.pos.x - 40}
-              y={node.pos.y - (node.hasImage ? 24 : 16) - 14}
-              width="80"
-              height="14"
-            >
-              <div
-                class="text-[10px] text-theme-accent text-center font-body leading-none select-none"
-                style="font-family: Inter, sans-serif;"
+        {#if graph.showLabels}
+          {#each timelineNodes as node}
+            <g transition:fade={{ duration: 150 }}>
+              <!-- Date (Purple) - Always above node -->
+              <foreignObject
+                x={node.pos.x - 40}
+                y={node.pos.y - (node.hasImage ? 24 : 16) - 14}
+                width="80"
+                height="14"
               >
-                {node.dateLabel}
-              </div>
-            </foreignObject>
+                <div
+                  class="text-[10px] text-theme-accent text-center font-body leading-none select-none"
+                  style="font-family: Inter, sans-serif;"
+                >
+                  {node.dateLabel}
+                </div>
+              </foreignObject>
 
-            <!-- Title (Normal Style) - Always below node -->
-            <foreignObject
-              x={node.pos.x - 40}
-              y={node.pos.y + (node.hasImage ? 24 : 16) + 4}
-              width="80"
-              height="60"
-            >
-              <div
-                class="text-[10px] text-theme-primary text-center font-body leading-tight line-clamp-3 select-none"
-                style="font-family: Inter, sans-serif;"
+              <!-- Title (Normal Style) - Always below node -->
+              <foreignObject
+                x={node.pos.x - 40}
+                y={node.pos.y + (node.hasImage ? 24 : 16) + 4}
+                width="80"
+                height="60"
               >
-                {node.label}
-              </div>
-            </foreignObject>
-          </g>
-        {/each}
+                <div
+                  class="text-[10px] text-theme-primary text-center font-body leading-tight line-clamp-3 select-none"
+                  style="font-family: Inter, sans-serif;"
+                >
+                  {node.label}
+                </div>
+              </foreignObject>
+            </g>
+          {/each}
+        {/if}
       </g>
     </svg>
   </div>

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -52,6 +52,7 @@ class GraphStore {
 
   // Labels state
   showLabels = $state(true);
+  showImages = $state(true);
 
   // Timeline State
   timelineMode = $state(false);
@@ -100,6 +101,11 @@ class GraphStore {
     if (savedShowLabels !== undefined) {
       this.showLabels = savedShowLabels;
     }
+
+    const savedShowImages = await db.get("settings", "graphShowImages");
+    if (savedShowImages !== undefined) {
+      this.showImages = savedShowImages;
+    }
   }
 
   async saveEras() {
@@ -138,8 +144,22 @@ class GraphStore {
 
   async toggleLabels() {
     this.showLabels = !this.showLabels;
-    const db = await getDB();
-    await db.put("settings", this.showLabels, "graphShowLabels");
+    try {
+      const db = await getDB();
+      await db.put("settings", this.showLabels, "graphShowLabels");
+    } catch (err) {
+      console.error("Failed to persist graph labels setting:", err);
+    }
+  }
+
+  async toggleImages() {
+    this.showImages = !this.showImages;
+    try {
+      const db = await getDB();
+      await db.put("settings", this.showImages, "graphShowImages");
+    } catch (err) {
+      console.error("Failed to persist graph image setting:", err);
+    }
   }
 
   toggleTimeline() {

--- a/apps/web/src/lib/stores/graph.test.ts
+++ b/apps/web/src/lib/stores/graph.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { graph } from "./graph.svelte";
+import { getDB } from "../utils/idb";
+
+// Mock dependencies
+vi.mock("./vault.svelte", () => ({
+  vault: {
+    allEntities: [],
+    defaultVisibility: "visible",
+    activeVaultId: "v1",
+    isInitialized: true,
+  },
+}));
+
+vi.mock("./ui.svelte", () => ({
+  ui: {
+    sharedMode: false,
+  },
+}));
+
+vi.mock("../utils/idb", () => ({
+  getDB: vi.fn().mockResolvedValue({
+    get: vi.fn(),
+    put: vi.fn(),
+    getAll: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+describe("GraphStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset graph state
+    graph.showLabels = true;
+    graph.showImages = true;
+    graph.timelineMode = false;
+    graph.orbitMode = false;
+  });
+
+  it("should initialize with default values", () => {
+    expect(graph.showLabels).toBe(true);
+    expect(graph.showImages).toBe(true);
+  });
+
+  it("should toggle images and persist to IDB", async () => {
+    const mockDB = {
+      put: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockResolvedValue(true),
+      getAll: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(getDB).mockResolvedValue(mockDB as any);
+
+    await graph.toggleImages();
+    expect(graph.showImages).toBe(false);
+    expect(mockDB.put).toHaveBeenCalledWith(
+      "settings",
+      false,
+      "graphShowImages",
+    );
+
+    await graph.toggleImages();
+    expect(graph.showImages).toBe(true);
+    expect(mockDB.put).toHaveBeenCalledWith(
+      "settings",
+      true,
+      "graphShowImages",
+    );
+  });
+
+  it("should toggle labels and persist to IDB", async () => {
+    const mockDB = {
+      put: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockResolvedValue(true),
+      getAll: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(getDB).mockResolvedValue(mockDB as any);
+
+    await graph.toggleLabels();
+    expect(graph.showLabels).toBe(false);
+    expect(mockDB.put).toHaveBeenCalledWith(
+      "settings",
+      false,
+      "graphShowLabels",
+    );
+
+    await graph.toggleLabels();
+    expect(graph.showLabels).toBe(true);
+    expect(mockDB.put).toHaveBeenCalledWith(
+      "settings",
+      true,
+      "graphShowLabels",
+    );
+  });
+
+  it("should load saved settings on init", async () => {
+    const mockDB = {
+      get: vi.fn().mockImplementation((store, key) => {
+        if (key === "graphShowLabels") return false;
+        if (key === "graphShowImages") return false;
+        return undefined;
+      }),
+      getAll: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(getDB).mockResolvedValue(mockDB as any);
+
+    await graph.init();
+    expect(graph.showLabels).toBe(false);
+    expect(graph.showImages).toBe(false);
+  });
+});

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -177,11 +177,12 @@ const sanitizeFontForCytoscape = (fontFamily?: string): string => {
 export const getGraphStyle = (
   template: StylingTemplate,
   categories: Category[],
+  showImages: boolean,
 ): any[] => {
   const { tokens, graph } = template;
 
   // Base styles (excluding revealed overrides which need to come last)
-  const baseStyle = [
+  const baseStyle: any[] = [
     {
       selector: "node",
       style: {
@@ -203,7 +204,10 @@ export const getGraphStyle = (
         "transition-duration": 200,
       },
     },
-    {
+  ];
+
+  if (showImages) {
+    baseStyle.push({
       selector: "node[resolvedImage][width][height]",
       style: {
         "background-fit": "cover",
@@ -214,7 +218,10 @@ export const getGraphStyle = (
         "border-width": graph.nodeBorderWidth + 1,
         "border-color": tokens.primary,
       },
-    },
+    });
+  }
+
+  baseStyle.push(
     {
       selector: "node:selected",
       style: {
@@ -312,11 +319,10 @@ export const getGraphStyle = (
         "z-index": 50,
       },
     },
-  ];
+  );
 
   const categoryStyles = categories.map((cat) => ({
-    // Include specific selector for image nodes to override base image style (which has [resolvedImage][width][height])
-    selector: `node[type="${cat.id}"], node[type="${cat.id}"][resolvedImage][width][height]`,
+    selector: `node[type="${cat.id}"]`,
     style: {
       "border-color": cat.color,
       "border-width": graph.nodeBorderWidth + 2,
@@ -324,7 +330,7 @@ export const getGraphStyle = (
   }));
 
   // Revealed styles come LAST to override category borders,
-  const revealedStyles = [
+  const revealedStyles: any[] = [
     {
       selector: "node[isRevealed]",
       style: {
@@ -333,7 +339,10 @@ export const getGraphStyle = (
         "overlay-opacity": 0,
       },
     },
-    {
+  ];
+
+  if (showImages) {
+    revealedStyles.push({
       selector: "node[isRevealed][resolvedImage]",
       style: {
         "background-image": "data(resolvedImage)",
@@ -342,8 +351,8 @@ export const getGraphStyle = (
         "background-position-y": "50%",
         "border-width": graph.nodeBorderWidth + 4,
       },
-    },
-  ];
+    });
+  }
 
   return [...baseStyle, ...categoryStyles, ...revealedStyles];
 };

--- a/packages/graph-engine/tests/transformer.test.ts
+++ b/packages/graph-engine/tests/transformer.test.ts
@@ -85,7 +85,7 @@ describe("GraphTransformer", () => {
       themeId: "dark",
     };
 
-    const styles = getGraphStyle(mockTemplate, []);
+    const styles = getGraphStyle(mockTemplate, [], true);
 
     const friendlyStyle = styles.find(
       (s: any) => s.selector === 'edge[connectionType="friendly"]',
@@ -98,5 +98,39 @@ describe("GraphTransformer", () => {
     );
     expect(enemyStyle).toBeDefined();
     expect(enemyStyle.style["line-color"]).toBe(CONNECTION_COLORS.enemy);
+  });
+
+  it("should conditionally include image selectors based on showImages", () => {
+    const mockTemplate: StylingTemplate = {
+      tokens: {
+        background: "#000",
+        primary: "#f00",
+        surface: "#111",
+        text: "#fff",
+        fontBody: "Arial",
+        fontHeading: "Arial",
+      },
+      graph: {
+        nodeBorderWidth: 1,
+        nodeShape: "ellipse",
+        edgeColor: "#555",
+        edgeStyle: "solid",
+      },
+      themeId: "dark",
+    };
+
+    const imageSelector = "node[resolvedImage][width][height]";
+
+    // Test with images enabled (default)
+    const styleWithImages = getGraphStyle(mockTemplate, [], true);
+    expect(styleWithImages.some((s: any) => s.selector === imageSelector)).toBe(
+      true,
+    );
+
+    // Test with images disabled
+    const styleWithoutImages = getGraphStyle(mockTemplate, [], false);
+    expect(
+      styleWithoutImages.some((s: any) => s.selector === imageSelector),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Implement a toggle to show/hide images in the graph view, addressing issue #339. This is useful for reducing distractions or complying with sharing policies.

### Changes
- Added `showImages` state to `GraphStore` with persistence in IndexedDB.
- Updated `getGraphStyle` in `packages/graph-engine` to conditionally apply image-related styles.
- Added a toggle button in the `GraphView` zoom controls.
- Added a keyboard shortcut 'I' to toggle images.