### PR TITLE
feat: add 'Find in Graph' button to entity detail header

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -755,7 +755,7 @@
   $effect(() => {
     const currentCy = cy;
     const _id = selectedId; // Track selection state
-    const _findTrigger = ui.findNodeCounter;
+    const _findTrigger = ui.findNodeCounter; // Trigger effect when findInGraph is called
 
     if (currentCy) {
       applyFocus(selectedId);

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -755,8 +755,11 @@
   $effect(() => {
     const currentCy = cy;
     const _id = selectedId; // Track selection state
+    const _findTrigger = ui.findNodeCounter;
+
     if (currentCy) {
       applyFocus(selectedId);
+
       // Small delay to allow flex layout to settle before resizing
       const timer = setTimeout(() => {
         currentCy.resize();

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -7,6 +7,8 @@
   import LabelBadge from "$lib/components/labels/LabelBadge.svelte";
   import LabelInput from "$lib/components/labels/LabelInput.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
+  import { page } from "$app/state";
+  import { base } from "$app/paths";
 
   let {
     entity,
@@ -19,6 +21,10 @@
     editTitle: string;
     onClose: () => void;
   }>();
+
+  const isGraphView = $derived(
+    page.url.pathname === `${base}/` || page.url.pathname === base,
+  );
 
   let isObscured = $derived.by(() => {
     if (!entity || !ui.sharedMode) return false;
@@ -78,6 +84,17 @@
 
     <div class="flex items-center gap-1">
       {#if !isEditing}
+        {#if isGraphView}
+          <button
+            onclick={() => ui.findInGraph()}
+            class="text-theme-secondary hover:text-theme-primary transition flex items-center justify-center p-1"
+            aria-label="Find in Graph"
+            title="Find in Graph"
+            data-testid="find-in-graph-button"
+          >
+            <span class="icon-[lucide--target] w-5 h-5"></span>
+          </button>
+        {/if}
         <button
           onclick={() => ui.openZenMode(entity.id)}
           class="text-theme-secondary hover:text-theme-primary transition flex items-center justify-center p-1"

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -22,9 +22,11 @@
     onClose: () => void;
   }>();
 
-  const isGraphView = $derived(
-    page.url.pathname === `${base}/` || page.url.pathname === base,
-  );
+  const isGraphView = $derived.by(() => {
+    const path = page.url.pathname;
+    const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+    return path === base || path === normalizedBase || path === "/";
+  });
 
   let isObscured = $derived.by(() => {
     if (!entity || !ui.sharedMode) return false;

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -144,6 +144,13 @@ class UIStore {
   // Canvas Palette State
   showCanvasPalette = $state(true);
 
+  // Find in Graph State
+  findNodeCounter = $state(0);
+
+  findInGraph() {
+    this.findNodeCounter++;
+  }
+
   // Merge Dialog State
   mergeDialog = $state<{
     open: boolean;

--- a/apps/web/tests/find-button.spec.ts
+++ b/apps/web/tests/find-button.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Find in Graph Button", () => {
+  test("should center the graph on the node when clicked", async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+    });
+
+    await page.goto("/");
+
+    // Wait for vault initialization
+    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
+      timeout: 15000,
+    });
+    await expect(page.getByTestId("graph-canvas")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Create a node
+    await page.getByTestId("new-entity-button").click();
+    await page.getByPlaceholder("Chronicle Title...").fill("Target Node");
+    await page.getByRole("button", { name: "ADD" }).click();
+
+    // Wait for entities to be created
+    await expect(page.getByTestId("entity-count")).toHaveText("1 CHRONICLE", {
+      timeout: 10000,
+    });
+
+    // Get the node ID
+    const nodeId = await page.evaluate(() => {
+      const entities = Object.values((window as any).vault.entities) as any[];
+      return entities.find((e) => e.title === "Target Node").id;
+    });
+
+    // Open the node in sidebar
+    await page.evaluate((id) => {
+      (window as any).vault.selectedEntityId = id;
+    }, nodeId);
+
+    // Wait for sidebar to open and button to be visible
+    const findBtn = page.getByTestId("find-in-graph-button");
+    await expect(findBtn).toBeVisible();
+
+    // Pan the graph far away
+    await page.evaluate(() => {
+      const cy = (window as any).cy;
+      cy.stop(); // Stop any ongoing animations
+      cy.pan({ x: 2000, y: 2000 });
+    });
+
+    // Wait for pan to settle
+    await page.waitForTimeout(500);
+
+    // Check that node is NOT centered
+    const initialFocusState = await page.evaluate((id) => {
+      const cy = (window as any).cy;
+      const node = cy.$id(id);
+      const pos = node.renderedPosition();
+      const centerX = cy.width() / 2;
+      const centerY = cy.height() / 2;
+      return {
+        pos,
+        centerX,
+        centerY,
+        isCentered:
+          Math.abs(pos.x - centerX) < 50 && Math.abs(pos.y - centerY) < 50,
+      };
+    }, nodeId);
+
+    expect(initialFocusState.isCentered).toBe(false);
+
+    // Click Find in Graph button
+    await findBtn.click();
+
+    // Wait for animation (500ms duration in code + some buffer)
+    await page.waitForTimeout(1000);
+
+    // Check that node IS centered
+    const isCentered = await page.evaluate((id) => {
+      const cy = (window as any).cy;
+      const node = cy.$id(id);
+      const pos = node.renderedPosition();
+      const centerX = cy.width() / 2;
+      const centerY = cy.height() / 2;
+      // Allow for some tolerance due to sidebar width affecting center
+      return Math.abs(pos.x - centerX) < 100 && Math.abs(pos.y - centerY) < 100;
+    }, nodeId);
+
+    expect(isCentered).toBe(true);
+  });
+});

--- a/apps/web/tests/find-button.spec.ts
+++ b/apps/web/tests/find-button.spec.ts
@@ -47,7 +47,7 @@ test.describe("Find in Graph Button", () => {
     await page.evaluate(() => {
       const cy = (window as any).cy;
       cy.stop(); // Stop any ongoing animations
-      cy.pan({ x: 2000, y: 2000 });
+      cy.panBy({ x: 1000, y: 1000 });
     });
 
     // Wait for pan to settle


### PR DESCRIPTION
## Description
This PR adds a "Find in Graph" button to the entity detail header. This button allows users to quickly re-center the graph on the currently open entity, which is particularly useful in large or complex graphs where the node might be panned out of view.

### Key Changes
- **UIStore**: Added `findNodeCounter` state and a `findInGraph()` method to trigger re-centering.
- **DetailHeader Component**: Added a "target" icon button next to the Zen Mode button, visible only when in Graph View.
- **GraphView Component**: Updated the centering effect to react to `findNodeCounter`, allowing it to re-center even if the `selectedId` hasn't changed.
- **E2E Test**: Added a new test `apps/web/tests/find-button.spec.ts` to verify that clicking the button correctly centers the graph on the target node after it has been panned away.

### Verification
- Verified manually that the button appears in Graph View and correctly centers the node.
- Verified that all E2E tests pass, including the new `find-button.spec.ts`.

Fixes #345