### PR TITLE
🎨 Palette: Add aria-pressed to Editor Bubble Menu buttons

### DIFF
--- a/apps/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/apps/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -38,6 +38,7 @@
     onclick={() => editor?.chain().focus().toggleBold().run()}
     class="menu-btn {isBold ? 'active' : ''}"
     aria-label="Bold"
+    aria-pressed={isBold}
   >
     <span class="icon-[lucide--bold] w-4 h-4"></span>
   </button>
@@ -45,6 +46,7 @@
     onclick={() => editor?.chain().focus().toggleItalic().run()}
     class="menu-btn {isItalic ? 'active' : ''}"
     aria-label="Italic"
+    aria-pressed={isItalic}
   >
     <span class="icon-[lucide--italic] w-4 h-4"></span>
   </button>
@@ -52,6 +54,7 @@
     onclick={setLink}
     class="menu-btn {isLink ? 'active' : ''}"
     aria-label="Link"
+    aria-pressed={isLink}
   >
     <span class="icon-[lucide--link] w-4 h-4"></span>
   </button>


### PR DESCRIPTION
💡 What: Added `aria-pressed` to the formatting toggle buttons (Bold, Italic, Link) in the rich text editor's bubble menu.
🎯 Why: Screen reader users need to know if a text formatting option is currently active. The buttons previously relied only on CSS classes for visual state.
📸 Before/After: No visual change; improves accessibility tree.
♿ Accessibility: Ensures `aria-pressed` state mirrors the `isBold`, `isItalic`, and `isLink` state variables.

---
*PR created automatically by Jules for task [11503851190899213676](https://jules.google.com/task/11503851190899213676) started by @eserlan*