### PR TITLE
docs: document dual-path deployment strategy (ADR 005)

### DIFF
--- a/docs/CI_DEPLOYMENT.md
+++ b/docs/CI_DEPLOYMENT.md
@@ -1,0 +1,57 @@
+# CI/CD Deployment Architecture
+
+This document describes the automated build and deployment pipeline for Codex Cryptica.
+
+## Overview
+
+Codex Cryptica uses **GitHub Pages** for hosting. We employ a "Dual-Path" deployment strategy that allows for safe testing of features before they are "live" on the main site.
+
+- **Production:** Hosted at the root ([ eserlan.github.io/Codex-Cryptica/](https://eserlan.github.io/Codex-Cryptica/)).
+- **Staging:** Hosted at the [/staging](https://eserlan.github.io/Codex-Cryptica/staging) sub-path.
+
+## The Deployment Workflow (`deploy.yml`)
+
+The main deployment script is located at `.github/workflows/deploy.yml`. It triggers on **every push** to **any branch**.
+
+### 1. Build Phase (Matrix)
+
+The workflow runs a build matrix for two environments simultaneously:
+
+- **`production`**: Always checks out the `main` branch. It uses `BASE_PATH=""`.
+- **`staging`**: Checks out the branch that triggered the workflow. It uses `BASE_PATH="/staging"`.
+
+### 2. Deploy Phase
+
+The deployment job waits for both builds to finish, then combines them:
+
+- It puts the production build in the root folder.
+- It puts the staging build in the `/staging/` sub-folder.
+- It uploads the combined artifact to GitHub Pages.
+
+## The Version Bump Workflow (`auto-bump-web-version.yml`)
+
+When a Pull Request is merged into `main`:
+
+1. **Auto-Bump Trigger:** A workflow runs to increment the version in `apps/web/package.json`.
+2. **Commit & Push:** The bot commits the new version back to `main`.
+3. **Redundant Triggers:** This push triggers `deploy.yml` automatically.
+4. **Manual Dispatch:** The bot also executes `gh workflow run deploy.yml`.
+
+**Note:** Because of the `concurrency` setting in `deploy.yml`, you may see "Cancelled" runs in your Actions tab after a merge. This is normal behavior; the system is simply cancelling the "Merge" deployment in favor of the "Version Bump" deployment to ensure the live site always shows the correct version number.
+
+## Environment Variables
+
+The following secrets must be configured in GitHub for the build to succeed:
+
+- `VITE_GOOGLE_CLIENT_ID`: OAuth client ID.
+- `VITE_GEMINI_API_KEY`: API key for the Lore Oracle.
+- `VITE_DISCORD_WEBHOOK_URL_PROD`: For production notifications.
+- `VITE_DISCORD_WEBHOOK_URL_STAGING`: For staging notifications.
+
+## Troubleshooting
+
+If a merge to `main` doesn't result in a site update:
+
+1. Check the **Actions** tab. Look for the _latest_ "Deploy to GitHub Pages" run.
+2. If it failed, check the "Build Application" step for linting or test errors.
+3. If it was cancelled, wait for the subsequent run (the one triggered by the bot) to finish.

--- a/docs/adr/005-dual-path-deployment-strategy.md
+++ b/docs/adr/005-dual-path-deployment-strategy.md
@@ -1,0 +1,54 @@
+# ADR 005: Dual-Path CI/CD Deployment Strategy
+
+- **Status:** Active
+- **Date:** 2026-03-06
+
+---
+
+## Context and Problem Statement
+
+As the Codex Cryptica project grows, we need a way to:
+
+1.  **Safely test features** in a live-like environment before they are merged into the `main` branch.
+2.  **Provide a stable production environment** for end-users that is only updated with verified code.
+3.  **Automate versioning** to maintain a clear history of releases and coordinate with the `Lore Oracle` AI capabilities.
+4.  **Notify the team** of successful deployments via Discord.
+
+## Decision
+
+We have implemented a "Dual-Path" CI/CD pipeline using GitHub Actions and GitHub Pages:
+
+1.  **Branch-Based Matrix Builds:**
+    - Every push to _any_ branch triggers a build matrix that generates two separate versions of the site:
+      - **Production Path:** Always built from the `main` branch, served at the domain root (`/`).
+      - **Staging Path:** Built from the _current_ branch (the one that triggered the push), served at the `/staging` sub-path.
+2.  **Combined Artifact Deployment:**
+    - The deployment job waits for both matrix builds to complete.
+    - It merges the two builds into a single directory structure:
+      - `dist/` (Production)
+      - `dist/staging/` (Staging)
+    - The entire `dist/` folder is uploaded as a single GitHub Pages artifact.
+3.  **Post-Merge Automation:**
+    - When a Pull Request is merged into `main`, a separate `auto-bump-web-version` workflow triggers.
+    - This workflow increments the version in `package.json`, updates the service worker cache version, and pushes a commit back to `main`.
+    - This push then triggers the final `production` deployment with the new version number.
+
+## Decision Outcome
+
+### Pros
+
+- **Immediate Feedback:** Developers can see their changes live at `/staging` before merging.
+- **Zero-Risk Main:** The production site at `/` is protected and only updates when `main` changes.
+- **Unified Hosting:** Both environments coexist on the same GitHub Pages instance, simplifying configuration.
+- **Automated Traceability:** Version numbers are always in sync with the live code without manual intervention.
+
+### Cons
+
+- **Build Redundancy:** Every push builds `main` twice (once as the target and once as the "Production" part of the matrix).
+- **Concurrency Cancellations:** Rapid pushes or the auto-bump bot can cause previous deployment runs to be cancelled, which can look like failures in the GitHub UI (though the latest run always prevails).
+- **Environment Leakage:** Since both sites share the same domain (different paths), they share `localStorage` and `IndexedDB`. Developers must be careful when testing breaking schema changes in staging.
+
+## Alternatives Considered
+
+- **Separate Repositories:** Too much overhead for a small team.
+- **Vercel/Netlify:** Excellent for PR previews, but GitHub Pages was chosen to keep the entire stack within the GitHub ecosystem and avoid extra third-party dependencies for this static site.


### PR DESCRIPTION
This is a clean, surgically extracted PR for the CI/CD deployment architecture documentation and ADR 005.

It replaces #369, which had become polluted with unrelated commits.

**Changes:**
- Added `docs/CI_DEPLOYMENT.md`: Documentation for the "Dual-Path" deployment strategy.
- Added `docs/adr/005-dual-path-deployment-strategy.md`: Architecture Decision Record for the deployment strategy.