### PR TITLE
🎨 Palette: Improve MobileMenu button accessibility

### DIFF
--- a/apps/web/src/lib/components/layout/MobileMenu.svelte
+++ b/apps/web/src/lib/components/layout/MobileMenu.svelte
@@ -151,6 +151,7 @@
         </h3>
         <button
           class="flex items-center gap-3 p-3 rounded border border-theme-border hover:border-theme-primary hover:bg-theme-primary/10 transition-all text-left group focus:outline-none focus:ring-2 focus:ring-theme-primary min-h-[44px]"
+          aria-label="Application Settings"
           onclick={() => {
             uiStore.toggleSettings("vault");
             close();
@@ -202,6 +203,7 @@
         </a>
         <button
           class="flex items-center gap-3 p-2 text-sm font-mono text-theme-secondary hover:text-theme-primary transition-colors focus:outline-none focus:ring-1 focus:ring-theme-primary rounded text-left w-full cursor-pointer"
+          aria-label="Help"
           onclick={() => {
             uiStore.openSettings("help");
             close();


### PR DESCRIPTION
💡 **What**: Added missing `aria-label`s to the Application Settings and Help buttons in `MobileMenu.svelte`.
🎯 **Why**: To ensure icon-only and interactive buttons are fully accessible to screen reader users, making the navigation menu easier to use for everyone.
♿ **Accessibility**: Improves keyboard and screen reader navigation by providing clear, descriptive labels for buttons that previously lacked them.

---
*PR created automatically by Jules for task [8285870634772867815](https://jules.google.com/task/8285870634772867815) started by @eserlan*