### PR TITLE
🚀 feat: add daily E2E test job

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -6,6 +6,13 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: "e2e-tests"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test-e2e:
     name: Run E2E Tests
@@ -26,13 +33,14 @@ jobs:
         run: npm ci
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+        run: npm exec --workspace=web -- playwright install --with-deps chromium
 
       - name: Run E2E Tests
         env:
           VITE_GEMINI_API_KEY: ${{ secrets.VITE_GEMINI_API_KEY }}
           VITE_SHARED_GEMINI_KEY: ${{ secrets.VITE_GEMINI_API_KEY }}
-        run: npm run test:e2e
+        # We override the reporter to include HTML for the artifact, while keeping 'list' for CI visibility
+        run: npm run test:e2e -- --reporter=list,html
 
       - name: Upload Playwright Report
         if: always()


### PR DESCRIPTION
Establishes a daily GitHub Actions job to run all E2E tests at 03:00 UTC.
- **Schedule**: 03:00 UTC daily.
- **Artifacts**: Uploads Playwright HTML reports (7-day retention).
- **Manual Control**: Supports manual trigger via `workflow_dispatch`.