### PR TITLE
🧪 test: add verification tests and fix type warnings

### DIFF
--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -17,7 +17,7 @@
 
   // Logic & State Hooks
   let editState = $state(createEditState(null));
-  const actions = createZenModeActions(editState);
+  const actions = createZenModeActions(() => editState);
 
   let isEditing = $derived(editState.isEditing);
   let isSaving = $derived(actions.isSaving);

--- a/apps/web/src/lib/hooks/useZenModeActions.svelte.ts
+++ b/apps/web/src/lib/hooks/useZenModeActions.svelte.ts
@@ -8,16 +8,22 @@ export interface ZenModeActionsDependencies {
 }
 
 export function createZenModeActions(
-  editState: any,
+  editStateOrGetter: any | (() => any),
   deps: ZenModeActionsDependencies = {},
 ) {
   const uiStore = deps.uiStore ?? defaultUiStore;
   const vault = deps.vault ?? defaultVault;
 
+  const getEditState = () =>
+    typeof editStateOrGetter === "function"
+      ? editStateOrGetter()
+      : editStateOrGetter;
+
   let isSaving = $state(false);
 
   const saveChanges = async (entityId: string) => {
     isSaving = true;
+    const editState = getEditState();
     try {
       await vault.updateEntity(entityId, {
         title: editState.title,
@@ -46,7 +52,7 @@ export function createZenModeActions(
       try {
         await vault.deleteEntity(entity.id);
         uiStore.notify(`"${entity.title}" deleted.`, "success");
-        editState.isEditing = false;
+        getEditState().isEditing = false;
         onDeleted();
       } catch (err: any) {
         console.error("[ZenModeActions] Failed to delete entity", err);
@@ -56,6 +62,7 @@ export function createZenModeActions(
   };
 
   const handleClose = (onClose: () => void) => {
+    const editState = getEditState();
     if (editState.isEditing) {
       if (!confirm("Discard unsaved changes?")) return;
     }

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -5,7 +5,7 @@ import { canvasRegistry } from "./canvas-registry.svelte";
 import { themeStore } from "./theme.svelte";
 import { debugStore } from "./debug.svelte";
 import * as vaultMigration from "./vault/migration";
-import type { LocalEntity } from "./vault/types";
+import type { LocalEntity, BatchCreateInput } from "./vault/types";
 import type { Entity } from "schema";
 import { getDB } from "../utils/idb";
 import { VaultCrudManager } from "./vault/crud";
@@ -413,12 +413,7 @@ export class VaultStore {
   bulkRemoveLabel(ids: string[], label: string) {
     return this.crudManager.bulkRemoveLabel(ids, label);
   }
-  batchCreateEntities(
-    newEntitiesList: (
-      | LocalEntity
-      | { type: string; title: string; initialData: Partial<Entity> }
-    )[],
-  ) {
+  batchCreateEntities(newEntitiesList: BatchCreateInput[]) {
     return this.crudManager.batchCreateEntities(newEntitiesList);
   }
 

--- a/apps/web/src/lib/stores/vault/crud.ts
+++ b/apps/web/src/lib/stores/vault/crud.ts
@@ -1,5 +1,5 @@
 import * as vaultEntities from "./entities";
-import type { LocalEntity } from "./types";
+import type { LocalEntity, BatchCreateInput } from "./types";
 import type { Entity } from "schema";
 import { uiStore } from "../ui.svelte";
 
@@ -244,12 +244,7 @@ export class VaultCrudManager {
     return false;
   }
 
-  async batchCreateEntities(
-    newEntitiesList: (
-      | LocalEntity
-      | { type: string; title: string; initialData: Partial<Entity> }
-    )[],
-  ): Promise<void> {
+  async batchCreateEntities(newEntitiesList: BatchCreateInput[]): Promise<void> {
     const { entities, created } = vaultEntities.batchCreateEntities(
       this.getEntities(),
       newEntitiesList,

--- a/apps/web/src/lib/stores/vault/entities.test.ts
+++ b/apps/web/src/lib/stores/vault/entities.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { batchCreateEntities } from "./entities";
+import type { LocalEntity } from "./types";
+
+describe("vault/entities - batchCreateEntities", () => {
+  it("should handle full LocalEntity objects", () => {
+    const existingEntities: Record<string, LocalEntity> = {};
+    const newEntities: LocalEntity[] = [
+      {
+        id: "hero-1",
+        title: "Hero 1",
+        type: "character",
+        tags: [],
+        labels: [],
+        connections: [],
+        content: "Content 1",
+        updatedAt: 100,
+      } as LocalEntity,
+    ];
+
+    const { entities, created } = batchCreateEntities(
+      existingEntities,
+      newEntities,
+    );
+
+    expect(entities["hero-1"]).toBeDefined();
+    expect(entities["hero-1"].title).toBe("Hero 1");
+    expect(entities["hero-1"].updatedAt).toBeGreaterThan(100); // Should be refreshed
+    expect(created).toHaveLength(1);
+    expect(created[0].id).toBe("hero-1");
+  });
+
+  it("should handle creation requests without IDs", () => {
+    const existingEntities: Record<string, LocalEntity> = {};
+    const requests = [
+      {
+        type: "location",
+        title: "The Misty Mountains",
+        initialData: {
+          content: "Very cold.",
+        },
+      },
+    ];
+
+    const { entities, created } = batchCreateEntities(
+      existingEntities,
+      requests as any,
+    );
+
+    const createdEntity = created[0];
+    expect(createdEntity.id).toBe("the-misty-mountains");
+    expect(createdEntity.title).toBe("The Misty Mountains");
+    expect(entities[createdEntity.id]).toBeDefined();
+    expect(entities[createdEntity.id].content).toBe("Very cold.");
+  });
+
+  it("should generate unique IDs for creation requests when collision occurs", () => {
+    const existingEntities: Record<string, LocalEntity> = {
+      forest: { id: "forest", title: "Forest" } as LocalEntity,
+    };
+    const requests = [
+      {
+        type: "location",
+        title: "Forest",
+        initialData: { content: "New Forest" },
+      },
+    ];
+
+    const { entities, created } = batchCreateEntities(
+      existingEntities,
+      requests as any,
+    );
+
+    expect(created[0].id).toBe("forest-1");
+    expect(entities["forest"]).toBeDefined();
+    expect(entities["forest-1"]).toBeDefined();
+  });
+
+  it("should support mixed full entities and creation requests", () => {
+    const existingEntities: Record<string, LocalEntity> = {};
+    const mixed = [
+      { id: "existing-1", title: "Existing", type: "note" } as LocalEntity,
+      { type: "character", title: "New Character", initialData: {} },
+    ];
+
+    const { entities, created } = batchCreateEntities(
+      existingEntities,
+      mixed as any,
+    );
+
+    expect(created).toHaveLength(2);
+    expect(entities["existing-1"]).toBeDefined();
+    expect(entities["new-character"]).toBeDefined();
+  });
+});

--- a/apps/web/src/lib/stores/vault/entities.test.ts
+++ b/apps/web/src/lib/stores/vault/entities.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { batchCreateEntities } from "./entities";
-import type { LocalEntity } from "./types";
+import type { LocalEntity, BatchCreateInput } from "./types";
 
 describe("vault/entities - batchCreateEntities", () => {
   it("should handle full LocalEntity objects", () => {
@@ -32,7 +32,7 @@ describe("vault/entities - batchCreateEntities", () => {
 
   it("should handle creation requests without IDs", () => {
     const existingEntities: Record<string, LocalEntity> = {};
-    const requests = [
+    const requests: BatchCreateInput[] = [
       {
         type: "location",
         title: "The Misty Mountains",
@@ -44,7 +44,7 @@ describe("vault/entities - batchCreateEntities", () => {
 
     const { entities, created } = batchCreateEntities(
       existingEntities,
-      requests as any,
+      requests,
     );
 
     const createdEntity = created[0];
@@ -58,7 +58,7 @@ describe("vault/entities - batchCreateEntities", () => {
     const existingEntities: Record<string, LocalEntity> = {
       forest: { id: "forest", title: "Forest" } as LocalEntity,
     };
-    const requests = [
+    const requests: BatchCreateInput[] = [
       {
         type: "location",
         title: "Forest",
@@ -68,7 +68,7 @@ describe("vault/entities - batchCreateEntities", () => {
 
     const { entities, created } = batchCreateEntities(
       existingEntities,
-      requests as any,
+      requests,
     );
 
     expect(created[0].id).toBe("forest-1");
@@ -78,15 +78,12 @@ describe("vault/entities - batchCreateEntities", () => {
 
   it("should support mixed full entities and creation requests", () => {
     const existingEntities: Record<string, LocalEntity> = {};
-    const mixed = [
+    const mixed: BatchCreateInput[] = [
       { id: "existing-1", title: "Existing", type: "note" } as LocalEntity,
       { type: "character", title: "New Character", initialData: {} },
     ];
 
-    const { entities, created } = batchCreateEntities(
-      existingEntities,
-      mixed as any,
-    );
+    const { entities, created } = batchCreateEntities(existingEntities, mixed);
 
     expect(created).toHaveLength(2);
     expect(entities["existing-1"]).toBeDefined();

--- a/apps/web/src/lib/stores/vault/entities.ts
+++ b/apps/web/src/lib/stores/vault/entities.ts
@@ -1,6 +1,6 @@
 import type { Entity, Connection } from "schema";
 import { sanitizeId } from "../../utils/markdown";
-import type { LocalEntity } from "./types";
+import type { LocalEntity, BatchCreateInput } from "./types";
 import { deleteOpfsEntry } from "../../utils/opfs";
 
 /**
@@ -320,10 +320,7 @@ export function bulkRemoveLabel(
 
 export function batchCreateEntities(
   entities: Record<string, LocalEntity>,
-  newEntitiesList: (
-    | LocalEntity
-    | { type: string; title: string; initialData: Partial<Entity> }
-  )[],
+  newEntitiesList: BatchCreateInput[],
 ): { entities: Record<string, LocalEntity>; created: LocalEntity[] } {
   const newEntities = { ...entities };
   const created: LocalEntity[] = [];

--- a/apps/web/src/lib/stores/vault/types.ts
+++ b/apps/web/src/lib/stores/vault/types.ts
@@ -3,3 +3,11 @@ import type { Entity } from "schema";
 export type LocalEntity = Omit<Entity, "_path"> & {
   _path?: string[];
 };
+
+export interface EntityCreationRequest {
+  type: string;
+  title: string;
+  initialData: Partial<Entity>;
+}
+
+export type BatchCreateInput = LocalEntity | EntityCreationRequest;

--- a/apps/web/src/lib/utils/opfs.test.ts
+++ b/apps/web/src/lib/utils/opfs.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { deleteVaultDir, isNotFoundError } from "./opfs";
+
+// Mock idb
+vi.mock("./idb", () => ({
+  getDB: vi.fn().mockResolvedValue({
+    transaction: vi.fn().mockReturnValue({
+      store: {
+        index: vi.fn().mockReturnValue({
+          openCursor: vi.fn().mockResolvedValue(null),
+        }),
+      },
+      done: Promise.resolve(),
+    }),
+  }),
+}));
+
+describe("opfs - deleteVaultDir", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should ignore NotFoundError when deleting a vault", async () => {
+    const mockRemoveEntry = vi
+      .fn()
+      .mockRejectedValue({ name: "NotFoundError" });
+    const mockVaultsDir = {
+      getDirectoryHandle: vi.fn().mockResolvedValue({}), // placeholder
+      removeEntry: mockRemoveEntry,
+    };
+
+    const mockRoot = {
+      getDirectoryHandle: vi.fn().mockImplementation((name) => {
+        if (name === "vaults") return mockVaultsDir;
+        throw { name: "NotFoundError" };
+      }),
+    };
+
+    // Should not throw
+    await expect(
+      deleteVaultDir(mockRoot as any, "non-existent-vault"),
+    ).resolves.not.toThrow();
+    expect(mockVaultsDir.removeEntry).toHaveBeenCalledWith(
+      "non-existent-vault",
+      { recursive: true },
+    );
+  });
+
+  it("should throw other errors when deleting a vault", async () => {
+    const mockRemoveEntry = vi
+      .fn()
+      .mockRejectedValue(new Error("Permission Denied"));
+    const mockVaultsDir = {
+      removeEntry: mockRemoveEntry,
+    };
+
+    const mockRoot = {
+      getDirectoryHandle: vi.fn().mockResolvedValue(mockVaultsDir),
+    };
+
+    await expect(deleteVaultDir(mockRoot as any, "vault-1")).rejects.toThrow(
+      "Permission Denied",
+    );
+  });
+
+  it("should normalize vaultId before deletion", async () => {
+    const mockVaultsDir = {
+      removeEntry: vi.fn().mockResolvedValue(undefined),
+    };
+    const mockRoot = {
+      getDirectoryHandle: vi.fn().mockResolvedValue(mockVaultsDir),
+    };
+
+    await deleteVaultDir(mockRoot as any, "  vault-with-spaces  ");
+
+    // Should use trimmed ID
+    expect(mockVaultsDir.removeEntry).toHaveBeenCalledWith(
+      "vault-with-spaces",
+      { recursive: true },
+    );
+  });
+});
+
+describe("opfs - isNotFoundError", () => {
+  it("should identify various NotFoundError shapes", () => {
+    expect(isNotFoundError({ name: "NotFoundError" })).toBe(true);
+    expect(isNotFoundError({ code: 8 })).toBe(true);
+    expect(isNotFoundError({ cause: { name: "NotFoundError" } })).toBe(true);
+    expect(isNotFoundError(new Error("file not found"))).toBe(true);
+    expect(isNotFoundError(new Error("other error"))).toBe(false);
+    expect(isNotFoundError(null)).toBe(false);
+  });
+});

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -305,4 +305,19 @@ describe("GraphTransformer", () => {
     const edge2 = elements2.find((e) => e.group === "edges");
     expect(edge2).toBeDefined(); // Edge should exist
   });
+
+  it("should not crash on entities with missing ID", () => {
+    const entities: any[] = [
+      {
+        type: "npc",
+        title: "Broken Node",
+        content: "",
+      },
+    ];
+
+    // This should not throw TypeError
+    const elements = GraphTransformer.entitiesToElements(entities);
+    expect(elements).toHaveLength(1);
+    expect(elements[0].data.id).toBeUndefined(); // Or "unknown" if we decided to fallback, current code preserves original
+  });
 });

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -306,18 +306,14 @@ describe("GraphTransformer", () => {
     expect(edge2).toBeDefined(); // Edge should exist
   });
 
-  it("should not crash on entities with missing ID", () => {
+  it("should filter out entities with missing ID", () => {
     const entities: any[] = [
-      {
-        type: "npc",
-        title: "Broken Node",
-        content: "",
-      },
+      { id: "valid-1", type: "npc", title: "Valid" },
+      { type: "npc", title: "Broken Node" },
     ];
 
-    // This should not throw TypeError
     const elements = GraphTransformer.entitiesToElements(entities);
     expect(elements).toHaveLength(1);
-    expect(elements[0].data.id).toBeUndefined(); // Or "unknown" if we decided to fallback, current code preserves original
+    expect(elements[0].data.id).toBe("valid-1");
   });
 });

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -84,6 +84,8 @@ export class GraphTransformer {
     // Length is accessed directly as modern engines optimize this and it avoids inconsistent local caching.
     for (let i = 0; i < entities.length; i++) {
       const entity = entities[i];
+      if (!entity.id) continue;
+
       const dateLabel = formatDate(
         entity.date || entity.start_date || entity.end_date,
       );
@@ -144,7 +146,7 @@ export class GraphTransformer {
       // Performance: Compute a simple hash in a single pass to avoid multiple split/reduce cycles.
       let hash = 0;
       if (!hasValidCoords) {
-        const id = entity.id || "unknown";
+        const id = entity.id;
         const len = id.length;
         for (let j = 0; j < len; j++) {
           hash = (hash << 5) - hash + id.charCodeAt(j);


### PR DESCRIPTION
Properly handles batch creation requests, adds safety checks to the graph transformer to prevent fatal errors on missing IDs, and resolves a Svelte 5 reactivity warning in ZenModeModal.