### PR TITLE
🔧 fix: resolve graph selection type error in GraphView

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -32,6 +32,7 @@
   let imageManager: GraphImageManager | undefined = $state();
   let isLayoutRunning = $state(false);
   let graphVisible = $state(false);
+  let selectedCount = $state(0);
 
   let graphStyle = $derived(
     getGraphStyles(
@@ -195,6 +196,12 @@
           cy = instance;
           layoutManager = new LayoutManager(instance);
           imageManager = new GraphImageManager(instance);
+
+          const updateSelectionCount = () => {
+            selectedCount = instance.$("node:selected").length;
+          };
+          instance.on("select unselect", "node", updateSelectionCount);
+          updateSelectionCount();
 
           if (import.meta.env.DEV || (window as any).__E2E__) {
             (window as any).cy = instance;
@@ -421,7 +428,7 @@
     {cy}
     {isLayoutRunning}
     onApplyLayout={applyCurrentLayout}
-    selectedCount={graph.selection.length}
+    {selectedCount}
   />
 
   <OrbitControls />


### PR DESCRIPTION
Resolves a TypeScript error where `graph.selection` was being accessed but did not exist on the `GraphStore`.

Changes:
- Added a local `selectedCount` state to `GraphView.svelte`.
- Initialized and updated this state by listening to Cytoscape `select` and `unselect` events.
- Passed the local `selectedCount` to the `GraphToolbar` component.

This should fix the CI linting failure.