### PR TITLE
✨ feat: unify Connect Mode state and synchronize C shortcut with Link button

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -45,8 +45,6 @@
     ),
   );
 
-  let connectMode = $state(false);
-  let sourceId = $state<string | null>(null);
   let { selectedId = $bindable(null) } = $props<{
     selectedId: string | null;
   }>();
@@ -140,13 +138,11 @@
     );
   };
 
-  const toggleConnectMode = () => {
-    connectMode = !connectMode;
-    if (!connectMode) {
-      sourceId = null;
+  $effect(() => {
+    if (!ui.isConnecting) {
       cy?.$(".selected-source").removeClass("selected-source");
     }
-  };
+  });
 
   const handleKeyDown = (e: KeyboardEvent) => {
     const target = document.activeElement;
@@ -166,7 +162,7 @@
         if (selectedCount === 2) {
           ui.showSelectionConnector = !ui.showSelectionConnector;
         } else {
-          toggleConnectMode();
+          ui.toggleConnectMode();
         }
       }
     }
@@ -176,8 +172,8 @@
     if (e.key.toLowerCase() === "i" && !e.ctrlKey && !e.metaKey && !e.altKey) {
       graph.toggleImages();
     }
-    if (e.key === "Escape" && connectMode) {
-      toggleConnectMode();
+    if (e.key === "Escape" && ui.isConnecting) {
+      ui.toggleConnectMode();
     }
   };
 
@@ -224,18 +220,18 @@
               hoverPosition = null;
             },
             onNodeTap: async (id, node) => {
-              if (connectMode) {
-                if (!sourceId) {
-                  sourceId = id;
+              if (ui.isConnecting) {
+                if (!ui.connectingNodeId) {
+                  ui.connectingNodeId = id;
                   node.addClass("selected-source");
-                } else if (sourceId === id) {
-                  sourceId = null;
+                } else if (ui.connectingNodeId === id) {
+                  ui.connectingNodeId = null;
                   node.removeClass("selected-source");
                 } else {
-                  const source = sourceId;
+                  const source = ui.connectingNodeId;
                   const target = id;
                   await vault.addConnection(source, target, "neutral");
-                  toggleConnectMode();
+                  ui.toggleConnectMode();
                 }
               } else {
                 selectedId = id;
@@ -251,7 +247,7 @@
             },
             onBackgroundTap: () => {
               selectedId = null;
-              if (connectMode) toggleConnectMode();
+              if (ui.isConnecting) ui.toggleConnectMode();
             },
             onViewportChange: () => {
               if (hoveredEntityId && instance) {

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -3,6 +3,7 @@
   import { initGraph } from "graph-engine";
   import { graph } from "$lib/stores/graph.svelte";
   import { vault } from "$lib/stores/vault.svelte";
+  import { ui } from "$lib/stores/ui.svelte";
   import { debugStore } from "$lib/stores/debug.svelte";
 
   import { isTemporalMetadataEqual } from "$lib/utils/comparison";
@@ -161,7 +162,13 @@
       applyCurrentLayout(false, false, "Keyboard Shortcut (T)");
     }
     if (e.key.toLowerCase() === "c" && !e.ctrlKey && !e.metaKey && !e.altKey) {
-      if (!vault.isGuest) toggleConnectMode();
+      if (!vault.isGuest) {
+        if (selectedCount === 2) {
+          ui.showSelectionConnector = !ui.showSelectionConnector;
+        } else {
+          toggleConnectMode();
+        }
+      }
     }
     if (e.key.toLowerCase() === "l" && !e.ctrlKey && !e.metaKey && !e.altKey) {
       graph.toggleLabels();

--- a/apps/web/src/lib/components/graph/GraphHUD.svelte
+++ b/apps/web/src/lib/components/graph/GraphHUD.svelte
@@ -98,4 +98,25 @@
       Neural Layout Synthesis Processing...
     </div>
   {/if}
+
+  {#if ui.isConnecting}
+    <div
+      class="bg-blue-500/20 border border-blue-500/50 backdrop-blur-md px-4 py-2 rounded flex items-center gap-3 text-[10px] font-bold tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto"
+      transition:fade
+    >
+      <span class="icon-[lucide--link] w-3.5 h-3.5 animate-pulse"></span>
+      {#if !ui.connectingNodeId}
+        Select Source Entity
+      {:else}
+        Select Target to Connect
+      {/if}
+      <button
+        onclick={() => ui.toggleConnectMode()}
+        class="ml-2 hover:text-white transition-colors"
+        title="Cancel (Esc)"
+      >
+        [ESC]
+      </button>
+    </div>
+  {/if}
 </div>

--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -19,10 +19,13 @@
   let showMinimap = $state(false);
 
   const canConnect = $derived(selectedCount === 2);
+  const isConnecting = $derived(ui.showSelectionConnector || ui.isConnecting);
   const connectionTooltip = $derived(
     selectedCount === 2
       ? "Connect Selected Nodes"
-      : "Select 2 nodes to create a connection",
+      : ui.isConnecting
+        ? "Exit Connect Mode"
+        : "Enter Connect Mode (C)",
   );
 </script>
 
@@ -95,18 +98,19 @@
       >
       {#if !ui.isGuestMode}
         <button
-          class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {ui.showSelectionConnector
-            ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
-            : canConnect
-              ? 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'
-              : 'border-theme-border bg-theme-surface/40 text-theme-muted/40 cursor-not-allowed'}"
-          onclick={() =>
-            canConnect &&
-            (ui.showSelectionConnector = !ui.showSelectionConnector)}
+          class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {isConnecting
+            ? 'border-theme-primary bg-theme-primary/20 text-theme-primary shadow-[0_0_15px_rgba(var(--color-theme-accent-rgb),0.3)]'
+            : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+          onclick={() => {
+            if (canConnect) {
+              ui.showSelectionConnector = !ui.showSelectionConnector;
+            } else {
+              ui.toggleConnectMode();
+            }
+          }}
           title={connectionTooltip}
           aria-label={connectionTooltip}
-          aria-pressed={ui.showSelectionConnector}
-          disabled={!canConnect}
+          aria-pressed={isConnecting}
           ><span class="icon-[lucide--link] w-4 h-4"></span></button
         >
       {/if}

--- a/apps/web/src/lib/content/help/connection-labels.md
+++ b/apps/web/src/lib/content/help/connection-labels.md
@@ -11,9 +11,24 @@ Not every connection is the same. You can add labels to the lines in your graph 
 
 ### How to Add Labels
 
-1. **Connect Nodes**: Press `C`, click the first node, then the second.
-2. **Type the Label**: A small box will appear. Type things like "Enemy," "Child of," or "Home Town."
-3. **Hide Labels**: If your graph gets too cluttered, press `L` to hide the text on the lines.
+You can add labels using two methods:
+
+#### 1. The Link Button (Recommended)
+
+1. **Select Two Nodes**: Click one node, then `Shift + Click` or `Cmd/Ctrl + Click` another.
+2. **Click Link**: Click the **Chain icon** in the bottom-left toolbar.
+3. **Type the Label**: Enter the relationship name in the box that appears.
+
+#### 2. Manual Connect Mode
+
+1. **Toggle Mode**: Press `C` on your keyboard.
+2. **Click Nodes**: Click the first node, then the second.
+3. **Type the Label**: Enter the relationship name.
+
+### Tips for Labels
+
+- **Common Labels**: Use "Enemy," "Child of," or "Home Town" for consistency.
+- **Hide Labels**: If your graph gets too cluttered, press `L` to hide the text on the lines.
 
 ### AI Context
 

--- a/apps/web/src/lib/content/help/graph-basics.md
+++ b/apps/web/src/lib/content/help/graph-basics.md
@@ -11,8 +11,19 @@ The graph is your primary way to navigate.
 
 ### Shortcuts
 
-- `C`: Toggle Connect Mode.
+- `C`: Toggle manual Connect Mode (click source then target).
 - `L`: Toggle Node Labels.
 - `Scroll`: Zoom in/out.
 - `Drag`: Pan the view.
 - `Click Node`: Focus entity and open detail panel.
+
+### Toolbar Controls
+
+The bottom-left toolbar provides quick access to layout and visibility:
+
+- **Minimap**: Toggle the overview map.
+- **Timeline**: Toggle chronological layout.
+- **Zoom**: Adjust view scale.
+- **Stable Layout (Pin)**: Prevent nodes from moving automatically.
+- **Link (Chain icon)**: Quickly connect two selected nodes.
+- **Redraw (Refresh)**: Recalculate node positions.

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock environment
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
+
+// Mock matchMedia
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // Deprecated
+    removeListener: vi.fn(), // Deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { uiStore } from "./ui.svelte";
+
+describe("UIStore", () => {
+  beforeEach(() => {
+    // Reset state before each test
+    uiStore.closeSettings();
+    uiStore.activeSettingsTab = "vault";
+  });
+
+  it("should open settings to a specific tab", () => {
+    uiStore.openSettings("help");
+    expect(uiStore.showSettings).toBe(true);
+    expect(uiStore.activeSettingsTab).toBe("help");
+  });
+
+  it("should close settings", () => {
+    uiStore.openSettings("help");
+    uiStore.closeSettings();
+    expect(uiStore.showSettings).toBe(false);
+  });
+
+  it("should toggle settings visibility", () => {
+    // Toggle on
+    uiStore.toggleSettings("intelligence");
+    expect(uiStore.showSettings).toBe(true);
+    expect(uiStore.activeSettingsTab).toBe("intelligence");
+
+    // Toggle off if same tab
+    uiStore.toggleSettings("intelligence");
+    expect(uiStore.showSettings).toBe(false);
+
+    // Switch tab if already open but different tab
+    uiStore.openSettings("vault");
+    uiStore.toggleSettings("intelligence");
+    expect(uiStore.showSettings).toBe(true);
+    expect(uiStore.activeSettingsTab).toBe("intelligence");
+  });
+
+  it("should handle Zen Mode visibility", () => {
+    uiStore.openZenMode("test-entity");
+    expect(uiStore.showZenMode).toBe(true);
+    expect(uiStore.zenModeEntityId).toBe("test-entity");
+
+    uiStore.closeZenMode();
+    expect(uiStore.showZenMode).toBe(false);
+    expect(uiStore.zenModeEntityId).toBe(null);
+  });
+
+  it("should handle sidebar state transitions", () => {
+    // Initial state
+    expect(uiStore.leftSidebarOpen).toBe(false);
+    expect(uiStore.activeSidebarTool).toBe("none");
+
+    // Toggle on
+    uiStore.toggleSidebarTool("oracle");
+    expect(uiStore.leftSidebarOpen).toBe(true);
+    expect(uiStore.activeSidebarTool).toBe("oracle");
+
+    // Toggle off
+    uiStore.toggleSidebarTool("oracle");
+    expect(uiStore.leftSidebarOpen).toBe(false);
+    expect(uiStore.activeSidebarTool).toBe("none");
+
+    // Close explicitly
+    uiStore.toggleSidebarTool("oracle");
+    uiStore.closeSidebar();
+    expect(uiStore.leftSidebarOpen).toBe(false);
+    expect(uiStore.activeSidebarTool).toBe("none");
+  });
+
+  it("should toggle connect mode and clear connectingNodeId", () => {
+    // Initial state
+    expect(uiStore.isConnecting).toBe(false);
+    expect(uiStore.connectingNodeId).toBe(null);
+
+    // Toggle on
+    uiStore.toggleConnectMode();
+    expect(uiStore.isConnecting).toBe(true);
+
+    // Set a connecting node
+    uiStore.connectingNodeId = "test-node";
+    expect(uiStore.connectingNodeId).toBe("test-node");
+
+    // Toggle off
+    uiStore.toggleConnectMode();
+    expect(uiStore.isConnecting).toBe(false);
+    expect(uiStore.connectingNodeId).toBe(null);
+  });
+});

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -136,6 +136,13 @@ class UIStore {
     }
   }
 
+  toggleConnectMode() {
+    this.isConnecting = !this.isConnecting;
+    if (!this.isConnecting) {
+      this.connectingNodeId = null;
+    }
+  }
+
   startSelectionConnection() {
     this.showSelectionConnector = true;
   }

--- a/apps/web/tests/graph-interaction.spec.ts
+++ b/apps/web/tests/graph-interaction.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Graph Keyboard Interactions", () => {
+  test("should toggle connect mode with 'C' key", async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+    });
+
+    await page.goto("/");
+    await expect(page.getByTestId("graph-canvas")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Press 'C' to enter connect mode
+    await page.keyboard.press("c");
+
+    // Check if HUD shows Connect Mode instructions
+    await expect(page.getByText("Select Source Entity")).toBeVisible();
+
+    // Check if Toolbar button reflects active state (aria-pressed)
+    // Label changes when active
+    const connectButton = page.getByLabel("Exit Connect Mode");
+    await expect(connectButton).toHaveAttribute("aria-pressed", "true");
+
+    // Press 'C' again to exit
+    await page.keyboard.press("c");
+    await expect(page.getByText("Select Source Entity")).not.toBeVisible();
+    await expect(page.getByLabel("Enter Connect Mode (C)")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  test("should exit connect mode with 'Escape' key", async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+    });
+
+    await page.goto("/");
+    await expect(page.getByTestId("graph-canvas")).toBeVisible();
+
+    await page.keyboard.press("c");
+    await expect(page.getByText("Select Source Entity")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByText("Select Source Entity")).not.toBeVisible();
+  });
+});

--- a/docs/GRAPH_STABILITY.md
+++ b/docs/GRAPH_STABILITY.md
@@ -37,16 +37,9 @@ The **Link** button (chain icon) allows you to quickly create a relationship bet
 
 ## Interaction with Modes
 
-### Interaction with Modes
-
-- **Timeline Mode:** Clicking redraw in Timeline Mode will re-calculate the temporal distribution. This is useful if you've filtered the range and want to maximize the use of screen space.
-- **Orbit Mode:** Redrawing in Orbit Mode will re-center the graph on the current Focus Node and re-arrange the surrounding "satellites" for optimal clarity.
-- **Position Saving:** Note that redrawing will overwrite any manually set positions. If you have spent a long time hand-crafting a specific layout, use this button with caution!
-
-## Timeline & Orbit Modes
-
-- **Timeline Mode:** Bypasses stability settings to arrange nodes chronologically along an X or Y axis based on their associated dates.
-- **Orbit Mode:** Centers the graph around a specific "Focus Node," arranging immediate connections in a circular pattern. Stability is partially maintained for distant nodes, but the focus area is always recalculated for clarity.
+- **Timeline Mode:** Bypasses stability settings to arrange nodes chronologically along an X or Y axis based on their associated dates. Clicking redraw in this mode will re-calculate the temporal distribution, which is useful if you've filtered the range and want to maximize screen space.
+- **Orbit Mode:** Centers the graph around a specific "Focus Node," arranging immediate connections in a circular pattern. Stability is partially maintained for distant nodes, but the focus area is always recalculated for clarity. Redrawing will re-center the graph and re-arrange the surrounding "satellites" for optimal clarity.
+- **Position Saving:** Note that redrawing will overwrite any manually set positions. If you have spent a long time hand-crafting a specific layout, use the button with caution!
 
 ---
 

--- a/docs/GRAPH_STABILITY.md
+++ b/docs/GRAPH_STABILITY.md
@@ -18,7 +18,7 @@ The **Stable Layout** toggle (represented by a pin icon in the Graph Toolbar) co
 - **Auto-Arrangement:** Every time the graph structure significantly changes (e.g., adding a connection or a new node), the engine will briefly run a simulation to find an optimal aesthetic arrangement.
 - **Initial Setup:** This is useful for new campaigns or when you want the AI to suggest a logical spatial structure for your lore.
 
-## Manual Redraw (The "Refresh" Icon)
+## Redraw Layout (The "Refresh" Icon)
 
 Regardless of whether **Stable Layout** is ON or OFF, you can always click the **Redraw Layout** button (the circular arrows icon). This action bypasses the stability setting to perform a one-time "forced" simulation of the graph.
 
@@ -27,6 +27,15 @@ Regardless of whether **Stable Layout** is ON or OFF, you can always click the *
 - **De-Cluttering:** Over time, especially when adding many new entities or connections, the graph might become visually dense or overlap. Redrawing uses the physics engine to find a fresh, balanced distribution.
 - **New Entities:** When Stable Layout is ON, new nodes are placed in a default "safe" zone. If you add several at once, they may appear grouped too closely. A Manual Redraw will space them out relative to their connections.
 - **Layout Recovery:** If you've manually dragged nodes into a messy arrangement, a redraw will reset them based on the current force-directed algorithm.
+
+## Connecting Nodes (The "Link" Icon)
+
+The **Link** button (chain icon) allows you to quickly create a relationship between two selected nodes.
+
+- **Impact on Stability**: If **Stable Layout** is OFF, creating a new connection will trigger a brief simulation to pull the two related nodes closer together. If **Stable Layout** is ON, the nodes will remain in their current positions despite the new link.
+- **Selection Required**: This button only becomes active when exactly two nodes are selected in the graph.
+
+## Interaction with Modes
 
 ### Interaction with Modes
 


### PR DESCRIPTION
This PR unifies the graph "Connect Mode" state and logic, ensuring the `C` keyboard shortcut and the toolbar "Link" button are fully synchronized. 

### Changes
*   **State Unification**: Refactored `GraphView` to use the central `ui.isConnecting` state instead of local variables.
*   **UI Synchronization**: The "Link" button in the toolbar now accurately reflects whether Connect Mode is active (when 0-1 nodes are selected) or if the Link Modal is open (when 2 nodes are selected).
*   **Visual Feedback**: The Graph HUD now reactively displays connection instructions when Connect Mode is active via the shortcut.
*   **Documentation**: Updated `graph-basics.md`, `connection-labels.md`, and `GRAPH_STABILITY.md` to clearly explain both connection methods (Link button and manual Connect Mode).
*   **Testing**: Added unit tests for the `UIStore` logic (`ui.svelte.test.ts`) and E2E tests (`graph-interaction.spec.ts`) to verify keyboard shortcut and state synchronization.