### PR TITLE
docs: reprioritize next god-file refactors and bump web version

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.16.24",
+  "version": "0.16.25",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -8,7 +8,7 @@ const versionFromBuild =
     : undefined;
 
 export const VERSION =
-  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.16.24";
+  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.16.25";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";

--- a/apps/web/src/service-worker.ts
+++ b/apps/web/src/service-worker.ts
@@ -5,7 +5,7 @@
 
 import { build, files, version } from "$service-worker";
 
-const CACHE_VERSION = "213";
+const CACHE_VERSION = "214";
 const CACHE = `cache-${version}-${CACHE_VERSION}`;
 
 const ASSETS = [

--- a/docs/GOD_FILES_ANALYSIS.md
+++ b/docs/GOD_FILES_ANALYSIS.md
@@ -9,13 +9,13 @@ This report identifies the top 10 potential "God Files" (files with excessive re
 | 1    | `apps/web/src/lib/stores/oracle.svelte.ts`                  | ~~1,484~~ 233 | Store (State/Logic) | ✅ FIXED |
 | 2    | `apps/web/src/lib/stores/vault.svelte.ts`                   | ~~1,381~~ 364 | Store (State/Logic) | ✅ FIXED |
 | 3    | `apps/web/src/lib/components/GraphView.svelte`              | ~~1,371~~ 449 | UI Component        | ✅ FIXED |
-| 4    | `apps/web/src/lib/components/modals/ZenModeModal.svelte`    | ~~1,058~~ 331 | UI Component        | ✅ FIXED |
+| 4    | `apps/web/src/lib/components/modals/ZenModeModal.svelte`    | ~~1,058~~ 364 | UI Component        | ✅ FIXED |
 | 5    | `apps/web/src/lib/services/ai.ts`                           | ~~819~~ 1     | Service (API/Logic) | ✅ FIXED |
-| 6    | `apps/web/src/routes/+layout.svelte`                        | 723           | UI Layout           |          |
-| 7    | `packages/sync-engine/src/SyncService.ts`                   | 607           | Engine Core         |          |
-| 8    | `apps/web/src/lib/components/oracle/ChatMessage.svelte`     | 620           | UI Component        |          |
+| 6    | `apps/web/src/routes/+layout.svelte`                        | 795           | UI Layout           | 🔥 NEXT |
+| 7    | `apps/web/src/lib/components/map/MapView.svelte`            | 681           | UI Component        | 🔥 NEXT |
+| 8    | `packages/sync-engine/src/SyncService.ts`                   | 663           | Engine Core         | 🟡 SOON |
 | 9    | `apps/web/src/lib/components/canvas/CanvasWorkspace.svelte` | 618           | UI Component        |          |
-| 10   | `apps/web/src/lib/components/map/MapView.svelte`            | 535           | UI Component        |          |
+| 10   | `apps/web/src/lib/components/oracle/ChatMessage.svelte`     | 632           | UI Component        |          |
 
 ---
 
@@ -39,23 +39,19 @@ This report identifies the top 10 potential "God Files" (files with excessive re
 **Summary:** Refactored into modular components and decoupled logic. Extracted `GraphHUD`, `GraphToolbar`, `GraphTooltip`, and `EdgeEditorModal` UI components. Moved layout execution to `LayoutManager`, styling to `GraphStyles`, event handling to `useGraphEvents`, and element synchronization to `useGraphSync`.
 **Outcome:** Reduced from 1,371 lines to 449 lines. Improved viewport stability and eliminated image loading jitter. Established a clear separation between the UI layer and the visualization engine.
 
-### 4. `ZenModeModal.svelte` (1,058 lines)
+### 4. `ZenModeModal.svelte` (Refactored)
 
-**Current State:** Likely contains a massive amount of inline editing logic, Tiptap editor initialization, markdown parsing, and complex UI state for reading/writing lore.
-**Refactoring Strategy:**
+**Status:** ✅ **COMPLETED (2026-03-12)**
+**Summary:** Refactored into a modal orchestration shell with extracted editor/view subcomponents and isolated state handling.
+**Outcome:** Reduced from 1,058 lines to 364 lines and aligned with the modular component patterns established by GraphView.
 
-- **Extract Editor Instance:** Move the Tiptap setup and plugin configuration into a dedicated `RichTextEditor.svelte` component.
-- **Split Read/Write Modes:** If Zen Mode handles both viewing and editing, consider creating separate `ZenReader.svelte` and `ZenEditor.svelte` components, and have the modal act as a simple toggle between them.
+### 5. `ai.ts` (Refactored)
 
-### 5. `ai.ts` (819 lines)
+**Status:** ✅ **COMPLETED (2026-03-13)**
+**Summary:** Decomposed into specialized services under `services/ai/` for orchestration, prompts, generation, and retrieval.
+**Outcome:** `ai.ts` now serves as a compatibility/export shim (1 line), dramatically reducing coupling and making AI capabilities independently testable.
 
-**Current State:** Manages the Gemini API SDK, system prompt construction, RAG (Retrieval-Augmented Generation) context fusion, fuzzy matching for known entities, and specialized tasks like JSON extraction and image generation.
-**Refactoring Strategy:**
-
-- **Split by Capability:** Divide this file into domain-specific services: `TextGenerationService.ts`, `ImageGenerationService.ts`, and `ContextRetrievalService.ts`.
-- **Prompt Library:** Move large string templates (like the system constitution or JSON extraction prompts) into a dedicated `prompts/` folder.
-
-### 6. `+layout.svelte` (753 lines)
+### 6. `+layout.svelte` (795 lines)
 
 **Current State:** The root layout handles global app initialization (checking OS, setting up OPFS, checking tokens), the main shell layout, sidebar toggling, global keyboard shortcuts, and mounting all global modals.
 **Refactoring Strategy:**
@@ -68,4 +64,4 @@ This report identifies the top 10 potential "God Files" (files with excessive re
 
 ## Conclusion
 
-The highest priority for refactoring should now shift to **`ZenModeModal.svelte`** and **`ai.ts`**. The successful refactors of `oracle.svelte.ts`, `vault.svelte.ts`, and `GraphView.svelte` have established strong patterns for modularity and isolation that can be applied to these remaining large files. By extracting logic into specialized components and services, we continue to improve the codebase's velocity and long-term stability.
+The highest priority for refactoring should now shift to **`+layout.svelte`** and **`MapView.svelte`**, followed by **`SyncService.ts`**. The successful refactors of `oracle.svelte.ts`, `vault.svelte.ts`, `GraphView.svelte`, `ZenModeModal.svelte`, and `ai.ts` have validated a modular extraction strategy that should now be applied to global shell orchestration, map interactions, and sync-core responsibilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       }
     },
     "apps/web": {
-      "version": "0.16.21",
+      "version": "0.16.25",
       "dependencies": {
         "@codex/canvas-engine": "^0.0.0",
         "@codex/importer": "*",
@@ -13501,11 +13501,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13521,11 +13523,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13541,11 +13545,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13561,11 +13567,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13581,11 +13589,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13601,11 +13611,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13621,11 +13633,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13641,11 +13655,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13661,11 +13677,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13681,11 +13699,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -13701,11 +13721,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },


### PR DESCRIPTION
### Motivation
- Update the god-file prioritization to reflect completed refactors and identify the next high-impact targets for work (root layout and map view) so engineering effort is focused on the largest remaining monoliths. 
- Bump the web build version and service-worker cache to ensure build metadata and SW caching are in sync after the documentation and metadata updates.

### Description
- Updated `docs/GOD_FILES_ANALYSIS.md` to reflect current line counts and statuses and to mark `apps/web/src/routes/+layout.svelte` and `apps/web/src/lib/components/map/MapView.svelte` as the next refactor targets. 
- Bumped the web package version from `0.16.24` to `0.16.25` in `apps/web/package.json` and updated the default `VERSION` fallback in `apps/web/src/lib/config/index.ts` accordingly. 
- Incremented the service-worker cache version from `213` to `214` in `apps/web/src/service-worker.ts` to force SW clients to refresh cached assets.

### Testing
- Ran `node scripts/bump-web-version.mjs` which completed successfully and reported the version and cache bump. 
- Verified the updated values via file inspection commands (`jq`/`sed`/`rg`) and validated the SW constant and `VERSION` fallback reflect `0.16.25` and `CACHE_VERSION = "214"`. 
- Ran a line-count check (`wc -l`) and document previews (`sed -n`) to confirm `docs/GOD_FILES_ANALYSIS.md` and referenced files show the expected updates and line counts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a77a14a08328abaa3c77ee559b33)