### PR TITLE
🎨 Palette: Add `aria-pressed` states to Oracle Tier buttons

### DIFF
--- a/apps/web/src/lib/components/settings/AISettings.svelte
+++ b/apps/web/src/lib/components/settings/AISettings.svelte
@@ -73,6 +73,7 @@
           ? 'bg-theme-primary/10 border-theme-primary ring-1 ring-theme-primary/50'
           : 'bg-theme-bg/30 border-theme-border hover:border-theme-primary/50'}"
         onclick={() => oracle.setTier("lite")}
+        aria-pressed={oracle.tier === 'lite'}
       >
         <span
           class="text-sm font-bold tracking-widest uppercase font-header {oracle.tier ===
@@ -93,6 +94,7 @@
           ? 'bg-theme-accent/10 border-theme-accent ring-1 ring-theme-accent/50'
           : 'bg-theme-bg/30 border-theme-border hover:border-theme-accent/30'}"
         onclick={() => oracle.setTier("advanced")}
+        aria-pressed={oracle.tier === 'advanced'}
       >
         <span
           class="text-sm font-bold tracking-widest uppercase font-header {oracle.tier ===


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` boolean attributes to the Oracle Intelligence Tier toggle buttons (Lite vs. Advanced) in the `AISettings.svelte` component.
🎯 **Why**: Screen reader users need to know which tier is currently selected, but the visual "active" class changes were not communicated via accessible HTML attributes. This makes the toggle group accessible.
♿ **Accessibility**: Enhanced screen reader UX by ensuring toggle buttons communicate their active state correctly with `aria-pressed`.

---
*PR created automatically by Jules for task [18391239987303519715](https://jules.google.com/task/18391239987303519715) started by @eserlan*