### PR TITLE
🎨 Palette: Add autofocus to vault rename input

### DIFF
--- a/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
+++ b/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
@@ -141,6 +141,10 @@
       minute: "2-digit",
     });
   };
+
+  const focusNode = (node: HTMLElement) => {
+    node.focus();
+  };
 </script>
 
 <svelte:window onkeydown={(e) => e.key === "Escape" && onClose()} />
@@ -212,6 +216,7 @@
               <input
                 bind:value={editName}
                 aria-label="New vault name"
+                use:focusNode
                 class="bg-theme-bg border border-theme-primary rounded px-2 py-1 text-sm flex-1 text-theme-text focus:outline-none"
                 onclick={(e) => e.stopPropagation()}
               />


### PR DESCRIPTION
Added a custom Svelte action to automatically focus the rename input field in the vault switcher modal, reducing friction and improving keyboard accessibility.

---
*PR created automatically by Jules for task [15329543292178336419](https://jules.google.com/task/15329543292178336419) started by @eserlan*