### PR TITLE
⚡ Bolt: Optimize new node mapping lookup in graph sync from O(N^2) to O(N)

### DIFF
--- a/packages/graph-engine/src/sync/useGraphSync.ts
+++ b/packages/graph-engine/src/sync/useGraphSync.ts
@@ -56,10 +56,20 @@ export function syncGraphElements(cy: Core, options: SyncOptions) {
 
     if (newNodes.length > 0 || newEdges.length > 0) {
       if (newNodes.length > 0) {
+        // ⚡ Bolt Optimization: Replace O(N^2) nested .forEach + .find with an O(N) Map lookup.
+        // This avoids N array iterations when applying initial node positions.
+        const newNodesMap = new Map();
+        for (let i = 0; i < newNodes.length; i++) {
+          if (!newNodesMap.has(newNodes[i].data.id)) {
+            newNodesMap.set(newNodes[i].data.id, newNodes[i]);
+          }
+        }
+
         const addedNodes = cy.add(newNodes);
+
         addedNodes.forEach((n) => {
           elementMap.set(n.id(), n);
-          const originalNode = newNodes.find((nn) => nn.data.id === n.id());
+          const originalNode = newNodesMap.get(n.id());
           if (originalNode && originalNode.position) {
             n.position(originalNode.position);
           }


### PR DESCRIPTION
💡 What: Replaced an $O(N^2)$ array lookup with an $O(N)$ Map-based lookup in `syncGraphElements` when applying positions to newly added nodes.
🎯 Why: Iterating over newly added nodes and using `.find` on the original `newNodes` array to find their positions creates a severe performance bottleneck for large graphs.
📊 Impact: Reduces time complexity from $O(N^2)$ to $O(N)$, resulting in a significantly faster rendering initialization for large sets of new elements.
🔬 Measurement: Verified by running all tests via `npm run test -w packages/graph-engine`.

---
*PR created automatically by Jules for task [12257284991932434139](https://jules.google.com/task/12257284991932434139) started by @eserlan*