### PR TITLE
⚡ Bolt: Refactor full sync cleanup to concurrent execution

### DIFF
--- a/packages/sync-engine/src/SyncService.ts
+++ b/packages/sync-engine/src/SyncService.ts
@@ -195,10 +195,21 @@ export class SyncService {
 
       // Cleanup registry for completely gone files (Only during full sync)
       if (!isDeltaSync) {
+        // ⚡ Bolt: Execute registry deletions concurrently using Promise.all in batches to prevent I/O bottlenecks.
+        // Impact: Reduces full sync cleanup time from O(N) sequential I/O to bounded concurrent execution for deleted files.
+        const BATCH_SIZE = 50;
+        let deletePromises: Promise<void>[] = [];
         for (const path of registryMap.keys()) {
           if (!fsMap.has(path) && !opfsMap.has(path)) {
-            await this.registry.deleteEntry(vaultId, path);
+            deletePromises.push(this.registry.deleteEntry(vaultId, path));
+            if (deletePromises.length >= BATCH_SIZE) {
+              await Promise.all(deletePromises);
+              deletePromises = [];
+            }
           }
+        }
+        if (deletePromises.length > 0) {
+          await Promise.all(deletePromises);
         }
       }
 


### PR DESCRIPTION
💡 What: Refactored the full sync cleanup loop to execute `this.registry.deleteEntry` concurrently using `Promise.all` in batches.
🎯 Why: A sequential loop waiting on I/O for `deleteEntry` creates a performance bottleneck during a full sync.
📊 Impact: Reduces full sync cleanup time from O(N) sequential I/O to bounded concurrent execution for deleted files.
🔬 Measurement: Verified with `vitest run` tests for `packages/sync-engine`.

---
*PR created automatically by Jules for task [7787520391032218787](https://jules.google.com/task/7787520391032218787) started by @eserlan*