### PR TITLE
🎨 Palette: Add ARIA labels to Category Settings buttons

### DIFF
--- a/apps/web/src/lib/components/settings/CategorySettings.svelte
+++ b/apps/web/src/lib/components/settings/CategorySettings.svelte
@@ -131,6 +131,7 @@
           onclick={() => openPicker(cat.id)}
           class="w-8 h-8 flex items-center justify-center bg-theme-bg/30 border border-theme-border rounded hover:border-theme-primary transition-all text-theme-primary"
           title="Change Icon"
+          aria-label="Change icon for {cat.label}"
         >
           <span class="{getIconClass(cat.icon)} w-4 h-4"></span>
         </button>
@@ -176,6 +177,7 @@
         onclick={() => openPicker("new")}
         class="w-9 h-9 flex items-center justify-center bg-theme-surface border border-theme-border rounded hover:border-theme-primary transition-all text-theme-primary shrink-0"
         title="Select Icon"
+        aria-label="Select icon for new category"
       >
         <span class="{getIconClass(newIcon)} w-5 h-5"></span>
       </button>
@@ -244,6 +246,7 @@
             onclick={() => selectIcon(icon)}
             class="aspect-square flex items-center justify-center rounded border border-theme-border hover:border-theme-primary/50 hover:bg-theme-primary/10 text-theme-muted hover:text-theme-primary transition-all"
             title={icon}
+            aria-label="Select {icon} icon"
           >
             <span class="{getIconClass(icon)} w-5 h-5"></span>
           </button>


### PR DESCRIPTION
💡 What: Added dynamically generated `aria-label` attributes to the icon-only buttons in the Category Settings component (including the glyph selector modal).
🎯 Why: These buttons previously lacked accessible names and relied solely on native `title` attributes, making them opaque to screen-reader users navigating the application.
📸 Before/After: Visual presentation remains identical, but underlying semantic HTML now correctly announces actions like "Change icon for Character" or "Select crown icon".
♿ Accessibility: Improved screen reader support significantly in the schema configuration panel by adding context-aware labels.

---
*PR created automatically by Jules for task [15950428970615048631](https://jules.google.com/task/15950428970615048631) started by @eserlan*