### PR TITLE
✨ feat: gate batch-add notification by active canvas presence

### DIFF
--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
@@ -507,12 +507,12 @@
     await canvasRegistry.touch(currentCanvasId);
   }
   onMount(() => {
-    canvasRegistry.isMounted = true;
+    canvasRegistry.isWorkspaceMounted = true;
     window.addEventListener("add-to-canvas", handleQuickSpawn as any);
     window.addEventListener("edit-edge-label", handleEditLabel as any);
 
     return () => {
-      canvasRegistry.isMounted = false;
+      canvasRegistry.isWorkspaceMounted = false;
       window.removeEventListener("add-to-canvas", handleQuickSpawn as any);
       window.removeEventListener("edit-edge-label", handleEditLabel as any);
     };

--- a/apps/web/src/lib/components/graph/GraphHUD.svelte
+++ b/apps/web/src/lib/components/graph/GraphHUD.svelte
@@ -49,9 +49,9 @@
       ),
     );
 
-    if (canvasRegistry.isMounted) {
+    if (canvasRegistry.isWorkspaceMounted) {
       ui.notify(
-        `${entitiesToQueue.length} entities added to active workspace`,
+        `${entitiesToQueue.length} entities queued for active workspace`,
         "success",
       );
     } else {

--- a/apps/web/src/lib/stores/canvas-registry.svelte.ts
+++ b/apps/web/src/lib/stores/canvas-registry.svelte.ts
@@ -8,7 +8,7 @@ class CanvasRegistryStore {
   canvases = $state<Record<string, any>>({});
   status = $state<"idle" | "loading" | "saving" | "error">("idle");
   isLoaded = $state(false);
-  isMounted = $state(false);
+  isWorkspaceMounted = $state(false);
   pendingEntities = $state<
     { id: string; position?: { x: number; y: number } }[]
   >([]);


### PR DESCRIPTION
## Overview

This PR adds an `isMounted` state to `CanvasRegistryStore` to allow other components (like `GraphHUD`) to detect if a canvas workspace is currently active.

## Changes

- **CanvasRegistryStore**: Added reactive `isMounted` state.
- **CanvasWorkspace**: Sets `isMounted = true` on mount and `false` on destroy.
- **GraphHUD**: Updated `addFilteredToCanvas` to check `isMounted`. 
    - If active: Shows "Added to active workspace" success toast.
    - If inactive: Shows "Entities queued. Open a canvas workspace..." info toast.

This provides much better UX than the previous behavior of always claiming success even if no canvas was open to receive the nodes.

Resolves the UX improvement from PR #475.