### PR TITLE
🎨 Palette: Add ARIA labels to main action buttons and search results

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,5 +14,6 @@
 **Action:** When working on Svelte components or reviewing existing ones, ensure that `aria-label` is populated using context variables (e.g., `{era.name}`) to provide clear actions for screen readers.
 
 ## 2026-03-27 - Timeline Keyboard Scrolling
-**Learning:** Svelte's `a11y_no_noninteractive_tabindex` will flag scrollable `div` containers if given `tabindex="0"`. While generally a good rule, WCAG guidelines *require* custom scrollable regions (overflow containers without natively focusable children) to be keyboard focusable so users can scroll them with arrow keys.
+
+**Learning:** Svelte's `a11y_no_noninteractive_tabindex` will flag scrollable `div` containers if given `tabindex="0"`. While generally a good rule, WCAG guidelines _require_ custom scrollable regions (overflow containers without natively focusable children) to be keyboard focusable so users can scroll them with arrow keys.
 **Action:** When adding `tabindex="0"`, `role="region"`, and `aria-label` to custom scrollable containers, use `<!-- svelte-ignore a11y_no_noninteractive_tabindex -->` alongside `focus-visible` ring styles to ensure accessibility without breaking the build.

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -114,6 +114,7 @@
         }}
         data-testid="save-as-campaign-button"
         title={`Save this demo exploration as your own persistent ${themeStore.jargon.vault}`}
+        aria-label={`Save this demo exploration as your own persistent ${themeStore.jargon.vault}`}
       >
         <span class="icon-[lucide--save] w-3 h-3"></span>
         SAVE AS {themeStore.jargon.vault.toUpperCase()}
@@ -123,6 +124,7 @@
           ? `${btnGhost} py-3 text-sm justify-center gap-2`
           : `${btnGhost} px-3 md:px-4 py-1.5 text-[10px] md:text-xs gap-2`}
         onclick={() => demoService.exitDemo()}
+        aria-label="Exit Demo"
       >
         <span class="icon-[lucide--log-out] w-3 h-3"></span>
         EXIT DEMO
@@ -216,6 +218,7 @@
               window.location.origin + window.location.pathname;
           }}
           data-testid="exit-guest-mode-button"
+          aria-label="Exit Guest Mode"
         >
           <span class="icon-[lucide--log-out] w-3 h-3"></span>
           EXIT GUEST MODE
@@ -251,6 +254,7 @@
             onclick={() => ui.openImportWindow()}
             data-testid="import-vault-button"
             title="Import markdown notes or JSON data into your archive."
+            aria-label="Import Data"
           >
             <span class="icon-[lucide--folder-input] w-3.5 h-3.5"></span>
             IMPORT

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -113,12 +113,17 @@
           }
         }}
         data-testid="save-as-campaign-button"
+        aria-label={`Save as ${themeStore.jargon.vault}`}
+        aria-describedby="save-as-campaign-desc-text"
         title={`Save this demo exploration as your own persistent ${themeStore.jargon.vault}`}
-        aria-label={`Save this demo exploration as your own persistent ${themeStore.jargon.vault}`}
       >
         <span class="icon-[lucide--save] w-3 h-3"></span>
         SAVE AS {themeStore.jargon.vault.toUpperCase()}
       </button>
+      <div class="sr-only" id="save-as-campaign-desc-text">
+        Save this demo exploration as your own persistent {themeStore.jargon
+          .vault}
+      </div>
       <button
         class={isVertical
           ? `${btnGhost} py-3 text-sm justify-center gap-2`

--- a/apps/web/src/lib/components/ui/Autocomplete.svelte
+++ b/apps/web/src/lib/components/ui/Autocomplete.svelte
@@ -210,6 +210,7 @@
           id="{finalId}-option-{i}"
           role="option"
           aria-selected={i === selectedIndex}
+          aria-label={result.title}
           class="w-full text-left px-3 py-2 flex items-center gap-2 transition-colors
             {i === selectedIndex
             ? 'bg-theme-primary/20 text-theme-primary'

--- a/apps/web/src/lib/components/ui/Autocomplete.svelte
+++ b/apps/web/src/lib/components/ui/Autocomplete.svelte
@@ -209,6 +209,7 @@
         <button
           id="{finalId}-option-{i}"
           role="option"
+          tabindex="-1"
           aria-selected={i === selectedIndex}
           aria-label={result.title}
           class="w-full text-left px-3 py-2 flex items-center gap-2 transition-colors


### PR DESCRIPTION
🎨 Palette: Added `aria-label` attributes to main action buttons in `VaultControls` to provide clearer context for screen readers. Also added `aria-label` attributes to the search result buttons in `Autocomplete` to correctly announce their names. Evaluated and confirmed via automated UI screenshot verification.

---
*PR created automatically by Jules for task [430924462372129560](https://jules.google.com/task/430924462372129560) started by @eserlan*