### PR TITLE
🎨 Palette: Add ARIA dialog attributes to PinLinker modal

### DIFF
--- a/apps/web/src/lib/components/map/PinLinker.svelte
+++ b/apps/web/src/lib/components/map/PinLinker.svelte
@@ -44,11 +44,15 @@
   <div
     class="w-full max-w-md bg-theme-surface border border-theme-border rounded-xl shadow-2xl overflow-hidden"
     transition:scale
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="pin-linker-title"
   >
     <header
       class="p-4 border-b border-theme-border flex justify-between items-center bg-theme-bg/20"
     >
       <h3
+        id="pin-linker-title"
         class="text-sm font-bold text-theme-text uppercase font-header tracking-widest"
       >
         Link Lore Pin
@@ -68,6 +72,7 @@
         type="text"
         bind:value={query}
         placeholder="Search for an entity..."
+        aria-label="Search for an entity"
         class="w-full bg-theme-bg border border-theme-border text-theme-text px-4 py-2 rounded-lg focus:border-theme-primary outline-none transition-colors mb-4 text-sm"
       />
 


### PR DESCRIPTION
Adds accessibility dialog attributes to the Map View PinLinker component.
- `role="dialog"` added to modal container.
- `aria-modal="true"` added to modal container.
- `id="pin-linker-title"` added to the `<header> <h3>` and linked via `aria-labelledby` from the container.
- `aria-label="Search for an entity"` added to the input field, which lacked an explicit label element.

Fixes missing ARIA structural contexts within the map editor popups, improving screen reader compatibility when creating/linking map pins.

---
*PR created automatically by Jules for task [5293122576356089351](https://jules.google.com/task/5293122576356089351) started by @eserlan*