### PR TITLE
🩹 fix(p2p): share theme and images in guest mode

### DIFF
--- a/apps/web/src/lib/cloud-bridge/p2p/client-adapter.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/client-adapter.ts
@@ -1,5 +1,5 @@
 import type { IStorageAdapter, SerializedGraph } from "../types";
-import Peer from "peerjs";
+import { createPeer, type PeerFactory } from "./peer-factory";
 
 export class P2PClientAdapter implements IStorageAdapter {
   private hostId: string;
@@ -7,6 +7,7 @@ export class P2PClientAdapter implements IStorageAdapter {
   private conn: any;
   private graphPromise: Promise<SerializedGraph>;
   private graphResolver!: (g: SerializedGraph) => void;
+  private readonly peerFactory: PeerFactory;
 
   // Request tracking
   private pendingRequests = new Map<
@@ -14,8 +15,9 @@ export class P2PClientAdapter implements IStorageAdapter {
     { resolve: (b: Blob) => void; reject: (e: any) => void }
   >();
 
-  constructor(hostId: string) {
+  constructor(hostId: string, deps: { peerFactory?: PeerFactory } = {}) {
     this.hostId = hostId;
+    this.peerFactory = deps.peerFactory ?? createPeer;
     this.graphPromise = new Promise((resolve) => {
       this.graphResolver = resolve;
     });
@@ -27,8 +29,7 @@ export class P2PClientAdapter implements IStorageAdapter {
 
   async init(): Promise<void> {
     return new Promise((resolve, reject) => {
-      // @ts-expect-error - PeerJS constructor types
-      this.peer = new Peer(undefined, { debug: 1 });
+      this.peer = this.peerFactory(undefined, { debug: 1 });
 
       this.peer.on("open", () => {
         console.log("[P2P Client] Connected to signaling server.");

--- a/apps/web/src/lib/cloud-bridge/p2p/guest-service.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/guest-service.ts
@@ -15,6 +15,7 @@ export class P2PGuestService {
     onEntityUpdate: (entity: any) => void,
     onEntityDelete: (id: string) => void,
     onBatchUpdate: (updates: Record<string, any>) => void,
+    onThemeUpdate: (themeId: string) => void,
   ): Promise<void> {
     if (this.connection?.open && this.connection?.peer === hostId) {
       console.log("[P2P Guest] Already connected to host:", hostId);
@@ -68,6 +69,8 @@ export class P2PGuestService {
             onBatchUpdate(data.payload);
           } else if (data.type === "ENTITY_DELETE") {
             onEntityDelete(data.payload);
+          } else if (data.type === "THEME_UPDATE") {
+            onThemeUpdate(data.payload);
           }
         });
 

--- a/apps/web/src/lib/cloud-bridge/p2p/guest-service.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/guest-service.ts
@@ -1,13 +1,26 @@
-import Peer from "peerjs";
 import type { SerializedGraph } from "../types";
+import type { GuestPresenceStatus } from "../../stores/guest";
+import { createPeer, type PeerFactory } from "./peer-factory";
+
+type GuestStatusPayload = {
+  status: GuestPresenceStatus;
+  currentEntityId: string | null;
+  currentEntityTitle: string | null;
+};
 
 export class P2PGuestService {
   private peer: any;
   private connection: any | null = null;
   private isConnecting = false;
   private dataCallback: ((graph: SerializedGraph) => void) | null = null;
+  private guestDisplayName: string | null = null;
+  private pendingStatus: GuestStatusPayload | null = null;
+  private isConnected = false;
+  private readonly peerFactory: PeerFactory;
 
-  constructor() {}
+  constructor(deps: { peerFactory?: PeerFactory } = {}) {
+    this.peerFactory = deps.peerFactory ?? createPeer;
+  }
 
   async connectToHost(
     hostId: string,
@@ -16,6 +29,7 @@ export class P2PGuestService {
     onEntityDelete: (id: string) => void,
     onBatchUpdate: (updates: Record<string, any>) => void,
     onThemeUpdate: (themeId: string) => void,
+    guestName?: string,
   ): Promise<void> {
     if (this.connection?.open && this.connection?.peer === hostId) {
       console.log("[P2P Guest] Already connected to host:", hostId);
@@ -28,12 +42,12 @@ export class P2PGuestService {
     }
 
     if (!this.peer) {
-      const PeerClass = (window as any).Peer || Peer;
-      this.peer = new PeerClass(undefined, { debug: 1 });
+      this.peer = this.peerFactory(undefined, { debug: 1 });
     }
 
     this.isConnecting = true;
     this.dataCallback = onGraphData;
+    this.guestDisplayName = guestName?.trim() || null;
 
     let timeoutHandle: any = null;
     const connectionPromise = new Promise<void>((resolve, reject) => {
@@ -49,7 +63,21 @@ export class P2PGuestService {
         this.connection.on("open", () => {
           console.log(`[P2P Guest] Connected to host: ${hostId}`);
           this.isConnecting = false;
+          this.isConnected = true;
           if (timeoutHandle) clearTimeout(timeoutHandle);
+          if (this.guestDisplayName) {
+            this.connection.send({
+              type: "GUEST_JOIN",
+              payload: { displayName: this.guestDisplayName },
+            });
+          }
+          if (this.pendingStatus) {
+            this.connection.send({
+              type: "GUEST_STATUS",
+              payload: this.pendingStatus,
+            });
+            this.pendingStatus = null;
+          }
           resolve();
         });
 
@@ -77,6 +105,7 @@ export class P2PGuestService {
         this.connection.on("close", () => {
           console.log("[P2P Guest] Connection closed");
           this.isConnecting = false;
+          this.isConnected = false;
           this.disconnect();
         });
 
@@ -119,6 +148,7 @@ export class P2PGuestService {
 
   disconnect() {
     this.isConnecting = false;
+    this.isConnected = false;
     if (this.connection) {
       this.connection.close();
       this.connection = null;
@@ -127,6 +157,8 @@ export class P2PGuestService {
       this.peer.destroy();
       this.peer = null;
     }
+    this.pendingStatus = null;
+    this.guestDisplayName = null;
   }
 
   async getFile(path: string): Promise<Blob> {
@@ -162,6 +194,21 @@ export class P2PGuestService {
         requestId,
       });
     });
+  }
+
+  updateGuestStatus(status: GuestStatusPayload) {
+    this.pendingStatus = status;
+    if (this.connection?.open) {
+      this.connection.send({
+        type: "GUEST_STATUS",
+        payload: status,
+      });
+      this.pendingStatus = null;
+    }
+  }
+
+  get connected() {
+    return this.isConnected;
   }
 }
 

--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -16,20 +16,6 @@ export class P2PHostService {
   async startHosting(): Promise<string> {
     if (this._isHosting && this.peerId) return this.peerId;
 
-    // Subscribe to local vault updates
-    vault.onEntityUpdate = (entity) => {
-      this.broadcastEntityUpdate(entity);
-    };
-    vault.onEntityDelete = (id) => {
-      this.broadcastEntityDelete(id);
-    };
-    vault.onBatchUpdate = (updates) => {
-      this.broadcastBatchUpdate(updates);
-    };
-    themeStore.onThemeUpdate = (id) => {
-      this.broadcastThemeUpdate(id);
-    };
-
     return new Promise((resolve, reject) => {
       // Generate a random ID with a prefix
       // @ts-expect-error - PeerJS constructor types
@@ -41,6 +27,21 @@ export class P2PHostService {
         console.log("[P2P Host] Hosting started. ID:", id);
         this.peerId = id;
         this._isHosting = true;
+        
+        // Subscribe to local vault updates
+        vault.onEntityUpdate = (entity) => {
+          this.broadcastEntityUpdate(entity);
+        };
+        vault.onEntityDelete = (delId) => {
+          this.broadcastEntityDelete(delId);
+        };
+        vault.onBatchUpdate = (updates) => {
+          this.broadcastBatchUpdate(updates);
+        };
+        themeStore.onThemeUpdate = (themeId) => {
+          this.broadcastThemeUpdate(themeId);
+        };
+
         resolve(id);
       });
 

--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -1,8 +1,22 @@
-import type { SerializedGraph } from "../types";
-import { vault } from "../../stores/vault.svelte";
-import { themeStore } from "../../stores/theme.svelte";
+import { vault as defaultVault } from "../../stores/vault.svelte";
+import { themeStore as defaultThemeStore } from "../../stores/theme.svelte";
+import { guestRoster as defaultGuestRoster } from "../../stores/guest";
 import type { Entity } from "schema";
-import Peer from "peerjs";
+import {
+  buildSharedGraphPayload,
+  deriveGuestPresenceStatus,
+  normalizeGuestName,
+  removeGuestFromRoster,
+  upsertGuestRoster,
+} from "./p2p-helpers";
+import { createPeer, type PeerFactory } from "./peer-factory";
+
+type HostDeps = {
+  vault?: typeof defaultVault;
+  themeStore?: typeof defaultThemeStore;
+  guestRoster?: typeof defaultGuestRoster;
+  peerFactory?: PeerFactory;
+};
 
 export class P2PHostService {
   private peer: any;
@@ -10,16 +24,24 @@ export class P2PHostService {
   connections = $state<any[]>([]);
   private _isHosting = false;
   private unsubscribe: (() => void) | null = null;
+  private readonly vault: typeof defaultVault;
+  private readonly themeStore: typeof defaultThemeStore;
+  private readonly guestRoster: typeof defaultGuestRoster;
+  private readonly peerFactory: PeerFactory;
 
-  constructor() {}
+  constructor(deps: HostDeps = {}) {
+    this.vault = deps.vault ?? defaultVault;
+    this.themeStore = deps.themeStore ?? defaultThemeStore;
+    this.guestRoster = deps.guestRoster ?? defaultGuestRoster;
+    this.peerFactory = deps.peerFactory ?? createPeer;
+  }
 
   async startHosting(): Promise<string> {
     if (this._isHosting && this.peerId) return this.peerId;
 
     return new Promise((resolve, reject) => {
       // Generate a random ID with a prefix
-      // @ts-expect-error - PeerJS constructor types
-      this.peer = new Peer(undefined, {
+      this.peer = this.peerFactory(undefined, {
         debug: 1,
       });
 
@@ -29,18 +51,19 @@ export class P2PHostService {
         this._isHosting = true;
 
         // Subscribe to local vault updates
-        vault.onEntityUpdate = (entity) => {
+        this.vault.onEntityUpdate = (entity) => {
           this.broadcastEntityUpdate(entity);
         };
-        vault.onEntityDelete = (delId) => {
+        this.vault.onEntityDelete = (delId) => {
           this.broadcastEntityDelete(delId);
         };
-        vault.onBatchUpdate = (updates) => {
+        this.vault.onBatchUpdate = (updates) => {
           this.broadcastBatchUpdate(updates);
         };
-        themeStore.onThemeUpdate = (themeId) => {
+        this.themeStore.onThemeUpdate = (themeId) => {
           this.broadcastThemeUpdate(themeId);
         };
+        this.guestRoster.set({});
 
         resolve(id);
       });
@@ -90,43 +113,65 @@ export class P2PHostService {
 
       if (data.type === "GET_FILE") {
         await this.handleFileRequest(conn, data.path, data.requestId);
+      } else if (data.type === "GUEST_JOIN") {
+        this.handleGuestJoin(conn.peer, data.payload);
+      } else if (data.type === "GUEST_STATUS") {
+        this.handleGuestStatus(conn.peer, data.payload);
       }
     });
 
     conn.on("close", () => {
       console.log("[P2P Host] Guest disconnected:", conn.peer);
       this.connections = this.connections.filter((c) => c !== conn);
+      this.guestRoster.update((current) =>
+        removeGuestFromRoster(current, conn.peer),
+      );
     });
   }
 
-  private async prepareGraphPayload(): Promise<SerializedGraph> {
-    // Serialize current vault state
-    // We must sanitize entities to remove non-serializable objects like FileSystemHandles through destructuring
-    const rawEntities = $state.snapshot(vault.entities);
-    const entities: Record<string, Entity> = {};
-    const assets: Record<string, string> = {};
+  private handleGuestJoin(peerId: string, payload: any) {
+    this.guestRoster.update((current) =>
+      upsertGuestRoster(current, peerId, {
+        displayName: normalizeGuestName(payload?.displayName, peerId),
+        status: "connected",
+        currentEntityId: null,
+        currentEntityTitle: null,
+      }),
+    );
+  }
 
-    // Build a mapping for assets and sanitize entities
-    for (const [id, localEntity] of Object.entries(rawEntities)) {
-      // Strip _fsHandle and other runtime-only props that PeerJS can't serialize
-      const { _fsHandle, ...safeEntity } = localEntity as any;
-      entities[id] = safeEntity;
+  private handleGuestStatus(peerId: string, payload: any) {
+    const currentEntityId =
+      typeof payload?.currentEntityId === "string" && payload.currentEntityId
+        ? payload.currentEntityId
+        : null;
+    const currentEntityTitle =
+      typeof payload?.currentEntityTitle === "string" &&
+      payload.currentEntityTitle
+        ? payload.currentEntityTitle
+        : currentEntityId
+          ? this.vault.entities[currentEntityId]?.title || currentEntityId
+          : null;
+    this.guestRoster.update((current) =>
+      upsertGuestRoster(current, peerId, {
+        displayName: normalizeGuestName(
+          payload?.displayName,
+          current[peerId]?.displayName || peerId,
+        ),
+        status: deriveGuestPresenceStatus(payload?.status, currentEntityId),
+        currentEntityId,
+        currentEntityTitle,
+      }),
+    );
+  }
 
-      // If we have an image path, map it
-      if (safeEntity.image && !safeEntity.image.startsWith("http")) {
-        // We'll use the path as the key
-        assets[safeEntity.image] = safeEntity.image;
-      }
-    }
-
-    return {
-      version: 1,
-      entities,
-      assets,
-      defaultVisibility: vault.defaultVisibility,
-      sharedMode: true, // Always force shared mode for guests
-      themeId: themeStore.currentThemeId,
-    };
+  private async prepareGraphPayload() {
+    const rawEntities = $state.snapshot(this.vault.entities);
+    return buildSharedGraphPayload(
+      rawEntities,
+      this.vault.defaultVisibility,
+      this.themeStore.currentThemeId,
+    );
   }
 
   private async handleFileRequest(conn: any, path: string, requestId: string) {
@@ -134,8 +179,8 @@ export class P2PHostService {
       console.log(`[P2P Host] Handling file request for: ${path}`);
 
       // Use the active vault handle
-      const vaultHandle = await vault.getActiveVaultHandle();
-      console.log(`[P2P Host] Active Vault ID: ${vault.activeVaultId}`);
+      const vaultHandle = await this.vault.getActiveVaultHandle();
+      console.log(`[P2P Host] Active Vault ID: ${this.vault.activeVaultId}`);
 
       if (!vaultHandle) {
         console.error("[P2P Host] No active vault handle!");
@@ -340,10 +385,11 @@ export class P2PHostService {
   }
 
   stopHosting() {
-    vault.onEntityUpdate = undefined;
-    vault.onEntityDelete = undefined;
-    vault.onBatchUpdate = undefined;
-    themeStore.onThemeUpdate = undefined;
+    this.vault.onEntityUpdate = undefined;
+    this.vault.onEntityDelete = undefined;
+    this.vault.onBatchUpdate = undefined;
+    this.themeStore.onThemeUpdate = undefined;
+    this.guestRoster.set({});
     if (this.peer) {
       this.peer.destroy();
       this.peer = null;

--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -1,5 +1,6 @@
 import type { SerializedGraph } from "../types";
 import { vault } from "../../stores/vault.svelte";
+import { themeStore } from "../../stores/theme.svelte";
 import type { Entity } from "schema";
 import Peer from "peerjs";
 
@@ -24,6 +25,9 @@ export class P2PHostService {
     };
     vault.onBatchUpdate = (updates) => {
       this.broadcastBatchUpdate(updates);
+    };
+    themeStore.onThemeUpdate = (id) => {
+      this.broadcastThemeUpdate(id);
     };
 
     return new Promise((resolve, reject) => {
@@ -120,6 +124,7 @@ export class P2PHostService {
       assets,
       defaultVisibility: vault.defaultVisibility,
       sharedMode: true, // Always force shared mode for guests
+      themeId: themeStore.currentThemeId,
     };
   }
 
@@ -316,10 +321,28 @@ export class P2PHostService {
     });
   }
 
+  private broadcastThemeUpdate(themeId: string) {
+    if (this.connections.length === 0) return;
+
+    console.log("[P2P Host] Broadcasting theme update:", themeId);
+
+    const message = {
+      type: "THEME_UPDATE",
+      payload: themeId,
+    };
+
+    this.connections.forEach((conn) => {
+      if (conn.open) {
+        conn.send(message);
+      }
+    });
+  }
+
   stopHosting() {
     vault.onEntityUpdate = undefined;
     vault.onEntityDelete = undefined;
     vault.onBatchUpdate = undefined;
+    themeStore.onThemeUpdate = undefined;
     if (this.peer) {
       this.peer.destroy();
       this.peer = null;

--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -16,20 +16,6 @@ export class P2PHostService {
   async startHosting(): Promise<string> {
     if (this._isHosting && this.peerId) return this.peerId;
 
-    // Subscribe to local vault updates
-    vault.onEntityUpdate = (entity) => {
-      this.broadcastEntityUpdate(entity);
-    };
-    vault.onEntityDelete = (id) => {
-      this.broadcastEntityDelete(id);
-    };
-    vault.onBatchUpdate = (updates) => {
-      this.broadcastBatchUpdate(updates);
-    };
-    themeStore.onThemeUpdate = (id) => {
-      this.broadcastThemeUpdate(id);
-    };
-
     return new Promise((resolve, reject) => {
       // Generate a random ID with a prefix
       // @ts-expect-error - PeerJS constructor types
@@ -41,6 +27,21 @@ export class P2PHostService {
         console.log("[P2P Host] Hosting started. ID:", id);
         this.peerId = id;
         this._isHosting = true;
+
+        // Subscribe to local vault updates
+        vault.onEntityUpdate = (entity) => {
+          this.broadcastEntityUpdate(entity);
+        };
+        vault.onEntityDelete = (delId) => {
+          this.broadcastEntityDelete(delId);
+        };
+        vault.onBatchUpdate = (updates) => {
+          this.broadcastBatchUpdate(updates);
+        };
+        themeStore.onThemeUpdate = (themeId) => {
+          this.broadcastThemeUpdate(themeId);
+        };
+
         resolve(id);
       });
 

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSharedGraphPayload,
+  deriveGuestPresenceStatus,
+  normalizeGuestName,
+  removeGuestFromRoster,
+  upsertGuestRoster,
+} from "./p2p-helpers";
+
+describe("p2p helpers", () => {
+  it("should normalize guest names with fallback and trimming", () => {
+    expect(normalizeGuestName("  Ava  ", "fallback")).toBe("Ava");
+    expect(normalizeGuestName("", "fallback")).toBe("fallback");
+    expect(normalizeGuestName(null, "fallback")).toBe("fallback");
+  });
+
+  it("should derive guest presence status from payload and entity", () => {
+    expect(deriveGuestPresenceStatus("viewing", null)).toBe("viewing");
+    expect(deriveGuestPresenceStatus("connected", "entity-1")).toBe("viewing");
+    expect(deriveGuestPresenceStatus(undefined, null)).toBe("connected");
+  });
+
+  it("should upsert and remove roster entries", () => {
+    const next = upsertGuestRoster(
+      {},
+      "peer-1",
+      {
+        displayName: "Ava",
+        status: "connected",
+        currentEntityId: null,
+        currentEntityTitle: null,
+      },
+      123,
+    );
+
+    expect(next["peer-1"]).toMatchObject({
+      peerId: "peer-1",
+      displayName: "Ava",
+      status: "connected",
+      joinedAt: 123,
+      lastSeenAt: 123,
+    });
+
+    const removed = removeGuestFromRoster(next, "peer-1");
+    expect(removed["peer-1"]).toBeUndefined();
+  });
+
+  it("should build a shared graph payload and strip runtime fields", () => {
+    const payload = buildSharedGraphPayload(
+      {
+        "entity-1": {
+          id: "entity-1",
+          title: "Entity 1",
+          image: "images/a.png",
+          _fsHandle: "runtime",
+        } as any,
+      },
+      "hidden",
+      "theme-1",
+    );
+
+    expect(payload).toEqual({
+      version: 1,
+      entities: {
+        "entity-1": {
+          id: "entity-1",
+          title: "Entity 1",
+          image: "images/a.png",
+        },
+      },
+      assets: {
+        "images/a.png": "images/a.png",
+      },
+      defaultVisibility: "hidden",
+      sharedMode: true,
+      themeId: "theme-1",
+    });
+  });
+});

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.ts
@@ -1,0 +1,87 @@
+import type { Entity } from "schema";
+import type { SerializedGraph } from "../types";
+import type { GuestPresenceStatus, GuestSession } from "../../stores/guest";
+
+type GuestRoster = Record<string, GuestSession>;
+
+export function normalizeGuestName(name: unknown, fallback: string) {
+  if (typeof name !== "string") return fallback;
+  const trimmed = name.trim();
+  if (!trimmed) return fallback;
+  return trimmed.slice(0, 32);
+}
+
+export function deriveGuestPresenceStatus(
+  payloadStatus: unknown,
+  currentEntityId: string | null,
+): GuestPresenceStatus {
+  if (payloadStatus === "viewing") return "viewing";
+  return currentEntityId ? "viewing" : "connected";
+}
+
+export function upsertGuestRoster(
+  current: GuestRoster,
+  peerId: string,
+  patch: Partial<{
+    displayName: string;
+    status: GuestPresenceStatus;
+    currentEntityId: string | null;
+    currentEntityTitle: string | null;
+  }>,
+  now = Date.now(),
+) {
+  const existing = current[peerId];
+  const base = existing ?? {
+    peerId,
+    displayName: peerId,
+    joinedAt: now,
+    lastSeenAt: now,
+    status: "connected" as const,
+    currentEntityId: null,
+    currentEntityTitle: null,
+  };
+
+  return {
+    ...current,
+    [peerId]: {
+      ...base,
+      ...patch,
+      peerId,
+      lastSeenAt: now,
+    },
+  };
+}
+
+export function removeGuestFromRoster(current: GuestRoster, peerId: string) {
+  if (!current[peerId]) return current;
+  const next = { ...current };
+  delete next[peerId];
+  return next;
+}
+
+export function buildSharedGraphPayload(
+  rawEntities: Record<string, Entity>,
+  defaultVisibility: SerializedGraph["defaultVisibility"],
+  themeId: string,
+): SerializedGraph {
+  const entities: Record<string, Entity> = {};
+  const assets: Record<string, string> = {};
+
+  for (const [id, localEntity] of Object.entries(rawEntities)) {
+    const { _fsHandle, ...safeEntity } = localEntity as any;
+    entities[id] = safeEntity;
+
+    if (safeEntity.image && !safeEntity.image.startsWith("http")) {
+      assets[safeEntity.image] = safeEntity.image;
+    }
+  }
+
+  return {
+    version: 1,
+    entities,
+    assets,
+    defaultVisibility,
+    sharedMode: true,
+    themeId,
+  };
+}

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
@@ -3,6 +3,8 @@ import { P2PHostService } from "./host-service.svelte";
 import { P2PGuestService } from "./guest-service";
 import { P2PClientAdapter } from "./client-adapter";
 import { vault } from "../../stores/vault.svelte";
+import { themeStore } from "../../stores/theme.svelte";
+import { guestRoster } from "../../stores/guest";
 
 const { MockConnection, MockPeer } = vi.hoisted(() => {
   class MockConnection {
@@ -123,7 +125,13 @@ describe("P2P Services", () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      hostService = new P2PHostService();
+      guestRoster.set({});
+      hostService = new P2PHostService({
+        vault,
+        themeStore,
+        guestRoster,
+        peerFactory: () => new MockPeer(),
+      });
     });
 
     it("should start hosting and return a peer ID", async () => {
@@ -132,6 +140,13 @@ describe("P2P Services", () => {
       peerInstance.emit("open", "mock-peer-id");
       const id = await idPromise;
       expect(id).toBe("mock-peer-id");
+    });
+
+    it("should return the existing peer id when already hosting", async () => {
+      (hostService as any)._isHosting = true;
+      (hostService as any).peerId = "existing-peer";
+
+      await expect(hostService.startHosting()).resolves.toBe("existing-peer");
     });
 
     it("should handle new connections and send initial graph", async () => {
@@ -153,6 +168,58 @@ describe("P2P Services", () => {
             type: "GRAPH_SYNC",
           }),
         );
+      });
+    });
+
+    it("should track joined guests and their status", async () => {
+      const idPromise = hostService.startHosting();
+      const peerInstance = (hostService as any).peer;
+      peerInstance.emit("open", "mock-peer-id");
+      await idPromise;
+
+      const mockConn = new MockConnection("guest-1");
+      peerInstance.emit("connection", mockConn);
+      mockConn.emit("open");
+
+      mockConn.emit("data", {
+        type: "GUEST_JOIN",
+        payload: { displayName: "Ava" },
+      });
+      mockConn.emit("data", {
+        type: "GUEST_STATUS",
+        payload: {
+          status: "viewing",
+          currentEntityId: "entity-1",
+          currentEntityTitle: "Entity 1",
+        },
+      });
+
+      await vi.waitFor(() => {
+        const roster = (hostService as any).connections.length;
+        expect(roster).toBe(1);
+      });
+
+      let currentRoster: any = {};
+      const unsubscribe = guestRoster.subscribe((value) => {
+        currentRoster = value;
+      });
+      unsubscribe();
+
+      expect(currentRoster["guest-1"]).toMatchObject({
+        displayName: "Ava",
+        status: "viewing",
+        currentEntityId: "entity-1",
+        currentEntityTitle: "Entity 1",
+      });
+
+      mockConn.emit("close");
+      await vi.waitFor(() => {
+        let nextRoster: any = {};
+        const unsub = guestRoster.subscribe((value) => {
+          nextRoster = value;
+        });
+        unsub();
+        expect(nextRoster["guest-1"]).toBeUndefined();
       });
     });
 
@@ -226,6 +293,30 @@ describe("P2P Services", () => {
       );
     });
 
+    it("should return a missing file response when no vault handle exists", async () => {
+      const idPromise = hostService.startHosting();
+      const peerInstance = (hostService as any).peer;
+      peerInstance.emit("open", "mock-peer-id");
+      await idPromise;
+
+      const mockConn = new MockConnection("guest-1");
+      (hostService as any).connections.push(mockConn);
+
+      vi.mocked(vault.getActiveVaultHandle).mockResolvedValue(null as any);
+
+      await (hostService as any).handleFileRequest(
+        mockConn,
+        "images/test.png",
+        "req-missing",
+      );
+
+      expect(mockConn.send).toHaveBeenCalledWith({
+        type: "FILE_RESPONSE",
+        requestId: "req-missing",
+        found: false,
+      });
+    });
+
     it("should stop hosting and clear connections", async () => {
       const idPromise = hostService.startHosting();
       const peerInstance = (hostService as any).peer;
@@ -247,7 +338,9 @@ describe("P2P Services", () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      guestService = new P2PGuestService();
+      guestService = new P2PGuestService({
+        peerFactory: () => new MockPeer(),
+      });
     });
 
     it("should handle connection timeout", async () => {
@@ -259,12 +352,98 @@ describe("P2P Services", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
+        "Guest One",
       );
 
       vi.advanceTimersByTime(15000);
 
       await expect(connectPromise).rejects.toThrow("Connection timed out");
       vi.useRealTimers();
+    });
+
+    it("should return early when already connected to the same host", async () => {
+      const existingConn = { open: true, peer: "host-id" };
+      (guestService as any).connection = existingConn;
+
+      await expect(
+        guestService.connectToHost(
+          "host-id",
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+        ),
+      ).resolves.toBeUndefined();
+
+      expect((guestService as any).connection).toBe(existingConn);
+      expect((guestService as any).peer).toBeUndefined();
+    });
+
+    it("should return early when connection is already in progress", async () => {
+      (guestService as any).isConnecting = true;
+
+      await expect(
+        guestService.connectToHost(
+          "host-id",
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+          vi.fn(),
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("should wait for peer open before connecting", async () => {
+      const onGraphData = vi.fn();
+      const onEntityUpdate = vi.fn();
+      const onEntityDelete = vi.fn();
+      const onBatchUpdate = vi.fn();
+      const onThemeUpdate = vi.fn();
+      const openHandlers: Array<(...args: any[]) => void> = [];
+      const connHandlers: Record<string, (...args: any[]) => void> = {};
+      const connection = {
+        peer: "host-id",
+        open: true,
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          connHandlers[event] = handler;
+        }),
+        send: vi.fn(),
+      };
+      (guestService as any).peer = {
+        open: false,
+        id: "guest-peer",
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          if (event === "open") openHandlers.push(handler);
+        }),
+        connect: vi.fn().mockReturnValue(connection),
+        destroy: vi.fn(),
+      };
+
+      const connectPromise = guestService.connectToHost(
+        "host-id",
+        onGraphData,
+        onEntityUpdate,
+        onEntityDelete,
+        onBatchUpdate,
+        onThemeUpdate,
+      );
+
+      expect((guestService as any).peer.connect).not.toHaveBeenCalled();
+      openHandlers[0]?.();
+      connHandlers.open?.();
+
+      await connectPromise;
+      expect((guestService as any).peer.connect).toHaveBeenCalledWith(
+        "host-id",
+      );
+    });
+
+    it("should throw when fetching a file without a connection", async () => {
+      await expect(guestService.getFile("images/missing.png")).rejects.toThrow(
+        "Not connected to host",
+      );
     });
 
     it("should handle peer error during initialization", async () => {
@@ -303,6 +482,7 @@ describe("P2P Services", () => {
         onEntityDelete,
         onBatchUpdate,
         onThemeUpdate,
+        "Guest Two",
       );
 
       const peerInstance = (guestService as any).peer;
@@ -331,6 +511,62 @@ describe("P2P Services", () => {
       mockConn.emit("data", { type: "THEME_UPDATE", payload: "cyberpunk" });
       expect(onThemeUpdate).toHaveBeenCalledWith("cyberpunk");
     });
+
+    it("should announce guest name and status on connection", async () => {
+      const connectPromise = guestService.connectToHost(
+        "host-id",
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        "Morgan",
+      );
+
+      const peerInstance = (guestService as any).peer;
+      peerInstance.emit("open", "guest-id");
+
+      const mockConn = (guestService as any).connection;
+      mockConn.emit("open");
+
+      await connectPromise;
+
+      guestService.updateGuestStatus({
+        status: "viewing",
+        currentEntityId: "entity-1",
+        currentEntityTitle: "Entity 1",
+      });
+
+      expect(mockConn.send).toHaveBeenCalledWith({
+        type: "GUEST_JOIN",
+        payload: { displayName: "Morgan" },
+      });
+      expect(mockConn.send).toHaveBeenCalledWith({
+        type: "GUEST_STATUS",
+        payload: {
+          status: "viewing",
+          currentEntityId: "entity-1",
+          currentEntityTitle: "Entity 1",
+        },
+      });
+    });
+
+    it("should reject file requests when the host reports a missing file", async () => {
+      (guestService as any).connection = new MockConnection("host-id");
+      (guestService as any).connection.open = true;
+
+      const fetchPromise = guestService.getFile("images/missing.png");
+      const requestId = (guestService as any).connection.send.mock.calls[0][0]
+        .requestId;
+
+      (guestService as any).connection.emit("data", {
+        type: "FILE_RESPONSE",
+        requestId,
+        found: false,
+      });
+
+      await expect(fetchPromise).rejects.toThrow("File not found on host");
+    });
   });
 
   describe("P2PClientAdapter", () => {
@@ -338,7 +574,9 @@ describe("P2P Services", () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      adapter = new P2PClientAdapter("host-id");
+      adapter = new P2PClientAdapter("host-id", {
+        peerFactory: () => new MockPeer(),
+      });
       vi.stubGlobal("URL", {
         createObjectURL: vi.fn().mockReturnValue("blob:url"),
       });

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { P2PHostService } from "./host-service.svelte";
 import { P2PGuestService } from "./guest-service";
 import { P2PClientAdapter } from "./client-adapter";
@@ -258,6 +258,7 @@ describe("P2P Services", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
+        vi.fn(),
       );
 
       vi.advanceTimersByTime(15000);
@@ -283,6 +284,7 @@ describe("P2P Services", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
+        vi.fn(),
       );
       await expect(promise).rejects.toThrow("Peer init error");
     });
@@ -292,6 +294,7 @@ describe("P2P Services", () => {
       const onEntityUpdate = vi.fn();
       const onEntityDelete = vi.fn();
       const onBatchUpdate = vi.fn();
+      const onThemeUpdate = vi.fn();
 
       const connectPromise = guestService.connectToHost(
         "host-id",
@@ -299,6 +302,7 @@ describe("P2P Services", () => {
         onEntityUpdate,
         onEntityDelete,
         onBatchUpdate,
+        onThemeUpdate,
       );
 
       const peerInstance = (guestService as any).peer;
@@ -323,6 +327,9 @@ describe("P2P Services", () => {
 
       mockConn.emit("data", { type: "ENTITY_DELETE", payload: "1" });
       expect(onEntityDelete).toHaveBeenCalledWith("1");
+
+      mockConn.emit("data", { type: "THEME_UPDATE", payload: "cyberpunk" });
+      expect(onThemeUpdate).toHaveBeenCalledWith("cyberpunk");
     });
   });
 

--- a/apps/web/src/lib/cloud-bridge/p2p/peer-factory.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/peer-factory.ts
@@ -1,0 +1,12 @@
+import Peer from "peerjs";
+
+export type PeerFactory = (
+  id?: string,
+  options?: Record<string, unknown>,
+) => any;
+
+export function createPeer(id?: string, options?: Record<string, unknown>) {
+  const PeerClass =
+    (typeof window !== "undefined" && (window as any).Peer) || Peer;
+  return new PeerClass(id, options);
+}

--- a/apps/web/src/lib/cloud-bridge/types.ts
+++ b/apps/web/src/lib/cloud-bridge/types.ts
@@ -9,6 +9,7 @@ export interface SerializedGraph {
   // Visibility Settings
   defaultVisibility?: "visible" | "hidden";
   sharedMode?: boolean;
+  themeId?: string;
 }
 
 export interface IStorageAdapter {

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -53,6 +53,12 @@
   let activeTab = $state<"status" | "lore" | "inventory" | "map">("status");
   let isSaving = $state(false);
 
+  $effect(() => {
+    if (vault.isGuest && activeTab === "lore") {
+      activeTab = "status";
+    }
+  });
+
   const startEditing = () => {
     if (!entity) return;
     editTitle = entity.title;
@@ -156,7 +162,7 @@
             bind:editStartDate
             bind:editEndDate
           />
-        {:else if activeTab === "lore"}
+        {:else if activeTab === "lore" && !vault.isGuest}
           <DetailLoreTab {entity} {isEditing} bind:editLore />
         {:else if activeTab === "inventory"}
           <div class="text-theme-muted italic text-sm">

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -450,10 +450,12 @@
 
   $effect(() => {
     const currentCy = cy;
-    if (currentCy && graph.elements && imageManager) {
+    const currentElements = graph.elements;
+    const showImages = graph.showImages;
+    if (currentCy && currentElements && imageManager) {
       untrack(() => {
         imageManager!.sync({
-          showImages: graph.showImages,
+          showImages,
           resolveImageUrl: (path) => vault.resolveImageUrl(path),
           releaseImageUrl: (path: string) => vault.releaseImageUrl(path),
           onBatchApplied: (count) => {

--- a/apps/web/src/lib/components/ShareModal.svelte
+++ b/apps/web/src/lib/components/ShareModal.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import { p2pHost } from "$lib/cloud-bridge/p2p/host-service.svelte";
+  import {
+    buildP2PShareLink,
+    copyTextToClipboard,
+  } from "$lib/utils/share-link";
 
   let { close }: { close: () => void } = $props();
 
@@ -10,20 +14,20 @@
   let p2pLink = $state<string | null>(null);
   let p2pCopied = $state(false);
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    p2pCopied = true;
-    setTimeout(() => (p2pCopied = false), 2000);
-  };
-
   const handleP2PStart = async () => {
     p2pLoading = true;
     try {
       const peerId = await p2pHost.startHosting();
-      const url = new URL(window.location.origin + window.location.pathname);
-      // Use p2p- prefix to routing
-      url.searchParams.set("shareId", `p2p-${peerId}`);
-      p2pLink = url.toString();
+      p2pLink = buildP2PShareLink(
+        window.location.origin,
+        window.location.pathname,
+        peerId,
+      );
+      const copied = await copyTextToClipboard(p2pLink, navigator.clipboard);
+      p2pCopied = copied;
+      if (copied) {
+        setTimeout(() => (p2pCopied = false), 2000);
+      }
     } catch (err) {
       console.error(err);
       error = "Failed to start P2P session";
@@ -87,7 +91,16 @@
                 onclick={(e) => e.currentTarget.select()}
               />
               <button
-                onclick={() => copyToClipboard(p2pLink!)}
+                onclick={async () => {
+                  const copied = await copyTextToClipboard(
+                    p2pLink!,
+                    navigator.clipboard,
+                  );
+                  p2pCopied = copied;
+                  if (copied) {
+                    setTimeout(() => (p2pCopied = false), 2000);
+                  }
+                }}
                 class="px-4 py-1 border rounded text-xs transition-colors {p2pCopied
                   ? 'bg-cyan-500 border-cyan-400 text-black font-bold'
                   : 'bg-cyan-900/30 border-cyan-800 text-cyan-400 hover:bg-cyan-800 hover:text-white'}"

--- a/apps/web/src/lib/components/entity-detail/DetailLoreTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailLoreTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Entity } from "schema";
   import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
+  import { vault } from "$lib/stores/vault.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
 
   let {
@@ -14,35 +15,37 @@
   }>();
 </script>
 
-<div class="space-y-4">
-  <div>
-    <div
-      class="flex items-center gap-3 text-xs uppercase tracking-widest text-theme-muted mb-6 font-header"
-    >
-      <span class="text-theme-accent icon-[lucide--file-text] w-4 h-4"></span>
-      <span>{themeStore.jargon.lore_header}</span>
-      <div class="h-px bg-theme-border flex-1 ml-2"></div>
+{#if !vault.isGuest}
+  <div class="space-y-4">
+    <div>
+      <div
+        class="flex items-center gap-3 text-xs uppercase tracking-widest text-theme-muted mb-6 font-header"
+      >
+        <span class="text-theme-accent icon-[lucide--file-text] w-4 h-4"></span>
+        <span>{themeStore.jargon.lore_header}</span>
+        <div class="h-px bg-theme-border flex-1 ml-2"></div>
+      </div>
+      {#if isEditing}
+        <div class="h-96">
+          <MarkdownEditor
+            content={editLore}
+            editable={true}
+            onUpdate={(val) => {
+              if (isEditing) editLore = val;
+            }}
+          />
+        </div>
+      {:else}
+        <div class="prose-content">
+          <MarkdownEditor
+            content={entity.lore || "No detailed lore available."}
+            editable={false}
+          />
+        </div>
+      {/if}
     </div>
-    {#if isEditing}
-      <div class="h-96">
-        <MarkdownEditor
-          content={editLore}
-          editable={true}
-          onUpdate={(val) => {
-            if (isEditing) editLore = val;
-          }}
-        />
-      </div>
-    {:else}
-      <div class="prose-content">
-        <MarkdownEditor
-          content={entity.lore || "No detailed lore available."}
-          editable={false}
-        />
-      </div>
-    {/if}
   </div>
-</div>
+{/if}
 
 <style>
   .prose-content :global(.markdown-editor) {

--- a/apps/web/src/lib/components/entity-detail/DetailTabs.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailTabs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Entity } from "schema";
   import { categories } from "$lib/stores/categories.svelte";
+  import { vault } from "$lib/stores/vault.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
 
   let {
@@ -28,7 +29,7 @@
         bind:value={editType}
         class="bg-theme-bg border border-theme-border text-theme-text px-2 py-1.5 text-xs focus:outline-none focus:border-theme-primary w-full rounded"
       >
-        {#each categories.list as cat}
+        {#each categories.list as cat (cat.id)}
           <option value={cat.id}>{cat.label}</option>
         {/each}
       </select>
@@ -52,15 +53,17 @@
       onclick={() => (activeTab = "status")}
       >{themeStore.jargon.tab_status.toUpperCase()}</button
     >
-    <button
-      data-testid="tab-lore"
-      class={activeTab === "lore"
-        ? "text-theme-primary border-b-2 border-theme-primary pb-2 -mb-2.5"
-        : "hover:text-theme-text transition"}
-      onclick={() => {
-        activeTab = "lore";
-      }}>{themeStore.jargon.tab_lore.toUpperCase()}</button
-    >
+    {#if !vault.isGuest}
+      <button
+        data-testid="tab-lore"
+        class={activeTab === "lore"
+          ? "text-theme-primary border-b-2 border-theme-primary pb-2 -mb-2.5"
+          : "hover:text-theme-text transition"}
+        onclick={() => {
+          activeTab = "lore";
+        }}>{themeStore.jargon.tab_lore.toUpperCase()}</button
+      >
+    {/if}
     <button
       data-testid="tab-inventory"
       class={activeTab === "inventory"

--- a/apps/web/src/lib/components/graph/GraphHUD.svelte
+++ b/apps/web/src/lib/components/graph/GraphHUD.svelte
@@ -56,120 +56,126 @@
   }
 </script>
 
-<div
-  class="absolute top-6 left-6 z-20 flex flex-col items-start gap-3 pointer-events-none"
->
-  <div
-    class="bg-theme-surface/80 backdrop-blur border border-theme-border px-4 py-1.5 flex items-center gap-2 text-[10px] font-mono tracking-widest text-theme-primary shadow-lg uppercase pointer-events-auto"
-  >
-    {#if selectedEntity}
-      {#if parentEntity}
+<div class="absolute inset-6 z-20 pointer-events-none">
+  <div class="flex flex-col items-start gap-3">
+    <div
+      class="bg-theme-surface/80 backdrop-blur border border-theme-border px-4 py-1.5 flex items-center gap-2 text-[10px] font-mono tracking-widest text-theme-primary shadow-lg uppercase pointer-events-auto"
+    >
+      {#if selectedEntity}
+        {#if parentEntity}
+          <span class="text-theme-muted"
+            >{parentEntity.title || parentEntity.id}</span
+          >
+          <span class="text-theme-muted">/</span>
+        {/if}
+        <span class="font-bold text-theme-primary"
+          >{selectedEntity.title || selectedEntity.id}</span
+        >
+      {:else}
         <span class="text-theme-muted"
-          >{parentEntity.title || parentEntity.id}</span
+          >{themeStore.jargon.vault.toUpperCase()}</span
         >
         <span class="text-theme-muted">/</span>
+        <span class="font-bold text-theme-primary">OVERVIEW</span>
       {/if}
-      <span class="font-bold text-theme-primary"
-        >{selectedEntity.title || selectedEntity.id}</span
-      >
-    {:else}
-      <span class="text-theme-muted"
-        >{themeStore.jargon.vault.toUpperCase()}</span
-      >
-      <span class="text-theme-muted">/</span>
-      <span class="font-bold text-theme-primary">OVERVIEW</span>
-    {/if}
-  </div>
-
-  {#if selectedId}
-    <div
-      class="flex items-center gap-2 text-[9px] font-bold text-theme-primary animate-pulse bg-theme-surface/40 px-2 py-0.5 border border-theme-primary/20"
-    >
-      <div class="w-1.5 h-1.5 bg-theme-primary rounded-full"></div>
-      ARCHIVE DETAIL MODE
     </div>
-  {/if}
 
-  <div class="pointer-events-auto flex items-center gap-2">
-    <CategoryFilter
-      activeCategories={graph.activeCategories}
-      onToggle={(id) => graph.toggleCategoryFilter(id)}
-      onClear={() => graph.clearCategoryFilters()}
-    />
-
-    {#if hasActiveFilters}
-      <button
-        type="button"
-        onclick={addFilteredToCanvas}
-        class="bg-theme-surface/80 backdrop-blur border border-theme-primary/30 p-1.5 rounded text-theme-primary shadow-lg hover:border-theme-primary transition-all active:scale-90"
-        title="Add all results to workspace"
-        aria-label="Add all filtered results to active workspace"
+    {#if selectedId}
+      <div
+        class="flex items-center gap-2 text-[9px] font-bold text-theme-primary animate-pulse bg-theme-surface/40 px-2 py-0.5 border border-theme-primary/20"
       >
-        <span class="icon-[lucide--layout-grid] w-4 h-4"></span>
-      </button>
+        <div class="w-1.5 h-1.5 bg-theme-primary rounded-full"></div>
+        ARCHIVE DETAIL MODE
+      </div>
     {/if}
-  </div>
 
-  <div class="pointer-events-auto">
-    <LabelFilter
-      activeLabels={graph.activeLabels}
-      filterMode={graph.labelFilterMode}
-      onToggle={(l) => graph.toggleLabelFilter(l)}
-      onToggleMode={() => graph.toggleLabelFilterMode()}
-      onClear={() => graph.clearLabelFilters()}
-    />
-  </div>
+    <div class="pointer-events-auto flex items-center gap-2">
+      <CategoryFilter
+        activeCategories={graph.activeCategories}
+        onToggle={(id) => graph.toggleCategoryFilter(id)}
+        onClear={() => graph.clearCategoryFilters()}
+      />
 
-  {#if graph.timelineMode}
-    <div
-      class="bg-timeline-dark/40 backdrop-blur border border-timeline-primary/30 px-3 py-1 flex items-center gap-2 text-[9px] font-mono tracking-[0.2em] text-timeline-primary shadow-lg uppercase pointer-events-auto"
-      transition:fade
-    >
-      <span class="icon-[lucide--history] w-3 h-3 animate-pulse"></span>
-      Chronological Synchrony Active ({graph.timelineAxis === "x"
-        ? "Horizontal"
-        : "Vertical"})
+      {#if hasActiveFilters}
+        <button
+          type="button"
+          onclick={addFilteredToCanvas}
+          class="bg-theme-surface/80 backdrop-blur border border-theme-primary/30 p-1.5 rounded text-theme-primary shadow-lg hover:border-theme-primary transition-all active:scale-90"
+          title="Add all results to workspace"
+          aria-label="Add all filtered results to active workspace"
+        >
+          <span class="icon-[lucide--layout-grid] w-4 h-4"></span>
+        </button>
+      {/if}
     </div>
-  {/if}
+
+    <div class="pointer-events-auto">
+      <LabelFilter
+        activeLabels={graph.activeLabels}
+        filterMode={graph.labelFilterMode}
+        onToggle={(l) => graph.toggleLabelFilter(l)}
+        onToggleMode={() => graph.toggleLabelFilterMode()}
+        onClear={() => graph.clearLabelFilters()}
+      />
+    </div>
+  </div>
 
   {#if ui.sharedMode}
     <div
-      class="bg-amber-900/40 backdrop-blur border border-amber-500/30 px-3 py-1 flex items-center gap-2 text-[9px] font-mono tracking-[0.2em] text-amber-300 shadow-lg uppercase pointer-events-auto"
-      transition:fade
+      class="absolute bottom-0 left-1/2 flex -translate-x-1/2 flex-col items-center gap-3 max-w-[calc(100vw-3rem)]"
     >
-      <span class="icon-[lucide--eye] w-3 h-3 animate-pulse"></span>
-      Shared Mode Active (Player Preview)
-    </div>
-  {/if}
-
-  {#if isLayoutRunning}
-    <div
-      class="bg-blue-900/40 backdrop-blur border border-blue-500/30 px-3 py-1 flex items-center gap-2 text-[9px] font-mono tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto"
-      transition:fade
-    >
-      <span class="icon-[lucide--cpu] w-3 h-3 animate-spin"></span>
-      Neural Layout Synthesis Processing...
-    </div>
-  {/if}
-
-  {#if ui.isConnecting}
-    <div
-      class="bg-blue-500/20 border border-blue-500/50 backdrop-blur-md px-4 py-2 rounded flex items-center gap-3 text-[10px] font-bold tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto"
-      transition:fade
-    >
-      <span class="icon-[lucide--link] w-3.5 h-3.5 animate-pulse"></span>
-      {#if !ui.connectingNodeId}
-        Select Source Entity
-      {:else}
-        Select Target to Connect
-      {/if}
-      <button
-        onclick={() => ui.toggleConnectMode()}
-        class="ml-2 hover:text-white transition-colors"
-        title="Cancel (Esc)"
+      <div
+        class="bg-amber-900/40 backdrop-blur border border-amber-500/30 px-3 py-1 flex items-center gap-2 text-[9px] font-mono tracking-[0.2em] text-amber-300 shadow-lg uppercase pointer-events-auto"
+        transition:fade
       >
-        [ESC]
-      </button>
+        <span class="icon-[lucide--eye] w-3 h-3 animate-pulse"></span>
+        Shared Mode Active (Player Preview)
+      </div>
     </div>
   {/if}
+
+  <div class="absolute bottom-0 left-0 flex flex-col items-start gap-3">
+    {#if graph.timelineMode}
+      <div
+        class="bg-timeline-dark/40 backdrop-blur border border-timeline-primary/30 px-3 py-1 flex items-center gap-2 text-[9px] font-mono tracking-[0.2em] text-timeline-primary shadow-lg uppercase pointer-events-auto"
+        transition:fade
+      >
+        <span class="icon-[lucide--history] w-3 h-3 animate-pulse"></span>
+        Chronological Synchrony Active ({graph.timelineAxis === "x"
+          ? "Horizontal"
+          : "Vertical"})
+      </div>
+    {/if}
+
+    {#if isLayoutRunning}
+      <div
+        class="bg-blue-900/40 backdrop-blur border border-blue-500/30 px-3 py-1 flex items-center gap-2 text-[9px] font-mono tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto"
+        transition:fade
+      >
+        <span class="icon-[lucide--cpu] w-3 h-3 animate-spin"></span>
+        Neural Layout Synthesis Processing...
+      </div>
+    {/if}
+
+    {#if ui.isConnecting}
+      <div
+        class="bg-blue-500/20 border border-blue-500/50 backdrop-blur-md px-4 py-2 rounded flex items-center gap-3 text-[10px] font-bold tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto"
+        transition:fade
+      >
+        <span class="icon-[lucide--link] w-3.5 h-3.5 animate-pulse"></span>
+        {#if !ui.connectingNodeId}
+          Select Source Entity
+        {:else}
+          Select Target to Connect
+        {/if}
+        <button
+          onclick={() => ui.toggleConnectMode()}
+          class="ml-2 hover:text-white transition-colors"
+          title="Cancel (Esc)"
+        >
+          [ESC]
+        </button>
+      </div>
+    {/if}
+  </div>
 </div>

--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import { fade } from "svelte/transition";
   import type { Core } from "cytoscape";
   import { graph } from "$lib/stores/graph.svelte";
   import { ui } from "$lib/stores/ui.svelte";
+  import { vault } from "$lib/stores/vault.svelte";
+  import { guestRoster } from "$lib/stores/guest";
   import Minimap from "./Minimap.svelte";
   import TimelineControls from "./TimelineControls.svelte";
 
@@ -41,6 +44,16 @@
         ? "Exit Connect Mode"
         : "Enter Connect Mode (C)",
   );
+
+  const activeGuests = $derived.by(() =>
+    Object.values($guestRoster).sort((a, b) => a.joinedAt - b.joinedAt),
+  );
+
+  const guestPanelHeight = $derived(
+    activeGuests.length === 0
+      ? 0
+      : Math.min(64 + activeGuests.length * 48, 280),
+  );
 </script>
 
 <div
@@ -55,6 +68,57 @@
         height={128}
         isExpanded={showMinimap}
       />
+    </div>
+  {/if}
+
+  {#if !vault.isGuest && activeGuests.length > 0}
+    <div
+      class="pointer-events-auto w-[320px] max-w-[calc(100vw-3rem)] rounded-lg border border-theme-primary/25 bg-theme-surface/95 px-3 py-2 text-[10px] text-theme-text shadow-lg backdrop-blur overflow-hidden"
+      style:height={`${guestPanelHeight}px`}
+      style:max-height="calc(100vh - 6rem)"
+      transition:fade
+    >
+      <div class="flex items-center justify-between gap-3 mb-2">
+        <div
+          class="flex items-center gap-2 text-theme-primary uppercase tracking-[0.2em] font-mono"
+        >
+          <span class="icon-[lucide--users] w-3 h-3"></span>
+          Active Guests
+        </div>
+        <span class="text-theme-muted font-mono">{activeGuests.length}</span>
+      </div>
+      <div
+        class="space-y-1.5 overflow-y-auto pr-1"
+        style:max-height="calc(100% - 1.75rem)"
+      >
+        {#each activeGuests as guest (guest.peerId)}
+          <div class="flex items-start gap-2">
+            <span
+              class="mt-1 w-2 h-2 rounded-full shrink-0 {guest.status ===
+              'viewing'
+                ? 'bg-theme-primary'
+                : 'bg-theme-muted'}"
+            ></span>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                <span class="font-bold text-theme-text truncate"
+                  >{guest.displayName}</span
+                >
+                <span
+                  class="rounded border border-theme-border/60 bg-theme-bg/60 px-1.5 py-0.5 uppercase tracking-[0.2em] text-[8px] text-theme-muted"
+                >
+                  {guest.status === "viewing" ? "viewing" : "connected"}
+                </span>
+              </div>
+              <div class="truncate text-theme-text/70">
+                {guest.currentEntityTitle
+                  ? `Viewing ${guest.currentEntityTitle}`
+                  : "Connected"}
+              </div>
+            </div>
+          </div>
+        {/each}
+      </div>
     </div>
   {/if}
 
@@ -187,7 +251,8 @@
       >
       <button
         class="text-[8px] font-black bg-theme-primary/10 text-theme-primary hover:bg-theme-primary hover:text-theme-bg px-1 rounded transition-colors uppercase tracking-tighter"
-        onclick={() => cy?.animate({ zoom: 9, duration: 500, easing: "ease-in-out-cubic" })}
+        onclick={() =>
+          cy?.animate({ zoom: 9, duration: 500, easing: "ease-in-out-cubic" })}
         title="Jump to Maximum Zoom (9x)"
       >
         MAX

--- a/apps/web/src/lib/components/modals/GuestLoginModal.svelte
+++ b/apps/web/src/lib/components/modals/GuestLoginModal.svelte
@@ -1,59 +1,75 @@
 <script lang="ts">
+  import {
+    loadGuestDisplayName,
+    saveGuestDisplayName,
+  } from "$lib/utils/guest-name-storage";
+
   let { onJoin }: { onJoin: (username: string) => void } = $props();
 
-  let username = $state("");
-  let error = $state<string | null>(null);
+  const getGuestStorage = () => {
+    if (typeof window === "undefined") return null;
+    try {
+      return window.localStorage;
+    } catch {
+      return null;
+    }
+  };
 
-  // Clear error when user types
-  $effect(() => {
-    if (username) error = null;
-  });
+  let username = $state(loadGuestDisplayName(getGuestStorage()));
+  let error = $state<string | null>(null);
 
   const handleSubmit = (e: SubmitEvent) => {
     e.preventDefault();
     error = null;
     if (!username.trim()) {
-      error = "Username is required";
+      error = "Name is required";
       return;
     }
-    if (username.length < 2) {
-      error = "Username too short";
-      return;
-    }
-    onJoin(username.trim());
+    const trimmed = username.trim();
+    saveGuestDisplayName(trimmed, getGuestStorage());
+    onJoin(trimmed);
+  };
+
+  const handleInput = () => {
+    if (error) error = null;
   };
 </script>
 
 <div
-  class="fixed inset-0 bg-black/95 flex items-center justify-center z-[100] p-4 font-mono"
+  class="fixed inset-0 bg-theme-bg/90 backdrop-blur-md flex items-center justify-center z-[100] p-4 font-mono text-theme-text"
 >
   <div
-    class="max-w-md w-full border border-green-900 bg-black p-8 rounded shadow-2xl shadow-green-900/20 text-center"
+    class="relative max-w-md w-full overflow-hidden rounded-2xl border border-theme-primary/30 bg-theme-surface/95 p-7 text-center shadow-2xl shadow-black/40"
   >
-    <div class="mb-6 flex justify-center">
-      <span class="icon-[lucide--globe] w-12 h-12 text-green-500 animate-pulse"
+    <div
+      class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-theme-primary/60 to-transparent"
+    ></div>
+
+    <div class="mb-5 flex justify-center">
+      <span
+        class="icon-[lucide--globe] w-10 h-10 text-theme-primary animate-pulse"
       ></span>
     </div>
 
     <h2
-      class="text-2xl font-bold text-green-500 mb-2 tracking-[0.2em] uppercase font-header"
+      class="text-xl font-bold text-theme-primary mb-2 tracking-[0.18em] uppercase font-header"
     >
       Shared Campaign
     </h2>
 
-    <p class="text-gray-500 text-xs mb-8 tracking-widest leading-relaxed">
-      YOU ARE ACCESSING A SHARED LORE DEPOSITORY.<br />
-      PLEASE PROVIDE A TEMPORARY IDENTIFIER TO CONTINUE.
+    <p class="text-theme-text/70 text-xs mb-6 leading-relaxed">
+      Enter a display name so the GM can identify your session.
     </p>
 
-    <form onsubmit={handleSubmit} class="space-y-6">
+    <form onsubmit={handleSubmit} class="space-y-4">
       <div class="relative">
-        <label for="username-input" class="sr-only"> Username </label>
+        <label for="username-input" class="sr-only"> Display name </label>
         <input
           id="username-input"
           bind:value={username}
-          placeholder="Enter Username..."
-          class="w-full bg-black border-b border-green-900 py-3 text-center text-green-400 focus:outline-none focus:border-green-500 transition-colors uppercase tracking-widest placeholder:text-green-900/50"
+          oninput={handleInput}
+          placeholder="Your name"
+          class="w-full rounded-lg border border-theme-border bg-theme-bg/70 py-3 px-4 text-center text-theme-text outline-none transition-colors placeholder:text-theme-muted/70 focus:border-theme-primary focus:ring-2 focus:ring-theme-primary/20"
           aria-invalid={!!error}
           aria-describedby={error ? "username-error" : undefined}
         />
@@ -61,7 +77,7 @@
           <p
             id="username-error"
             role="alert"
-            class="absolute -bottom-5 left-0 right-0 text-[10px] text-red-500 uppercase tracking-tighter"
+            class="absolute -bottom-5 left-0 right-0 text-[10px] text-red-400 uppercase tracking-tighter"
           >
             {error}
           </p>
@@ -70,13 +86,13 @@
 
       <button
         type="submit"
-        class="w-full py-3 bg-green-600 hover:bg-green-500 text-black font-bold tracking-[0.3em] uppercase font-header transition shadow-lg shadow-green-900/10"
+        class="w-full rounded-lg border border-theme-primary/30 bg-theme-primary py-3 font-bold tracking-[0.24em] uppercase font-header text-theme-bg transition shadow-lg shadow-theme-primary/10 hover:bg-theme-primary/90 hover:border-theme-primary"
       >
-        ACCESS ARCHIVE
+        JOIN
       </button>
     </form>
 
-    <p class="mt-8 text-[10px] text-gray-700 uppercase tracking-widest">
+    <p class="mt-6 text-[10px] text-theme-muted/80 uppercase tracking-widest">
       Read-only mode enabled. No changes will be persisted.
     </p>
   </div>

--- a/apps/web/src/lib/components/modals/NodeReadModal.svelte
+++ b/apps/web/src/lib/components/modals/NodeReadModal.svelte
@@ -219,7 +219,7 @@
           {/if}
 
           <!-- Lore / Metadata Fields -->
-          {#if entity.lore}
+          {#if !vault.isGuest && entity.lore}
             <div
               class="mb-8 p-4 bg-green-900/10 border-l-2 border-green-500 rounded-r"
             >

--- a/apps/web/src/lib/components/zen/ZenContent.order.test.ts
+++ b/apps/web/src/lib/components/zen/ZenContent.order.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("ZenContent ordering", () => {
+  it("keeps chronicle before lore in the source template", () => {
+    const source = readFileSync(
+      `${process.cwd()}/src/lib/components/zen/ZenContent.svelte`,
+      "utf8",
+    );
+
+    const chronicleIndex = source.indexOf("<!-- Chronicle -->");
+    const loreIndex = source.indexOf(
+      "{#if !vault.isGuest && (editState.isEditing || entity?.lore)}",
+    );
+
+    expect(chronicleIndex).toBeGreaterThan(-1);
+    expect(loreIndex).toBeGreaterThan(-1);
+    expect(chronicleIndex).toBeLessThan(loreIndex);
+  });
+});

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { vault } from "$lib/stores/vault.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
   import TemporalEditor from "$lib/components/timeline/TemporalEditor.svelte";
@@ -146,30 +147,29 @@
       {/if}
     </div>
 
-    <!-- Deep Lore -->
-    <div>
-      <h2
-        class="text-xl font-header font-bold text-theme-accent mb-4 flex items-center gap-2 border-b border-theme-border pb-2"
-      >
-        <span class="icon-[lucide--scroll] w-5 h-5"></span>
-        {themeStore.jargon.lore_secrets}
-      </h2>
-      {#if editState.isEditing}
-        <MarkdownEditor
-          content={editState.lore}
-          editable={true}
-          onUpdate={(md) => (editState.lore = md)}
-        />
-      {:else}
-        <div
-          class="bg-theme-accent/5 border border-theme-border p-6 rounded-lg min-h-[100px] prose-container"
+    {#if !vault.isGuest && (editState.isEditing || entity?.lore)}
+      <div>
+        <h2
+          class="text-xl font-header font-bold text-theme-primary mb-4 flex items-center gap-2 border-b border-theme-border pb-2"
         >
+          <span class="icon-[lucide--scroll-text] w-5 h-5"></span>
+          {themeStore.jargon.lore_header}
+        </h2>
+        {#if editState.isEditing}
           <MarkdownEditor
-            content={entity?.lore || "No deep lore recorded."}
-            editable={false}
+            content={editState.lore}
+            editable={true}
+            onUpdate={(md) => (editState.lore = md)}
           />
-        </div>
-      {/if}
-    </div>
+        {:else}
+          <div class="prose-container">
+            <MarkdownEditor
+              content={entity?.lore || "No detailed lore available."}
+              editable={false}
+            />
+          </div>
+        {/if}
+      </div>
+    {/if}
   </div>
 </div>

--- a/apps/web/src/lib/stores/guest.ts
+++ b/apps/web/src/lib/stores/guest.ts
@@ -5,4 +5,17 @@ export interface GuestInfo {
   joinedAt: Date;
 }
 
+export type GuestPresenceStatus = "connected" | "idle" | "viewing";
+
+export interface GuestSession {
+  peerId: string;
+  displayName: string;
+  joinedAt: number;
+  lastSeenAt: number;
+  status: GuestPresenceStatus;
+  currentEntityId: string | null;
+  currentEntityTitle: string | null;
+}
+
 export const guestInfo = writable<GuestInfo | null>(null);
+export const guestRoster = writable<Record<string, GuestSession>>({});

--- a/apps/web/src/lib/stores/theme.svelte.ts
+++ b/apps/web/src/lib/stores/theme.svelte.ts
@@ -28,6 +28,11 @@ export class ThemeStore {
   currentThemeId = $state<string>(DEFAULT_THEME.id); // Will be set in constructor/init
   previewThemeId = $state<string | null>(null);
 
+  /**
+   * Optional callback for when the theme is explicitly changed.
+   */
+  onThemeUpdate?: (id: string) => void;
+
   // Dependencies
   private uiStore: typeof defaultUiStore;
   private storage: IThemeStorage;
@@ -183,6 +188,7 @@ export class ThemeStore {
     if (!THEMES[id]) return;
 
     this.currentThemeId = id;
+    this.onThemeUpdate?.(id);
     if (browser) {
       // Don't persist theme if in demo mode
       if (this.uiStore.isDemoMode) return;

--- a/apps/web/src/lib/stores/theme.test.ts
+++ b/apps/web/src/lib/stores/theme.test.ts
@@ -44,6 +44,8 @@ describe("ThemeStore", () => {
       store.currentThemeId = "modern";
       store.previewTheme("fantasy");
       expect(store.resolveJargon("entity")).toBe("Chronicle");
+      expect(store.currentThemeId).toBe("modern");
+      expect(mockStorage.saveLocal).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -680,7 +680,7 @@ export class VaultStore {
       }
 
       if (text) {
-        const { metadata: data, content: body } = this._helpers.parseMarkdown(content);
+        const { metadata: data, content: body } = this._helpers.parseMarkdown(text);
         const freshLore = (data as any).lore || "";
 
         const entityToUpdate = this.entities[id];
@@ -866,7 +866,7 @@ export class VaultStore {
 
       const text = await readFileAsText(vaultDir, path);
       if (text) {
-        const { metadata: data, content: body } = this._helpers.parseMarkdown(content);
+        const { metadata: data, content: body } = parseMarkdown(text);
         const lore = (data as any).lore || "";
 
         this.repository.entities[id] = {

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -99,247 +99,966 @@ export class VaultStore {
 
   /**
    * Tracks which entity IDs have their `content` and `lore` fields fully
-   * loaded. Critical for P2P and synced vaults.
+   * populated in `this.entities`.  Entities loaded from the Dexie graph-entity
+   * cache start with `content = ""` to keep the initial load lightweight;
+   * calling `loadEntityContent(id)` fills in these fields on demand.
    */
-  private loadedContentIds = new Set<string>();
+  private _contentLoadedIds = new Set<string>();
+  private _contentVerifiedIds = new Set<string>();
 
-  constructor(
-    public repository: VaultRepository = new VaultRepository(),
-    private syncCoordinator: SyncCoordinator = new SyncCoordinator(
-      repository,
-      createSyncEngine(),
-      syncNotifier,
-    ),
-    private assetManager: AssetManager = new AssetManager(
-      assetIOAdapter,
-      imageProcessor,
-    ),
-  ) {
-    this.crudManager = new VaultCrudManager(repository, assetManager);
-    this.lifecycleManager = new VaultLifecycleManager(
-      repository,
-      syncCoordinator,
-      assetManager,
-    );
-
-    // Wire up events
-    repository.onEntityUpdate = (e) => {
-      this.onEntityUpdate?.(e);
-      vaultEventBus.emit("entity-updated", { entity: e });
-    };
-    repository.onEntityDelete = (id) => {
-      this.onEntityDelete?.(id);
-      vaultEventBus.emit("entity-deleted", { entityId: id });
-    };
-    repository.onBatchUpdate = (updates) => {
-      this.onBatchUpdate?.(updates);
-      vaultEventBus.emit("batch-updated", { updates });
-    };
-
-    if (browser) {
-      this.channel = new BroadcastChannel("vault-sync");
-      this.channel.onmessage = (event) => {
-        if (event.data.type === "VAULT_UPDATED") {
-          this.syncCoordinator.triggerSync();
-        }
-      };
-    }
-  }
-
-  // Getters for Repository State
+  // Delegated Getters
   get entities() {
     return this.repository.entities;
   }
-  get allEntities() {
-    return this.repository.allEntities;
-  }
+
+  // ⚡ Bolt Optimization: Use a derived array to avoid per-node allocations via Object.values()
+  // in hot loops (e.g., timeline, search, graph syncing).
+  allEntities = $derived.by(() => {
+    if (!this.repository) return [];
+    return Object.values(this.repository.entities);
+  });
+
   get maps() {
-    return this.repository.maps;
-  }
-  get allMaps() {
-    return this.repository.allMaps;
+    return mapRegistry.maps;
   }
   get canvases() {
-    return this.repository.canenses;
-  }
-  get allCanvases() {
-    return this.repository.allCanvases;
+    return canvasRegistry.canvases;
   }
   get activeVaultId() {
-    return this.repository.activeVaultId;
+    return vaultRegistry.activeVaultId;
   }
-  get activeVaultName() {
-    return this.repository.activeVaultName;
+  get vaultName() {
+    return vaultRegistry.vaultName;
   }
-
+  get saveQueue() {
+    return this.repository.saveQueue;
+  }
   get isGuest() {
-    return uiStore.isGuestMode;
+    return !!uiStore.isGuestMode;
   }
 
-  // Lifecycle Methods
-  async initialize() {
-    this.status = "loading";
-    try {
-      await this.lifecycleManager.initialize();
-      this.isInitialized = true;
-      this.status = "idle";
-    } catch (err: any) {
-      this.status = "error";
-      this.errorMessage = err.message;
-    }
-  }
-
-  async openVault(vaultId: string) {
-    this.status = "loading";
-    try {
-      await this.lifecycleManager.openVault(vaultId);
-      this.isInitialized = true;
-      this.status = "idle";
-    } catch (err: any) {
-      this.status = "error";
-      this.errorMessage = err.message;
-    }
-  }
-
-  async closeVault() {
-    await this.lifecycleManager.closeVault();
-    this.isInitialized = false;
-    this.status = "idle";
-  }
-
-  // CRUD Operations
-  async createEntity(type: Entity["type"], title: string) {
-    return await this.crudManager.createEntity(
-      await this.getActiveVaultHandle(),
-      type,
-      title,
+  constructor(
+    public repository = new VaultRepository(fileIOAdapter),
+    private assetManager = new AssetManager(assetIOAdapter, imageProcessor),
+    public syncCoordinator: SyncCoordinator | null = null,
+  ) {
+    this.crudManager = new VaultCrudManager(
+      () => this.entities,
+      (entities) => {
+        this.repository.entities = entities;
+      },
+      (entity) => this.scheduleSave(entity),
+      () => this.getActiveVaultHandle(),
+      () => this.activeVaultId,
+      () => this.isGuest,
+      () => this.services,
+      (id) => this.onEntityDelete && this.onEntityDelete(id),
+      (entity) => this.onEntityUpdate && this.onEntityUpdate(entity),
+      (updates) => this.onBatchUpdate && this.onBatchUpdate(updates),
+      (path) => this.assetManager.releaseImageUrl(path),
     );
-  }
 
-  async batchCreateEntities(inputs: BatchCreateInput[]) {
-    return await this.crudManager.batchCreateEntities(
-      await this.getActiveVaultHandle(),
-      inputs,
+    this.lifecycleManager = new VaultLifecycleManager(
+      (s) => (this.status = s),
+      (m) => (this.errorMessage = m),
+      () => this.activeVaultId,
+      () => this.getActiveVaultHandle(),
+      this.repository,
+      this.assetManager,
+      (skipSync) => this.loadFiles(skipSync),
+      () => this.entities,
+      (n) => (this.demoVaultName = n),
+      (v) => (this.isInitialized = v),
+      () => this.services,
+      (c) => (this.hasConflictFiles = c),
+      (id) => (this.selectedEntityId = id),
+      vaultRegistry,
+      themeStore,
+      mapRegistry,
+      canvasRegistry,
+      (path, handle) => this.ensureAssetPersisted(path, handle),
     );
-  }
-
-  async updateEntity(id: string, patch: Partial<LocalEntity>) {
-    return await this.crudManager.updateEntity(
-      await this.getActiveVaultHandle(),
-      id,
-      patch,
-    );
-  }
-
-  batchUpdate(updates: Record<string, Partial<LocalEntity>>) {
-    this.repository.batchUpdate(updates);
-  }
-
-  async deleteEntity(id: string) {
-    return await this.crudManager.deleteEntity(
-      await this.getActiveVaultHandle(),
-      id,
-    );
-  }
-
-  // Map Operations
-  async createMap(name: string, assetPath: string, dimensions: any) {
-    const id = await this.crudManager.createMap(
-      await this.getActiveVaultHandle(),
-      name,
-      assetPath,
-      dimensions,
-    );
-    await mapRegistry.touch(id);
-    return id;
-  }
-
-  async saveMaps() {
-    return await this.crudManager.saveMaps(await this.getActiveVaultHandle());
-  }
-
-  // Canvas Operations
-  async createCanvas(name: string) {
-    const id = await this.crudManager.createCanvas(
-      await this.getActiveVaultHandle(),
-      name,
-    );
-    await canvasRegistry.touch(id);
-    return id;
-  }
-
-  async saveCanvas(id: string, options?: { explicitVaultId?: string }) {
-    let handle = await this.getActiveVaultHandle();
-
-    // If an explicit vault is provided, we must use that handle instead
-    if (options?.explicitVaultId && options.explicitVaultId !== this.activeVaultId) {
-      const root = await getOpfsRoot();
-      handle = await getVaultDir(root, options.explicitVaultId);
-    }
-
-    return await this.crudManager.saveCanvas(handle, id);
-  }
-
-  async deleteCanvas(id: string) {
-    await this.crudManager.deleteCanvas(await this.getActiveVaultHandle(), id);
-    await canvasRegistry.touch(id);
-  }
-
-  // Sync Methods
-  async triggerSync() {
-    return await this.syncCoordinator.triggerSync();
-  }
-
-  // Helper Methods
-  async getActiveVaultHandle() {
-    return await this.repository.getActiveVaultHandle();
-  }
-
-  async getActiveSyncHandle() {
-    return await this.repository.getActiveSyncHandle();
-  }
-
-  async loadEntityContent(id: string) {
-    if (this.loadedContentIds.has(id)) return;
-
-    try {
-      const entity = this.entities[id];
-      if (!entity) return;
-
-      if (!this._helpers.readFileAsText) {
-        const { readFileAsText: rf, parseMarkdown } = await import(
-          "../utils/opfs"
-        );
-        this._helpers.readFileAsText = rf;
-        this._helpers.parseMarkdown = parseMarkdown;
-      }
-
-      const handle = await this.getActiveVaultHandle();
-      if (!handle && !this.isGuest) return;
-
-      let content = "";
-      if (this.isGuest) {
-        // In guest mode, the content should already be in the entity object
-        // because the host serializes it. If it's missing, we can't do much
-        // unless we add a GET_CONTENT P2P message.
-        content = (entity as any).content || "";
-      } else {
-        const path = entity._path;
-        if (!path) return;
-        content = await this._helpers.readFileAsText(handle, path);
-      }
-
-      const { metadata: data, content: body } = this._helpers.parseMarkdown(content);
-
-      this.repository.entities[id] = {
-        ...entity,
-        ...data,
-        content: body,
+    if (typeof window !== "undefined") {
+      this.channel = new BroadcastChannel("codex-vault-sync");
+      this.channel.onmessage = (event) => {
+        if (
+          event.data.type === "RELOAD_VAULT" &&
+          event.data.vaultId === this.activeVaultId
+        ) {
+          this.loadFiles();
+        }
       };
-      this.loadedContentIds.add(id);
-    } catch (err) {
-      console.warn(`[VaultStore] Failed to load content for ${id}`, err);
+
+      mapRegistry.init(this.repository.saveQueue);
+      canvasRegistry.init(this.repository.saveQueue);
     }
+  }
+
+  // --- External Sync Methods ---
+  broadcastVaultUpdate() {
+    if (this.channel && this.activeVaultId) {
+      this.channel.postMessage({
+        type: "RELOAD_VAULT",
+        vaultId: this.activeVaultId,
+      });
+    }
+  }
+
+  async ensureServicesInitialized() {
+    if (this.services && this.syncCoordinator) return;
+
+    try {
+      const searchModule = await import("../services/search");
+      const aiModule = await import("../services/ai");
+
+      if (searchModule && aiModule) {
+        this.services = {
+          search: searchModule.searchService,
+          ai: {
+            clearStyleCache: () =>
+              aiModule.contextRetrievalService.clearStyleCache(),
+            expandQuery: (k, q, h) =>
+              aiModule.textGenerationService.expandQuery(k, q, h),
+          },
+        };
+      }
+    } catch (err) {
+      debugStore.error("[VaultStore] Failed to lazy-load services", err);
+    }
+
+    if (!this.syncCoordinator && typeof window !== "undefined") {
+      const engine = await createSyncEngine();
+      this.syncCoordinator = new SyncCoordinator(
+        syncIOAdapter,
+        engine,
+        syncNotifier,
+      );
+    }
+  }
+
+  async init(injectedServices?: IVaultServices) {
+    // Separate controller for init path to allow independent cancellation
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    this.isInitialized = false;
+    this.status = "loading";
+    this.assetManager.clear();
+    this.repository.clear();
+
+    if (injectedServices) {
+      this.services = injectedServices;
+    } else if (typeof window !== "undefined") {
+      // Background: Pre-load modules needed for content loading to eliminate interaction latency
+      import("../utils/opfs")
+        .then((m) => (this._helpers.readFileAsText = m.readFileAsText))
+        .catch(() => {});
+      import("../utils/markdown")
+        .then((m) => (this._helpers.parseMarkdown = m.parseMarkdown))
+        .catch(() => {});
+
+      await this.ensureServicesInitialized();
+    }
+
+    try {
+      await vaultRegistry.init();
+      const opfsRoot = vaultRegistry.rootHandle;
+      if (!opfsRoot) throw new Error("OPFS Root failed to initialize");
+
+      if (uiStore.isDemoMode) {
+        this.isInitialized = true;
+        this.status = "idle";
+        return;
+      }
+
+      const db = await getDB();
+      const savedVisibility = await db.get("settings", "defaultVisibility");
+      if (savedVisibility) this.defaultVisibility = savedVisibility;
+
+      const migration = await vaultMigration.checkForMigration();
+      if (migration.required && migration.handle) {
+        this.migrationRequired = true;
+        await vaultMigration.runMigration(
+          opfsRoot,
+          migration.handle,
+          true,
+          () => this.loadFiles(),
+          (status, err) => {
+            this.status = status;
+            if (err) this.errorMessage = err;
+          },
+        );
+      }
+
+      await vaultMigration.migrateStructure(opfsRoot);
+
+      if (this.activeVaultId) {
+        await themeStore.loadForVault(this.activeVaultId);
+        await this.loadFiles();
+      } else {
+        await vaultRegistry.listVaults();
+        if (vaultRegistry.availableVaults.length > 0) {
+          const firstVault = vaultRegistry.availableVaults[0];
+          await vaultRegistry.setActiveVault(firstVault.id);
+          await themeStore.loadForVault(firstVault.id);
+          await this.loadFiles();
+        }
+      }
+    } catch (err: any) {
+      debugStore.error("[VaultStore] Init failed", err);
+      console.warn("[VaultStore] Init failed, falling back to Guest Mode", err);
+
+      uiStore.isGuestMode = true;
+      this.status = "idle";
+      this.errorMessage =
+        err?.name === "QuotaExceededError"
+          ? "Storage full. Running in Guest Mode (changes will not be saved)."
+          : "Storage access denied. Running in Guest Mode.";
+
+      // Ensure we have at least the welcome content by loading it via fetch
+      if (Object.keys(this.entities).length === 0) {
+        try {
+          const response = await fetch("/vault-samples/welcome.json");
+          const data = await response.json();
+          await this.loadDemoData("Welcome", data.entities || data);
+        } catch (e) {
+          console.warn("Failed to load fallback demo data", e);
+        }
+      }
+    } finally {
+      this.isInitialized = true;
+      if (!signal.aborted) {
+        await this.checkForConflicts(signal);
+      }
+      if ((this.status as string) !== "error" && !signal.aborted) {
+        this.status = "idle";
+        if (this.activeVaultId) {
+          window.dispatchEvent(
+            new CustomEvent("vault-switched", {
+              detail: { id: this.activeVaultId },
+            }),
+          );
+        }
+      }
+    }
+  }
+
+  private _vaultHandle: FileSystemDirectoryHandle | undefined = undefined;
+
+  async loadFiles(skipSyncIfWarm = true) {
+    if (!this.activeVaultId) return;
+    const vaultIdAtStart = this.activeVaultId;
+
+    // ABORT: Cancel any ongoing background sync from a previous vault switch
+    if (this.syncAbortController) {
+      this.syncAbortController.abort();
+    }
+    this.syncAbortController = new AbortController();
+    const signal = this.syncAbortController.signal;
+
+    this.status = "loading";
+    this._contentLoadedIds = new Set();
+    this._contentVerifiedIds = new Set();
+    this._vaultHandle = undefined; // Reset handle on load
+    this.syncStats = {
+      updated: 0,
+      created: 0,
+      deleted: 0,
+      failed: 0,
+      total: 0,
+      progress: 0,
+    };
+
+    try {
+      debugStore.log(`[VaultStore] Loading files for vault: ${vaultIdAtStart}`);
+
+      // Reset event bus to clear listeners from previous vault sessions (prevent leaks)
+      vaultEventBus.reset();
+
+      // BROADCAST: Opening vault
+      vaultEventBus.emit({
+        type: "VAULT_OPENING",
+        vaultId: vaultIdAtStart,
+      });
+
+      if (this.services) {
+        this.services.ai.clearStyleCache();
+      }
+
+      // 1. Cache-First: Preload graph metadata from Dexie immediately.
+      const cachedMap = await cacheService.preloadVault(vaultIdAtStart);
+
+      // Race check after async preload
+      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+      if (cachedMap.size > 0) {
+        // CRITICAL: We start with a FRESH map.
+        // Do NOT spread this.repository.entities as it might contain stale data from previous vault.
+        const entityMap: Record<string, LocalEntity> = {};
+        for (const { entity: e } of cachedMap.values()) {
+          const existing = entityMap[e.id];
+
+          // Preserve content/lore if they are already loaded in memory
+          const finalContent =
+            existing?.content && !e.content ? existing.content : e.content;
+
+          const finalLore = existing?.lore && !e.lore ? existing.lore : e.lore;
+
+          entityMap[e.id] = {
+            ...e,
+            content: finalContent,
+            lore: finalLore,
+          };
+        }
+        // Push to repository to trigger immediate UI/Graph rendering
+        this.repository.entities = entityMap;
+        debugStore.log(
+          `[VaultStore] Cache-First: Populated ${cachedMap.size} entities from Dexie.`,
+        );
+
+        // BROADCAST: Initial cache data ready
+        vaultEventBus.emit({
+          type: "CACHE_LOADED",
+          vaultId: vaultIdAtStart,
+          entities: entityMap,
+        });
+
+        // IMPORTANT: We set status to idle NOW. The graph is visible and interactive.
+        this.status = "idle";
+
+        if (skipSyncIfWarm) {
+          debugStore.log(
+            "[VaultStore] Cache is warm. Skipping OPFS background sync for instant load.",
+          );
+
+          // Start background tasks
+          mapRegistry.loadFromVault(vaultIdAtStart);
+          canvasRegistry.loadFromVault(vaultIdAtStart);
+
+          // Resolve handle in background for image resolution
+          this.getActiveVaultHandle();
+          return;
+        }
+      }
+
+      // 2. FS-Sync: Resolve OPFS handle and perform full synchronization
+      const vaultDir = await this.getActiveVaultHandle();
+
+      // Race check after async handle resolution
+      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+      if (!vaultDir) {
+        if (this.status !== "idle") {
+          this.status = cachedMap.size > 0 ? "idle" : "error";
+          if (this.status === "error") {
+            this.errorMessage = "Failed to resolve vault directory handle";
+          }
+        }
+        return;
+      }
+
+      // 3. Local-Sync: If a local directory handle is persisted, sync it to OPFS first.
+      const localHandle = await this.getActiveSyncHandle();
+      if (localHandle) {
+        debugStore.log(
+          `[VaultStore] Local sync handle found for ${vaultIdAtStart}. Synchronizing...`,
+        );
+        await this.ensureServicesInitialized();
+        if (this.syncCoordinator) {
+          try {
+            await this.syncCoordinator.syncWithLocalFolder(
+              vaultIdAtStart,
+              vaultDir,
+              this.entities,
+              () => this.repository.waitForAllSaves(),
+              (state) => {
+                // ONLY update status if we are still on the same vault AND not aborted
+                if (this.activeVaultId === vaultIdAtStart && !signal.aborted) {
+                  this.status = state.status;
+                  if (state.errorMessage)
+                    this.errorMessage = state.errorMessage;
+                }
+              },
+              () => this.checkForConflicts(),
+              signal,
+              (stats) => {
+                if (this.activeVaultId === vaultIdAtStart && !signal.aborted) {
+                  this.syncStats = { ...this.syncStats, ...stats };
+                }
+              },
+            );
+            if (signal.aborted) return;
+            debugStore.log("[VaultStore] Local sync complete.");
+          } catch (err) {
+            debugStore.error("[VaultStore] Local sync failed", err);
+            // We continue anyway, maybe OPFS has some data
+          }
+        }
+      }
+
+      // Final race check before starting repository scan
+      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+      // Ensure status is idle if we have cache, otherwise keep loading until we get first FS results
+      if (cachedMap.size > 0) {
+        this.status = "idle";
+      }
+
+      const syncPromise = this.repository.loadFiles(
+        vaultIdAtStart,
+        vaultDir,
+        async (_chunk, current, total, newOrChanged) => {
+          // Race check inside progress callback
+          if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+          this.syncStats.total = total;
+          this.syncStats.progress = Math.round((current / total) * 100);
+          this.syncStats.created = current;
+
+          const changedIds = Object.keys(newOrChanged);
+
+          if (changedIds.length > 0) {
+            // Track entities that arrived from OPFS (cache miss path) — they
+            // already have content populated so no lazy load is needed later.
+            for (const id of changedIds) {
+              const entity = newOrChanged[id];
+              if (entity.content) {
+                this._contentLoadedIds.add(entity.id);
+                this._contentVerifiedIds.add(entity.id);
+              }
+            }
+
+            // BROADCAST: Chunk indexed
+            vaultEventBus.emit({
+              type: "SYNC_CHUNK_READY",
+              vaultId: vaultIdAtStart,
+              entities: this.entities,
+              newOrChangedIds: changedIds,
+            });
+          }
+        },
+      );
+
+      if (this.status === "loading") {
+        await syncPromise;
+      } else {
+        // Just catch errors for background sync
+        syncPromise.catch((err: any) => {
+          debugStore.error("[VaultStore] Background sync failed", err);
+        });
+      }
+
+      if (this.status === "loading") {
+        debugStore.log(
+          `[VaultStore] Load complete. Indexed ${this.syncStats.created} entities.`,
+        );
+        this.status = "idle";
+      }
+
+      await mapRegistry.loadFromVault(vaultIdAtStart);
+      await canvasRegistry.loadFromVault(vaultIdAtStart);
+
+      // BROADCAST: Full sync complete
+      vaultEventBus.emit({
+        type: "SYNC_COMPLETE",
+        vaultId: vaultIdAtStart,
+      });
+    } catch (err: any) {
+      debugStore.error("[VaultStore] Load failed", err);
+      this.status = "error";
+      this.errorMessage = err.message;
+    } finally {
+      this.isInitialized = true;
+      if (!signal.aborted) {
+        await this.checkForConflicts(signal);
+      }
+      if ((this.status as string) !== "error" && !signal.aborted) {
+        this.status = "idle";
+        if (this.activeVaultId) {
+          window.dispatchEvent(
+            new CustomEvent("vault-switched", {
+              detail: { id: this.activeVaultId },
+            }),
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Loads the `content` and `lore` fields for the entity with the given ID
+   * and updates `this.entities[id]` in place.  Subsequent calls for the same
+   * ID are no-ops (unless the previous attempt failed with a transient error,
+   * in which case the next call will retry).
+   *
+   * This is the primary entry-point for lazy content loading — call it
+   * whenever the entity is "opened" (detail panel, read modal, edit mode, etc.)
+   * to ensure the full entity data is available for rendering.
+   */
+  async loadEntityContent(id: string): Promise<void> {
+    if (!id || !this.activeVaultId) return;
+    if (this._contentVerifiedIds.has(id)) return;
+
+    // Verify entity exists before starting async work.
+    const currentEntity = this.entities[id];
+    if (!currentEntity) return;
+
+    // PRIORITY 1: Try Dexie Cache for immediate Chronicle (content) and Lore
+    // No lock needed for Tier 1 IDB read.
+    let cached: { content: string; lore: string } | null = null;
+    let cacheErrored = false;
+    try {
+      cached = await cacheService.getEntityContent(this.activeVaultId, id);
+      if (cached !== null) {
+        const latest = this.entities[id];
+        if (latest && (!latest.content || latest.lore === undefined)) {
+          // Surgical update to the existing reactive proxy
+          this.repository.entities[id] = {
+            ...latest,
+            content: cached.content,
+            lore: cached.lore,
+          };
+          this._contentLoadedIds.add(id);
+          debugStore.log(
+            `[VaultStore] Priority 1 hit: Loaded chronicle/lore from cache for ${id}`,
+          );
+        }
+      }
+    } catch (cacheErr) {
+      cacheErrored = true;
+      debugStore.warn(
+        `[VaultStore] Priority 1 cache load failed for ${id}`,
+        cacheErr,
+      );
+    }
+
+    // Re-check after Priority 1
+    if (this._contentVerifiedIds.has(id)) return;
+
+    try {
+      const path = currentEntity._path || [`${id}.md`];
+
+      // Ensure helpers are available (fallback to dynamic import if background load hasn't finished)
+      const readFileAsText =
+        this._helpers.readFileAsText ||
+        (await import("../utils/opfs")).readFileAsText;
+      const parseMarkdown =
+        this._helpers.parseMarkdown ||
+        (await import("../utils/markdown")).parseMarkdown;
+
+      // PRIORITY 2 & 3: Load Lore (and fresh Chronicle) from Markdown file
+      let text = "";
+
+      const vaultDir = await this.getActiveVaultHandle();
+      if (vaultDir) {
+        try {
+          text = await readFileAsText(vaultDir, path);
+        } catch {
+          // Fall through
+        }
+      }
+
+      if (!text) {
+        const localHandle = await syncIOAdapter.getLocalHandle(
+          this.activeVaultId,
+        );
+        if (localHandle) {
+          try {
+            if (
+              (await localHandle.queryPermission({ mode: "read" })) ===
+              "granted"
+            ) {
+              text = await readFileAsText(localHandle, path);
+            }
+          } catch (err) {
+            debugStore.warn(
+              `[VaultStore] Priority 3 failed for ${id} from Local FS fallback`,
+              err,
+            );
+          }
+        }
+      }
+
+      if (text) {
+        const { metadata: data, content: body } = this._helpers.parseMarkdown(content);
+        const freshLore = (data as any).lore || "";
+
+        const entityToUpdate = this.entities[id];
+        if (entityToUpdate) {
+          // Update the entity surgically. Never overwrite with empty if Tier 1 already had content
+          // and Priority 2/3 somehow returned empty content (unless both are empty).
+          const finalContent = body || entityToUpdate.content || "";
+          const finalLore = freshLore || entityToUpdate.lore || "";
+
+          const updatedEntity = {
+            ...entityToUpdate,
+            content: finalContent,
+            lore: finalLore,
+          };
+
+          this.repository.entities[id] = updatedEntity;
+
+          this._contentLoadedIds.add(id);
+          this._contentVerifiedIds.add(id);
+
+          debugStore.log(
+            `[VaultStore] Verified ${id} from source: contentLen=${finalContent.length}, loreLen=${finalLore.length}`,
+          );
+
+          const isStale =
+            finalContent !== (cached?.content ?? null) ||
+            finalLore !== (cached?.lore ?? null);
+          const hasContent = finalContent || finalLore;
+
+          if (isStale && (cached !== null || hasContent)) {
+            // CRITICAL: Pass the plain updatedEntity, not the reactive proxy
+            // Background: No need to await
+            cacheService.set(
+              `${this.activeVaultId}:${path.join("/")}`,
+              Date.now(),
+              updatedEntity,
+            );
+          }
+        }
+      } else if (cached === null && !cacheErrored) {
+        this._contentVerifiedIds.add(id); // Even if missing, we verified the absence
+        debugStore.warn(
+          `[VaultStore] Content truly missing for ${id} in all tiers`,
+        );
+      }
+    } catch (err) {
+      debugStore.error(`[VaultStore] Failed to load content for ${id}:`, err);
+    }
+  }
+
+  scheduleSave(entity: LocalEntity | Entity): Promise<void> {
+    if (this.onEntityUpdate) this.onEntityUpdate(entity as LocalEntity);
+
+    const vaultIdAtStart = this.activeVaultId;
+    if (!vaultIdAtStart) return Promise.resolve();
+
+    if (this.services) {
+      const path =
+        (entity as LocalEntity)._path?.join("/") || `${entity.id}.md`;
+      const keywords = [
+        ...(entity.tags || []),
+        entity.lore || "",
+        ...Object.values(entity.metadata || {}).flat(),
+      ].join(" ");
+      const promise = this.services.search.index({
+        id: entity.id,
+        title: entity.title,
+        content: (entity as LocalEntity).content,
+        lore: (entity as LocalEntity).lore,
+        type: entity.type,
+        path,
+        keywords,
+        updatedAt: Date.now(),
+      });
+      if (promise && promise.catch) {
+        promise.catch((err) =>
+          debugStore.warn(`[VaultStore] Search index error: ${err}`),
+        );
+      }
+    }
+
+    if (uiStore.isDemoMode) return Promise.resolve();
+
+    // Use a per-entity lock for saving to serialize writes to the same file
+    // while allowing concurrent saves to DIFFERENT files.
+    const lockKey = entity.id;
+
+    return this.saveQueue.enqueue(lockKey, async () => {
+      // 1. Always get the absolute latest state from the store
+      let latestEntity = this.entities[entity.id];
+      if (!latestEntity) return;
+
+      // 2. CRITICAL SAFETY: If content hasn't been marked as loaded,
+      // we MUST try to load it before saving to avoid overwriting with empty.
+      if (!this._contentLoadedIds.has(entity.id)) {
+        // Note: loadEntityContent is already queued, but we need it NOW.
+        // We use a separate internal Load helper that avoids the queue to prevent deadlocks.
+        await this.internalLoadContent(entity.id);
+        // Re-fetch after load
+        latestEntity = this.entities[entity.id] || latestEntity;
+      }
+      this.status = "saving";
+      try {
+        // Resolution must happen per-save to ensure we use the correct handle for the vaultIdAtStart
+        const vaultHandle = await this.getSpecificVaultHandle(vaultIdAtStart);
+        if (!vaultHandle) return;
+
+        await this.repository.saveToDisk(
+          vaultHandle,
+          vaultIdAtStart,
+          latestEntity,
+          this.isGuest,
+        );
+
+        // Update Dexie cache immediately so it's fresh for Tier 1 lookups
+        const path = latestEntity._path || [`${latestEntity.id}.md`];
+        await cacheService.set(
+          `${vaultIdAtStart}:${path.join("/")}`,
+          Date.now(),
+          latestEntity,
+        );
+
+        // Mark as verified since we just wrote it
+        this._contentVerifiedIds.add(latestEntity.id);
+
+        this.status = "idle";
+      } catch (error) {
+        debugStore.error("[VaultStore] Failed to save entity to disk", error);
+        this.status = "error";
+        this.errorMessage = "Failed to access storage for saving.";
+      }
+    });
+  }
+
+  async getSpecificVaultHandle(
+    vaultId: string,
+  ): Promise<FileSystemDirectoryHandle | undefined> {
+    if (!vaultId || !vaultRegistry.rootHandle) return undefined;
+
+    try {
+      const vaultsDir = await vaultRegistry.rootHandle.getDirectoryHandle(
+        "vaults",
+        { create: true },
+      );
+      return await vaultsDir.getDirectoryHandle(vaultId, {
+        create: true,
+      });
+    } catch (err) {
+      debugStore.warn(
+        `[VaultStore] Failed to get handle for vault: ${vaultId}`,
+        err,
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Internal helper to load content WITHOUT using the task queue.
+   * ONLY call this from within a queued task or when you know no write is active.
+   */
+  private async internalLoadContent(id: string): Promise<void> {
+    const currentEntity = this.entities[id];
+    if (!currentEntity) return;
+
+    try {
+      const path = currentEntity._path || [`${id}.md`];
+      const opfsModule = await import("../utils/opfs");
+      const markdownModule = await import("../utils/markdown");
+
+      if (!opfsModule || !markdownModule) {
+        throw new Error("Failed to load helper modules (opfs/markdown)");
+      }
+
+      const readFileAsText = opfsModule.readFileAsText;
+      const parseMarkdown = markdownModule.parseMarkdown;
+
+      if (!readFileAsText || !parseMarkdown) {
+        throw new Error("Missing helper functions in loaded modules");
+      }
+
+      const vaultDir = await this.getActiveVaultHandle();
+      if (!vaultDir) return;
+
+      const text = await readFileAsText(vaultDir, path);
+      if (text) {
+        const { metadata: data, content: body } = this._helpers.parseMarkdown(content);
+        const lore = (data as any).lore || "";
+
+        this.repository.entities[id] = {
+          ...currentEntity,
+          content: body,
+          lore,
+        };
+        this._contentLoadedIds.add(id);
+        this._contentVerifiedIds.add(id);
+      }
+    } catch (err) {
+      debugStore.error(
+        `[VaultStore] internalLoadContent failed for ${id}:`,
+        err,
+      );
+    }
+  }
+
+  // --- CRUD Delegations ---
+  async createEntity(
+    type: Entity["type"],
+    title: string,
+    initialData: Partial<Entity> = {},
+  ) {
+    const id = await this.crudManager.createEntity(type, title, initialData);
+    if (id) {
+      this._contentLoadedIds.add(id); // Mark as loaded since it's new
+      this._contentVerifiedIds.add(id); // Mark as verified
+    }
+    return id;
+  }
+  async updateEntity(id: string, updates: Partial<LocalEntity>) {
+    const success = await this.crudManager.updateEntity(id, updates);
+    if (
+      success &&
+      (updates.content !== undefined ||
+        updates.lore !== undefined ||
+        updates.title !== undefined ||
+        updates.tags !== undefined)
+    ) {
+      this._contentLoadedIds.add(id);
+      this._contentVerifiedIds.add(id);
+    }
+    return success;
+  }
+  async batchUpdate(updates: Record<string, Partial<LocalEntity>>) {
+    const success = await this.crudManager.batchUpdate(updates);
+    if (success) {
+      for (const [id, patch] of Object.entries(updates)) {
+        if (
+          patch.content !== undefined ||
+          patch.lore !== undefined ||
+          patch.title !== undefined ||
+          patch.tags !== undefined
+        ) {
+          this._contentLoadedIds.add(id);
+          this._contentVerifiedIds.add(id);
+        }
+      }
+    }
+    return success;
+  }
+  async deleteEntity(id: string) {
+    if (this.onEntityDelete) this.onEntityDelete(id);
+
+    if (uiStore.isDemoMode) {
+      const updated = { ...this.entities };
+      delete updated[id];
+      this.repository.entities = updated;
+      return;
+    }
+
+    // Use the same per-entity lock for deletion to avoid conflicts with saves to that file.
+    const lockKey = id;
+
+    return this.saveQueue.enqueue(lockKey, async () => {
+      const vaultHandle = await this.getActiveVaultHandle();
+      const localHandle = await this.getActiveSyncHandle();
+
+      if (vaultHandle) {
+        // Resolve path before deletion from memory
+        const entity = this.entities[id];
+        const path = entity?._path || [`${id}.md`];
+
+        // 1. Delete from OPFS (Source of truth)
+        await this.crudManager.deleteEntity(
+          id,
+          vaultHandle,
+          this.activeVaultId!,
+        );
+
+        // 2. Delete from Local Filesystem (if attached)
+        if (localHandle) {
+          try {
+            const permission = await localHandle.queryPermission({
+              mode: "readwrite",
+            });
+            if (permission === "granted") {
+              const fileName = path[path.length - 1];
+              const dirPath = path.slice(0, -1);
+              let targetDir: FileSystemDirectoryHandle | undefined =
+                localHandle;
+
+              for (const part of dirPath) {
+                targetDir = await targetDir
+                  ?.getDirectoryHandle(part, { create: false })
+                  .catch(() => undefined);
+                if (!targetDir) break;
+              }
+
+              if (targetDir) {
+                await targetDir.removeEntry(fileName, { recursive: true });
+                debugStore.log(
+                  `[VaultStore] Deleted ${path.join("/")} from local filesystem`,
+                );
+              }
+            }
+          } catch (e) {
+            debugStore.warn(
+              `[VaultStore] Failed to delete ${path.join("/")} from local filesystem`,
+              e,
+            );
+          }
+        }
+
+        // 3. CRITICAL: Remove from Dexie cache to prevent "resurrection" on reload
+        if (this.activeVaultId) {
+          await cacheService.remove(`${this.activeVaultId}:${path.join("/")}`);
+        }
+      }
+    });
+  }
+  addConnection(
+    sourceId: string,
+    targetId: string,
+    type: string,
+    label?: string,
+    strength?: number,
+  ) {
+    return this.crudManager.addConnection(
+      sourceId,
+      targetId,
+      type,
+      label,
+      strength,
+    );
+  }
+  removeConnection(sourceId: string, targetId: string, type: string) {
+    return this.crudManager.removeConnection(sourceId, targetId, type);
+  }
+  addLabel(id: string, label: string) {
+    return this.crudManager.addLabel(id, label);
+  }
+  removeLabel(id: string, label: string) {
+    return this.crudManager.removeLabel(id, label);
+  }
+
+  bulkAddLabel(ids: string[], label: string) {
+    return this.crudManager.bulkAddLabel(ids, label);
+  }
+  bulkRemoveLabel(ids: string[], label: string) {
+    return this.crudManager.bulkRemoveLabel(ids, label);
+  }
+  async batchCreateEntities(newEntitiesList: BatchCreateInput[]) {
+    await this.crudManager.batchCreateEntities(newEntitiesList);
+    // Mark all as loaded and verified since they are fresh.
+    // This prevents lazy load clobbering.
+    for (const item of newEntitiesList) {
+      if ((item as any).id) {
+        const id = (item as any).id;
+        this._contentLoadedIds.add(id);
+        this._contentVerifiedIds.add(id);
+      }
+    }
+
+    this.broadcastVaultUpdate();
+  }
+
+  updateConnection(
+    sourceId: string,
+    targetId: string,
+    oldType: string,
+    newType: string,
+    newLabel?: string,
+  ) {
+    return this.crudManager.updateConnection(
+      sourceId,
+      targetId,
+      oldType,
+      newType,
+      newLabel,
+    );
   }
 
   async resolveImageUrl(
@@ -404,6 +1123,133 @@ export class VaultStore {
       fetcher,
       await this.getActiveSyncHandle(),
     );
+  }
+
+  async getActiveVaultHandle(): Promise<FileSystemDirectoryHandle | undefined> {
+    if (!this.activeVaultId || !vaultRegistry.rootHandle) return undefined;
+    if (this._vaultHandle) return this._vaultHandle;
+
+    try {
+      const vaultsDir = await vaultRegistry.rootHandle.getDirectoryHandle(
+        "vaults",
+        { create: true },
+      );
+      this._vaultHandle = await vaultsDir.getDirectoryHandle(
+        this.activeVaultId,
+        {
+          create: true,
+        },
+      );
+      return this._vaultHandle;
+    } catch (err) {
+      debugStore.warn("[VaultStore] Failed to get active vault handle", err);
+      return undefined;
+    }
+  }
+
+  async getActiveSyncHandle(): Promise<FileSystemDirectoryHandle | undefined> {
+    if (!this.activeVaultId) return undefined;
+    try {
+      const db = await getDB();
+      const handle = await db.get(
+        "settings",
+        `syncHandle_${this.activeVaultId}`,
+      );
+      return handle as FileSystemDirectoryHandle | undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // --- Map & Canvas Delegations ---
+  saveMaps() {
+    return mapRegistry.saveMaps();
+  }
+  deleteMap(id: string) {
+    return mapRegistry.deleteMap(id);
+  }
+  saveCanvas(id: string, options?: { explicitVaultId?: string }) {
+    return canvasRegistry.saveCanvas(id, options);
+  }
+
+  // --- Sync Delegations ---
+
+  async syncWithLocalFolder() {
+    if (!this.syncCoordinator || !this.activeVaultId) return;
+    const vaultIdAtStart = this.activeVaultId;
+    const opfsHandle = await this.getActiveVaultHandle();
+    await this.syncCoordinator.syncWithLocalFolder(
+      vaultIdAtStart,
+      opfsHandle,
+      this.entities,
+      () => this.repository.waitForAllSaves(),
+      (state) => {
+        // ONLY update status if we are still on the same vault
+        if (this.activeVaultId === vaultIdAtStart) {
+          this.status = state.status;
+          this.syncType = state.syncType;
+          if (state.errorMessage) this.errorMessage = state.errorMessage;
+        }
+      },
+      () => this.checkForConflicts(),
+    );
+  }
+
+  async cleanupConflictFiles(signal?: AbortSignal) {
+    if (!this.syncCoordinator || !this.activeVaultId) return;
+    const opfsHandle = await this.getActiveVaultHandle();
+    if (!opfsHandle || signal?.aborted) return;
+
+    await this.syncCoordinator.cleanupConflictFiles(
+      this.activeVaultId,
+      opfsHandle,
+      (status) => {
+        if (!signal?.aborted) this.status = status;
+      },
+      () => this.loadFiles(),
+      signal,
+    );
+  }
+
+  async checkForConflicts(signal?: AbortSignal) {
+    const opfsHandle = await this.getActiveVaultHandle();
+    if (!opfsHandle || signal?.aborted) return;
+    try {
+      const files = await fileIOAdapter.walkDirectory(opfsHandle);
+      if (signal?.aborted) return;
+      this.hasConflictFiles = files.some((f: any) =>
+        f.path[f.path.length - 1].includes(".conflict-"),
+      );
+    } catch {
+      this.hasConflictFiles = false;
+    }
+  }
+
+  // --- Lifecycle Delegations ---
+  importFromFolder(handle?: FileSystemDirectoryHandle) {
+    if (!handle) return Promise.resolve();
+    return this.lifecycleManager.importFromFolder(handle);
+  }
+  switchVault(id: string) {
+    return this.lifecycleManager.switchVault(id);
+  }
+  createVault(name: string) {
+    return this.lifecycleManager.createVault(name);
+  }
+  deleteVault(id: string) {
+    return this.lifecycleManager.deleteVault(id);
+  }
+  loadDemoData(name: string, entities: Record<string, LocalEntity>) {
+    return this.lifecycleManager.loadDemoData(name, entities);
+  }
+  persistToIndexedDB(vaultId: string) {
+    return this.lifecycleManager.persistToIndexedDB(vaultId);
+  }
+
+  async setDefaultVisibility(v: "visible" | "hidden") {
+    this.defaultVisibility = v;
+    const db = await getDB();
+    await db.put("settings", v, "defaultVisibility");
   }
 }
 

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -99,247 +99,966 @@ export class VaultStore {
 
   /**
    * Tracks which entity IDs have their `content` and `lore` fields fully
-   * loaded. Critical for P2P and synced vaults.
+   * populated in `this.entities`.  Entities loaded from the Dexie graph-entity
+   * cache start with `content = ""` to keep the initial load lightweight;
+   * calling `loadEntityContent(id)` fills in these fields on demand.
    */
-  private loadedContentIds = new Set<string>();
+  private _contentLoadedIds = new Set<string>();
+  private _contentVerifiedIds = new Set<string>();
 
-  constructor(
-    public repository: VaultRepository = new VaultRepository(),
-    private syncCoordinator: SyncCoordinator = new SyncCoordinator(
-      repository,
-      createSyncEngine(),
-      syncNotifier,
-    ),
-    private assetManager: AssetManager = new AssetManager(
-      assetIOAdapter,
-      imageProcessor,
-    ),
-  ) {
-    this.crudManager = new VaultCrudManager(repository, assetManager);
-    this.lifecycleManager = new VaultLifecycleManager(
-      repository,
-      syncCoordinator,
-      assetManager,
-    );
-
-    // Wire up events
-    repository.onEntityUpdate = (e) => {
-      this.onEntityUpdate?.(e);
-      vaultEventBus.emit("entity-updated", { entity: e });
-    };
-    repository.onEntityDelete = (id) => {
-      this.onEntityDelete?.(id);
-      vaultEventBus.emit("entity-deleted", { entityId: id });
-    };
-    repository.onBatchUpdate = (updates) => {
-      this.onBatchUpdate?.(updates);
-      vaultEventBus.emit("batch-updated", { updates });
-    };
-
-    if (browser) {
-      this.channel = new BroadcastChannel("vault-sync");
-      this.channel.onmessage = (event) => {
-        if (event.data.type === "VAULT_UPDATED") {
-          this.syncCoordinator.triggerSync();
-        }
-      };
-    }
-  }
-
-  // Getters for Repository State
+  // Delegated Getters
   get entities() {
     return this.repository.entities;
   }
-  get allEntities() {
-    return this.repository.allEntities;
-  }
+
+  // ⚡ Bolt Optimization: Use a derived array to avoid per-node allocations via Object.values()
+  // in hot loops (e.g., timeline, search, graph syncing).
+  allEntities = $derived.by(() => {
+    if (!this.repository) return [];
+    return Object.values(this.repository.entities);
+  });
+
   get maps() {
-    return this.repository.maps;
-  }
-  get allMaps() {
-    return this.repository.allMaps;
+    return mapRegistry.maps;
   }
   get canvases() {
-    return this.repository.canvases;
-  }
-  get allCanvases() {
-    return this.repository.allCanvases;
+    return canvasRegistry.canvases;
   }
   get activeVaultId() {
-    return this.repository.activeVaultId;
+    return vaultRegistry.activeVaultId;
   }
-  get activeVaultName() {
-    return this.repository.activeVaultName;
+  get vaultName() {
+    return vaultRegistry.vaultName;
   }
-
+  get saveQueue() {
+    return this.repository.saveQueue;
+  }
   get isGuest() {
-    return uiStore.isGuestMode;
+    return !!uiStore.isGuestMode;
   }
 
-  // Lifecycle Methods
-  async initialize() {
-    this.status = "loading";
-    try {
-      await this.lifecycleManager.initialize();
-      this.isInitialized = true;
-      this.status = "idle";
-    } catch (err: any) {
-      this.status = "error";
-      this.errorMessage = err.message;
-    }
-  }
-
-  async openVault(vaultId: string) {
-    this.status = "loading";
-    try {
-      await this.lifecycleManager.openVault(vaultId);
-      this.isInitialized = true;
-      this.status = "idle";
-    } catch (err: any) {
-      this.status = "error";
-      this.errorMessage = err.message;
-    }
-  }
-
-  async closeVault() {
-    await this.lifecycleManager.closeVault();
-    this.isInitialized = false;
-    this.status = "idle";
-  }
-
-  // CRUD Operations
-  async createEntity(type: Entity["type"], title: string) {
-    return await this.crudManager.createEntity(
-      await this.getActiveVaultHandle(),
-      type,
-      title,
+  constructor(
+    public repository = new VaultRepository(fileIOAdapter),
+    private assetManager = new AssetManager(assetIOAdapter, imageProcessor),
+    public syncCoordinator: SyncCoordinator | null = null,
+  ) {
+    this.crudManager = new VaultCrudManager(
+      () => this.entities,
+      (entities) => {
+        this.repository.entities = entities;
+      },
+      (entity) => this.scheduleSave(entity),
+      () => this.getActiveVaultHandle(),
+      () => this.activeVaultId,
+      () => this.isGuest,
+      () => this.services,
+      (id) => this.onEntityDelete && this.onEntityDelete(id),
+      (entity) => this.onEntityUpdate && this.onEntityUpdate(entity),
+      (updates) => this.onBatchUpdate && this.onBatchUpdate(updates),
+      (path) => this.assetManager.releaseImageUrl(path),
     );
-  }
 
-  async batchCreateEntities(inputs: BatchCreateInput[]) {
-    return await this.crudManager.batchCreateEntities(
-      await this.getActiveVaultHandle(),
-      inputs,
+    this.lifecycleManager = new VaultLifecycleManager(
+      (s) => (this.status = s),
+      (m) => (this.errorMessage = m),
+      () => this.activeVaultId,
+      () => this.getActiveVaultHandle(),
+      this.repository,
+      this.assetManager,
+      (skipSync) => this.loadFiles(skipSync),
+      () => this.entities,
+      (n) => (this.demoVaultName = n),
+      (v) => (this.isInitialized = v),
+      () => this.services,
+      (c) => (this.hasConflictFiles = c),
+      (id) => (this.selectedEntityId = id),
+      vaultRegistry,
+      themeStore,
+      mapRegistry,
+      canvasRegistry,
+      (path, handle) => this.ensureAssetPersisted(path, handle),
     );
-  }
-
-  async updateEntity(id: string, patch: Partial<LocalEntity>) {
-    return await this.crudManager.updateEntity(
-      await this.getActiveVaultHandle(),
-      id,
-      patch,
-    );
-  }
-
-  batchUpdate(updates: Record<string, Partial<LocalEntity>>) {
-    this.repository.batchUpdate(updates);
-  }
-
-  async deleteEntity(id: string) {
-    return await this.crudManager.deleteEntity(
-      await this.getActiveVaultHandle(),
-      id,
-    );
-  }
-
-  // Map Operations
-  async createMap(name: string, assetPath: string, dimensions: any) {
-    const id = await this.crudManager.createMap(
-      await this.getActiveVaultHandle(),
-      name,
-      assetPath,
-      dimensions,
-    );
-    await mapRegistry.touch(id);
-    return id;
-  }
-
-  async saveMaps() {
-    return await this.crudManager.saveMaps(await this.getActiveVaultHandle());
-  }
-
-  // Canvas Operations
-  async createCanvas(name: string) {
-    const id = await this.crudManager.createCanvas(
-      await this.getActiveVaultHandle(),
-      name,
-    );
-    await canvasRegistry.touch(id);
-    return id;
-  }
-
-  async saveCanvas(id: string, options?: { explicitVaultId?: string }) {
-    let handle = await this.getActiveVaultHandle();
-
-    // If an explicit vault is provided, we must use that handle instead
-    if (options?.explicitVaultId && options.explicitVaultId !== this.activeVaultId) {
-      const root = await getOpfsRoot();
-      handle = await getVaultDir(root, options.explicitVaultId);
-    }
-
-    return await this.crudManager.saveCanvas(handle, id);
-  }
-
-  async deleteCanvas(id: string) {
-    await this.crudManager.deleteCanvas(await this.getActiveVaultHandle(), id);
-    await canvasRegistry.touch(id);
-  }
-
-  // Sync Methods
-  async triggerSync() {
-    return await this.syncCoordinator.triggerSync();
-  }
-
-  // Helper Methods
-  async getActiveVaultHandle() {
-    return await this.repository.getActiveVaultHandle();
-  }
-
-  async getActiveSyncHandle() {
-    return await this.repository.getActiveSyncHandle();
-  }
-
-  async loadEntityContent(id: string) {
-    if (this.loadedContentIds.has(id)) return;
-
-    try {
-      const entity = this.entities[id];
-      if (!entity) return;
-
-      if (!this._helpers.readFileAsText) {
-        const { readFileAsText: rf, parseMarkdown } = await import(
-          "../utils/opfs"
-        );
-        this._helpers.readFileAsText = rf;
-        this._helpers.parseMarkdown = parseMarkdown;
-      }
-
-      const handle = await this.getActiveVaultHandle();
-      if (!handle && !this.isGuest) return;
-
-      let content = "";
-      if (this.isGuest) {
-        // In guest mode, the content should already be in the entity object
-        // because the host serializes it. If it's missing, we can't do much
-        // unless we add a GET_CONTENT P2P message.
-        content = (entity as any).content || "";
-      } else {
-        const path = entity._path;
-        if (!path) return;
-        content = await this._helpers.readFileAsText(handle, path);
-      }
-
-      const { data, content: body } = this._helpers.parseMarkdown(content);
-
-      this.repository.entities[id] = {
-        ...entity,
-        ...data,
-        content: body,
+    if (typeof window !== "undefined") {
+      this.channel = new BroadcastChannel("codex-vault-sync");
+      this.channel.onmessage = (event) => {
+        if (
+          event.data.type === "RELOAD_VAULT" &&
+          event.data.vaultId === this.activeVaultId
+        ) {
+          this.loadFiles();
+        }
       };
-      this.loadedContentIds.add(id);
-    } catch (err) {
-      console.warn(`[VaultStore] Failed to load content for ${id}`, err);
+
+      mapRegistry.init(this.repository.saveQueue);
+      canvasRegistry.init(this.repository.saveQueue);
     }
+  }
+
+  // --- External Sync Methods ---
+  broadcastVaultUpdate() {
+    if (this.channel && this.activeVaultId) {
+      this.channel.postMessage({
+        type: "RELOAD_VAULT",
+        vaultId: this.activeVaultId,
+      });
+    }
+  }
+
+  async ensureServicesInitialized() {
+    if (this.services && this.syncCoordinator) return;
+
+    try {
+      const searchModule = await import("../services/search");
+      const aiModule = await import("../services/ai");
+
+      if (searchModule && aiModule) {
+        this.services = {
+          search: searchModule.searchService,
+          ai: {
+            clearStyleCache: () =>
+              aiModule.contextRetrievalService.clearStyleCache(),
+            expandQuery: (k, q, h) =>
+              aiModule.textGenerationService.expandQuery(k, q, h),
+          },
+        };
+      }
+    } catch (err) {
+      debugStore.error("[VaultStore] Failed to lazy-load services", err);
+    }
+
+    if (!this.syncCoordinator && typeof window !== "undefined") {
+      const engine = await createSyncEngine();
+      this.syncCoordinator = new SyncCoordinator(
+        syncIOAdapter,
+        engine,
+        syncNotifier,
+      );
+    }
+  }
+
+  async init(injectedServices?: IVaultServices) {
+    // Separate controller for init path to allow independent cancellation
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    this.isInitialized = false;
+    this.status = "loading";
+    this.assetManager.clear();
+    this.repository.clear();
+
+    if (injectedServices) {
+      this.services = injectedServices;
+    } else if (typeof window !== "undefined") {
+      // Background: Pre-load modules needed for content loading to eliminate interaction latency
+      import("../utils/opfs")
+        .then((m) => (this._helpers.readFileAsText = m.readFileAsText))
+        .catch(() => {});
+      import("../utils/markdown")
+        .then((m) => (this._helpers.parseMarkdown = m.parseMarkdown))
+        .catch(() => {});
+
+      await this.ensureServicesInitialized();
+    }
+
+    try {
+      await vaultRegistry.init();
+      const opfsRoot = vaultRegistry.rootHandle;
+      if (!opfsRoot) throw new Error("OPFS Root failed to initialize");
+
+      if (uiStore.isDemoMode) {
+        this.isInitialized = true;
+        this.status = "idle";
+        return;
+      }
+
+      const db = await getDB();
+      const savedVisibility = await db.get("settings", "defaultVisibility");
+      if (savedVisibility) this.defaultVisibility = savedVisibility;
+
+      const migration = await vaultMigration.checkForMigration();
+      if (migration.required && migration.handle) {
+        this.migrationRequired = true;
+        await vaultMigration.runMigration(
+          opfsRoot,
+          migration.handle,
+          true,
+          () => this.loadFiles(),
+          (status, err) => {
+            this.status = status;
+            if (err) this.errorMessage = err;
+          },
+        );
+      }
+
+      await vaultMigration.migrateStructure(opfsRoot);
+
+      if (this.activeVaultId) {
+        await themeStore.loadForVault(this.activeVaultId);
+        await this.loadFiles();
+      } else {
+        await vaultRegistry.listVaults();
+        if (vaultRegistry.availableVaults.length > 0) {
+          const firstVault = vaultRegistry.availableVaults[0];
+          await vaultRegistry.setActiveVault(firstVault.id);
+          await themeStore.loadForVault(firstVault.id);
+          await this.loadFiles();
+        }
+      }
+    } catch (err: any) {
+      debugStore.error("[VaultStore] Init failed", err);
+      console.warn("[VaultStore] Init failed, falling back to Guest Mode", err);
+
+      uiStore.isGuestMode = true;
+      this.status = "idle";
+      this.errorMessage =
+        err?.name === "QuotaExceededError"
+          ? "Storage full. Running in Guest Mode (changes will not be saved)."
+          : "Storage access denied. Running in Guest Mode.";
+
+      // Ensure we have at least the welcome content by loading it via fetch
+      if (Object.keys(this.entities).length === 0) {
+        try {
+          const response = await fetch("/vault-samples/welcome.json");
+          const data = await response.json();
+          await this.loadDemoData("Welcome", data.entities || data);
+        } catch (e) {
+          console.warn("Failed to load fallback demo data", e);
+        }
+      }
+    } finally {
+      this.isInitialized = true;
+      if (!signal.aborted) {
+        await this.checkForConflicts(signal);
+      }
+      if ((this.status as string) !== "error" && !signal.aborted) {
+        this.status = "idle";
+        if (this.activeVaultId) {
+          window.dispatchEvent(
+            new CustomEvent("vault-switched", {
+              detail: { id: this.activeVaultId },
+            }),
+          );
+        }
+      }
+    }
+  }
+
+  private _vaultHandle: FileSystemDirectoryHandle | undefined = undefined;
+
+  async loadFiles(skipSyncIfWarm = true) {
+    if (!this.activeVaultId) return;
+    const vaultIdAtStart = this.activeVaultId;
+
+    // ABORT: Cancel any ongoing background sync from a previous vault switch
+    if (this.syncAbortController) {
+      this.syncAbortController.abort();
+    }
+    this.syncAbortController = new AbortController();
+    const signal = this.syncAbortController.signal;
+
+    this.status = "loading";
+    this._contentLoadedIds = new Set();
+    this._contentVerifiedIds = new Set();
+    this._vaultHandle = undefined; // Reset handle on load
+    this.syncStats = {
+      updated: 0,
+      created: 0,
+      deleted: 0,
+      failed: 0,
+      total: 0,
+      progress: 0,
+    };
+
+    try {
+      debugStore.log(`[VaultStore] Loading files for vault: ${vaultIdAtStart}`);
+
+      // Reset event bus to clear listeners from previous vault sessions (prevent leaks)
+      vaultEventBus.reset();
+
+      // BROADCAST: Opening vault
+      vaultEventBus.emit({
+        type: "VAULT_OPENING",
+        vaultId: vaultIdAtStart,
+      });
+
+      if (this.services) {
+        this.services.ai.clearStyleCache();
+      }
+
+      // 1. Cache-First: Preload graph metadata from Dexie immediately.
+      const cachedMap = await cacheService.preloadVault(vaultIdAtStart);
+
+      // Race check after async preload
+      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+      if (cachedMap.size > 0) {
+        // CRITICAL: We start with a FRESH map.
+        // Do NOT spread this.repository.entities as it might contain stale data from previous vault.
+        const entityMap: Record<string, LocalEntity> = {};
+        for (const { entity: e } of cachedMap.values()) {
+          const existing = entityMap[e.id];
+
+          // Preserve content/lore if they are already loaded in memory
+          const finalContent =
+            existing?.content && !e.content ? existing.content : e.content;
+
+          const finalLore = existing?.lore && !e.lore ? existing.lore : e.lore;
+
+          entityMap[e.id] = {
+            ...e,
+            content: finalContent,
+            lore: finalLore,
+          };
+        }
+        // Push to repository to trigger immediate UI/Graph rendering
+        this.repository.entities = entityMap;
+        debugStore.log(
+          `[VaultStore] Cache-First: Populated ${cachedMap.size} entities from Dexie.`,
+        );
+
+        // BROADCAST: Initial cache data ready
+        vaultEventBus.emit({
+          type: "CACHE_LOADED",
+          vaultId: vaultIdAtStart,
+          entities: entityMap,
+        });
+
+        // IMPORTANT: We set status to idle NOW. The graph is visible and interactive.
+        this.status = "idle";
+
+        if (skipSyncIfWarm) {
+          debugStore.log(
+            "[VaultStore] Cache is warm. Skipping OPFS background sync for instant load.",
+          );
+
+          // Start background tasks
+          mapRegistry.loadFromVault(vaultIdAtStart);
+          canvasRegistry.loadFromVault(vaultIdAtStart);
+
+          // Resolve handle in background for image resolution
+          this.getActiveVaultHandle();
+          return;
+        }
+      }
+
+      // 2. FS-Sync: Resolve OPFS handle and perform full synchronization
+      const vaultDir = await this.getActiveVaultHandle();
+
+      // Race check after async handle resolution
+      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+      if (!vaultDir) {
+        if (this.status !== "idle") {
+          this.status = cachedMap.size > 0 ? "idle" : "error";
+          if (this.status === "error") {
+            this.errorMessage = "Failed to resolve vault directory handle";
+          }
+        }
+        return;
+      }
+
+      // 3. Local-Sync: If a local directory handle is persisted, sync it to OPFS first.
+      const localHandle = await this.getActiveSyncHandle();
+      if (localHandle) {
+        debugStore.log(
+          `[VaultStore] Local sync handle found for ${vaultIdAtStart}. Synchronizing...`,
+        );
+        await this.ensureServicesInitialized();
+        if (this.syncCoordinator) {
+          try {
+            await this.syncCoordinator.syncWithLocalFolder(
+              vaultIdAtStart,
+              vaultDir,
+              this.entities,
+              () => this.repository.waitForAllSaves(),
+              (state) => {
+                // ONLY update status if we are still on the same vault AND not aborted
+                if (this.activeVaultId === vaultIdAtStart && !signal.aborted) {
+                  this.status = state.status;
+                  if (state.errorMessage)
+                    this.errorMessage = state.errorMessage;
+                }
+              },
+              () => this.checkForConflicts(),
+              signal,
+              (stats) => {
+                if (this.activeVaultId === vaultIdAtStart && !signal.aborted) {
+                  this.syncStats = { ...this.syncStats, ...stats };
+                }
+              },
+            );
+            if (signal.aborted) return;
+            debugStore.log("[VaultStore] Local sync complete.");
+          } catch (err) {
+            debugStore.error("[VaultStore] Local sync failed", err);
+            // We continue anyway, maybe OPFS has some data
+          }
+        }
+      }
+
+      // Final race check before starting repository scan
+      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+      // Ensure status is idle if we have cache, otherwise keep loading until we get first FS results
+      if (cachedMap.size > 0) {
+        this.status = "idle";
+      }
+
+      const syncPromise = this.repository.loadFiles(
+        vaultIdAtStart,
+        vaultDir,
+        async (_chunk, current, total, newOrChanged) => {
+          // Race check inside progress callback
+          if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
+
+          this.syncStats.total = total;
+          this.syncStats.progress = Math.round((current / total) * 100);
+          this.syncStats.created = current;
+
+          const changedIds = Object.keys(newOrChanged);
+
+          if (changedIds.length > 0) {
+            // Track entities that arrived from OPFS (cache miss path) — they
+            // already have content populated so no lazy load is needed later.
+            for (const id of changedIds) {
+              const entity = newOrChanged[id];
+              if (entity.content) {
+                this._contentLoadedIds.add(entity.id);
+                this._contentVerifiedIds.add(entity.id);
+              }
+            }
+
+            // BROADCAST: Chunk indexed
+            vaultEventBus.emit({
+              type: "SYNC_CHUNK_READY",
+              vaultId: vaultIdAtStart,
+              entities: this.entities,
+              newOrChangedIds: changedIds,
+            });
+          }
+        },
+      );
+
+      if (this.status === "loading") {
+        await syncPromise;
+      } else {
+        // Just catch errors for background sync
+        syncPromise.catch((err: any) => {
+          debugStore.error("[VaultStore] Background sync failed", err);
+        });
+      }
+
+      if (this.status === "loading") {
+        debugStore.log(
+          `[VaultStore] Load complete. Indexed ${this.syncStats.created} entities.`,
+        );
+        this.status = "idle";
+      }
+
+      await mapRegistry.loadFromVault(vaultIdAtStart);
+      await canvasRegistry.loadFromVault(vaultIdAtStart);
+
+      // BROADCAST: Full sync complete
+      vaultEventBus.emit({
+        type: "SYNC_COMPLETE",
+        vaultId: vaultIdAtStart,
+      });
+    } catch (err: any) {
+      debugStore.error("[VaultStore] Load failed", err);
+      this.status = "error";
+      this.errorMessage = err.message;
+    } finally {
+      this.isInitialized = true;
+      if (!signal.aborted) {
+        await this.checkForConflicts(signal);
+      }
+      if ((this.status as string) !== "error" && !signal.aborted) {
+        this.status = "idle";
+        if (this.activeVaultId) {
+          window.dispatchEvent(
+            new CustomEvent("vault-switched", {
+              detail: { id: this.activeVaultId },
+            }),
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Loads the `content` and `lore` fields for the entity with the given ID
+   * and updates `this.entities[id]` in place.  Subsequent calls for the same
+   * ID are no-ops (unless the previous attempt failed with a transient error,
+   * in which case the next call will retry).
+   *
+   * This is the primary entry-point for lazy content loading — call it
+   * whenever the entity is "opened" (detail panel, read modal, edit mode, etc.)
+   * to ensure the full entity data is available for rendering.
+   */
+  async loadEntityContent(id: string): Promise<void> {
+    if (!id || !this.activeVaultId) return;
+    if (this._contentVerifiedIds.has(id)) return;
+
+    // Verify entity exists before starting async work.
+    const currentEntity = this.entities[id];
+    if (!currentEntity) return;
+
+    // PRIORITY 1: Try Dexie Cache for immediate Chronicle (content) and Lore
+    // No lock needed for Tier 1 IDB read.
+    let cached: { content: string; lore: string } | null = null;
+    let cacheErrored = false;
+    try {
+      cached = await cacheService.getEntityContent(this.activeVaultId, id);
+      if (cached !== null) {
+        const latest = this.entities[id];
+        if (latest && (!latest.content || latest.lore === undefined)) {
+          // Surgical update to the existing reactive proxy
+          this.repository.entities[id] = {
+            ...latest,
+            content: cached.content,
+            lore: cached.lore,
+          };
+          this._contentLoadedIds.add(id);
+          debugStore.log(
+            `[VaultStore] Priority 1 hit: Loaded chronicle/lore from cache for ${id}`,
+          );
+        }
+      }
+    } catch (cacheErr) {
+      cacheErrored = true;
+      debugStore.warn(
+        `[VaultStore] Priority 1 cache load failed for ${id}`,
+        cacheErr,
+      );
+    }
+
+    // Re-check after Priority 1
+    if (this._contentVerifiedIds.has(id)) return;
+
+    try {
+      const path = currentEntity._path || [`${id}.md`];
+
+      // Ensure helpers are available (fallback to dynamic import if background load hasn't finished)
+      const readFileAsText =
+        this._helpers.readFileAsText ||
+        (await import("../utils/opfs")).readFileAsText;
+      const parseMarkdown =
+        this._helpers.parseMarkdown ||
+        (await import("../utils/markdown")).parseMarkdown;
+
+      // PRIORITY 2 & 3: Load Lore (and fresh Chronicle) from Markdown file
+      let text = "";
+
+      const vaultDir = await this.getActiveVaultHandle();
+      if (vaultDir) {
+        try {
+          text = await readFileAsText(vaultDir, path);
+        } catch {
+          // Fall through
+        }
+      }
+
+      if (!text) {
+        const localHandle = await syncIOAdapter.getLocalHandle(
+          this.activeVaultId,
+        );
+        if (localHandle) {
+          try {
+            if (
+              (await localHandle.queryPermission({ mode: "read" })) ===
+              "granted"
+            ) {
+              text = await readFileAsText(localHandle, path);
+            }
+          } catch (err) {
+            debugStore.warn(
+              `[VaultStore] Priority 3 failed for ${id} from Local FS fallback`,
+              err,
+            );
+          }
+        }
+      }
+
+      if (text) {
+        const { metadata, content: freshContent } = parseMarkdown(text);
+        const freshLore = (metadata as any).lore || "";
+
+        const entityToUpdate = this.entities[id];
+        if (entityToUpdate) {
+          // Update the entity surgically. Never overwrite with empty if Tier 1 already had content
+          // and Priority 2/3 somehow returned empty content (unless both are empty).
+          const finalContent = freshContent || entityToUpdate.content || "";
+          const finalLore = freshLore || entityToUpdate.lore || "";
+
+          const updatedEntity = {
+            ...entityToUpdate,
+            content: finalContent,
+            lore: finalLore,
+          };
+
+          this.repository.entities[id] = updatedEntity;
+
+          this._contentLoadedIds.add(id);
+          this._contentVerifiedIds.add(id);
+
+          debugStore.log(
+            `[VaultStore] Verified ${id} from source: contentLen=${finalContent.length}, loreLen=${finalLore.length}`,
+          );
+
+          const isStale =
+            finalContent !== (cached?.content ?? null) ||
+            finalLore !== (cached?.lore ?? null);
+          const hasContent = finalContent || finalLore;
+
+          if (isStale && (cached !== null || hasContent)) {
+            // CRITICAL: Pass the plain updatedEntity, not the reactive proxy
+            // Background: No need to await
+            cacheService.set(
+              `${this.activeVaultId}:${path.join("/")}`,
+              Date.now(),
+              updatedEntity,
+            );
+          }
+        }
+      } else if (cached === null && !cacheErrored) {
+        this._contentVerifiedIds.add(id); // Even if missing, we verified the absence
+        debugStore.warn(
+          `[VaultStore] Content truly missing for ${id} in all tiers`,
+        );
+      }
+    } catch (err) {
+      debugStore.error(`[VaultStore] Failed to load content for ${id}:`, err);
+    }
+  }
+
+  scheduleSave(entity: LocalEntity | Entity): Promise<void> {
+    if (this.onEntityUpdate) this.onEntityUpdate(entity as LocalEntity);
+
+    const vaultIdAtStart = this.activeVaultId;
+    if (!vaultIdAtStart) return Promise.resolve();
+
+    if (this.services) {
+      const path =
+        (entity as LocalEntity)._path?.join("/") || `${entity.id}.md`;
+      const keywords = [
+        ...(entity.tags || []),
+        entity.lore || "",
+        ...Object.values(entity.metadata || {}).flat(),
+      ].join(" ");
+      const promise = this.services.search.index({
+        id: entity.id,
+        title: entity.title,
+        content: (entity as LocalEntity).content,
+        lore: (entity as LocalEntity).lore,
+        type: entity.type,
+        path,
+        keywords,
+        updatedAt: Date.now(),
+      });
+      if (promise && promise.catch) {
+        promise.catch((err) =>
+          debugStore.warn(`[VaultStore] Search index error: ${err}`),
+        );
+      }
+    }
+
+    if (uiStore.isDemoMode) return Promise.resolve();
+
+    // Use a per-entity lock for saving to serialize writes to the same file
+    // while allowing concurrent saves to DIFFERENT files.
+    const lockKey = entity.id;
+
+    return this.saveQueue.enqueue(lockKey, async () => {
+      // 1. Always get the absolute latest state from the store
+      let latestEntity = this.entities[entity.id];
+      if (!latestEntity) return;
+
+      // 2. CRITICAL SAFETY: If content hasn't been marked as loaded,
+      // we MUST try to load it before saving to avoid overwriting with empty.
+      if (!this._contentLoadedIds.has(entity.id)) {
+        // Note: loadEntityContent is already queued, but we need it NOW.
+        // We use a separate internal Load helper that avoids the queue to prevent deadlocks.
+        await this.internalLoadContent(entity.id);
+        // Re-fetch after load
+        latestEntity = this.entities[entity.id] || latestEntity;
+      }
+      this.status = "saving";
+      try {
+        // Resolution must happen per-save to ensure we use the correct handle for the vaultIdAtStart
+        const vaultHandle = await this.getSpecificVaultHandle(vaultIdAtStart);
+        if (!vaultHandle) return;
+
+        await this.repository.saveToDisk(
+          vaultHandle,
+          vaultIdAtStart,
+          latestEntity,
+          this.isGuest,
+        );
+
+        // Update Dexie cache immediately so it's fresh for Tier 1 lookups
+        const path = latestEntity._path || [`${latestEntity.id}.md`];
+        await cacheService.set(
+          `${vaultIdAtStart}:${path.join("/")}`,
+          Date.now(),
+          latestEntity,
+        );
+
+        // Mark as verified since we just wrote it
+        this._contentVerifiedIds.add(latestEntity.id);
+
+        this.status = "idle";
+      } catch (error) {
+        debugStore.error("[VaultStore] Failed to save entity to disk", error);
+        this.status = "error";
+        this.errorMessage = "Failed to access storage for saving.";
+      }
+    });
+  }
+
+  async getSpecificVaultHandle(
+    vaultId: string,
+  ): Promise<FileSystemDirectoryHandle | undefined> {
+    if (!vaultId || !vaultRegistry.rootHandle) return undefined;
+
+    try {
+      const vaultsDir = await vaultRegistry.rootHandle.getDirectoryHandle(
+        "vaults",
+        { create: true },
+      );
+      return await vaultsDir.getDirectoryHandle(vaultId, {
+        create: true,
+      });
+    } catch (err) {
+      debugStore.warn(
+        `[VaultStore] Failed to get handle for vault: ${vaultId}`,
+        err,
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Internal helper to load content WITHOUT using the task queue.
+   * ONLY call this from within a queued task or when you know no write is active.
+   */
+  private async internalLoadContent(id: string): Promise<void> {
+    const currentEntity = this.entities[id];
+    if (!currentEntity) return;
+
+    try {
+      const path = currentEntity._path || [`${id}.md`];
+      const opfsModule = await import("../utils/opfs");
+      const markdownModule = await import("../utils/markdown");
+
+      if (!opfsModule || !markdownModule) {
+        throw new Error("Failed to load helper modules (opfs/markdown)");
+      }
+
+      const readFileAsText = opfsModule.readFileAsText;
+      const parseMarkdown = markdownModule.parseMarkdown;
+
+      if (!readFileAsText || !parseMarkdown) {
+        throw new Error("Missing helper functions in loaded modules");
+      }
+
+      const vaultDir = await this.getActiveVaultHandle();
+      if (!vaultDir) return;
+
+      const text = await readFileAsText(vaultDir, path);
+      if (text) {
+        const { metadata, content } = parseMarkdown(text);
+        const lore = (metadata as any).lore || "";
+
+        this.repository.entities[id] = {
+          ...currentEntity,
+          content,
+          lore,
+        };
+        this._contentLoadedIds.add(id);
+        this._contentVerifiedIds.add(id);
+      }
+    } catch (err) {
+      debugStore.error(
+        `[VaultStore] internalLoadContent failed for ${id}:`,
+        err,
+      );
+    }
+  }
+
+  // --- CRUD Delegations ---
+  async createEntity(
+    type: Entity["type"],
+    title: string,
+    initialData: Partial<Entity> = {},
+  ) {
+    const id = await this.crudManager.createEntity(type, title, initialData);
+    if (id) {
+      this._contentLoadedIds.add(id); // Mark as loaded since it's new
+      this._contentVerifiedIds.add(id); // Mark as verified
+    }
+    return id;
+  }
+  async updateEntity(id: string, updates: Partial<LocalEntity>) {
+    const success = await this.crudManager.updateEntity(id, updates);
+    if (
+      success &&
+      (updates.content !== undefined ||
+        updates.lore !== undefined ||
+        updates.title !== undefined ||
+        updates.tags !== undefined)
+    ) {
+      this._contentLoadedIds.add(id);
+      this._contentVerifiedIds.add(id);
+    }
+    return success;
+  }
+  async batchUpdate(updates: Record<string, Partial<LocalEntity>>) {
+    const success = await this.crudManager.batchUpdate(updates);
+    if (success) {
+      for (const [id, patch] of Object.entries(updates)) {
+        if (
+          patch.content !== undefined ||
+          patch.lore !== undefined ||
+          patch.title !== undefined ||
+          patch.tags !== undefined
+        ) {
+          this._contentLoadedIds.add(id);
+          this._contentVerifiedIds.add(id);
+        }
+      }
+    }
+    return success;
+  }
+  async deleteEntity(id: string) {
+    if (this.onEntityDelete) this.onEntityDelete(id);
+
+    if (uiStore.isDemoMode) {
+      const updated = { ...this.entities };
+      delete updated[id];
+      this.repository.entities = updated;
+      return;
+    }
+
+    // Use the same per-entity lock for deletion to avoid conflicts with saves to that file.
+    const lockKey = id;
+
+    return this.saveQueue.enqueue(lockKey, async () => {
+      const vaultHandle = await this.getActiveVaultHandle();
+      const localHandle = await this.getActiveSyncHandle();
+
+      if (vaultHandle) {
+        // Resolve path before deletion from memory
+        const entity = this.entities[id];
+        const path = entity?._path || [`${id}.md`];
+
+        // 1. Delete from OPFS (Source of truth)
+        await this.crudManager.deleteEntity(
+          id,
+          vaultHandle,
+          this.activeVaultId!,
+        );
+
+        // 2. Delete from Local Filesystem (if attached)
+        if (localHandle) {
+          try {
+            const permission = await localHandle.queryPermission({
+              mode: "readwrite",
+            });
+            if (permission === "granted") {
+              const fileName = path[path.length - 1];
+              const dirPath = path.slice(0, -1);
+              let targetDir: FileSystemDirectoryHandle | undefined =
+                localHandle;
+
+              for (const part of dirPath) {
+                targetDir = await targetDir
+                  ?.getDirectoryHandle(part, { create: false })
+                  .catch(() => undefined);
+                if (!targetDir) break;
+              }
+
+              if (targetDir) {
+                await targetDir.removeEntry(fileName, { recursive: true });
+                debugStore.log(
+                  `[VaultStore] Deleted ${path.join("/")} from local filesystem`,
+                );
+              }
+            }
+          } catch (e) {
+            debugStore.warn(
+              `[VaultStore] Failed to delete ${path.join("/")} from local filesystem`,
+              e,
+            );
+          }
+        }
+
+        // 3. CRITICAL: Remove from Dexie cache to prevent "resurrection" on reload
+        if (this.activeVaultId) {
+          await cacheService.remove(`${this.activeVaultId}:${path.join("/")}`);
+        }
+      }
+    });
+  }
+  addConnection(
+    sourceId: string,
+    targetId: string,
+    type: string,
+    label?: string,
+    strength?: number,
+  ) {
+    return this.crudManager.addConnection(
+      sourceId,
+      targetId,
+      type,
+      label,
+      strength,
+    );
+  }
+  removeConnection(sourceId: string, targetId: string, type: string) {
+    return this.crudManager.removeConnection(sourceId, targetId, type);
+  }
+  addLabel(id: string, label: string) {
+    return this.crudManager.addLabel(id, label);
+  }
+  removeLabel(id: string, label: string) {
+    return this.crudManager.removeLabel(id, label);
+  }
+
+  bulkAddLabel(ids: string[], label: string) {
+    return this.crudManager.bulkAddLabel(ids, label);
+  }
+  bulkRemoveLabel(ids: string[], label: string) {
+    return this.crudManager.bulkRemoveLabel(ids, label);
+  }
+  async batchCreateEntities(newEntitiesList: BatchCreateInput[]) {
+    await this.crudManager.batchCreateEntities(newEntitiesList);
+    // Mark all as loaded and verified since they are fresh.
+    // This prevents lazy load clobbering.
+    for (const item of newEntitiesList) {
+      if ((item as any).id) {
+        const id = (item as any).id;
+        this._contentLoadedIds.add(id);
+        this._contentVerifiedIds.add(id);
+      }
+    }
+
+    this.broadcastVaultUpdate();
+  }
+
+  updateConnection(
+    sourceId: string,
+    targetId: string,
+    oldType: string,
+    newType: string,
+    newLabel?: string,
+  ) {
+    return this.crudManager.updateConnection(
+      sourceId,
+      targetId,
+      oldType,
+      newType,
+      newLabel,
+    );
   }
 
   async resolveImageUrl(
@@ -349,9 +1068,7 @@ export class VaultStore {
     // If we are in guest mode, we need to fetch files from the host
     const effectiveFetcher =
       fileFetcher ||
-      (this.isGuest
-        ? (p: string) => p2pGuestService.getFile(p)
-        : undefined);
+      (this.isGuest ? (p: string) => p2pGuestService.getFile(p) : undefined);
 
     return this.assetManager.resolveImageUrl(
       await this.getActiveVaultHandle(),
@@ -388,8 +1105,9 @@ export class VaultStore {
           const url = p.startsWith("vault-samples/")
             ? `${base}/${p}`
             : `${base}/vault-samples/${p}`;
-          const res = await fetch(url);
-          return await res.blob();
+          const r = await fetch(url);
+          if (!r.ok) throw new Error(`Failed to fetch sample asset: ${url}`);
+          return r.blob();
         }
       : undefined;
 
@@ -400,10 +1118,143 @@ export class VaultStore {
       await this.getActiveSyncHandle(),
     );
   }
+
+  async getActiveVaultHandle(): Promise<FileSystemDirectoryHandle | undefined> {
+    if (!this.activeVaultId || !vaultRegistry.rootHandle) return undefined;
+    if (this._vaultHandle) return this._vaultHandle;
+
+    try {
+      const vaultsDir = await vaultRegistry.rootHandle.getDirectoryHandle(
+        "vaults",
+        { create: true },
+      );
+      this._vaultHandle = await vaultsDir.getDirectoryHandle(
+        this.activeVaultId,
+        {
+          create: true,
+        },
+      );
+      return this._vaultHandle;
+    } catch (err) {
+      debugStore.warn("[VaultStore] Failed to get active vault handle", err);
+      return undefined;
+    }
+  }
+
+  async getActiveSyncHandle(): Promise<FileSystemDirectoryHandle | undefined> {
+    if (!this.activeVaultId) return undefined;
+    try {
+      const db = await getDB();
+      const handle = await db.get(
+        "settings",
+        `syncHandle_${this.activeVaultId}`,
+      );
+      return handle as FileSystemDirectoryHandle | undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // --- Map & Canvas Delegations ---
+  saveMaps() {
+    return mapRegistry.saveMaps();
+  }
+  deleteMap(id: string) {
+    return mapRegistry.deleteMap(id);
+  }
+  saveCanvas(id: string, options?: { explicitVaultId?: string }) {
+    return canvasRegistry.saveCanvas(id, options);
+  }
+
+  // --- Sync Delegations ---
+
+  async syncWithLocalFolder() {
+    if (!this.syncCoordinator || !this.activeVaultId) return;
+    const vaultIdAtStart = this.activeVaultId;
+    const opfsHandle = await this.getActiveVaultHandle();
+    await this.syncCoordinator.syncWithLocalFolder(
+      vaultIdAtStart,
+      opfsHandle,
+      this.entities,
+      () => this.repository.waitForAllSaves(),
+      (state) => {
+        // ONLY update status if we are still on the same vault
+        if (this.activeVaultId === vaultIdAtStart) {
+          this.status = state.status;
+          this.syncType = state.syncType;
+          if (state.errorMessage) this.errorMessage = state.errorMessage;
+        }
+      },
+      () => this.checkForConflicts(),
+    );
+  }
+
+  async cleanupConflictFiles(signal?: AbortSignal) {
+    if (!this.syncCoordinator || !this.activeVaultId) return;
+    const opfsHandle = await this.getActiveVaultHandle();
+    if (!opfsHandle || signal?.aborted) return;
+
+    await this.syncCoordinator.cleanupConflictFiles(
+      this.activeVaultId,
+      opfsHandle,
+      (status) => {
+        if (!signal?.aborted) this.status = status;
+      },
+      () => this.loadFiles(),
+      signal,
+    );
+  }
+
+  async checkForConflicts(signal?: AbortSignal) {
+    const opfsHandle = await this.getActiveVaultHandle();
+    if (!opfsHandle || signal?.aborted) return;
+    try {
+      const files = await fileIOAdapter.walkDirectory(opfsHandle);
+      if (signal?.aborted) return;
+      this.hasConflictFiles = files.some((f: any) =>
+        f.path[f.path.length - 1].includes(".conflict-"),
+      );
+    } catch {
+      this.hasConflictFiles = false;
+    }
+  }
+
+  // --- Lifecycle Delegations ---
+  importFromFolder(handle?: FileSystemDirectoryHandle) {
+    if (!handle) return Promise.resolve();
+    return this.lifecycleManager.importFromFolder(handle);
+  }
+  switchVault(id: string) {
+    return this.lifecycleManager.switchVault(id);
+  }
+  createVault(name: string) {
+    return this.lifecycleManager.createVault(name);
+  }
+  deleteVault(id: string) {
+    return this.lifecycleManager.deleteVault(id);
+  }
+  loadDemoData(name: string, entities: Record<string, LocalEntity>) {
+    return this.lifecycleManager.loadDemoData(name, entities);
+  }
+  persistToIndexedDB(vaultId: string) {
+    return this.lifecycleManager.persistToIndexedDB(vaultId);
+  }
+
+  async setDefaultVisibility(v: "visible" | "hidden") {
+    this.defaultVisibility = v;
+    const db = await getDB();
+    await db.put("settings", v, "defaultVisibility");
+  }
 }
 
-export const vault = new VaultStore();
-
-if (typeof window !== "undefined") {
+const VAULT_KEY = "__codex_vault_instance__";
+export const vault: VaultStore =
+  (globalThis as any)[VAULT_KEY] ??
+  ((globalThis as any)[VAULT_KEY] = new VaultStore());
+if (
+  typeof window !== "undefined" &&
+  (import.meta.env.DEV || (window as any).__E2E__)
+) {
   (window as any).vault = vault;
+  console.log("[VaultStore] Module loaded, vault attached to window");
 }

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -1,4 +1,5 @@
 import { uiStore } from "./ui.svelte";
+import { p2pGuestService } from "../cloud-bridge/p2p/guest-service";
 import { base } from "$app/paths";
 import { vaultRegistry } from "./vault-registry.svelte";
 import { mapRegistry } from "./map-registry.svelte";
@@ -98,976 +99,264 @@ export class VaultStore {
 
   /**
    * Tracks which entity IDs have their `content` and `lore` fields fully
-   * populated in `this.entities`.  Entities loaded from the Dexie graph-entity
-   * cache start with `content = ""` to keep the initial load lightweight;
-   * calling `loadEntityContent(id)` fills in these fields on demand.
+   * loaded. Critical for P2P and synced vaults.
    */
-  private _contentLoadedIds = new Set<string>();
-  private _contentVerifiedIds = new Set<string>();
+  private loadedContentIds = new Set<string>();
 
-  // Delegated Getters
+  constructor(
+    public repository: VaultRepository = new VaultRepository(),
+    private syncCoordinator: SyncCoordinator = new SyncCoordinator(
+      repository,
+      createSyncEngine(),
+      syncNotifier,
+    ),
+    private assetManager: AssetManager = new AssetManager(
+      assetIOAdapter,
+      imageProcessor,
+    ),
+  ) {
+    this.crudManager = new VaultCrudManager(repository, assetManager);
+    this.lifecycleManager = new VaultLifecycleManager(
+      repository,
+      syncCoordinator,
+      assetManager,
+    );
+
+    // Wire up events
+    repository.onEntityUpdate = (e) => {
+      this.onEntityUpdate?.(e);
+      vaultEventBus.emit("entity-updated", { entity: e });
+    };
+    repository.onEntityDelete = (id) => {
+      this.onEntityDelete?.(id);
+      vaultEventBus.emit("entity-deleted", { entityId: id });
+    };
+    repository.onBatchUpdate = (updates) => {
+      this.onBatchUpdate?.(updates);
+      vaultEventBus.emit("batch-updated", { updates });
+    };
+
+    if (browser) {
+      this.channel = new BroadcastChannel("vault-sync");
+      this.channel.onmessage = (event) => {
+        if (event.data.type === "VAULT_UPDATED") {
+          this.syncCoordinator.triggerSync();
+        }
+      };
+    }
+  }
+
+  // Getters for Repository State
   get entities() {
     return this.repository.entities;
   }
-
-  // ⚡ Bolt Optimization: Use a derived array to avoid per-node allocations via Object.values()
-  // in hot loops (e.g., timeline, search, graph syncing).
-  allEntities = $derived.by(() => {
-    if (!this.repository) return [];
-    return Object.values(this.repository.entities);
-  });
-
+  get allEntities() {
+    return this.repository.allEntities;
+  }
   get maps() {
-    return mapRegistry.maps;
+    return this.repository.maps;
+  }
+  get allMaps() {
+    return this.repository.allMaps;
   }
   get canvases() {
-    return canvasRegistry.canvases;
+    return this.repository.canvases;
+  }
+  get allCanvases() {
+    return this.repository.allCanvases;
   }
   get activeVaultId() {
-    return vaultRegistry.activeVaultId;
+    return this.repository.activeVaultId;
   }
-  get vaultName() {
-    return vaultRegistry.vaultName;
+  get activeVaultName() {
+    return this.repository.activeVaultName;
   }
-  get saveQueue() {
-    return this.repository.saveQueue;
-  }
+
   get isGuest() {
-    return !!uiStore.isGuestMode;
+    return uiStore.isGuestMode;
   }
 
-  constructor(
-    public repository = new VaultRepository(fileIOAdapter),
-    private assetManager = new AssetManager(assetIOAdapter, imageProcessor),
-    public syncCoordinator: SyncCoordinator | null = null,
-  ) {
-    this.crudManager = new VaultCrudManager(
-      () => this.entities,
-      (entities) => {
-        this.repository.entities = entities;
-      },
-      (entity) => this.scheduleSave(entity),
-      () => this.getActiveVaultHandle(),
-      () => this.activeVaultId,
-      () => this.isGuest,
-      () => this.services,
-      (id) => this.onEntityDelete && this.onEntityDelete(id),
-      (entity) => this.onEntityUpdate && this.onEntityUpdate(entity),
-      (updates) => this.onBatchUpdate && this.onBatchUpdate(updates),
-      (path) => this.assetManager.releaseImageUrl(path),
-    );
-
-    this.lifecycleManager = new VaultLifecycleManager(
-      (s) => (this.status = s),
-      (m) => (this.errorMessage = m),
-      () => this.activeVaultId,
-      () => this.getActiveVaultHandle(),
-      this.repository,
-      this.assetManager,
-      (skipSync) => this.loadFiles(skipSync),
-      () => this.entities,
-      (n) => (this.demoVaultName = n),
-      (v) => (this.isInitialized = v),
-      () => this.services,
-      (c) => (this.hasConflictFiles = c),
-      (id) => (this.selectedEntityId = id),
-      vaultRegistry,
-      themeStore,
-      mapRegistry,
-      canvasRegistry,
-      (path, handle) => this.ensureAssetPersisted(path, handle),
-    );
-    if (typeof window !== "undefined") {
-      this.channel = new BroadcastChannel("codex-vault-sync");
-      this.channel.onmessage = (event) => {
-        if (
-          event.data.type === "RELOAD_VAULT" &&
-          event.data.vaultId === this.activeVaultId
-        ) {
-          this.loadFiles();
-        }
-      };
-
-      mapRegistry.init(this.repository.saveQueue);
-      canvasRegistry.init(this.repository.saveQueue);
-    }
-  }
-
-  // --- External Sync Methods ---
-  broadcastVaultUpdate() {
-    if (this.channel && this.activeVaultId) {
-      this.channel.postMessage({
-        type: "RELOAD_VAULT",
-        vaultId: this.activeVaultId,
-      });
-    }
-  }
-
-  async ensureServicesInitialized() {
-    if (this.services && this.syncCoordinator) return;
-
-    try {
-      const searchModule = await import("../services/search");
-      const aiModule = await import("../services/ai");
-
-      if (searchModule && aiModule) {
-        this.services = {
-          search: searchModule.searchService,
-          ai: {
-            clearStyleCache: () =>
-              aiModule.contextRetrievalService.clearStyleCache(),
-            expandQuery: (k, q, h) =>
-              aiModule.textGenerationService.expandQuery(k, q, h),
-          },
-        };
-      }
-    } catch (err) {
-      debugStore.error("[VaultStore] Failed to lazy-load services", err);
-    }
-
-    if (!this.syncCoordinator && typeof window !== "undefined") {
-      const engine = await createSyncEngine();
-      this.syncCoordinator = new SyncCoordinator(
-        syncIOAdapter,
-        engine,
-        syncNotifier,
-      );
-    }
-  }
-
-  async init(injectedServices?: IVaultServices) {
-    // Separate controller for init path to allow independent cancellation
-    const controller = new AbortController();
-    const signal = controller.signal;
-
-    this.isInitialized = false;
+  // Lifecycle Methods
+  async initialize() {
     this.status = "loading";
-    this.assetManager.clear();
-    this.repository.clear();
-
-    if (injectedServices) {
-      this.services = injectedServices;
-    } else if (typeof window !== "undefined") {
-      // Background: Pre-load modules needed for content loading to eliminate interaction latency
-      import("../utils/opfs")
-        .then((m) => (this._helpers.readFileAsText = m.readFileAsText))
-        .catch(() => {});
-      import("../utils/markdown")
-        .then((m) => (this._helpers.parseMarkdown = m.parseMarkdown))
-        .catch(() => {});
-
-      await this.ensureServicesInitialized();
-    }
-
     try {
-      await vaultRegistry.init();
-      const opfsRoot = vaultRegistry.rootHandle;
-      if (!opfsRoot) throw new Error("OPFS Root failed to initialize");
-
-      if (uiStore.isDemoMode) {
-        this.isInitialized = true;
-        this.status = "idle";
-        return;
-      }
-
-      const db = await getDB();
-      const savedVisibility = await db.get("settings", "defaultVisibility");
-      if (savedVisibility) this.defaultVisibility = savedVisibility;
-
-      const migration = await vaultMigration.checkForMigration();
-      if (migration.required && migration.handle) {
-        this.migrationRequired = true;
-        await vaultMigration.runMigration(
-          opfsRoot,
-          migration.handle,
-          true,
-          () => this.loadFiles(),
-          (status, err) => {
-            this.status = status;
-            if (err) this.errorMessage = err;
-          },
-        );
-      }
-
-      await vaultMigration.migrateStructure(opfsRoot);
-
-      if (this.activeVaultId) {
-        await themeStore.loadForVault(this.activeVaultId);
-        await this.loadFiles();
-      } else {
-        await vaultRegistry.listVaults();
-        if (vaultRegistry.availableVaults.length > 0) {
-          const firstVault = vaultRegistry.availableVaults[0];
-          await vaultRegistry.setActiveVault(firstVault.id);
-          await themeStore.loadForVault(firstVault.id);
-          await this.loadFiles();
-        }
-      }
-    } catch (err: any) {
-      debugStore.error("[VaultStore] Init failed", err);
-      console.warn("[VaultStore] Init failed, falling back to Guest Mode", err);
-
-      uiStore.isGuestMode = true;
-      this.status = "idle";
-      this.errorMessage =
-        err?.name === "QuotaExceededError"
-          ? "Storage full. Running in Guest Mode (changes will not be saved)."
-          : "Storage access denied. Running in Guest Mode.";
-
-      // Ensure we have at least the welcome content by loading it via fetch
-      if (Object.keys(this.entities).length === 0) {
-        try {
-          const response = await fetch("/vault-samples/welcome.json");
-          const data = await response.json();
-          await this.loadDemoData("Welcome", data.entities || data);
-        } catch (e) {
-          console.warn("Failed to load fallback demo data", e);
-        }
-      }
-    } finally {
+      await this.lifecycleManager.initialize();
       this.isInitialized = true;
-      if (!signal.aborted) {
-        await this.checkForConflicts(signal);
-      }
-      if ((this.status as string) !== "error" && !signal.aborted) {
-        this.status = "idle";
-        if (this.activeVaultId) {
-          window.dispatchEvent(
-            new CustomEvent("vault-switched", {
-              detail: { id: this.activeVaultId },
-            }),
-          );
-        }
-      }
-    }
-  }
-
-  private _vaultHandle: FileSystemDirectoryHandle | undefined = undefined;
-
-  async loadFiles(skipSyncIfWarm = true) {
-    if (!this.activeVaultId) return;
-    const vaultIdAtStart = this.activeVaultId;
-
-    // ABORT: Cancel any ongoing background sync from a previous vault switch
-    if (this.syncAbortController) {
-      this.syncAbortController.abort();
-    }
-    this.syncAbortController = new AbortController();
-    const signal = this.syncAbortController.signal;
-
-    this.status = "loading";
-    this._contentLoadedIds = new Set();
-    this._contentVerifiedIds = new Set();
-    this._vaultHandle = undefined; // Reset handle on load
-    this.syncStats = {
-      updated: 0,
-      created: 0,
-      deleted: 0,
-      failed: 0,
-      total: 0,
-      progress: 0,
-    };
-
-    try {
-      debugStore.log(`[VaultStore] Loading files for vault: ${vaultIdAtStart}`);
-
-      // Reset event bus to clear listeners from previous vault sessions (prevent leaks)
-      vaultEventBus.reset();
-
-      // BROADCAST: Opening vault
-      vaultEventBus.emit({
-        type: "VAULT_OPENING",
-        vaultId: vaultIdAtStart,
-      });
-
-      if (this.services) {
-        this.services.ai.clearStyleCache();
-      }
-
-      // 1. Cache-First: Preload graph metadata from Dexie immediately.
-      const cachedMap = await cacheService.preloadVault(vaultIdAtStart);
-
-      // Race check after async preload
-      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
-
-      if (cachedMap.size > 0) {
-        // CRITICAL: We start with a FRESH map.
-        // Do NOT spread this.repository.entities as it might contain stale data from previous vault.
-        const entityMap: Record<string, LocalEntity> = {};
-        for (const { entity: e } of cachedMap.values()) {
-          const existing = entityMap[e.id];
-
-          // Preserve content/lore if they are already loaded in memory
-          const finalContent =
-            existing?.content && !e.content ? existing.content : e.content;
-
-          const finalLore = existing?.lore && !e.lore ? existing.lore : e.lore;
-
-          entityMap[e.id] = {
-            ...e,
-            content: finalContent,
-            lore: finalLore,
-          };
-        }
-        // Push to repository to trigger immediate UI/Graph rendering
-        this.repository.entities = entityMap;
-        debugStore.log(
-          `[VaultStore] Cache-First: Populated ${cachedMap.size} entities from Dexie.`,
-        );
-
-        // BROADCAST: Initial cache data ready
-        vaultEventBus.emit({
-          type: "CACHE_LOADED",
-          vaultId: vaultIdAtStart,
-          entities: entityMap,
-        });
-
-        // IMPORTANT: We set status to idle NOW. The graph is visible and interactive.
-        this.status = "idle";
-
-        if (skipSyncIfWarm) {
-          debugStore.log(
-            "[VaultStore] Cache is warm. Skipping OPFS background sync for instant load.",
-          );
-
-          // Start background tasks
-          mapRegistry.loadFromVault(vaultIdAtStart);
-          canvasRegistry.loadFromVault(vaultIdAtStart);
-
-          // Resolve handle in background for image resolution
-          this.getActiveVaultHandle();
-          return;
-        }
-      }
-
-      // 2. FS-Sync: Resolve OPFS handle and perform full synchronization
-      const vaultDir = await this.getActiveVaultHandle();
-
-      // Race check after async handle resolution
-      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
-
-      if (!vaultDir) {
-        if (this.status !== "idle") {
-          this.status = cachedMap.size > 0 ? "idle" : "error";
-          if (this.status === "error") {
-            this.errorMessage = "Failed to resolve vault directory handle";
-          }
-        }
-        return;
-      }
-
-      // 3. Local-Sync: If a local directory handle is persisted, sync it to OPFS first.
-      const localHandle = await this.getActiveSyncHandle();
-      if (localHandle) {
-        debugStore.log(
-          `[VaultStore] Local sync handle found for ${vaultIdAtStart}. Synchronizing...`,
-        );
-        await this.ensureServicesInitialized();
-        if (this.syncCoordinator) {
-          try {
-            await this.syncCoordinator.syncWithLocalFolder(
-              vaultIdAtStart,
-              vaultDir,
-              this.entities,
-              () => this.repository.waitForAllSaves(),
-              (state) => {
-                // ONLY update status if we are still on the same vault AND not aborted
-                if (this.activeVaultId === vaultIdAtStart && !signal.aborted) {
-                  this.status = state.status;
-                  if (state.errorMessage)
-                    this.errorMessage = state.errorMessage;
-                }
-              },
-              () => this.checkForConflicts(),
-              signal,
-              (stats) => {
-                if (this.activeVaultId === vaultIdAtStart && !signal.aborted) {
-                  this.syncStats = { ...this.syncStats, ...stats };
-                }
-              },
-            );
-            if (signal.aborted) return;
-            debugStore.log("[VaultStore] Local sync complete.");
-          } catch (err) {
-            debugStore.error("[VaultStore] Local sync failed", err);
-            // We continue anyway, maybe OPFS has some data
-          }
-        }
-      }
-
-      // Final race check before starting repository scan
-      if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
-
-      // Ensure status is idle if we have cache, otherwise keep loading until we get first FS results
-      if (cachedMap.size > 0) {
-        this.status = "idle";
-      }
-
-      const syncPromise = this.repository.loadFiles(
-        vaultIdAtStart,
-        vaultDir,
-        async (_chunk, current, total, newOrChanged) => {
-          // Race check inside progress callback
-          if (this.activeVaultId !== vaultIdAtStart || signal.aborted) return;
-
-          this.syncStats.total = total;
-          this.syncStats.progress = Math.round((current / total) * 100);
-          this.syncStats.created = current;
-
-          const changedIds = Object.keys(newOrChanged);
-
-          if (changedIds.length > 0) {
-            // Track entities that arrived from OPFS (cache miss path) — they
-            // already have content populated so no lazy load is needed later.
-            for (const id of changedIds) {
-              const entity = newOrChanged[id];
-              if (entity.content) {
-                this._contentLoadedIds.add(entity.id);
-                this._contentVerifiedIds.add(entity.id);
-              }
-            }
-
-            // BROADCAST: Chunk indexed
-            vaultEventBus.emit({
-              type: "SYNC_CHUNK_READY",
-              vaultId: vaultIdAtStart,
-              entities: this.entities,
-              newOrChangedIds: changedIds,
-            });
-          }
-        },
-      );
-
-      if (this.status === "loading") {
-        await syncPromise;
-      } else {
-        // Just catch errors for background sync
-        syncPromise.catch((err: any) => {
-          debugStore.error("[VaultStore] Background sync failed", err);
-        });
-      }
-
-      if (this.status === "loading") {
-        debugStore.log(
-          `[VaultStore] Load complete. Indexed ${this.syncStats.created} entities.`,
-        );
-        this.status = "idle";
-      }
-
-      await mapRegistry.loadFromVault(vaultIdAtStart);
-      await canvasRegistry.loadFromVault(vaultIdAtStart);
-
-      // BROADCAST: Full sync complete
-      vaultEventBus.emit({
-        type: "SYNC_COMPLETE",
-        vaultId: vaultIdAtStart,
-      });
+      this.status = "idle";
     } catch (err: any) {
-      debugStore.error("[VaultStore] Load failed", err);
       this.status = "error";
       this.errorMessage = err.message;
-    } finally {
+    }
+  }
+
+  async openVault(vaultId: string) {
+    this.status = "loading";
+    try {
+      await this.lifecycleManager.openVault(vaultId);
       this.isInitialized = true;
-      if (!signal.aborted) {
-        await this.checkForConflicts(signal);
-      }
-      if ((this.status as string) !== "error" && !signal.aborted) {
-        this.status = "idle";
-        if (this.activeVaultId) {
-          window.dispatchEvent(
-            new CustomEvent("vault-switched", {
-              detail: { id: this.activeVaultId },
-            }),
-          );
-        }
-      }
+      this.status = "idle";
+    } catch (err: any) {
+      this.status = "error";
+      this.errorMessage = err.message;
     }
   }
 
-  /**
-   * Loads the `content` and `lore` fields for the entity with the given ID
-   * and updates `this.entities[id]` in place.  Subsequent calls for the same
-   * ID are no-ops (unless the previous attempt failed with a transient error,
-   * in which case the next call will retry).
-   *
-   * This is the primary entry-point for lazy content loading — call it
-   * whenever the entity is "opened" (detail panel, read modal, edit mode, etc.)
-   * to ensure the full entity data is available for rendering.
-   */
-  async loadEntityContent(id: string): Promise<void> {
-    if (!id || !this.activeVaultId) return;
-    if (this._contentVerifiedIds.has(id)) return;
-
-    // Verify entity exists before starting async work.
-    const currentEntity = this.entities[id];
-    if (!currentEntity) return;
-
-    // PRIORITY 1: Try Dexie Cache for immediate Chronicle (content) and Lore
-    // No lock needed for Tier 1 IDB read.
-    let cached: { content: string; lore: string } | null = null;
-    let cacheErrored = false;
-    try {
-      cached = await cacheService.getEntityContent(this.activeVaultId, id);
-      if (cached !== null) {
-        const latest = this.entities[id];
-        if (latest && (!latest.content || latest.lore === undefined)) {
-          // Surgical update to the existing reactive proxy
-          this.repository.entities[id] = {
-            ...latest,
-            content: cached.content,
-            lore: cached.lore,
-          };
-          this._contentLoadedIds.add(id);
-          debugStore.log(
-            `[VaultStore] Priority 1 hit: Loaded chronicle/lore from cache for ${id}`,
-          );
-        }
-      }
-    } catch (cacheErr) {
-      cacheErrored = true;
-      debugStore.warn(
-        `[VaultStore] Priority 1 cache load failed for ${id}`,
-        cacheErr,
-      );
-    }
-
-    // Re-check after Priority 1
-    if (this._contentVerifiedIds.has(id)) return;
-
-    try {
-      const path = currentEntity._path || [`${id}.md`];
-
-      // Ensure helpers are available (fallback to dynamic import if background load hasn't finished)
-      const readFileAsText =
-        this._helpers.readFileAsText ||
-        (await import("../utils/opfs")).readFileAsText;
-      const parseMarkdown =
-        this._helpers.parseMarkdown ||
-        (await import("../utils/markdown")).parseMarkdown;
-
-      // PRIORITY 2 & 3: Load Lore (and fresh Chronicle) from Markdown file
-      let text = "";
-
-      const vaultDir = await this.getActiveVaultHandle();
-      if (vaultDir) {
-        try {
-          text = await readFileAsText(vaultDir, path);
-        } catch {
-          // Fall through
-        }
-      }
-
-      if (!text) {
-        const localHandle = await syncIOAdapter.getLocalHandle(
-          this.activeVaultId,
-        );
-        if (localHandle) {
-          try {
-            if (
-              (await localHandle.queryPermission({ mode: "read" })) ===
-              "granted"
-            ) {
-              text = await readFileAsText(localHandle, path);
-            }
-          } catch (err) {
-            debugStore.warn(
-              `[VaultStore] Priority 3 failed for ${id} from Local FS fallback`,
-              err,
-            );
-          }
-        }
-      }
-
-      if (text) {
-        const { metadata, content: freshContent } = parseMarkdown(text);
-        const freshLore = (metadata as any).lore || "";
-
-        const entityToUpdate = this.entities[id];
-        if (entityToUpdate) {
-          // Update the entity surgically. Never overwrite with empty if Tier 1 already had content
-          // and Priority 2/3 somehow returned empty content (unless both are empty).
-          const finalContent = freshContent || entityToUpdate.content || "";
-          const finalLore = freshLore || entityToUpdate.lore || "";
-
-          const updatedEntity = {
-            ...entityToUpdate,
-            content: finalContent,
-            lore: finalLore,
-          };
-
-          this.repository.entities[id] = updatedEntity;
-
-          this._contentLoadedIds.add(id);
-          this._contentVerifiedIds.add(id);
-
-          debugStore.log(
-            `[VaultStore] Verified ${id} from source: contentLen=${finalContent.length}, loreLen=${finalLore.length}`,
-          );
-
-          const isStale =
-            finalContent !== (cached?.content ?? null) ||
-            finalLore !== (cached?.lore ?? null);
-          const hasContent = finalContent || finalLore;
-
-          if (isStale && (cached !== null || hasContent)) {
-            // CRITICAL: Pass the plain updatedEntity, not the reactive proxy
-            // Background: No need to await
-            cacheService.set(
-              `${this.activeVaultId}:${path.join("/")}`,
-              Date.now(),
-              updatedEntity,
-            );
-          }
-        }
-      } else if (cached === null && !cacheErrored) {
-        this._contentVerifiedIds.add(id); // Even if missing, we verified the absence
-        debugStore.warn(
-          `[VaultStore] Content truly missing for ${id} in all tiers`,
-        );
-      }
-    } catch (err) {
-      debugStore.error(`[VaultStore] Failed to load content for ${id}:`, err);
-    }
+  async closeVault() {
+    await this.lifecycleManager.closeVault();
+    this.isInitialized = false;
+    this.status = "idle";
   }
 
-  scheduleSave(entity: LocalEntity | Entity): Promise<void> {
-    if (this.onEntityUpdate) this.onEntityUpdate(entity as LocalEntity);
-
-    const vaultIdAtStart = this.activeVaultId;
-    if (!vaultIdAtStart) return Promise.resolve();
-
-    if (this.services) {
-      const path =
-        (entity as LocalEntity)._path?.join("/") || `${entity.id}.md`;
-      const keywords = [
-        ...(entity.tags || []),
-        entity.lore || "",
-        ...Object.values(entity.metadata || {}).flat(),
-      ].join(" ");
-      const promise = this.services.search.index({
-        id: entity.id,
-        title: entity.title,
-        content: (entity as LocalEntity).content,
-        lore: (entity as LocalEntity).lore,
-        type: entity.type,
-        path,
-        keywords,
-        updatedAt: Date.now(),
-      });
-      if (promise && promise.catch) {
-        promise.catch((err) =>
-          debugStore.warn(`[VaultStore] Search index error: ${err}`),
-        );
-      }
-    }
-
-    if (uiStore.isDemoMode) return Promise.resolve();
-
-    // Use a per-entity lock for saving to serialize writes to the same file
-    // while allowing concurrent saves to DIFFERENT files.
-    const lockKey = entity.id;
-
-    return this.saveQueue.enqueue(lockKey, async () => {
-      // 1. Always get the absolute latest state from the store
-      let latestEntity = this.entities[entity.id];
-      if (!latestEntity) return;
-
-      // 2. CRITICAL SAFETY: If content hasn't been marked as loaded,
-      // we MUST try to load it before saving to avoid overwriting with empty.
-      if (!this._contentLoadedIds.has(entity.id)) {
-        // Note: loadEntityContent is already queued, but we need it NOW.
-        // We use a separate internal Load helper that avoids the queue to prevent deadlocks.
-        await this.internalLoadContent(entity.id);
-        // Re-fetch after load
-        latestEntity = this.entities[entity.id] || latestEntity;
-      }
-      this.status = "saving";
-      try {
-        // Resolution must happen per-save to ensure we use the correct handle for the vaultIdAtStart
-        const vaultHandle = await this.getSpecificVaultHandle(vaultIdAtStart);
-        if (!vaultHandle) return;
-
-        await this.repository.saveToDisk(
-          vaultHandle,
-          vaultIdAtStart,
-          latestEntity,
-          this.isGuest,
-        );
-
-        // Update Dexie cache immediately so it's fresh for Tier 1 lookups
-        const path = latestEntity._path || [`${latestEntity.id}.md`];
-        await cacheService.set(
-          `${vaultIdAtStart}:${path.join("/")}`,
-          Date.now(),
-          latestEntity,
-        );
-
-        // Mark as verified since we just wrote it
-        this._contentVerifiedIds.add(latestEntity.id);
-
-        this.status = "idle";
-      } catch (error) {
-        debugStore.error("[VaultStore] Failed to save entity to disk", error);
-        this.status = "error";
-        this.errorMessage = "Failed to access storage for saving.";
-      }
-    });
+  // CRUD Operations
+  async createEntity(type: Entity["type"], title: string) {
+    return await this.crudManager.createEntity(
+      await this.getActiveVaultHandle(),
+      type,
+      title,
+    );
   }
 
-  async getSpecificVaultHandle(
-    vaultId: string,
-  ): Promise<FileSystemDirectoryHandle | undefined> {
-    if (!vaultId || !vaultRegistry.rootHandle) return undefined;
-
-    try {
-      const vaultsDir = await vaultRegistry.rootHandle.getDirectoryHandle(
-        "vaults",
-        { create: true },
-      );
-      return await vaultsDir.getDirectoryHandle(vaultId, {
-        create: true,
-      });
-    } catch (err) {
-      debugStore.warn(
-        `[VaultStore] Failed to get handle for vault: ${vaultId}`,
-        err,
-      );
-      return undefined;
-    }
+  async batchCreateEntities(inputs: BatchCreateInput[]) {
+    return await this.crudManager.batchCreateEntities(
+      await this.getActiveVaultHandle(),
+      inputs,
+    );
   }
 
-  /**
-   * Internal helper to load content WITHOUT using the task queue.
-   * ONLY call this from within a queued task or when you know no write is active.
-   */
-  private async internalLoadContent(id: string): Promise<void> {
-    const currentEntity = this.entities[id];
-    if (!currentEntity) return;
-
-    try {
-      const path = currentEntity._path || [`${id}.md`];
-      const opfsModule = await import("../utils/opfs");
-      const markdownModule = await import("../utils/markdown");
-
-      if (!opfsModule || !markdownModule) {
-        throw new Error("Failed to load helper modules (opfs/markdown)");
-      }
-
-      const readFileAsText = opfsModule.readFileAsText;
-      const parseMarkdown = markdownModule.parseMarkdown;
-
-      if (!readFileAsText || !parseMarkdown) {
-        throw new Error("Missing helper functions in loaded modules");
-      }
-
-      const vaultDir = await this.getActiveVaultHandle();
-      if (!vaultDir) return;
-
-      const text = await readFileAsText(vaultDir, path);
-      if (text) {
-        const { metadata, content } = parseMarkdown(text);
-        const lore = (metadata as any).lore || "";
-
-        this.repository.entities[id] = {
-          ...currentEntity,
-          content,
-          lore,
-        };
-        this._contentLoadedIds.add(id);
-        this._contentVerifiedIds.add(id);
-      }
-    } catch (err) {
-      debugStore.error(
-        `[VaultStore] internalLoadContent failed for ${id}:`,
-        err,
-      );
-    }
+  async updateEntity(id: string, patch: Partial<LocalEntity>) {
+    return await this.crudManager.updateEntity(
+      await this.getActiveVaultHandle(),
+      id,
+      patch,
+    );
   }
 
-  // --- CRUD Delegations ---
-  async createEntity(
-    type: Entity["type"],
-    title: string,
-    initialData: Partial<Entity> = {},
-  ) {
-    const id = await this.crudManager.createEntity(type, title, initialData);
-    if (id) {
-      this._contentLoadedIds.add(id); // Mark as loaded since it's new
-      this._contentVerifiedIds.add(id); // Mark as verified
-    }
+  batchUpdate(updates: Record<string, Partial<LocalEntity>>) {
+    this.repository.batchUpdate(updates);
+  }
+
+  async deleteEntity(id: string) {
+    return await this.crudManager.deleteEntity(
+      await this.getActiveVaultHandle(),
+      id,
+    );
+  }
+
+  // Map Operations
+  async createMap(name: string, assetPath: string, dimensions: any) {
+    const id = await this.crudManager.createMap(
+      await this.getActiveVaultHandle(),
+      name,
+      assetPath,
+      dimensions,
+    );
+    await mapRegistry.touch(id);
     return id;
   }
-  async updateEntity(id: string, updates: Partial<LocalEntity>) {
-    const success = await this.crudManager.updateEntity(id, updates);
-    if (
-      success &&
-      (updates.content !== undefined ||
-        updates.lore !== undefined ||
-        updates.title !== undefined ||
-        updates.tags !== undefined)
-    ) {
-      this._contentLoadedIds.add(id);
-      this._contentVerifiedIds.add(id);
-    }
-    return success;
+
+  async saveMaps() {
+    return await this.crudManager.saveMaps(await this.getActiveVaultHandle());
   }
-  async batchUpdate(updates: Record<string, Partial<LocalEntity>>) {
-    const success = await this.crudManager.batchUpdate(updates);
-    if (success) {
-      for (const [id, patch] of Object.entries(updates)) {
-        if (
-          patch.content !== undefined ||
-          patch.lore !== undefined ||
-          patch.title !== undefined ||
-          patch.tags !== undefined
-        ) {
-          this._contentLoadedIds.add(id);
-          this._contentVerifiedIds.add(id);
-        }
-      }
-    }
-    return success;
+
+  // Canvas Operations
+  async createCanvas(name: string) {
+    const id = await this.crudManager.createCanvas(
+      await this.getActiveVaultHandle(),
+      name,
+    );
+    await canvasRegistry.touch(id);
+    return id;
   }
-  async deleteEntity(id: string) {
-    if (this.onEntityDelete) this.onEntityDelete(id);
 
-    if (uiStore.isDemoMode) {
-      const updated = { ...this.entities };
-      delete updated[id];
-      this.repository.entities = updated;
-      return;
+  async saveCanvas(id: string, options?: { explicitVaultId?: string }) {
+    let handle = await this.getActiveVaultHandle();
+
+    // If an explicit vault is provided, we must use that handle instead
+    if (options?.explicitVaultId && options.explicitVaultId !== this.activeVaultId) {
+      const root = await getOpfsRoot();
+      handle = await getVaultDir(root, options.explicitVaultId);
     }
 
-    // Use the same per-entity lock for deletion to avoid conflicts with saves to that file.
-    const lockKey = id;
+    return await this.crudManager.saveCanvas(handle, id);
+  }
 
-    return this.saveQueue.enqueue(lockKey, async () => {
-      const vaultHandle = await this.getActiveVaultHandle();
-      const localHandle = await this.getActiveSyncHandle();
+  async deleteCanvas(id: string) {
+    await this.crudManager.deleteCanvas(await this.getActiveVaultHandle(), id);
+    await canvasRegistry.touch(id);
+  }
 
-      if (vaultHandle) {
-        // Resolve path before deletion from memory
-        const entity = this.entities[id];
-        const path = entity?._path || [`${id}.md`];
+  // Sync Methods
+  async triggerSync() {
+    return await this.syncCoordinator.triggerSync();
+  }
 
-        // 1. Delete from OPFS (Source of truth)
-        await this.crudManager.deleteEntity(
-          id,
-          vaultHandle,
-          this.activeVaultId!,
+  // Helper Methods
+  async getActiveVaultHandle() {
+    return await this.repository.getActiveVaultHandle();
+  }
+
+  async getActiveSyncHandle() {
+    return await this.repository.getActiveSyncHandle();
+  }
+
+  async loadEntityContent(id: string) {
+    if (this.loadedContentIds.has(id)) return;
+
+    try {
+      const entity = this.entities[id];
+      if (!entity) return;
+
+      if (!this._helpers.readFileAsText) {
+        const { readFileAsText: rf, parseMarkdown } = await import(
+          "../utils/opfs"
         );
-
-        // 2. Delete from Local Filesystem (if attached)
-        if (localHandle) {
-          try {
-            const permission = await localHandle.queryPermission({
-              mode: "readwrite",
-            });
-            if (permission === "granted") {
-              const fileName = path[path.length - 1];
-              const dirPath = path.slice(0, -1);
-              let targetDir: FileSystemDirectoryHandle | undefined =
-                localHandle;
-
-              for (const part of dirPath) {
-                targetDir = await targetDir
-                  ?.getDirectoryHandle(part, { create: false })
-                  .catch(() => undefined);
-                if (!targetDir) break;
-              }
-
-              if (targetDir) {
-                await targetDir.removeEntry(fileName, { recursive: true });
-                debugStore.log(
-                  `[VaultStore] Deleted ${path.join("/")} from local filesystem`,
-                );
-              }
-            }
-          } catch (e) {
-            debugStore.warn(
-              `[VaultStore] Failed to delete ${path.join("/")} from local filesystem`,
-              e,
-            );
-          }
-        }
-
-        // 3. CRITICAL: Remove from Dexie cache to prevent "resurrection" on reload
-        if (this.activeVaultId) {
-          await cacheService.remove(`${this.activeVaultId}:${path.join("/")}`);
-        }
+        this._helpers.readFileAsText = rf;
+        this._helpers.parseMarkdown = parseMarkdown;
       }
-    });
-  }
-  addConnection(
-    sourceId: string,
-    targetId: string,
-    type: string,
-    label?: string,
-    strength?: number,
-  ) {
-    return this.crudManager.addConnection(
-      sourceId,
-      targetId,
-      type,
-      label,
-      strength,
-    );
-  }
-  removeConnection(sourceId: string, targetId: string, type: string) {
-    return this.crudManager.removeConnection(sourceId, targetId, type);
-  }
-  addLabel(id: string, label: string) {
-    return this.crudManager.addLabel(id, label);
-  }
-  removeLabel(id: string, label: string) {
-    return this.crudManager.removeLabel(id, label);
-  }
 
-  bulkAddLabel(ids: string[], label: string) {
-    return this.crudManager.bulkAddLabel(ids, label);
-  }
-  bulkRemoveLabel(ids: string[], label: string) {
-    return this.crudManager.bulkRemoveLabel(ids, label);
-  }
-  async batchCreateEntities(newEntitiesList: BatchCreateInput[]) {
-    await this.crudManager.batchCreateEntities(newEntitiesList);
-    // Mark all as loaded and verified since they are fresh.
-    // This prevents lazy load clobbering.
-    for (const item of newEntitiesList) {
-      if ((item as any).id) {
-        const id = (item as any).id;
-        this._contentLoadedIds.add(id);
-        this._contentVerifiedIds.add(id);
+      const handle = await this.getActiveVaultHandle();
+      if (!handle && !this.isGuest) return;
+
+      let content = "";
+      if (this.isGuest) {
+        // In guest mode, the content should already be in the entity object
+        // because the host serializes it. If it's missing, we can't do much
+        // unless we add a GET_CONTENT P2P message.
+        content = (entity as any).content || "";
+      } else {
+        const path = entity._path;
+        if (!path) return;
+        content = await this._helpers.readFileAsText(handle, path);
       }
+
+      const { data, content: body } = this._helpers.parseMarkdown(content);
+
+      this.repository.entities[id] = {
+        ...entity,
+        ...data,
+        content: body,
+      };
+      this.loadedContentIds.add(id);
+    } catch (err) {
+      console.warn(`[VaultStore] Failed to load content for ${id}`, err);
     }
-
-    this.broadcastVaultUpdate();
-  }
-
-  updateConnection(
-    sourceId: string,
-    targetId: string,
-    oldType: string,
-    newType: string,
-    newLabel?: string,
-  ) {
-    return this.crudManager.updateConnection(
-      sourceId,
-      targetId,
-      oldType,
-      newType,
-      newLabel,
-    );
   }
 
   async resolveImageUrl(
     path: string,
     fileFetcher?: (path: string) => Promise<Blob>,
   ) {
+    // If we are in guest mode, we need to fetch files from the host
+    const effectiveFetcher =
+      fileFetcher ||
+      (this.isGuest
+        ? (p: string) => p2pGuestService.getFile(p)
+        : undefined);
+
     return this.assetManager.resolveImageUrl(
       await this.getActiveVaultHandle(),
       path,
-      fileFetcher,
+      effectiveFetcher,
       await this.getActiveSyncHandle(),
     );
   }
@@ -1099,9 +388,8 @@ export class VaultStore {
           const url = p.startsWith("vault-samples/")
             ? `${base}/${p}`
             : `${base}/vault-samples/${p}`;
-          const r = await fetch(url);
-          if (!r.ok) throw new Error(`Failed to fetch sample asset: ${url}`);
-          return r.blob();
+          const res = await fetch(url);
+          return await res.blob();
         }
       : undefined;
 
@@ -1112,143 +400,10 @@ export class VaultStore {
       await this.getActiveSyncHandle(),
     );
   }
-
-  async getActiveVaultHandle(): Promise<FileSystemDirectoryHandle | undefined> {
-    if (!this.activeVaultId || !vaultRegistry.rootHandle) return undefined;
-    if (this._vaultHandle) return this._vaultHandle;
-
-    try {
-      const vaultsDir = await vaultRegistry.rootHandle.getDirectoryHandle(
-        "vaults",
-        { create: true },
-      );
-      this._vaultHandle = await vaultsDir.getDirectoryHandle(
-        this.activeVaultId,
-        {
-          create: true,
-        },
-      );
-      return this._vaultHandle;
-    } catch (err) {
-      debugStore.warn("[VaultStore] Failed to get active vault handle", err);
-      return undefined;
-    }
-  }
-
-  async getActiveSyncHandle(): Promise<FileSystemDirectoryHandle | undefined> {
-    if (!this.activeVaultId) return undefined;
-    try {
-      const db = await getDB();
-      const handle = await db.get(
-        "settings",
-        `syncHandle_${this.activeVaultId}`,
-      );
-      return handle as FileSystemDirectoryHandle | undefined;
-    } catch {
-      return undefined;
-    }
-  }
-
-  // --- Map & Canvas Delegations ---
-  saveMaps() {
-    return mapRegistry.saveMaps();
-  }
-  deleteMap(id: string) {
-    return mapRegistry.deleteMap(id);
-  }
-  saveCanvas(id: string, options?: { explicitVaultId?: string }) {
-    return canvasRegistry.saveCanvas(id, options);
-  }
-
-  // --- Sync Delegations ---
-
-  async syncWithLocalFolder() {
-    if (!this.syncCoordinator || !this.activeVaultId) return;
-    const vaultIdAtStart = this.activeVaultId;
-    const opfsHandle = await this.getActiveVaultHandle();
-    await this.syncCoordinator.syncWithLocalFolder(
-      vaultIdAtStart,
-      opfsHandle,
-      this.entities,
-      () => this.repository.waitForAllSaves(),
-      (state) => {
-        // ONLY update status if we are still on the same vault
-        if (this.activeVaultId === vaultIdAtStart) {
-          this.status = state.status;
-          this.syncType = state.syncType;
-          if (state.errorMessage) this.errorMessage = state.errorMessage;
-        }
-      },
-      () => this.checkForConflicts(),
-    );
-  }
-
-  async cleanupConflictFiles(signal?: AbortSignal) {
-    if (!this.syncCoordinator || !this.activeVaultId) return;
-    const opfsHandle = await this.getActiveVaultHandle();
-    if (!opfsHandle || signal?.aborted) return;
-
-    await this.syncCoordinator.cleanupConflictFiles(
-      this.activeVaultId,
-      opfsHandle,
-      (status) => {
-        if (!signal?.aborted) this.status = status;
-      },
-      () => this.loadFiles(),
-      signal,
-    );
-  }
-
-  async checkForConflicts(signal?: AbortSignal) {
-    const opfsHandle = await this.getActiveVaultHandle();
-    if (!opfsHandle || signal?.aborted) return;
-    try {
-      const files = await fileIOAdapter.walkDirectory(opfsHandle);
-      if (signal?.aborted) return;
-      this.hasConflictFiles = files.some((f: any) =>
-        f.path[f.path.length - 1].includes(".conflict-"),
-      );
-    } catch {
-      this.hasConflictFiles = false;
-    }
-  }
-
-  // --- Lifecycle Delegations ---
-  importFromFolder(handle?: FileSystemDirectoryHandle) {
-    if (!handle) return Promise.resolve();
-    return this.lifecycleManager.importFromFolder(handle);
-  }
-  switchVault(id: string) {
-    return this.lifecycleManager.switchVault(id);
-  }
-  createVault(name: string) {
-    return this.lifecycleManager.createVault(name);
-  }
-  deleteVault(id: string) {
-    return this.lifecycleManager.deleteVault(id);
-  }
-  loadDemoData(name: string, entities: Record<string, LocalEntity>) {
-    return this.lifecycleManager.loadDemoData(name, entities);
-  }
-  persistToIndexedDB(vaultId: string) {
-    return this.lifecycleManager.persistToIndexedDB(vaultId);
-  }
-
-  async setDefaultVisibility(v: "visible" | "hidden") {
-    this.defaultVisibility = v;
-    const db = await getDB();
-    await db.put("settings", v, "defaultVisibility");
-  }
 }
 
-const VAULT_KEY = "__codex_vault_instance__";
-export const vault: VaultStore =
-  (globalThis as any)[VAULT_KEY] ??
-  ((globalThis as any)[VAULT_KEY] = new VaultStore());
-if (
-  typeof window !== "undefined" &&
-  (import.meta.env.DEV || (window as any).__E2E__)
-) {
+export const vault = new VaultStore();
+
+if (typeof window !== "undefined") {
   (window as any).vault = vault;
-  console.log("[VaultStore] Module loaded, vault attached to window");
 }

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -160,7 +160,7 @@ export class VaultStore {
     return this.repository.allMaps;
   }
   get canvases() {
-    return this.repository.canvases;
+    return this.repository.canenses;
   }
   get allCanvases() {
     return this.repository.allCanvases;
@@ -329,7 +329,7 @@ export class VaultStore {
         content = await this._helpers.readFileAsText(handle, path);
       }
 
-      const { data, content: body } = this._helpers.parseMarkdown(content);
+      const { metadata: data, content: body } = this._helpers.parseMarkdown(content);
 
       this.repository.entities[id] = {
         ...entity,
@@ -389,6 +389,11 @@ export class VaultStore {
             ? `${base}/${p}`
             : `${base}/vault-samples/${p}`;
           const res = await fetch(url);
+          if (!res.ok) {
+            throw new Error(
+              `Failed to fetch sample asset "${p}" (HTTP ${res.status} ${res.statusText}) from ${url}`,
+            );
+          }
           return await res.blob();
         }
       : undefined;
@@ -402,7 +407,10 @@ export class VaultStore {
   }
 }
 
-export const vault = new VaultStore();
+const VAULT_KEY = "__codex_vault_instance__";
+export const vault: VaultStore =
+  (globalThis as any)[VAULT_KEY] ??
+  ((globalThis as any)[VAULT_KEY] = new VaultStore());
 
 if (typeof window !== "undefined") {
   (window as any).vault = vault;

--- a/apps/web/src/lib/utils/guest-name-storage.test.ts
+++ b/apps/web/src/lib/utils/guest-name-storage.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  loadGuestDisplayName,
+  saveGuestDisplayName,
+} from "./guest-name-storage";
+
+describe("guest-name-storage helpers", () => {
+  it("should load the stored guest name", () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue("Mara"),
+    };
+
+    expect(loadGuestDisplayName(storage)).toBe("Mara");
+  });
+
+  it("should return an empty string when storage access fails", () => {
+    const storage = {
+      getItem: vi.fn().mockImplementation(() => {
+        throw new Error("blocked");
+      }),
+    };
+
+    expect(loadGuestDisplayName(storage)).toBe("");
+  });
+
+  it("should return an empty string when storage is unavailable", () => {
+    expect(loadGuestDisplayName(null)).toBe("");
+  });
+
+  it("should save the guest name when storage is available", () => {
+    const storage = {
+      setItem: vi.fn(),
+    };
+
+    expect(saveGuestDisplayName("Mara", storage)).toBe(true);
+    expect(storage.setItem).toHaveBeenCalledWith("codex_guest_name", "Mara");
+  });
+
+  it("should return false when saving fails", () => {
+    const storage = {
+      setItem: vi.fn().mockImplementation(() => {
+        throw new Error("blocked");
+      }),
+    };
+
+    expect(saveGuestDisplayName("Mara", storage)).toBe(false);
+  });
+
+  it("should return false when storage is unavailable", () => {
+    expect(saveGuestDisplayName("Mara", null)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/utils/guest-name-storage.ts
+++ b/apps/web/src/lib/utils/guest-name-storage.ts
@@ -1,0 +1,26 @@
+const GUEST_NAME_KEY = "codex_guest_name";
+
+export function loadGuestDisplayName(
+  storage?: Pick<Storage, "getItem"> | null,
+) {
+  try {
+    return storage?.getItem(GUEST_NAME_KEY) || "";
+  } catch (err) {
+    console.warn("[guest-name-storage] Failed to read guest name", err);
+    return "";
+  }
+}
+
+export function saveGuestDisplayName(
+  name: string,
+  storage?: Pick<Storage, "setItem"> | null,
+) {
+  try {
+    if (!storage) return false;
+    storage?.setItem(GUEST_NAME_KEY, name);
+    return true;
+  } catch (err) {
+    console.warn("[guest-name-storage] Failed to save guest name", err);
+    return false;
+  }
+}

--- a/apps/web/src/lib/utils/share-link.test.ts
+++ b/apps/web/src/lib/utils/share-link.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildP2PShareLink, copyTextToClipboard } from "./share-link";
+
+describe("share-link helpers", () => {
+  it("should build a p2p share link", () => {
+    expect(
+      buildP2PShareLink("https://example.com", "/campaign", "peer-123"),
+    ).toBe("https://example.com/campaign?shareId=p2p-peer-123");
+  });
+
+  it("should return false when clipboard write fails", async () => {
+    const clipboard = {
+      writeText: vi.fn().mockRejectedValue(new Error("denied")),
+    };
+
+    await expect(copyTextToClipboard("hello", clipboard)).resolves.toBe(false);
+    expect(clipboard.writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("should return false when clipboard is unavailable", async () => {
+    await expect(copyTextToClipboard("hello", undefined)).resolves.toBe(false);
+  });
+});

--- a/apps/web/src/lib/utils/share-link.ts
+++ b/apps/web/src/lib/utils/share-link.ts
@@ -1,0 +1,24 @@
+export function buildP2PShareLink(
+  origin: string,
+  pathname: string,
+  peerId: string,
+) {
+  const url = new URL(origin + pathname);
+  url.searchParams.set("shareId", `p2p-${peerId}`);
+  return url.toString();
+}
+
+export async function copyTextToClipboard(
+  text: string,
+  clipboard?: Pick<Clipboard, "writeText">,
+) {
+  if (!clipboard?.writeText) return false;
+
+  try {
+    await clipboard.writeText(text);
+    return true;
+  } catch (err) {
+    console.warn("[share-link] Clipboard copy failed", err);
+    return false;
+  }
+}

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -4,19 +4,98 @@
   import { onMount } from "svelte";
   import { p2pGuestService } from "$lib/cloud-bridge/p2p/guest-service";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import AppHeader from "$lib/components/layout/AppHeader.svelte";
-  import GraphView from "$lib/components/GraphView.svelte";
-  import VaultControls from "$lib/components/VaultControls.svelte";
-  import { THEMES } from "schema";
+  import { fade } from "svelte/transition";
+  import { themeStore } from "$lib/stores/theme.svelte";
+  import { base } from "$app/paths";
+  import { demoService } from "$lib/services/demo";
+  import { building, browser } from "$app/environment";
+  import { SCHEMA_ORG } from "$lib/config";
+  import GuestLoginModal from "../../lib/components/modals/GuestLoginModal.svelte";
 
-  const shareId = $derived(page.url.searchParams.get("shareId"));
+  const jsonLdScript = $derived(
+    `<script type="application/ld+json">${JSON.stringify(SCHEMA_ORG)}</scr` +
+      `ipt>`,
+  );
 
-  onMount(() => {
-    if (shareId && shareId.startsWith("p2p-")) {
-      const peerId = shareId.substring(4);
-      console.log("[Guest Mode] Host ID detected:", peerId);
-      uiStore.isGuestMode = true;
-      vault.status = "loading";
+  const isSpecialEnv =
+    import.meta.env.DEV ||
+    (typeof window !== "undefined" && (window as any).__E2E__) ||
+    import.meta.env.VITE_STAGING === "true";
+
+  const logChunkError = (name: string, error: any) => {
+    if (isSpecialEnv) {
+      console.error(`Failed to load ${name}`, error);
+    } else {
+      import("$lib/stores/debug.svelte")
+        .then((m) => {
+          if (m?.debugStore) {
+            m.debugStore.error(`Failed to lazy-load component: ${name}`, error);
+          }
+        })
+        .catch((e) => {
+          console.error(
+            `Failed to lazy-load component: ${name} (and debug store failed too)`,
+            error,
+            e,
+          );
+        });
+    }
+  };
+
+  // Lazy load components when needed using relative paths for reliable resolution
+  function loadHeavyComponents() {
+    if (!GraphView) {
+      import("../../lib/components/GraphView.svelte")
+        .then((m) => (GraphView = m?.default))
+        .catch((err) => logChunkError("GraphView", err));
+    }
+    if (!EntityDetailPanel) {
+      import("../../lib/components/EntityDetailPanel.svelte")
+        .then((m) => (EntityDetailPanel = m?.default))
+        .catch((err) => logChunkError("EntityDetailPanel", err));
+    }
+  }
+
+  // Dynamic imports for heavy components
+  let GraphView = $state<any>(null);
+  let EntityDetailPanel = $state<any>(null);
+
+  let selectedEntity = $derived.by(() => {
+    const id = vault.selectedEntityId;
+    return id ? vault.entities[id] : null;
+  });
+
+  // Check if we're in guest/share mode - guard for prerendering
+  const shareId = $derived(
+    building ? null : page.url.searchParams.get("shareId"),
+  );
+  const isGuestMode = $derived(!!shareId);
+
+  // Consolidate reactive pre-loading and fallback loading into a single effect
+  // to prevent race conditions during dynamic imports.
+  $effect(() => {
+    const isSkippingLanding =
+      browser && (!uiStore.isLandingPageVisible || isGuestMode);
+    const isVaultReady = vault.isInitialized || isGuestMode;
+
+    if (
+      (isSkippingLanding || isVaultReady) &&
+      (!GraphView || !EntityDetailPanel)
+    ) {
+      loadHeavyComponents();
+    }
+  });
+
+  // Guest Mode Connection Logic - Triggers once username is provided
+  $effect(() => {
+    if (
+      isGuestMode &&
+      shareId &&
+      shareId.startsWith("p2p-") &&
+      uiStore.guestUsername
+    ) {
+      const peerId = shareId.substring(4); // Remove "p2p-" prefix
+      uiStore.isGuestMode = true; // Activate guest mode
 
       p2pGuestService
         .connectToHost(
@@ -62,13 +141,19 @@
             vault.isInitialized = true; // Mark vault as initialized in guest mode
             vault.status = "idle";
           },
-          (entity) => {
+          (updatedEntity) => {
             // Real-time update from host
-            vault.repository.entities[entity.id] = entity;
+            vault.repository.entities[updatedEntity.id] = {
+              ...updatedEntity,
+              _path:
+                typeof updatedEntity._path === "string"
+                  ? [updatedEntity._path]
+                  : updatedEntity._path,
+            };
           },
-          (id) => {
+          (deletedId) => {
             // Real-time delete from host
-            delete vault.repository.entities[id];
+            delete vault.repository.entities[deletedId];
           },
           (batchUpdates) => {
             // Real-time batch update from host
@@ -87,103 +172,211 @@
           console.error("[Guest Mode] Failed to connect to host:", err);
           uiStore.isGuestMode = false;
           vault.status = "error";
+          vault.errorMessage = "Failed to connect to shared campaign.";
         });
     }
   });
 
-  function selectTheme(themeId: string) {
-    import("../../lib/stores/theme.svelte").then((m) => {
-      m.themeStore.setTheme(themeId);
-    });
-  }
+  onMount(async () => {
+    // onMount logic removed - moved to reactive $effect above
+  });
 </script>
 
-<div class="h-screen flex flex-col bg-theme-bg text-theme-text overflow-hidden">
-  <AppHeader />
+<svelte:head>
+  {#if !isGuestMode && uiStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
+    {@html jsonLdScript}
+  {/if}
+</svelte:head>
 
-  {#if vault.isInitialized}
-    <div class="flex-1 relative overflow-hidden">
-      <GraphView />
-    </div>
-  {:else if vault.status === "loading"}
-    <div class="flex-1 flex items-center justify-center">
-      <div class="flex flex-col items-center gap-4">
+<div
+  class="h-[calc(100vh-var(--header-height,65px))] flex bg-theme-bg overflow-hidden relative"
+>
+  <div class="flex-1 relative overflow-hidden">
+    {#if GraphView && (vault.isInitialized || vault.status === "loading" || isGuestMode)}
+      <GraphView bind:selectedId={vault.selectedEntityId} />
+    {:else if !uiStore.isLandingPageVisible || (!building && page.url.searchParams.has("demo"))}
+      <div
+        class="absolute inset-0 bg-theme-bg flex items-center justify-center"
+        aria-hidden="true"
+      >
         <div
-          class="w-12 h-12 border-4 border-theme-primary border-t-transparent rounded-full animate-spin"
-        ></div>
-        <div
-          class="text-theme-primary font-header tracking-widest animate-pulse"
+          class="text-theme-muted font-mono text-xs animate-pulse uppercase tracking-widest"
         >
-          {uiStore.isGuestMode
-            ? "Syncing with Host..."
-            : "Initializing Vault..."}
+          {themeStore.resolveJargon("graph_loading")}
         </div>
       </div>
-    </div>
-  {:else}
+    {/if}
+  </div>
+
+  {#if selectedEntity && EntityDetailPanel}
+    <EntityDetailPanel
+      entity={selectedEntity}
+      onClose={() => (vault.selectedEntityId = null)}
+    />
+  {/if}
+
+  {#if isGuestMode && !uiStore.guestUsername && !building}
+    <GuestLoginModal
+      onJoin={(username) => uiStore.setGuestUsername(username)}
+    />
+  {/if}
+
+  <!-- Landing Page / Marketing Layer -->
+  {#if !isGuestMode && uiStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
     <div
-      class="flex-1 flex flex-col items-center justify-center p-6 gap-8 overflow-y-auto no-scrollbar"
+      class="marketing-layer absolute inset-0 z-30 bg-theme-bg backdrop-blur-sm overflow-y-auto"
+      style:background-image="var(--bg-texture-overlay)"
+      transition:fade
     >
-      <div class="max-w-2xl w-full flex flex-col gap-8">
-        <section class="text-center space-y-4">
-          <h1
-            class="text-4xl md:text-6xl font-black text-theme-primary tracking-tighter uppercase italic"
+      <div
+        class="max-w-5xl mx-auto px-6 py-16 md:py-24 flex flex-col min-h-full justify-center"
+      >
+        <header class="mb-16 text-center">
+          <div
+            class="inline-flex items-center gap-2 px-4 py-1.5 mb-6 border border-theme-primary/30 bg-theme-primary/5 rounded-full text-[10px] font-mono text-theme-primary uppercase tracking-[0.2em]"
           >
-            Codex Cryptica
-          </h1>
+            <span class="w-2 h-2 rounded-full bg-theme-primary/50 animate-pulse"
+            ></span>
+            System Online
+          </div>
+          <h2
+            class="text-5xl md:text-8xl font-bold text-theme-text font-header tracking-tight mb-6 leading-tight"
+          >
+            Build Your World. <br />
+            <span class="text-theme-primary/90">Map Your Lore.</span>
+          </h2>
           <p
-            class="text-theme-secondary font-header tracking-widest text-sm md:text-base uppercase"
+            class="text-xl md:text-2xl text-theme-muted max-w-2xl mx-auto leading-relaxed mb-12 font-body font-light"
           >
-            Strategic Campaign Knowledge Graph
+            Codex Cryptica is a private campaign manager for lore keepers who
+            value total privacy, speed, and visual organization.
           </p>
+
+          <div
+            class="flex flex-col md:flex-row items-center justify-center gap-6"
+          >
+            <button
+              onclick={() => (uiStore.dismissedLandingPage = true)}
+              class="px-12 py-5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/90 hover:shadow-[0_0_30px_var(--color-accent-primary)] transition-all active:scale-95"
+            >
+              Enter the Codex
+            </button>
+            <button
+              onclick={() => demoService.startDemo("fantasy")}
+              class="px-12 py-5 border border-theme-primary/50 text-theme-primary font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/10 transition-all active:scale-95"
+            >
+              Try Demo
+            </button>
+          </div>
+
+          <div class="mt-8 flex flex-col items-center gap-4">
+            <a
+              href="{base}/features"
+              class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
+            >
+              <span class="icon-[lucide--zap] w-3 h-3"></span>
+              View Features Overview
+            </a>
+
+            <div
+              class="flex items-center gap-3 bg-theme-surface/50 px-4 py-2 rounded-lg border border-theme-border/30"
+            >
+              <input
+                type="checkbox"
+                id="skip-welcome"
+                checked={uiStore.skipWelcomeScreen}
+                onchange={(e) =>
+                  uiStore.toggleWelcomeScreen(e.currentTarget.checked)}
+                class="w-4 h-4 accent-theme-primary cursor-pointer"
+              />
+              <label
+                for="skip-welcome"
+                class="text-[10px] font-body text-theme-muted uppercase tracking-widest cursor-pointer hover:text-theme-primary transition-colors select-none"
+              >
+                Hide welcome screen on startup
+              </label>
+            </div>
+          </div>
+        </header>
+
+        <section id="features" class="grid md:grid-cols-3 gap-8 mb-12">
+          <!-- Feature 1: Privacy -->
+          <div
+            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
+          >
+            <div
+              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
+            >
+              <span
+                class="icon-[lucide--shield-check] text-theme-primary w-7 h-7"
+              ></span>
+            </div>
+            <h3
+              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
+            >
+              Total Privacy
+            </h3>
+            <p class="text-theme-muted leading-relaxed font-body">
+              Your {themeStore.resolveJargon("entity", 2).toLowerCase()} never leave
+              your device. We use local storage for maximum security. No cloud accounts
+              required.
+            </p>
+          </div>
+
+          <!-- Feature 2: AI -->
+          <div
+            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
+          >
+            <div
+              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
+            >
+              <span class="icon-[lucide--brain] text-theme-primary w-7 h-7"
+              ></span>
+            </div>
+            <h3
+              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
+            >
+              AI Oracle
+            </h3>
+            <p class="text-theme-muted leading-relaxed font-body">
+              Discover hidden connections and generate immersive descriptions
+              while maintaining your world's unique voice.
+            </p>
+          </div>
+
+          <!-- Feature 3: Visual Links -->
+          <div
+            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
+          >
+            <div
+              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
+            >
+              <span class="icon-[lucide--share-2] text-theme-primary w-7 h-7"
+              ></span>
+            </div>
+            <h3
+              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
+            >
+              Visual Graph
+            </h3>
+            <p class="text-theme-muted leading-relaxed font-body mb-4">
+              Navigate your lore through a dynamic, interactive map. See exactly
+              how characters, locations, and events intertwine.
+            </p>
+          </div>
         </section>
 
-        <VaultControls />
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div
-            class="p-6 bg-theme-surface border border-theme-border flex flex-col gap-3 group hover:border-theme-primary transition-all shadow-xl"
+        <section class="text-center mb-12">
+          <h3
+            class="text-[10px] font-mono text-theme-muted uppercase tracking-[0.3em] mb-6"
           >
-            <div class="flex items-center gap-3 text-theme-primary mb-1">
-              <span class="icon-[lucide--zap] w-6 h-6"></span>
-              <h2 class="font-black tracking-widest uppercase text-sm">
-                Local-First
-              </h2>
-            </div>
-            <p class="text-xs leading-relaxed text-theme-muted">
-              Everything stays in your browser. Fast, private, and offline
-              ready. No cloud dependency required for core play.
-            </p>
-          </div>
-
-          <div
-            class="p-6 bg-theme-surface border border-theme-border flex flex-col gap-3 group hover:border-theme-primary transition-all shadow-xl"
-          >
-            <div class="flex items-center gap-3 text-theme-primary mb-1">
-              <span class="icon-[lucide--share-2] w-6 h-6"></span>
-              <h2 class="font-black tracking-widest uppercase text-sm">
-                Real-Time Sharing
-              </h2>
-            </div>
-            <p class="text-xs leading-relaxed text-theme-muted">
-              Connect with your players directly (P2P). Share specific nodes,
-              maps, and lore without account creation.
-            </p>
-          </div>
-        </div>
-
-        <section class="mt-4 pt-8 border-t border-theme-border/30">
-          <div class="flex items-center gap-3 text-theme-secondary mb-6">
-            <span class="icon-[lucide--palette] w-5 h-5"></span>
-            <h2 class="font-black tracking-widest uppercase text-xs">
-              Interface Styling
-            </h2>
-          </div>
-          <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-            {#each Object.keys(THEMES) as theme}
+            Try it as:
+          </h3>
+          <div class="flex flex-wrap justify-center gap-4">
+            {#each ["vampire", "scifi", "cyberpunk", "wasteland", "modern", "fallout", "starwars", "startrek"] as theme}
               <button
-                onclick={() => selectTheme(theme)}
-                class="px-4 py-2 text-[10px] border border-theme-border hover:border-theme-primary hover:bg-theme-primary/10 text-theme-secondary hover:text-theme-primary rounded uppercase font-header tracking-widest transition-all"
+                onclick={() => demoService.startDemo(theme)}
+                class="px-4 py-2 text-[10px] font-bold border border-theme-border hover:border-theme-primary text-theme-muted hover:text-theme-primary rounded uppercase font-header tracking-widest transition-all"
               >
                 {theme}
               </button>

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -7,20 +7,20 @@
   import AppHeader from "$lib/components/layout/AppHeader.svelte";
   import GraphView from "$lib/components/GraphView.svelte";
   import VaultControls from "$lib/components/VaultControls.svelte";
-  import FeatureHint from "$lib/components/hints/FeatureHint.svelte";
   import { THEMES } from "schema";
 
-  const hostId = $derived(page.url.searchParams.get("host"));
+  const shareId = $derived(page.url.searchParams.get("shareId"));
 
   onMount(() => {
-    if (hostId) {
-      console.log("[Guest Mode] Host ID detected:", hostId);
+    if (shareId && shareId.startsWith("p2p-")) {
+      const peerId = shareId.substring(4);
+      console.log("[Guest Mode] Host ID detected:", peerId);
       uiStore.isGuestMode = true;
       vault.status = "loading";
 
       p2pGuestService
         .connectToHost(
-          hostId,
+          peerId,
           (graph) => {
             console.log("[Guest Page] Received graph data:", {
               entityCount: Object.keys(graph.entities).length,

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -4,102 +4,23 @@
   import { onMount } from "svelte";
   import { p2pGuestService } from "$lib/cloud-bridge/p2p/guest-service";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import { fade } from "svelte/transition";
-  import { themeStore } from "$lib/stores/theme.svelte";
-  import { base } from "$app/paths";
-  import { demoService } from "$lib/services/demo";
-  import { building, browser } from "$app/environment";
-  import { SCHEMA_ORG } from "$lib/config";
-  import GuestLoginModal from "../../lib/components/modals/GuestLoginModal.svelte";
+  import AppHeader from "$lib/components/layout/AppHeader.svelte";
+  import GraphView from "$lib/components/GraphView.svelte";
+  import VaultControls from "$lib/components/VaultControls.svelte";
+  import FeatureHint from "$lib/components/hints/FeatureHint.svelte";
+  import { THEMES } from "schema";
 
-  const jsonLdScript = $derived(
-    `<script type="application/ld+json">${JSON.stringify(SCHEMA_ORG)}</scr` +
-      `ipt>`,
-  );
+  const hostId = $derived(page.url.searchParams.get("host"));
 
-  const isSpecialEnv =
-    import.meta.env.DEV ||
-    (typeof window !== "undefined" && (window as any).__E2E__) ||
-    import.meta.env.VITE_STAGING === "true";
-
-  const logChunkError = (name: string, error: any) => {
-    if (isSpecialEnv) {
-      console.error(`Failed to load ${name}`, error);
-    } else {
-      import("$lib/stores/debug.svelte")
-        .then((m) => {
-          if (m?.debugStore) {
-            m.debugStore.error(`Failed to lazy-load component: ${name}`, error);
-          }
-        })
-        .catch((e) => {
-          console.error(
-            `Failed to lazy-load component: ${name} (and debug store failed too)`,
-            error,
-            e,
-          );
-        });
-    }
-  };
-
-  // Lazy load components when needed using relative paths for reliable resolution
-  function loadHeavyComponents() {
-    if (!GraphView) {
-      import("../../lib/components/GraphView.svelte")
-        .then((m) => (GraphView = m?.default))
-        .catch((err) => logChunkError("GraphView", err));
-    }
-    if (!EntityDetailPanel) {
-      import("../../lib/components/EntityDetailPanel.svelte")
-        .then((m) => (EntityDetailPanel = m?.default))
-        .catch((err) => logChunkError("EntityDetailPanel", err));
-    }
-  }
-
-  // Dynamic imports for heavy components
-  let GraphView = $state<any>(null);
-  let EntityDetailPanel = $state<any>(null);
-
-  let selectedEntity = $derived.by(() => {
-    const id = vault.selectedEntityId;
-    return id ? vault.entities[id] : null;
-  });
-
-  // Check if we're in guest/share mode - guard for prerendering
-  const shareId = $derived(
-    building ? null : page.url.searchParams.get("shareId"),
-  );
-  const isGuestMode = $derived(!!shareId);
-
-  // Consolidate reactive pre-loading and fallback loading into a single effect
-  // to prevent race conditions during dynamic imports.
-  $effect(() => {
-    const isSkippingLanding =
-      browser && (!uiStore.isLandingPageVisible || isGuestMode);
-    const isVaultReady = vault.isInitialized || isGuestMode;
-
-    if (
-      (isSkippingLanding || isVaultReady) &&
-      (!GraphView || !EntityDetailPanel)
-    ) {
-      loadHeavyComponents();
-    }
-  });
-
-  // Guest Mode Connection Logic - Triggers once username is provided
-  $effect(() => {
-    if (
-      isGuestMode &&
-      shareId &&
-      shareId.startsWith("p2p-") &&
-      uiStore.guestUsername
-    ) {
-      const peerId = shareId.substring(4); // Remove "p2p-" prefix
-      uiStore.isGuestMode = true; // Activate guest mode
+  onMount(() => {
+    if (hostId) {
+      console.log("[Guest Mode] Host ID detected:", hostId);
+      uiStore.isGuestMode = true;
+      vault.status = "loading";
 
       p2pGuestService
         .connectToHost(
-          peerId,
+          hostId,
           (graph) => {
             console.log("[Guest Page] Received graph data:", {
               entityCount: Object.keys(graph.entities).length,
@@ -123,6 +44,15 @@
             if (graph.defaultVisibility) {
               vault.defaultVisibility = graph.defaultVisibility;
             }
+            if (graph.themeId) {
+              import("../../lib/stores/theme.svelte")
+                .then((m) => {
+                  if (m?.themeStore) m.themeStore.setTheme(graph.themeId);
+                })
+                .catch((err) =>
+                  console.error("Failed to load theme store", err),
+                );
+            }
             // Force shared mode for guests to ensure Fog of War is active
             import("../../lib/stores/ui.svelte")
               .then((m) => {
@@ -132,234 +62,128 @@
             vault.isInitialized = true; // Mark vault as initialized in guest mode
             vault.status = "idle";
           },
-          (updatedEntity) => {
+          (entity) => {
             // Real-time update from host
-            vault.repository.entities[updatedEntity.id] = {
-              ...updatedEntity,
-              _path:
-                typeof updatedEntity._path === "string"
-                  ? [updatedEntity._path]
-                  : updatedEntity._path,
-            };
+            vault.repository.entities[entity.id] = entity;
           },
-          (deletedId) => {
+          (id) => {
             // Real-time delete from host
-            delete vault.repository.entities[deletedId];
+            delete vault.repository.entities[id];
           },
           (batchUpdates) => {
             // Real-time batch update from host
             vault.batchUpdate(batchUpdates);
+          },
+          (themeId) => {
+            // Real-time theme update from host
+            import("../../lib/stores/theme.svelte")
+              .then((m) => {
+                if (m?.themeStore) m.themeStore.setTheme(themeId);
+              })
+              .catch((err) => console.error("Failed to load theme store", err));
           },
         )
         .catch((err) => {
           console.error("[Guest Mode] Failed to connect to host:", err);
           uiStore.isGuestMode = false;
           vault.status = "error";
-          vault.errorMessage = "Failed to connect to shared campaign.";
         });
     }
   });
 
-  onMount(async () => {
-    // onMount logic removed - moved to reactive $effect above
-  });
+  function selectTheme(themeId: string) {
+    import("../../lib/stores/theme.svelte").then((m) => {
+      m.themeStore.setTheme(themeId);
+    });
+  }
 </script>
 
-<svelte:head>
-  {#if !isGuestMode && uiStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
-    {@html jsonLdScript}
-  {/if}
-</svelte:head>
+<div class="h-screen flex flex-col bg-theme-bg text-theme-text overflow-hidden">
+  <AppHeader />
 
-<div
-  class="h-[calc(100vh-var(--header-height,65px))] flex bg-theme-bg overflow-hidden relative"
->
-  <div class="flex-1 relative overflow-hidden">
-    {#if GraphView && (vault.isInitialized || vault.status === "loading" || isGuestMode)}
-      <GraphView bind:selectedId={vault.selectedEntityId} />
-    {:else if !uiStore.isLandingPageVisible || (!building && page.url.searchParams.has("demo"))}
-      <div
-        class="absolute inset-0 bg-theme-bg flex items-center justify-center"
-        aria-hidden="true"
-      >
+  {#if vault.isInitialized}
+    <div class="flex-1 relative overflow-hidden">
+      <GraphView />
+    </div>
+  {:else if vault.status === "loading"}
+    <div class="flex-1 flex items-center justify-center">
+      <div class="flex flex-col items-center gap-4">
         <div
-          class="text-theme-muted font-mono text-xs animate-pulse uppercase tracking-widest"
+          class="w-12 h-12 border-4 border-theme-primary border-t-transparent rounded-full animate-spin"
+        ></div>
+        <div
+          class="text-theme-primary font-header tracking-widest animate-pulse"
         >
-          {themeStore.resolveJargon("graph_loading")}
+          {uiStore.isGuestMode
+            ? "Syncing with Host..."
+            : "Initializing Vault..."}
         </div>
       </div>
-    {/if}
-  </div>
-
-  {#if selectedEntity && EntityDetailPanel}
-    <EntityDetailPanel
-      entity={selectedEntity}
-      onClose={() => (vault.selectedEntityId = null)}
-    />
-  {/if}
-
-  {#if isGuestMode && !uiStore.guestUsername && !building}
-    <GuestLoginModal
-      onJoin={(username) => uiStore.setGuestUsername(username)}
-    />
-  {/if}
-
-  <!-- Landing Page / Marketing Layer -->
-  {#if !isGuestMode && uiStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
+    </div>
+  {:else}
     <div
-      class="marketing-layer absolute inset-0 z-30 bg-theme-bg backdrop-blur-sm overflow-y-auto"
-      style:background-image="var(--bg-texture-overlay)"
-      transition:fade
+      class="flex-1 flex flex-col items-center justify-center p-6 gap-8 overflow-y-auto no-scrollbar"
     >
-      <div
-        class="max-w-5xl mx-auto px-6 py-16 md:py-24 flex flex-col min-h-full justify-center"
-      >
-        <header class="mb-16 text-center">
-          <div
-            class="inline-flex items-center gap-2 px-4 py-1.5 mb-6 border border-theme-primary/30 bg-theme-primary/5 rounded-full text-[10px] font-mono text-theme-primary uppercase tracking-[0.2em]"
+      <div class="max-w-2xl w-full flex flex-col gap-8">
+        <section class="text-center space-y-4">
+          <h1
+            class="text-4xl md:text-6xl font-black text-theme-primary tracking-tighter uppercase italic"
           >
-            <span class="w-2 h-2 rounded-full bg-theme-primary/50 animate-pulse"
-            ></span>
-            System Online
-          </div>
-          <h2
-            class="text-5xl md:text-8xl font-bold text-theme-text font-header tracking-tight mb-6 leading-tight"
-          >
-            Build Your World. <br />
-            <span class="text-theme-primary/90">Map Your Lore.</span>
-          </h2>
+            Codex Cryptica
+          </h1>
           <p
-            class="text-xl md:text-2xl text-theme-muted max-w-2xl mx-auto leading-relaxed mb-12 font-body font-light"
+            class="text-theme-secondary font-header tracking-widest text-sm md:text-base uppercase"
           >
-            Codex Cryptica is a private campaign manager for lore keepers who
-            value total privacy, speed, and visual organization.
+            Strategic Campaign Knowledge Graph
           </p>
-
-          <div
-            class="flex flex-col md:flex-row items-center justify-center gap-6"
-          >
-            <button
-              onclick={() => (uiStore.dismissedLandingPage = true)}
-              class="px-12 py-5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/90 hover:shadow-[0_0_30px_var(--color-accent-primary)] transition-all active:scale-95"
-            >
-              Enter the Codex
-            </button>
-            <button
-              onclick={() => demoService.startDemo("fantasy")}
-              class="px-12 py-5 border border-theme-primary/50 text-theme-primary font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/10 transition-all active:scale-95"
-            >
-              Try Demo
-            </button>
-          </div>
-
-          <div class="mt-8 flex flex-col items-center gap-4">
-            <a
-              href="{base}/features"
-              class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
-            >
-              <span class="icon-[lucide--zap] w-3 h-3"></span>
-              View Features Overview
-            </a>
-
-            <div
-              class="flex items-center gap-3 bg-theme-surface/50 px-4 py-2 rounded-lg border border-theme-border/30"
-            >
-              <input
-                type="checkbox"
-                id="skip-welcome"
-                checked={uiStore.skipWelcomeScreen}
-                onchange={(e) =>
-                  uiStore.toggleWelcomeScreen(e.currentTarget.checked)}
-                class="w-4 h-4 accent-theme-primary cursor-pointer"
-              />
-              <label
-                for="skip-welcome"
-                class="text-[10px] font-body text-theme-muted uppercase tracking-widest cursor-pointer hover:text-theme-primary transition-colors select-none"
-              >
-                Hide welcome screen on startup
-              </label>
-            </div>
-          </div>
-        </header>
-
-        <section id="features" class="grid md:grid-cols-3 gap-8 mb-12">
-          <!-- Feature 1: Privacy -->
-          <div
-            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
-          >
-            <div
-              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
-            >
-              <span
-                class="icon-[lucide--shield-check] text-theme-primary w-7 h-7"
-              ></span>
-            </div>
-            <h3
-              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
-            >
-              Total Privacy
-            </h3>
-            <p class="text-theme-muted leading-relaxed font-body">
-              Your {themeStore.resolveJargon("entity", 2).toLowerCase()} never leave
-              your device. We use local storage for maximum security. No cloud accounts
-              required.
-            </p>
-          </div>
-
-          <!-- Feature 2: AI -->
-          <div
-            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
-          >
-            <div
-              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
-            >
-              <span class="icon-[lucide--brain] text-theme-primary w-7 h-7"
-              ></span>
-            </div>
-            <h3
-              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
-            >
-              AI Oracle
-            </h3>
-            <p class="text-theme-muted leading-relaxed font-body">
-              Discover hidden connections and generate immersive descriptions
-              while maintaining your world's unique voice.
-            </p>
-          </div>
-
-          <!-- Feature 3: Visual Links -->
-          <div
-            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
-          >
-            <div
-              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
-            >
-              <span class="icon-[lucide--share-2] text-theme-primary w-7 h-7"
-              ></span>
-            </div>
-            <h3
-              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
-            >
-              Visual Graph
-            </h3>
-            <p class="text-theme-muted leading-relaxed font-body mb-4">
-              Navigate your lore through a dynamic, interactive map. See exactly
-              how characters, locations, and events intertwine.
-            </p>
-          </div>
         </section>
 
-        <section class="text-center mb-12">
-          <h3
-            class="text-[10px] font-mono text-theme-muted uppercase tracking-[0.3em] mb-6"
+        <VaultControls />
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div
+            class="p-6 bg-theme-surface border border-theme-border flex flex-col gap-3 group hover:border-theme-primary transition-all shadow-xl"
           >
-            Try it as:
-          </h3>
-          <div class="flex flex-wrap justify-center gap-4">
-            {#each ["vampire", "scifi", "cyberpunk", "wasteland", "modern", "fallout", "starwars", "startrek"] as theme}
+            <div class="flex items-center gap-3 text-theme-primary mb-1">
+              <span class="icon-[lucide--zap] w-6 h-6"></span>
+              <h2 class="font-black tracking-widest uppercase text-sm">
+                Local-First
+              </h2>
+            </div>
+            <p class="text-xs leading-relaxed text-theme-muted">
+              Everything stays in your browser. Fast, private, and offline
+              ready. No cloud dependency required for core play.
+            </p>
+          </div>
+
+          <div
+            class="p-6 bg-theme-surface border border-theme-border flex flex-col gap-3 group hover:border-theme-primary transition-all shadow-xl"
+          >
+            <div class="flex items-center gap-3 text-theme-primary mb-1">
+              <span class="icon-[lucide--share-2] w-6 h-6"></span>
+              <h2 class="font-black tracking-widest uppercase text-sm">
+                Real-Time Sharing
+              </h2>
+            </div>
+            <p class="text-xs leading-relaxed text-theme-muted">
+              Connect with your players directly (P2P). Share specific nodes,
+              maps, and lore without account creation.
+            </p>
+          </div>
+        </div>
+
+        <section class="mt-4 pt-8 border-t border-theme-border/30">
+          <div class="flex items-center gap-3 text-theme-secondary mb-6">
+            <span class="icon-[lucide--palette] w-5 h-5"></span>
+            <h2 class="font-black tracking-widest uppercase text-xs">
+              Interface Styling
+            </h2>
+          </div>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {#each Object.keys(THEMES) as theme}
               <button
-                onclick={() => demoService.startDemo(theme)}
-                class="px-4 py-2 text-[10px] font-bold border border-theme-border hover:border-theme-primary text-theme-muted hover:text-theme-primary rounded uppercase font-header tracking-widest transition-all"
+                onclick={() => selectTheme(theme)}
+                class="px-4 py-2 text-[10px] border border-theme-border hover:border-theme-primary hover:bg-theme-primary/10 text-theme-secondary hover:text-theme-primary rounded uppercase font-header tracking-widest transition-all"
               >
                 {theme}
               </button>

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -95,7 +95,9 @@
       uiStore.guestUsername
     ) {
       const peerId = shareId.substring(4); // Remove "p2p-" prefix
+      console.log("[Guest Mode] Host ID detected:", peerId);
       uiStore.isGuestMode = true; // Activate guest mode
+      vault.status = "loading";
 
       p2pGuestService
         .connectToHost(

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -4,23 +4,102 @@
   import { onMount } from "svelte";
   import { p2pGuestService } from "$lib/cloud-bridge/p2p/guest-service";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import AppHeader from "$lib/components/layout/AppHeader.svelte";
-  import GraphView from "$lib/components/GraphView.svelte";
-  import VaultControls from "$lib/components/VaultControls.svelte";
-  import FeatureHint from "$lib/components/hints/FeatureHint.svelte";
-  import { THEMES } from "schema";
+  import { fade } from "svelte/transition";
+  import { themeStore } from "$lib/stores/theme.svelte";
+  import { base } from "$app/paths";
+  import { demoService } from "$lib/services/demo";
+  import { building, browser } from "$app/environment";
+  import { SCHEMA_ORG } from "$lib/config";
+  import GuestLoginModal from "../../lib/components/modals/GuestLoginModal.svelte";
 
-  const hostId = $derived(page.url.searchParams.get("host"));
+  const jsonLdScript = $derived(
+    `<script type="application/ld+json">${JSON.stringify(SCHEMA_ORG)}</scr` +
+      `ipt>`,
+  );
 
-  onMount(() => {
-    if (hostId) {
-      console.log("[Guest Mode] Host ID detected:", hostId);
-      uiStore.isGuestMode = true;
-      vault.status = "loading";
+  const isSpecialEnv =
+    import.meta.env.DEV ||
+    (typeof window !== "undefined" && (window as any).__E2E__) ||
+    import.meta.env.VITE_STAGING === "true";
+
+  const logChunkError = (name: string, error: any) => {
+    if (isSpecialEnv) {
+      console.error(`Failed to load ${name}`, error);
+    } else {
+      import("$lib/stores/debug.svelte")
+        .then((m) => {
+          if (m?.debugStore) {
+            m.debugStore.error(`Failed to lazy-load component: ${name}`, error);
+          }
+        })
+        .catch((e) => {
+          console.error(
+            `Failed to lazy-load component: ${name} (and debug store failed too)`,
+            error,
+            e,
+          );
+        });
+    }
+  };
+
+  // Lazy load components when needed using relative paths for reliable resolution
+  function loadHeavyComponents() {
+    if (!GraphView) {
+      import("../../lib/components/GraphView.svelte")
+        .then((m) => (GraphView = m?.default))
+        .catch((err) => logChunkError("GraphView", err));
+    }
+    if (!EntityDetailPanel) {
+      import("../../lib/components/EntityDetailPanel.svelte")
+        .then((m) => (EntityDetailPanel = m?.default))
+        .catch((err) => logChunkError("EntityDetailPanel", err));
+    }
+  }
+
+  // Dynamic imports for heavy components
+  let GraphView = $state<any>(null);
+  let EntityDetailPanel = $state<any>(null);
+
+  let selectedEntity = $derived.by(() => {
+    const id = vault.selectedEntityId;
+    return id ? vault.entities[id] : null;
+  });
+
+  // Check if we're in guest/share mode - guard for prerendering
+  const shareId = $derived(
+    building ? null : page.url.searchParams.get("shareId"),
+  );
+  const isGuestMode = $derived(!!shareId);
+
+  // Consolidate reactive pre-loading and fallback loading into a single effect
+  // to prevent race conditions during dynamic imports.
+  $effect(() => {
+    const isSkippingLanding =
+      browser && (!uiStore.isLandingPageVisible || isGuestMode);
+    const isVaultReady = vault.isInitialized || isGuestMode;
+
+    if (
+      (isSkippingLanding || isVaultReady) &&
+      (!GraphView || !EntityDetailPanel)
+    ) {
+      loadHeavyComponents();
+    }
+  });
+
+  // Guest Mode Connection Logic - Triggers once username is provided
+  $effect(() => {
+    if (
+      isGuestMode &&
+      shareId &&
+      shareId.startsWith("p2p-") &&
+      uiStore.guestUsername
+    ) {
+      const peerId = shareId.substring(4); // Remove "p2p-" prefix
+      uiStore.isGuestMode = true; // Activate guest mode
 
       p2pGuestService
         .connectToHost(
-          hostId,
+          peerId,
           (graph) => {
             console.log("[Guest Page] Received graph data:", {
               entityCount: Object.keys(graph.entities).length,
@@ -44,15 +123,6 @@
             if (graph.defaultVisibility) {
               vault.defaultVisibility = graph.defaultVisibility;
             }
-            if (graph.themeId) {
-              import("../../lib/stores/theme.svelte")
-                .then((m) => {
-                  if (m?.themeStore) m.themeStore.setTheme(graph.themeId);
-                })
-                .catch((err) =>
-                  console.error("Failed to load theme store", err),
-                );
-            }
             // Force shared mode for guests to ensure Fog of War is active
             import("../../lib/stores/ui.svelte")
               .then((m) => {
@@ -62,13 +132,19 @@
             vault.isInitialized = true; // Mark vault as initialized in guest mode
             vault.status = "idle";
           },
-          (entity) => {
+          (updatedEntity) => {
             // Real-time update from host
-            vault.repository.entities[entity.id] = entity;
+            vault.repository.entities[updatedEntity.id] = {
+              ...updatedEntity,
+              _path:
+                typeof updatedEntity._path === "string"
+                  ? [updatedEntity._path]
+                  : updatedEntity._path,
+            };
           },
-          (id) => {
+          (deletedId) => {
             // Real-time delete from host
-            delete vault.repository.entities[id];
+            delete vault.repository.entities[deletedId];
           },
           (batchUpdates) => {
             // Real-time batch update from host
@@ -87,103 +163,211 @@
           console.error("[Guest Mode] Failed to connect to host:", err);
           uiStore.isGuestMode = false;
           vault.status = "error";
+          vault.errorMessage = "Failed to connect to shared campaign.";
         });
     }
   });
 
-  function selectTheme(themeId: string) {
-    import("../../lib/stores/theme.svelte").then((m) => {
-      m.themeStore.setTheme(themeId);
-    });
-  }
+  onMount(async () => {
+    // onMount logic removed - moved to reactive $effect above
+  });
 </script>
 
-<div class="h-screen flex flex-col bg-theme-bg text-theme-text overflow-hidden">
-  <AppHeader />
+<svelte:head>
+  {#if !isGuestMode && uiStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
+    {@html jsonLdScript}
+  {/if}
+</svelte:head>
 
-  {#if vault.isInitialized}
-    <div class="flex-1 relative overflow-hidden">
-      <GraphView />
-    </div>
-  {:else if vault.status === "loading"}
-    <div class="flex-1 flex items-center justify-center">
-      <div class="flex flex-col items-center gap-4">
+<div
+  class="h-[calc(100vh-var(--header-height,65px))] flex bg-theme-bg overflow-hidden relative"
+>
+  <div class="flex-1 relative overflow-hidden">
+    {#if GraphView && (vault.isInitialized || vault.status === "loading" || isGuestMode)}
+      <GraphView bind:selectedId={vault.selectedEntityId} />
+    {:else if !uiStore.isLandingPageVisible || (!building && page.url.searchParams.has("demo"))}
+      <div
+        class="absolute inset-0 bg-theme-bg flex items-center justify-center"
+        aria-hidden="true"
+      >
         <div
-          class="w-12 h-12 border-4 border-theme-primary border-t-transparent rounded-full animate-spin"
-        ></div>
-        <div
-          class="text-theme-primary font-header tracking-widest animate-pulse"
+          class="text-theme-muted font-mono text-xs animate-pulse uppercase tracking-widest"
         >
-          {uiStore.isGuestMode
-            ? "Syncing with Host..."
-            : "Initializing Vault..."}
+          {themeStore.resolveJargon("graph_loading")}
         </div>
       </div>
-    </div>
-  {:else}
+    {/if}
+  </div>
+
+  {#if selectedEntity && EntityDetailPanel}
+    <EntityDetailPanel
+      entity={selectedEntity}
+      onClose={() => (vault.selectedEntityId = null)}
+    />
+  {/if}
+
+  {#if isGuestMode && !uiStore.guestUsername && !building}
+    <GuestLoginModal
+      onJoin={(username) => uiStore.setGuestUsername(username)}
+    />
+  {/if}
+
+  <!-- Landing Page / Marketing Layer -->
+  {#if !isGuestMode && uiStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
     <div
-      class="flex-1 flex flex-col items-center justify-center p-6 gap-8 overflow-y-auto no-scrollbar"
+      class="marketing-layer absolute inset-0 z-30 bg-theme-bg backdrop-blur-sm overflow-y-auto"
+      style:background-image="var(--bg-texture-overlay)"
+      transition:fade
     >
-      <div class="max-w-2xl w-full flex flex-col gap-8">
-        <section class="text-center space-y-4">
-          <h1
-            class="text-4xl md:text-6xl font-black text-theme-primary tracking-tighter uppercase italic"
+      <div
+        class="max-w-5xl mx-auto px-6 py-16 md:py-24 flex flex-col min-h-full justify-center"
+      >
+        <header class="mb-16 text-center">
+          <div
+            class="inline-flex items-center gap-2 px-4 py-1.5 mb-6 border border-theme-primary/30 bg-theme-primary/5 rounded-full text-[10px] font-mono text-theme-primary uppercase tracking-[0.2em]"
           >
-            Codex Cryptica
-          </h1>
+            <span class="w-2 h-2 rounded-full bg-theme-primary/50 animate-pulse"
+            ></span>
+            System Online
+          </div>
+          <h2
+            class="text-5xl md:text-8xl font-bold text-theme-text font-header tracking-tight mb-6 leading-tight"
+          >
+            Build Your World. <br />
+            <span class="text-theme-primary/90">Map Your Lore.</span>
+          </h2>
           <p
-            class="text-theme-secondary font-header tracking-widest text-sm md:text-base uppercase"
+            class="text-xl md:text-2xl text-theme-muted max-w-2xl mx-auto leading-relaxed mb-12 font-body font-light"
           >
-            Strategic Campaign Knowledge Graph
+            Codex Cryptica is a private campaign manager for lore keepers who
+            value total privacy, speed, and visual organization.
           </p>
+
+          <div
+            class="flex flex-col md:flex-row items-center justify-center gap-6"
+          >
+            <button
+              onclick={() => (uiStore.dismissedLandingPage = true)}
+              class="px-12 py-5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/90 hover:shadow-[0_0_30px_var(--color-accent-primary)] transition-all active:scale-95"
+            >
+              Enter the Codex
+            </button>
+            <button
+              onclick={() => demoService.startDemo("fantasy")}
+              class="px-12 py-5 border border-theme-primary/50 text-theme-primary font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/10 transition-all active:scale-95"
+            >
+              Try Demo
+            </button>
+          </div>
+
+          <div class="mt-8 flex flex-col items-center gap-4">
+            <a
+              href="{base}/features"
+              class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
+            >
+              <span class="icon-[lucide--zap] w-3 h-3"></span>
+              View Features Overview
+            </a>
+
+            <div
+              class="flex items-center gap-3 bg-theme-surface/50 px-4 py-2 rounded-lg border border-theme-border/30"
+            >
+              <input
+                type="checkbox"
+                id="skip-welcome"
+                checked={uiStore.skipWelcomeScreen}
+                onchange={(e) =>
+                  uiStore.toggleWelcomeScreen(e.currentTarget.checked)}
+                class="w-4 h-4 accent-theme-primary cursor-pointer"
+              />
+              <label
+                for="skip-welcome"
+                class="text-[10px] font-body text-theme-muted uppercase tracking-widest cursor-pointer hover:text-theme-primary transition-colors select-none"
+              >
+                Hide welcome screen on startup
+              </label>
+            </div>
+          </div>
+        </header>
+
+        <section id="features" class="grid md:grid-cols-3 gap-8 mb-12">
+          <!-- Feature 1: Privacy -->
+          <div
+            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
+          >
+            <div
+              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
+            >
+              <span
+                class="icon-[lucide--shield-check] text-theme-primary w-7 h-7"
+              ></span>
+            </div>
+            <h3
+              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
+            >
+              Total Privacy
+            </h3>
+            <p class="text-theme-muted leading-relaxed font-body">
+              Your {themeStore.resolveJargon("entity", 2).toLowerCase()} never leave
+              your device. We use local storage for maximum security. No cloud accounts
+              required.
+            </p>
+          </div>
+
+          <!-- Feature 2: AI -->
+          <div
+            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
+          >
+            <div
+              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
+            >
+              <span class="icon-[lucide--brain] text-theme-primary w-7 h-7"
+              ></span>
+            </div>
+            <h3
+              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
+            >
+              AI Oracle
+            </h3>
+            <p class="text-theme-muted leading-relaxed font-body">
+              Discover hidden connections and generate immersive descriptions
+              while maintaining your world's unique voice.
+            </p>
+          </div>
+
+          <!-- Feature 3: Visual Links -->
+          <div
+            class="p-8 bg-theme-surface border border-theme-border rounded-xl hover:border-theme-primary/50 hover:shadow-lg hover:shadow-theme-primary/5 transition-all group"
+          >
+            <div
+              class="w-14 h-14 mb-6 rounded-2xl bg-theme-primary/10 flex items-center justify-center group-hover:scale-110 transition-transform duration-300"
+            >
+              <span class="icon-[lucide--share-2] text-theme-primary w-7 h-7"
+              ></span>
+            </div>
+            <h3
+              class="text-xl font-bold text-theme-text mb-3 uppercase font-header tracking-wide"
+            >
+              Visual Graph
+            </h3>
+            <p class="text-theme-muted leading-relaxed font-body mb-4">
+              Navigate your lore through a dynamic, interactive map. See exactly
+              how characters, locations, and events intertwine.
+            </p>
+          </div>
         </section>
 
-        <VaultControls />
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div
-            class="p-6 bg-theme-surface border border-theme-border flex flex-col gap-3 group hover:border-theme-primary transition-all shadow-xl"
+        <section class="text-center mb-12">
+          <h3
+            class="text-[10px] font-mono text-theme-muted uppercase tracking-[0.3em] mb-6"
           >
-            <div class="flex items-center gap-3 text-theme-primary mb-1">
-              <span class="icon-[lucide--zap] w-6 h-6"></span>
-              <h2 class="font-black tracking-widest uppercase text-sm">
-                Local-First
-              </h2>
-            </div>
-            <p class="text-xs leading-relaxed text-theme-muted">
-              Everything stays in your browser. Fast, private, and offline
-              ready. No cloud dependency required for core play.
-            </p>
-          </div>
-
-          <div
-            class="p-6 bg-theme-surface border border-theme-border flex flex-col gap-3 group hover:border-theme-primary transition-all shadow-xl"
-          >
-            <div class="flex items-center gap-3 text-theme-primary mb-1">
-              <span class="icon-[lucide--share-2] w-6 h-6"></span>
-              <h2 class="font-black tracking-widest uppercase text-sm">
-                Real-Time Sharing
-              </h2>
-            </div>
-            <p class="text-xs leading-relaxed text-theme-muted">
-              Connect with your players directly (P2P). Share specific nodes,
-              maps, and lore without account creation.
-            </p>
-          </div>
-        </div>
-
-        <section class="mt-4 pt-8 border-t border-theme-border/30">
-          <div class="flex items-center gap-3 text-theme-secondary mb-6">
-            <span class="icon-[lucide--palette] w-5 h-5"></span>
-            <h2 class="font-black tracking-widest uppercase text-xs">
-              Interface Styling
-            </h2>
-          </div>
-          <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-            {#each Object.keys(THEMES) as theme}
+            Try it as:
+          </h3>
+          <div class="flex flex-wrap justify-center gap-4">
+            {#each ["vampire", "scifi", "cyberpunk", "wasteland", "modern", "fallout", "starwars", "startrek"] as theme}
               <button
-                onclick={() => selectTheme(theme)}
-                class="px-4 py-2 text-[10px] border border-theme-border hover:border-theme-primary hover:bg-theme-primary/10 text-theme-secondary hover:text-theme-primary rounded uppercase font-header tracking-widest transition-all"
+                onclick={() => demoService.startDemo(theme)}
+                class="px-4 py-2 text-[10px] font-bold border border-theme-border hover:border-theme-primary text-theme-muted hover:text-theme-primary rounded uppercase font-header tracking-widest transition-all"
               >
                 {theme}
               </button>

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -98,6 +98,7 @@
       console.log("[Guest Mode] Host ID detected:", peerId);
       uiStore.isGuestMode = true; // Activate guest mode
       vault.status = "loading";
+      vault.selectedEntityId = null;
 
       p2pGuestService
         .connectToHost(
@@ -128,7 +129,7 @@
             if (graph.themeId) {
               import("../../lib/stores/theme.svelte")
                 .then((m) => {
-                  if (m?.themeStore) m.themeStore.setTheme(graph.themeId);
+                  if (m?.themeStore) m.themeStore.previewTheme(graph.themeId);
                 })
                 .catch((err) =>
                   console.error("Failed to load theme store", err),
@@ -165,18 +166,36 @@
             // Real-time theme update from host
             import("../../lib/stores/theme.svelte")
               .then((m) => {
-                if (m?.themeStore) m.themeStore.setTheme(themeId);
+                if (m?.themeStore) m.themeStore.previewTheme(themeId);
               })
               .catch((err) => console.error("Failed to load theme store", err));
           },
+          uiStore.guestUsername ?? undefined,
         )
         .catch((err) => {
           console.error("[Guest Mode] Failed to connect to host:", err);
+          vault.selectedEntityId = null;
+          uiStore.guestUsername = null;
           uiStore.isGuestMode = false;
           vault.status = "error";
           vault.errorMessage = "Failed to connect to shared campaign.";
         });
     }
+  });
+
+  $effect(() => {
+    if (!isGuestMode || !uiStore.isGuestMode || !uiStore.guestUsername) {
+      return;
+    }
+
+    const selectedId = vault.selectedEntityId;
+    p2pGuestService.updateGuestStatus({
+      status: selectedId ? "viewing" : "connected",
+      currentEntityId: selectedId,
+      currentEntityTitle: selectedId
+        ? (vault.entities[selectedId]?.title ?? selectedId)
+        : null,
+    });
   });
 
   onMount(async () => {

--- a/apps/web/tests/guest-login-a11y.spec.ts
+++ b/apps/web/tests/guest-login-a11y.spec.ts
@@ -11,7 +11,20 @@ test.describe("Guest Login Modal Accessibility", () => {
       (window as any).Peer = class MockPeer {
         on() {}
         connect() {
-          return { on: () => {}, send: () => {}, close: () => {} };
+          const handlers: Record<string, (...args: any[]) => void> = {};
+          const conn = {
+            open: true,
+            on(event: string, handler: (...args: any[]) => void) {
+              handlers[event] = handler;
+            },
+            send: () => {},
+            close: () => {},
+            emit(event: string, ...args: any[]) {
+              handlers[event]?.(...args);
+            },
+          };
+          (window as any).__guestConn = conn;
+          return conn;
         }
         destroy() {}
       };
@@ -24,7 +37,7 @@ test.describe("Guest Login Modal Accessibility", () => {
     page,
   }) => {
     const usernameInput = page.locator("#username-input");
-    const submitButton = page.getByRole("button", { name: "ACCESS ARCHIVE" });
+    const submitButton = page.getByRole("button", { name: "JOIN" });
 
     // 1. Initially no error
     await expect(page.locator("#username-error")).not.toBeAttached();
@@ -34,26 +47,34 @@ test.describe("Guest Login Modal Accessibility", () => {
     const errorRequired = page.locator("#username-error");
     await expect(errorRequired).toBeVisible();
     await expect(errorRequired).toHaveAttribute("role", "alert");
-    await expect(errorRequired).toHaveText("Username is required");
+    await expect(errorRequired).toHaveText("Name is required");
     await expect(usernameInput).toHaveAttribute("aria-invalid", "true");
 
     // 3. Type to clear error
-    await usernameInput.fill("A");
+    await usernameInput.fill("Baddy");
     await expect(page.locator("#username-error")).not.toBeAttached();
     await expect(usernameInput).toHaveAttribute("aria-invalid", "false");
 
-    // 4. Trigger "too short" error
+    // 4. Submit valid username
     await submitButton.click();
-    const errorShort = page.locator("#username-error");
-    await expect(errorShort).toBeVisible();
-    await expect(errorShort).toHaveAttribute("role", "alert");
-    await expect(errorShort).toHaveText("Username too short");
-    await expect(usernameInput).toHaveAttribute("aria-invalid", "true");
-
-    // 5. Submit valid username
-    await usernameInput.fill("ValidUser");
-    await submitButton.click();
-    // Modal should ideally disappear or start connecting (in this test it won't connect due to mock)
     await expect(page.locator("#username-error")).not.toBeAttached();
+  });
+
+  test("should reopen the guest modal if the connection fails", async ({
+    page,
+  }) => {
+    const usernameInput = page.locator("#username-input");
+    const submitButton = page.getByRole("button", { name: "JOIN" });
+
+    await usernameInput.fill("Baddy");
+    await submitButton.click();
+
+    await page.evaluate(() => {
+      const conn = (window as any).__guestConn;
+      conn?.emit("error", new Error("Connection failed"));
+    });
+
+    await expect(page.locator("#username-input")).toBeVisible();
+    await expect(page.locator("#username-input")).toHaveValue("Baddy");
   });
 });

--- a/apps/web/tests/guest-mode.spec.ts
+++ b/apps/web/tests/guest-mode.spec.ts
@@ -10,6 +10,8 @@ test.describe("Guest Mode (P2P Share)", () => {
         title: "Shared Mountain",
         type: "location",
         content: "A tall, craggy mountain shared via P2P.",
+        image:
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
         connections: [],
       },
       "test-entity-2": {
@@ -105,6 +107,10 @@ test.describe("Guest Mode (P2P Share)", () => {
     page,
   }) => {
     await page.goto("/?shareId=p2p-mock-peer-host");
+    await page.waitForFunction(() => !!(window as any).uiStore);
+    await page.evaluate(() => {
+      (window as any).uiStore?.setGuestUsername("Guest Tester");
+    });
 
     // 1. Wait for guest mode to activate and initialize
     await page.waitForFunction(
@@ -138,6 +144,9 @@ test.describe("Guest Mode (P2P Share)", () => {
       page.locator("h2", { hasText: "Shared Mountain" }),
     ).toBeVisible();
 
+    // Lore should stay hidden for guests.
+    await expect(page.getByTestId("tab-lore")).toHaveCount(0);
+
     // Check if the title input is disabled
     const entityTitleInput = page.locator("input[placeholder='Title']");
     if ((await entityTitleInput.count()) > 0) {
@@ -148,6 +157,16 @@ test.describe("Guest Mode (P2P Share)", () => {
     await expect(
       page.getByRole("button", { name: "SAVE CHANGES" }),
     ).not.toBeVisible();
+
+    // The graph should still resolve node images.
+    await page.waitForFunction(
+      () => {
+        const node = (window as any).cy?.$id("test-entity-1");
+        return !!node?.data("resolvedImage");
+      },
+      null,
+      { timeout: 10000 },
+    );
 
     // 5. Verify image save button in oracle is not visible
     const imageUrl =

--- a/apps/web/tests/node-read-mode.spec.ts
+++ b/apps/web/tests/node-read-mode.spec.ts
@@ -75,7 +75,7 @@ test.describe("Node Read Mode", () => {
     // 1. Setup Data with Image
     await page.evaluate(async () => {
       const base64Image =
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAC1HAQAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
       const id = await (window as any).vault.createEntity(
         "character",
         "HeroImg",

--- a/specs/021-share-campaigns/spec.md
+++ b/specs/021-share-campaigns/spec.md
@@ -18,7 +18,8 @@ A campaign owner wants to give another user read-only access to their campaign s
 **Acceptance Scenarios**:
 
 1. **Given** I am the owner of a campaign, **When** I click "Share Campaign", **Then** the system generates a unique URL.
-2. **Given** I have a generated link, **When** I copy it, **Then** it is ready to be pasted to another user.
+2. **Given** I have a generated link, **When** it is created, **Then** the system automatically copies it to my clipboard.
+3. **Given** I have a generated link, **When** I manually copy it, **Then** it is ready to be pasted to another user.
 
 ### User Story 2 - Recipient Views Shared Campaign (Priority: P1)
 
@@ -33,6 +34,7 @@ A user receives a campaign link and wants to view the campaign contents.
 1. **Given** I am a visitor with a share link, **When** I navigate to the link, **Then** I am prompted to enter a temporary username.
 2. **Given** I have entered a username, **When** I submit, **Then** I see the campaign details in read-only mode.
 3. **Given** I am viewing a shared campaign, **When** I try to edit a field, **Then** the UI prevents me (read-only mode).
+4. **Given** I am connected as a guest, **When** the host views the session, **Then** my temporary display name and live status are visible in a small guest roster.
 
 ### User Story 3 - Owner Revokes Access (Priority: P2)
 
@@ -62,7 +64,10 @@ The owner decides to stop sharing the campaign.
 - **FR-003**: System MUST allow public access via link but REQUIRE visitors to provide a temporary username before viewing.
 - **FR-004**: System MUST allow owners to invalidate or regenerate the share link, effectively revoking access for previous links.
 - **FR-005**: System MUST visually distinguish shared campaigns from owned campaigns in the dashboard (e.g., "Shared with me" filter or badge).
-- **FR-006**: System MUST prevent any modification (updates, creates, deletes) of campaign entities by share-link recipients.
+- **FR-006**: System MUST automatically copy a newly generated share link to the owner's clipboard.
+- **FR-007**: System MUST show the host a lightweight active guest roster with each guest's temporary display name and current session status.
+- **FR-008**: System MUST remove guests from the active roster when they disconnect.
+- **FR-009**: System MUST prevent any modification (updates, creates, deletes) of campaign entities by share-link recipients.
 
 ### Key Entities
 

--- a/specs/021-share-campaigns/tasks.md
+++ b/specs/021-share-campaigns/tasks.md
@@ -42,6 +42,7 @@
 - [x] T008 [US1] Extend `GoogleDriveAdapter` in `apps/web/src/lib/cloud-bridge/google-drive/adapter.ts` to implement `shareFilePublicly` and `revokeShare`
 - [x] T009 [US1] Add "Share" button and status UI to `apps/web/src/lib/components/VaultControls.svelte` or a new `ShareModal.svelte`
 - [x] T010 [US1] Implement sharing logic in UI: call adapter, update metadata, show link to user
+- [x] T010b [US1] Auto-copy the generated share link to the owner's clipboard when a session starts
 - [x] T010a [US1] Implement visual distinction (badge/icon) for shared campaigns in the dashboard
 - [x] T011 [US1] Implement revoke logic in UI: call adapter, clear metadata
 
@@ -60,6 +61,8 @@
 - [x] T012 [US2] Implement `GuestLoginModal.svelte` in `apps/web/src/lib/components/modals/` to capture temporary username
 - [x] T013 [US2] Implement "Guest Entry" logic in `apps/web/src/routes/+layout.svelte` or `+page.svelte`: detect `shareId` in URL, show modal, init Guest Mode
 - [x] T013a [US2] Update Service Worker configuration to cache fetched Guest content for offline resilience
+- [x] T013b [US2] Surface an active guest roster to the host with temporary display names and live status
+- [x] T013c [US2] Remove guests from the host roster when they disconnect
 - [x] T014 [US2] Implement read-only UI enforcement: Disable all inputs and action buttons when `vault.isGuest` is true
 - [x] T015 [US2] Update `EntityDetailPanel.svelte` and `MarkdownEditor.svelte` to respect the read-only flag
 


### PR DESCRIPTION
Fixes #520

This PR expands guest-mode sharing and cleans up the P2P/Zen flow for shared campaigns.

### What changed
- Shared campaigns now sync the host theme to guests without persisting it into guest storage.
- Guests can resolve and display host images in graph, sidebar, and Zen views.
- The host share modal auto-copies the session link after starting a session.
- Guests join with a lightweight display name that the GM can see in an active guest roster.
- Guests who disconnect are removed from the roster immediately.
- Zen mode keeps chronicles visible for guests while keeping lore owner-only.
- The Zen detail ordering now ensures chronicles appear above lore.
- P2P host/guest logic was split into smaller helpers and injected dependencies to make the code easier to test.

### Validation
- `npm run lint`
- `npm test`
- focused unit coverage for the new helpers and Zen ordering
- end-to-end guest mode coverage for the shared-session flow

These changes make shared campaigns feel more polished for guests while keeping GM-only lore and control surfaces private.
