### PR TITLE
[codex] fix PR labeler permission handling

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.LABELER_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/scripts/pr-labeler.mjs
+++ b/scripts/pr-labeler.mjs
@@ -142,6 +142,14 @@ async function githubRequest(method, url, token, body) {
   return response.json();
 }
 
+function isLabelWritePermissionError(error) {
+  return (
+    error instanceof Error &&
+    (error.message.includes("Resource not accessible by integration") ||
+      error.message.includes("(403)"))
+  );
+}
+
 async function listPullRequestFiles(repo, pullNumber, token) {
   const files = [];
   let page = 1;
@@ -169,19 +177,39 @@ async function listIssueLabels(repo, issueNumber, token) {
 async function removeLabel(repo, issueNumber, label, token) {
   const encoded = encodeURIComponent(label);
   const url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/labels/${encoded}`;
-  await githubRequest("DELETE", url, token);
+  try {
+    await githubRequest("DELETE", url, token);
+    return true;
+  } catch (error) {
+    if (isLabelWritePermissionError(error)) {
+      console.warn(`Skipping label removal for #${issueNumber} (${label}): ${error.message}`);
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 async function addLabels(repo, issueNumber, labels, token) {
   if (labels.length === 0) {
-    return;
+    return true;
   }
 
   const url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/labels`;
-  await githubRequest("POST", url, token, { labels });
+  try {
+    await githubRequest("POST", url, token, { labels });
+    return true;
+  } catch (error) {
+    if (isLabelWritePermissionError(error)) {
+      console.warn(`Skipping label add for #${issueNumber} (${labels.join(", ")}): ${error.message}`);
+      return false;
+    }
+
+    throw error;
+  }
 }
 
-async function main() {
+export async function main() {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   const eventPath = process.env.GITHUB_EVENT_PATH;
   const repo = process.env.GITHUB_REPOSITORY;
@@ -214,15 +242,25 @@ async function main() {
   const currentLabels = await listIssueLabels(repo, pullRequest.number, token);
   const managedCurrentLabels = currentLabels.filter((label) => MANAGED_LABELS.includes(label));
   const currentSet = new Set(currentLabels);
+  let labelWritesSkipped = false;
 
   for (const label of managedCurrentLabels) {
     if (!desiredLabels.includes(label)) {
-      await removeLabel(repo, pullRequest.number, label, token);
+      const removed = await removeLabel(repo, pullRequest.number, label, token);
+      labelWritesSkipped ||= !removed;
     }
   }
 
   const labelsToAdd = desiredLabels.filter((label) => !currentSet.has(label));
-  await addLabels(repo, pullRequest.number, labelsToAdd, token);
+  const added = await addLabels(repo, pullRequest.number, labelsToAdd, token);
+  labelWritesSkipped ||= !added;
+
+  if (labelWritesSkipped) {
+    console.warn(
+      `Label sync skipped for #${pullRequest.number} because the workflow token cannot mutate labels.`,
+    );
+    return;
+  }
 
   console.log(
     desiredLabels.length > 0
@@ -237,4 +275,3 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     process.exit(1);
   });
 }
-

--- a/scripts/pr-labeler.test.mjs
+++ b/scripts/pr-labeler.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import test from "node:test";
-import { labelsForPullRequest } from "./pr-labeler.mjs";
+import { labelsForPullRequest, main } from "./pr-labeler.mjs";
 
 test("classifies feat prs as enhancement", () => {
   assert.deepEqual(labelsForPullRequest({ title: "✨ feat(graph): open zen mode", files: [] }), [
@@ -55,4 +58,86 @@ test("prefers github actions for workflow changes", () => {
     }),
     ["github_actions"],
   );
+});
+
+test("skips label writes when GitHub denies integration write access", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "pr-labeler-"));
+  const eventPath = path.join(tempDir, "event.json");
+
+  await writeFile(
+    eventPath,
+    JSON.stringify({
+      pull_request: {
+        number: 42,
+        title: "chore: update workflow",
+      },
+    }),
+  );
+
+  const originalEnv = {
+    GITHUB_EVENT_PATH: process.env.GITHUB_EVENT_PATH,
+    GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  };
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const warnings = [];
+
+  try {
+    process.env.GITHUB_EVENT_PATH = eventPath;
+    process.env.GITHUB_REPOSITORY = "owner/repo";
+    process.env.GITHUB_TOKEN = "token";
+
+    console.warn = (...args) => {
+      warnings.push(args.join(" "));
+    };
+
+    globalThis.fetch = async (input, init = {}) => {
+      const url = new URL(String(input));
+      const method = (init.method ?? "GET").toUpperCase();
+
+      if (method === "GET" && url.pathname === "/repos/owner/repo/pulls/42/files") {
+        return new Response(JSON.stringify([{ filename: ".github/workflows/release.yml" }]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (method === "GET" && url.pathname === "/repos/owner/repo/issues/42/labels") {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (method === "POST" && url.pathname === "/repos/owner/repo/issues/42/labels") {
+        return new Response(
+          JSON.stringify({
+            message: "Resource not accessible by integration",
+            status: 403,
+          }),
+          {
+            status: 403,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url.pathname}${url.search}`);
+    };
+
+    await main();
+
+    assert.match(warnings.join("\n"), /skipping label add/i);
+    assert.match(warnings.join("\n"), /label sync skipped/i);
+  } finally {
+    console.warn = originalWarn;
+    globalThis.fetch = originalFetch;
+
+    process.env.GITHUB_EVENT_PATH = originalEnv.GITHUB_EVENT_PATH;
+    process.env.GITHUB_REPOSITORY = originalEnv.GITHUB_REPOSITORY;
+    process.env.GITHUB_TOKEN = originalEnv.GITHUB_TOKEN;
+
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## What
- Make the PR labeler script tolerate GitHub label write permission failures instead of crashing the workflow.
- Add a regression test that reproduces the 403 path and verifies the script exits cleanly.
- Update the labeler workflow to prefer a dedicated `LABELER_TOKEN` secret when available, while falling back to `GITHUB_TOKEN`.

## Why
- The labeler job was failing with `403 Resource not accessible by integration` when the workflow token could not mutate labels.
- That failure blocked the PR check even though label sync is best-effort automation.

## Impact
- Label sync still runs when the token has write access.
- When the token cannot write labels, the workflow now logs a warning and does not fail the PR check.

## Validation
- `node --test scripts/pr-labeler.test.mjs`
- `git push -u origin codex/pr-labeler-permissions` (repo pre-push lint/test hook passed)
