### PR TITLE
🎨 Palette: Make 'Skip Welcome Screen' toggle accessible and clickable

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 
 **Learning:** Added ARIA roles, states, and keyboard navigation (arrow keys) to standard `<button>` based tabs to improve screen reader accessibility and keyboard usability within Svelte components.
 **Action:** Ensure all custom tab lists follow the W3C ARIA authoring practices by implementing `role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, and `tabindex` along with appropriate keyboard handlers.
+
+## 2026-04-03 - Missing Checkbox Labels
+**Learning:** Standalone checkbox inputs grouped with text blocks need explicit `<label for="...">` associations, as relying on proximity is insufficient for both screen readers and click hit areas. Some toggles in the app followed this pattern, but others used unlinked `<span>`s.
+**Action:** Always wrap text descriptions for checkboxes in a `<label>` tag and link it via the `for` and `id` attributes to improve both accessibility and click target area.

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -365,9 +365,10 @@
               >
                 <div class="flex items-center justify-between pb-4">
                   <div>
-                    <span
-                      class="block text-sm font-bold text-theme-text uppercase font-header"
-                      >Skip Welcome Screen</span
+                    <label
+                      class="block text-sm font-bold text-theme-text uppercase font-header cursor-pointer"
+                      for="skip-welcome-screen-toggle"
+                      >Skip Welcome Screen</label
                     >
                     <p class="text-[11px] text-theme-muted">
                       Hide the marketing landing page on startup even when no
@@ -375,6 +376,7 @@
                     </p>
                   </div>
                   <input
+                    id="skip-welcome-screen-toggle"
                     type="checkbox"
                     checked={uiStore.skipWelcomeScreen}
                     onchange={(e) =>


### PR DESCRIPTION
💡 What: Converted text span to a proper `<label>` linked to the checkbox via `id`.
🎯 Why: Increases click target area for users and provides programmatic association for screen readers.
♿ Accessibility: Added `for` and `id` linking.

---
*PR created automatically by Jules for task [15169612658145123902](https://jules.google.com/task/15169612658145123902) started by @eserlan*