### PR TITLE
🎨 Palette: Add aria-label to search input

### DIFF
--- a/apps/web/src/lib/components/layout/AppHeader.svelte
+++ b/apps/web/src/lib/components/layout/AppHeader.svelte
@@ -87,6 +87,7 @@
       <input
         type="text"
         placeholder="Search (Cmd+K)..."
+        aria-label="Search notes"
         class="w-full bg-theme-bg border border-theme-border hover:border-theme-primary/50 focus:border-theme-primary focus:ring-1 focus:ring-theme-primary/50 rounded py-1.5 pl-10 pr-4 text-sm font-body text-theme-text transition-all placeholder:text-theme-muted/50"
         onfocus={() => searchStore.open()}
         value={searchStore.query}


### PR DESCRIPTION
💡 What: Added `aria-label="Search notes"` to the desktop search input.
🎯 Why: To improve accessibility for screen reader users by providing explicit context for the search field.
♿ Accessibility: Ensures the input field is properly identified by screen readers, replacing the reliance solely on the visual placeholder.

---
*PR created automatically by Jules for task [13571668473288886147](https://jules.google.com/task/13571668473288886147) started by @eserlan*