### PR TITLE
feat: generalize campaign to world and add confirmation modal

### DIFF
--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -111,11 +111,15 @@
 
   const handleDelete = async () => {
     if (!entity) return;
-    if (
-      confirm(
-        `Are you sure you want to permanently delete "${entity.title}"? This cannot be undone.`,
-      )
-    ) {
+    const confirmed = await uiStore.confirm({
+      title: "Delete Entity",
+      message: `Are you sure you want to permanently delete "${entity.title}"? This action cannot be undone.`,
+      confirmLabel: "Delete permanently",
+      cancelLabel: "Keep entity",
+      isDangerous: true,
+    });
+
+    if (confirmed) {
       try {
         await vault.deleteEntity(entity.id);
         onClose();

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -103,7 +103,7 @@
           : `${btnPrimary} px-3 md:px-4 py-1.5 text-[10px] md:text-xs gap-2`}
         onclick={async () => {
           try {
-            await demoService.convertToCampaign();
+            await demoService.convertToWorld();
           } catch (error) {
             console.error(`Failed to save ${themeStore.jargon.vault}:`, error);
             ui.notify(

--- a/apps/web/src/lib/components/campaign/EntityCard.svelte
+++ b/apps/web/src/lib/components/campaign/EntityCard.svelte
@@ -87,7 +87,7 @@
 </script>
 
 <article
-  class={`group relative overflow-hidden rounded-2xl border border-theme-border bg-theme-bg/20 shadow-[0_12px_40px_rgba(0,0,0,0.12)] transition-all hover:-translate-y-0.5 hover:border-theme-primary/50 hover:shadow-[0_18px_48px_rgba(0,0,0,0.18)] ${imageUrl ? "text-theme-text" : ""}`}
+  class="group relative overflow-hidden rounded-2xl border border-theme-border/80 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_48%),linear-gradient(180deg,color-mix(in_srgb,var(--color-theme-surface)_82%,black),color-mix(in_srgb,var(--color-theme-bg)_92%,black))] text-theme-text shadow-[0_12px_40px_rgba(0,0,0,0.18)] transition-all hover:-translate-y-0.5 hover:border-theme-primary/55 hover:shadow-[0_18px_48px_rgba(0,0,0,0.24)]"
   data-testid="entity-card"
 >
   {#if imageUrl}
@@ -96,9 +96,32 @@
       style={`background-image: url("${imageUrl}")`}
     ></div>
     <div
-      class="absolute inset-0 bg-[linear-gradient(180deg,rgba(2,6,23,0.06),rgba(2,6,23,0.16),rgba(2,6,23,0.58))]"
+      class="absolute inset-0 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--color-theme-primary)_8%,transparent),rgba(2,6,23,0.14),rgba(2,6,23,0.68))]"
     ></div>
-    <div class="absolute inset-0 border border-theme-border/30"></div>
+    <div
+      class="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.08),transparent_46%)]"
+    ></div>
+    <div class="absolute inset-0 border border-theme-border/40"></div>
+  {:else}
+    <div
+      class="absolute inset-0 bg-[radial-gradient(circle_at_top,color-mix(in_srgb,var(--color-theme-primary)_18%,transparent),transparent_52%),linear-gradient(180deg,color-mix(in_srgb,var(--color-theme-surface)_78%,black),color-mix(in_srgb,var(--color-theme-bg)_94%,black))]"
+      data-testid="entity-card-placeholder"
+    ></div>
+    <div
+      class="absolute inset-0 bg-[linear-gradient(transparent_0,color-mix(in_srgb,var(--color-theme-primary)_12%,transparent)_1px,transparent_1px),linear-gradient(90deg,transparent_0,color-mix(in_srgb,var(--color-theme-primary)_12%,transparent)_1px,transparent_1px)] bg-[size:20px_20px] opacity-40"
+    ></div>
+    <div
+      class="absolute inset-x-0 top-[12%] h-[58%] flex items-center justify-center"
+    >
+      <div
+        class="flex h-28 w-28 items-center justify-center rounded-full border border-theme-primary/30 bg-[color-mix(in_srgb,var(--color-theme-primary)_14%,transparent)] text-theme-primary/75 shadow-[0_0_60px_color-mix(in_srgb,var(--color-theme-primary)_18%,transparent)] backdrop-blur-sm"
+      >
+        <span
+          class="{getIconClass(category?.icon)} h-14 w-14"
+          data-testid="entity-card-placeholder-icon"
+        ></span>
+      </div>
+    </div>
   {/if}
 
   <button
@@ -114,13 +137,15 @@
   <div class="relative z-20 flex min-h-[17rem] h-full flex-col justify-between">
     <div class="p-2.5 md:p-3">
       <header
-        class="flex items-center justify-between gap-3 rounded-2xl bg-[rgba(2,6,23,0.62)] border border-white/10 backdrop-blur-md px-3 py-2"
+        class="flex items-center justify-between gap-3 rounded-2xl border border-theme-primary/15 bg-[color-mix(in_srgb,var(--color-theme-bg)_74%,transparent)] backdrop-blur-md px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
       >
         <div
           class="min-w-0 flex items-center gap-1.5 text-theme-primary/90 flex-1"
         >
           <span
-            class="{getIconClass(category?.icon)} h-3 w-3 shrink-0"
+            class="{getIconClass(
+              category?.icon,
+            )} h-3.5 w-3.5 shrink-0 drop-shadow-[0_0_0.35px_currentColor]"
             data-testid="entity-card-category-icon"
           ></span>
           <h3
@@ -137,7 +162,7 @@
 
     <div class="p-2.5 md:p-3">
       <div
-        class="rounded-xl bg-[rgba(2,6,23,0.68)] border border-white/10 backdrop-blur-md p-3"
+        class="rounded-xl border border-theme-border/50 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--color-theme-bg)_78%,transparent),color-mix(in_srgb,var(--color-theme-surface)_76%,transparent))] backdrop-blur-md p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
       >
         <p
           class="text-sm leading-relaxed min-h-[4.5rem] text-theme-text/95 line-clamp-4"
@@ -149,7 +174,7 @@
           <div class="mt-4 flex flex-wrap gap-2">
             {#each activity.tags as tag (tag)}
               <span
-                class="rounded-full border border-theme-border bg-theme-bg/60 px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-theme-secondary backdrop-blur-sm"
+                class="rounded-full border border-theme-primary/20 bg-[color-mix(in_srgb,var(--color-theme-primary)_10%,var(--color-theme-bg))] px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-theme-secondary backdrop-blur-sm"
               >
                 {tag}
               </span>

--- a/apps/web/src/lib/components/campaign/FrontPage.svelte
+++ b/apps/web/src/lib/components/campaign/FrontPage.svelte
@@ -4,59 +4,35 @@
   import { campaignStore } from "$lib/stores/campaign.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import ArticleRenderer from "$lib/components/blog/ArticleRenderer.svelte";
+  import { contextRetrievalService } from "$lib/services/ai/context-retrieval.service";
   import CoverImage from "./CoverImage.svelte";
   import EntityCard from "./EntityCard.svelte";
   import ZenImageLightbox from "$lib/components/zen/ZenImageLightbox.svelte";
 
   let { onClose }: { onClose?: () => void } = $props();
 
-  const stripMarkdown = (value: string) =>
-    value
-      .replace(/[`*_~>#-]/g, "")
-      .replace(/\s+/g, " ")
-      .trim();
-
-  const createCampaignTagline = (
-    summary: string,
-    campaignTitle: string,
-    themeName: string,
-  ) => {
-    const cleanSummary = stripMarkdown(summary);
-    if (cleanSummary) {
-      const sentences = cleanSummary.split(/(?<=[.!?])\s+/);
-      const firstSentence = sentences[0] || cleanSummary;
-      const words = firstSentence.split(/\s+/).filter(Boolean);
-      const truncated =
-        words.length > 14 ? words.slice(0, 14).join(" ") + "…" : firstSentence;
-      return truncated.replace(/[.!?…]+$/, "");
-    }
-
-    const title = campaignTitle.trim() || "this vault";
-    const themeLabel = themeName.trim();
-    return themeLabel
-      ? `${themeLabel} world waiting for its first story`
-      : `${title} is waiting for its first story`;
-  };
-
   const createCampaignCoverPrompt = (
-    campaignTitle: string,
+    campaignName: string,
     themeName: string,
     themeDescription: string,
     summary: string,
-    tagline: string,
+    worldContext: string,
   ) => {
     const safeSummary = summary.trim() || "An unexplored campaign setting.";
-    const safeTagline = tagline.trim() || "A world waiting to be entered.";
+    const safeName = campaignName.trim() || "this campaign world";
+    const safeWorldContext =
+      worldContext.trim() || "No additional world context was retrieved.";
 
-    return `Create atmospheric portrait cover art for the campaign "${campaignTitle}".
+    return `Create atmospheric portrait cover art for "${safeName}".
 
 Theme:
 - Name: ${themeName}
 - Thematic scope: ${themeDescription}
 
 World cues:
-- Tagline: ${safeTagline}
 - Summary: ${safeSummary}
+- Retrieved world context:
+${safeWorldContext}
 
 Art direction:
 - Portrait composition, vertical framing, approximately 2:3 aspect ratio.
@@ -69,12 +45,7 @@ Art direction:
 
   let lastLoadedVaultId: string | null = null;
   let draftDescription = $state("");
-  let draftTitle = $state("");
-  let draftTagline = $state("");
   let isDraftDirty = $state(false);
-  let isTitleDirty = $state(false);
-  let isEditingTagline = $state(false);
-  let isTaglineDirty = $state(false);
 
   const activeVaultId = $derived(vault.activeVaultId);
   const metadata = $derived(campaignStore.metadata);
@@ -104,17 +75,13 @@ Art direction:
     return [...pinned, ...unpinned].slice(0, recentLimit);
   });
   const coverImage = $derived(metadata?.coverImage || "");
-  const title = $derived(metadata?.name || vault.vaultName || "Vault");
+  const campaignName = $derived(
+    metadata?.name?.trim() || vault.vaultName || "",
+  );
   const hasSummary = $derived(!!draftDescription.trim());
   const summaryPreview = $derived(draftDescription.trim());
-  const hasTitle = $derived(!!draftTitle.trim());
-  const taglinePreview = $derived(
-    metadata?.tagline?.trim() ||
-      createCampaignTagline(summaryPreview, title, themeStore.activeTheme.name),
-  );
 
   let isEditingSummary = $state(false);
-  let isEditingTitle = $state(false);
   let showCoverEditor = $state(false);
   let coverImageUrl = $state("");
   let lastCoverImage = "";
@@ -188,19 +155,6 @@ Art direction:
     if (!isEditingSummary && !isDraftDirty) {
       draftDescription = summarySource;
     }
-    if (!isEditingTitle && !isTitleDirty) {
-      draftTitle = title;
-    }
-    isTitleDirty = false;
-    if (!isEditingTagline) {
-      draftTagline =
-        metadata?.tagline?.trim() ||
-        createCampaignTagline(
-          summarySource,
-          title,
-          themeStore.activeTheme.name,
-        );
-    }
     if (!isEditingSummary && summarySource) isDraftDirty = false;
     if (coverImage !== lastCoverImage) {
       lastCoverImage = coverImage;
@@ -239,24 +193,37 @@ Art direction:
     }
   };
 
-  const handleSaveTitle = async () => {
-    await campaignStore.saveTitle(draftTitle.trim());
-    if (!campaignStore.error) {
-      isTitleDirty = false;
-      isEditingTitle = false;
-    }
-  };
+  const buildRetrievedWorldContext = async (isImage = false) => {
+    const campaignRef = campaignName.trim();
+    const themeRef = themeStore.activeTheme.name.trim();
+    const baseTerms = [campaignRef, themeRef].filter(Boolean).join(" ").trim();
+    const queries = [
+      `${baseTerms} setting world campaign overview premise tone central conflict`,
+      `${baseTerms} major players factions antagonists allies plot hooks current threats`,
+    ];
 
-  const handleSaveTagline = async () => {
-    await campaignStore.saveTagline(draftTagline.trim());
-    if (!campaignStore.error) {
-      isTaglineDirty = false;
-      isEditingTagline = false;
+    try {
+      const retrievedParts = await Promise.all(
+        queries.map(async (query) => {
+          const retrieved = await contextRetrievalService.retrieveContext(
+            query,
+            new Set<string>(),
+            vault,
+            campaignStore.frontPageEntity?.id,
+            isImage,
+          );
+          return retrieved.content.trim();
+        }),
+      );
+
+      const uniqueParts = [...new Set(retrievedParts.filter(Boolean))];
+      return uniqueParts.join("\n\n");
+    } catch {
+      return "";
     }
   };
 
   const handleGenerateSummary = async () => {
-    const existingTagline = metadata?.tagline?.trim() || "";
     if (hasSummary) {
       const confirmed = window.confirm(
         "Generate a new summary and replace the existing one?",
@@ -266,8 +233,11 @@ Art direction:
 
     const activeTheme = themeStore.activeTheme;
     const themeDescription = activeTheme.description.trim();
+    const retrievedWorldContext = await buildRetrievedWorldContext();
     const generated = await campaignStore.generateDescription(
-      `Write a front-page campaign summary for "${title}".
+      `Write a front-page campaign summary for "${
+        campaignName.trim() || "this campaign world"
+      }".
 
 Theme:
 - Name: ${activeTheme.name}
@@ -275,12 +245,17 @@ Theme:
 - Mood colors: primary ${activeTheme.tokens.primary}, accent ${activeTheme.tokens.accent}, background ${activeTheme.tokens.background}
 
 Requirements:
-- 2 to 4 short paragraphs or a compact single paragraph.
+- Start with 1 short atmospheric intro paragraph.
+- Follow with 3 to 5 markdown bullet points using bold labels such as **Current Conflict:**, **Key Players:**, **Immediate Hook:**, or **Threat Level:** when they fit the setting.
 - Clearly explain the setting, mood, and immediate premise.
 - Use specific details from the campaign instead of generic fantasy language.
 - Keep it readable, welcoming, and easy to scan.
-- Avoid headings, bullet points, and meta commentary.
+- Keep each bullet to one compact sentence.
+- Avoid headings and meta commentary.
 - Do not mention that you are an AI.
+
+Retrieved world context:
+${retrievedWorldContext || "No additional world context was retrieved."}
 
 Match the summary to the theme's atmosphere and visual identity, and focus on what a new player or returning GM needs to know at a glance.`,
     );
@@ -288,30 +263,11 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
       draftDescription = generated;
       isDraftDirty = false;
       isEditingSummary = false;
-      if (!existingTagline) {
-        draftTagline = createCampaignTagline(
-          generated,
-          title,
-          activeTheme.name,
-        );
-        await campaignStore.saveTagline(draftTagline);
-      }
     }
   };
 
   const startEditingSummary = async () => {
     isEditingSummary = true;
-  };
-
-  const startEditingTitle = async () => {
-    draftTitle = title;
-    isEditingTitle = true;
-  };
-
-  const startEditingTagline = () => {
-    draftTagline = taglinePreview;
-    isTaglineDirty = false;
-    isEditingTagline = true;
   };
 
   const openCoverEditor = () => {
@@ -326,18 +282,6 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
     draftDescription = summarySource;
     isDraftDirty = false;
     isEditingSummary = false;
-  };
-
-  const cancelEditingTitle = () => {
-    draftTitle = title;
-    isTitleDirty = false;
-    isEditingTitle = false;
-  };
-
-  const cancelEditingTagline = () => {
-    draftTagline = metadata?.tagline?.trim() || taglinePreview;
-    isTaglineDirty = false;
-    isEditingTagline = false;
   };
 
   const closeCoverEditor = () => {
@@ -358,15 +302,15 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
     const themeName = themeStore.activeTheme.name;
     const themeDescription = themeStore.activeTheme.description.trim();
     const summaryText = summaryPreview || "No campaign summary provided yet.";
-    const taglineText = taglinePreview;
+    const retrievedWorldContext = await buildRetrievedWorldContext(true);
     try {
       await campaignStore.generateCoverImage(
         createCampaignCoverPrompt(
-          title,
+          campaignName,
           themeName,
           themeDescription,
           summaryText,
-          taglineText,
+          retrievedWorldContext,
         ),
       );
     } catch {
@@ -474,127 +418,26 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
       >
         <div class="w-full space-y-4 xl:pr-56">
           <div
-            class="inline-flex items-center gap-2 rounded-full border border-theme-primary/30 bg-theme-primary/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.24em] text-theme-primary"
+            class="inline-flex items-center gap-2 rounded-full border border-theme-primary/45 bg-theme-surface/80 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.24em] text-theme-primary shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-theme-primary)_12%,transparent)] backdrop-blur-sm"
           >
             <span class="w-2 h-2 rounded-full bg-theme-primary animate-pulse"
             ></span>
             Front Page
           </div>
 
-          <div class="space-y-2">
-            {#if isEditingTitle}
-              <div class="flex flex-col gap-3">
-                <input
-                  bind:value={draftTitle}
-                  class="w-full rounded-2xl border border-theme-border bg-theme-bg/80 px-4 py-3 font-header text-2xl md:text-4xl uppercase tracking-[0.08em] text-theme-text leading-none placeholder:text-theme-muted/60 focus:border-theme-primary focus:outline-none"
-                  placeholder="Campaign title"
-                  oninput={() => (isTitleDirty = true)}
-                />
-                <div class="flex flex-wrap gap-2">
-                  <button
-                    class="rounded-lg bg-theme-primary px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-bg disabled:opacity-50"
-                    onclick={handleSaveTitle}
-                    disabled={campaignStore.isSaving ||
-                      !hasTitle ||
-                      !isTitleDirty}
-                  >
-                    Save Title
-                  </button>
-                  <button
-                    class="rounded-lg px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-muted hover:text-theme-text disabled:opacity-50"
-                    onclick={cancelEditingTitle}
-                    disabled={campaignStore.isSaving}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            {:else}
-              <div class="flex items-start gap-3">
-                <h1
-                  class="font-header text-4xl sm:text-5xl lg:text-6xl 2xl:text-7xl uppercase tracking-[0.08em] text-theme-text leading-none"
-                >
-                  {title}
-                </h1>
-              </div>
-              <ZenImageLightbox
-                bind:show={showCoverLightbox}
-                imageUrl={coverImageUrl}
-                {title}
-              />
-            {/if}
-            {#if isEditingTagline}
-              <div class="flex flex-col gap-3">
-                <input
-                  bind:value={draftTagline}
-                  class="w-full rounded-2xl border border-theme-border bg-theme-bg/80 px-4 py-3 text-sm md:text-base italic text-theme-text/75 leading-relaxed placeholder:text-theme-muted/60 focus:border-theme-primary focus:outline-none"
-                  placeholder="Campaign tagline"
-                  oninput={() => (isTaglineDirty = true)}
-                />
-                <div class="flex flex-wrap gap-2">
-                  <button
-                    class="rounded-lg bg-theme-primary px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-bg disabled:opacity-50"
-                    onclick={handleSaveTagline}
-                    disabled={campaignStore.isSaving ||
-                      !draftTagline.trim() ||
-                      !isTaglineDirty}
-                  >
-                    Save Tagline
-                  </button>
-                  <button
-                    class="rounded-lg px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-muted hover:text-theme-text disabled:opacity-50"
-                    onclick={cancelEditingTagline}
-                    disabled={campaignStore.isSaving}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            {:else}
-              <div class="flex items-start gap-2">
-                <p
-                  class="max-w-none text-sm md:text-base italic text-theme-text/75 leading-relaxed"
-                >
-                  {taglinePreview}
-                </p>
-                <button
-                  type="button"
-                  class="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-theme-border text-theme-muted transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
-                  onclick={startEditingTagline}
-                  disabled={campaignStore.isSaving}
-                  title="Edit tagline"
-                  aria-label="Edit tagline"
-                >
-                  <span class="icon-[lucide--pencil] h-3.5 w-3.5"></span>
-                </button>
-              </div>
-            {/if}
-          </div>
+          <ZenImageLightbox
+            bind:show={showCoverLightbox}
+            imageUrl={coverImageUrl}
+            title="Campaign cover"
+          />
         </div>
 
         <div
           class="flex flex-wrap justify-end gap-2 xl:absolute xl:right-0 xl:top-0 xl:gap-3"
         >
-          {#if onClose}
-            <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-theme-border bg-theme-bg/70 text-theme-muted backdrop-blur-sm transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
-              onclick={onClose}
-              aria-label="Close front page"
-              title="Close front page"
-            >
-              <span class="icon-[lucide--x] h-4 w-4"></span>
-            </button>
-          {/if}
-          <button
-            class="rounded-full border border-theme-border px-3 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-muted hover:border-theme-primary/50 hover:text-theme-primary"
-            onclick={startEditingTitle}
-            disabled={campaignStore.isSaving}
-          >
-            Edit Title
-          </button>
           {#if coverImage}
             <button
-              class="rounded-full border border-theme-primary/40 bg-theme-primary/10 px-3 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-primary hover:bg-theme-primary/20"
+              class="rounded-full border border-theme-primary/45 bg-theme-surface/80 px-3 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-primary shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-theme-primary)_12%,transparent)] transition-colors hover:bg-theme-primary/12 hover:border-theme-primary/60"
               onclick={openCoverEditor}
               disabled={campaignStore.isSaving}
             >
@@ -610,6 +453,16 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
               disabled={!coverImageUrl}
             >
               <span class="icon-[lucide--maximize-2] h-4 w-4"></span>
+            </button>
+          {/if}
+          {#if onClose}
+            <button
+              class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-theme-border bg-theme-bg/70 text-theme-muted backdrop-blur-sm transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
+              onclick={onClose}
+              aria-label="Close front page"
+              title="Close front page"
+            >
+              <span class="icon-[lucide--x] h-4 w-4"></span>
             </button>
           {/if}
         </div>
@@ -635,93 +488,7 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
         {/if}
 
         <section
-          class="flex flex-col rounded-3xl border border-theme-border bg-theme-surface/80 p-4 sm:p-5 md:p-6"
-        >
-          <div class="relative overflow-hidden rounded-2xl bg-theme-bg/80">
-            {#if isEditingSummary}
-              <textarea
-                bind:this={summaryTextarea}
-                bind:value={draftDescription}
-                oninput={() => (isDraftDirty = true)}
-                rows="1"
-                class="min-h-[12rem] w-full resize-none border-0 bg-transparent px-4 py-4 pr-32 pb-16 text-sm leading-relaxed text-theme-text placeholder:text-theme-muted/60 focus:outline-none sm:text-base overflow-hidden"
-                placeholder="Write a short campaign summary..."
-              ></textarea>
-            {:else}
-              <div class="relative w-full px-4 py-4 pr-16 sm:pr-20">
-                <div
-                  data-testid="summary-preview"
-                  role="region"
-                  aria-label="Campaign summary preview"
-                  class={`relative flex-1 overflow-hidden prose prose-invert max-w-none prose-p:my-0 prose-strong:text-theme-primary prose-a:text-theme-primary transition-[max-height] duration-300 ease-out ${isSummaryExpanded ? "max-h-[48rem]" : "max-h-[11rem]"}`}
-                  onmouseenter={beginSummaryPreviewHover}
-                  onmouseleave={endSummaryPreviewHover}
-                  onfocusin={beginSummaryPreviewHover}
-                  onfocusout={endSummaryPreviewHover}
-                >
-                  {#if hasSummary}
-                    <ArticleRenderer content={summaryPreview} />
-                    {#if !isSummaryExpanded}
-                      <div
-                        class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-b from-transparent to-theme-bg/95"
-                      ></div>
-                    {/if}
-                  {:else}
-                    <div
-                      class="flex min-h-[12rem] items-center justify-center px-4 py-8 text-center text-sm text-theme-muted/70"
-                    >
-                      No campaign summary yet. Use the edit or generate button
-                      to add one.
-                    </div>
-                  {/if}
-                </div>
-                <div
-                  class="absolute right-3 top-3 z-20 flex flex-wrap justify-end gap-1"
-                >
-                  <button
-                    class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-border text-theme-muted transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
-                    onclick={startEditingSummary}
-                    disabled={campaignStore.isSaving}
-                    title="Edit summary"
-                    aria-label="Edit summary"
-                  >
-                    <span class="icon-[lucide--pencil] h-4 w-4"></span>
-                  </button>
-                  <button
-                    class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-primary/30 bg-theme-primary/10 text-theme-primary transition-colors hover:bg-theme-primary/20 disabled:opacity-50"
-                    onclick={handleGenerateSummary}
-                    disabled={campaignStore.isSaving}
-                    title="Generate summary"
-                    aria-label="Generate summary"
-                  >
-                    <span class="icon-[lucide--sparkles] h-4 w-4"></span>
-                  </button>
-                </div>
-              </div>
-            {/if}
-          </div>
-
-          {#if isEditingSummary}
-            <div class="mt-3 flex flex-wrap gap-2">
-              <button
-                class="rounded-lg bg-theme-primary px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-bg disabled:opacity-50"
-                onclick={handleSaveDescription}
-                disabled={campaignStore.isSaving || !isDraftDirty}
-              >
-                Save Summary
-              </button>
-              <button
-                class="rounded-lg px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-muted hover:text-theme-text disabled:opacity-50"
-                onclick={cancelEditingSummary}
-                disabled={campaignStore.isSaving}
-              >
-                Cancel
-              </button>
-            </div>
-          {/if}
-        </section>
-
-        <section
+          data-testid="entities-section"
           class="flex flex-1 flex-col rounded-3xl border border-theme-border bg-theme-surface/80 p-4 sm:p-5 md:p-6"
         >
           <div class="mb-4 flex items-center justify-between">
@@ -780,6 +547,96 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
               class="rounded-2xl border border-dashed border-theme-border px-4 py-10 text-center text-sm text-theme-muted"
             >
               No recent entities yet. Create or import a note to see it here.
+            </div>
+          {/if}
+        </section>
+
+        <section
+          data-testid="summary-section"
+          class="flex flex-col overflow-hidden rounded-3xl border border-theme-border bg-theme-surface/80"
+        >
+          <div class="relative overflow-hidden bg-theme-bg/80">
+            {#if isEditingSummary}
+              <textarea
+                bind:this={summaryTextarea}
+                bind:value={draftDescription}
+                oninput={() => (isDraftDirty = true)}
+                rows="1"
+                class="min-h-[12rem] w-full resize-none border-0 bg-transparent px-5 py-5 pb-16 text-sm leading-relaxed text-theme-text placeholder:text-theme-muted/60 focus:outline-none sm:px-6 sm:py-6 sm:text-base overflow-hidden"
+                placeholder="Write a short campaign summary..."
+              ></textarea>
+            {:else}
+              <div class="relative w-full px-5 py-5 sm:px-6 sm:py-6">
+                <div
+                  data-testid="summary-preview"
+                  role="region"
+                  aria-label="Campaign summary preview"
+                  class={`relative flex-1 overflow-hidden prose prose-invert max-w-none prose-p:my-0 prose-p:leading-relaxed prose-ul:my-4 prose-ul:list-disc prose-ul:pl-5 prose-li:my-1 prose-li:marker:text-theme-primary prose-strong:text-theme-primary prose-a:text-theme-primary transition-[max-height] duration-300 ease-out ${isSummaryExpanded ? "max-h-[48rem]" : "max-h-[14rem]"}`}
+                  onmouseenter={beginSummaryPreviewHover}
+                  onmouseleave={endSummaryPreviewHover}
+                  onfocusin={beginSummaryPreviewHover}
+                  onfocusout={endSummaryPreviewHover}
+                >
+                  {#if hasSummary}
+                    <ArticleRenderer content={summaryPreview} />
+                    {#if !isSummaryExpanded}
+                      <div
+                        class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-b from-transparent to-theme-bg/95"
+                      ></div>
+                    {/if}
+                  {:else}
+                    <div
+                      class="flex min-h-[12rem] items-center justify-center px-4 py-8 text-center text-sm text-theme-muted/70"
+                    >
+                      No world brief yet. Use the edit or generate button to add
+                      one.
+                    </div>
+                  {/if}
+                </div>
+                <div
+                  class="absolute right-3 top-3 z-20 flex flex-wrap justify-end gap-1"
+                >
+                  <button
+                    class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-border/80 bg-theme-bg/75 text-theme-muted backdrop-blur-sm transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
+                    onclick={startEditingSummary}
+                    disabled={campaignStore.isSaving}
+                    title="Edit summary"
+                    aria-label="Edit summary"
+                  >
+                    <span class="icon-[lucide--pencil] h-4 w-4"></span>
+                  </button>
+                  <button
+                    class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-primary/30 bg-theme-bg/75 text-theme-primary backdrop-blur-sm transition-colors hover:bg-theme-primary/15 disabled:opacity-50"
+                    onclick={handleGenerateSummary}
+                    disabled={campaignStore.isSaving}
+                    title="Generate summary"
+                    aria-label="Generate summary"
+                  >
+                    <span class="icon-[lucide--sparkles] h-4 w-4"></span>
+                  </button>
+                </div>
+              </div>
+            {/if}
+          </div>
+
+          {#if isEditingSummary}
+            <div
+              class="flex flex-wrap gap-2 border-t border-theme-border/60 px-5 py-4 sm:px-6"
+            >
+              <button
+                class="rounded-lg bg-theme-primary px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-bg disabled:opacity-50"
+                onclick={handleSaveDescription}
+                disabled={campaignStore.isSaving || !isDraftDirty}
+              >
+                Save Summary
+              </button>
+              <button
+                class="rounded-lg px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-muted hover:text-theme-text disabled:opacity-50"
+                onclick={cancelEditingSummary}
+                disabled={campaignStore.isSaving}
+              >
+                Cancel
+              </button>
             </div>
           {/if}
         </section>

--- a/apps/web/src/lib/components/campaign/FrontPage.test.ts
+++ b/apps/web/src/lib/components/campaign/FrontPage.test.ts
@@ -16,19 +16,20 @@ vi.mock("svelte", async () => {
 
 const mocks = vi.hoisted(() => ({
   load: vi.fn(),
-  saveTitle: vi.fn(),
-  saveTagline: vi.fn(),
   saveDescription: vi.fn(),
   generateDescription: vi.fn().mockResolvedValue("Generated summary"),
   generateCoverImage: vi.fn().mockResolvedValue("images/cover.webp"),
   setCoverImage: vi.fn(),
+  retrieveContext: vi.fn().mockResolvedValue({
+    content: "--- File: World Primer ---\nSky-market politics and drone wars.",
+    sourceIds: ["front-1"],
+  }),
 }));
 
 const campaignMock = vi.hoisted(() => ({
   metadata: {
     id: "vault-1",
     name: "Moonfall",
-    tagline: "A city caught between collapse and light.",
     description: "A broken moon hangs over the **capital**.",
     coverImage: "images/cover.webp",
   },
@@ -48,8 +49,8 @@ const campaignMock = vi.hoisted(() => ({
       type: "npc",
       tags: ["npc"],
       lastModified: Date.now(),
-      image: "images/captain.webp",
-      thumbnail: "images/captain-thumb.webp",
+      image: "",
+      thumbnail: "",
     },
     {
       id: "front-1",
@@ -96,6 +97,12 @@ vi.mock("$lib/stores/theme.svelte", () => ({
   },
 }));
 
+vi.mock("$lib/services/ai/context-retrieval.service", () => ({
+  contextRetrievalService: {
+    retrieveContext: mocks.retrieveContext,
+  },
+}));
+
 vi.mock("$lib/stores/vault.svelte", () => ({
   vault: {
     activeVaultId: "vault-1",
@@ -127,8 +134,6 @@ vi.mock("$lib/stores/ui.svelte", () => ({
 vi.mock("$lib/stores/campaign.svelte", () => ({
   campaignStore: Object.assign(campaignStoreMock, {
     load: mocks.load,
-    saveTitle: mocks.saveTitle,
-    saveTagline: mocks.saveTagline,
     saveDescription: mocks.saveDescription,
     generateDescription: mocks.generateDescription,
     generateCoverImage: mocks.generateCoverImage,
@@ -139,6 +144,11 @@ vi.mock("$lib/stores/campaign.svelte", () => ({
 describe("FrontPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.retrieveContext.mockResolvedValue({
+      content:
+        "--- File: World Primer ---\nSky-market politics and drone wars.",
+      sourceIds: ["front-1"],
+    });
     uiStore.dismissedLandingPage = false;
     uiStore.dismissedCampaignPage = false;
     campaignStoreMock.error = null;
@@ -146,7 +156,6 @@ describe("FrontPage", () => {
     Object.assign(campaignMock.metadata, {
       id: "vault-1",
       name: "Moonfall",
-      tagline: "A city caught between collapse and light.",
       description: "A broken moon hangs over the **capital**.",
       coverImage: "images/cover.webp",
     });
@@ -157,8 +166,8 @@ describe("FrontPage", () => {
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
 
-    expect(screen.getByText("Moonfall")).toBeTruthy();
-    expect(screen.queryByPlaceholderText("Campaign title")).toBeNull();
+    expect(screen.getByText("Front Page")).toBeTruthy();
+    expect(screen.getByText("Relevant Entities")).toBeTruthy();
     expect(screen.getByText("capital").tagName).toBe("STRONG");
     expect(screen.getByText("Front Page Chronicle")).toBeTruthy();
     await waitFor(() =>
@@ -168,7 +177,7 @@ describe("FrontPage", () => {
     await waitFor(() =>
       expect(screen.getByRole("dialog", { name: "Image View" })).toBeTruthy(),
     );
-    expect(screen.getByAltText("Moonfall")).toBeTruthy();
+    expect(screen.getByAltText("Campaign cover")).toBeTruthy();
     await fireEvent.click(screen.getByLabelText("Close image view"));
     expect(
       (screen.getByTestId("front-page-hero-background") as HTMLElement).style
@@ -182,8 +191,10 @@ describe("FrontPage", () => {
       screen.getByText("Drop a new image to replace the current cover."),
     ).toBeTruthy();
     await fireEvent.click(screen.getByText("Generate Art"));
-    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
-      expect.stringContaining("Create atmospheric portrait cover art"),
+    await waitFor(() =>
+      expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+        expect.stringContaining("Create atmospheric portrait cover art"),
+      ),
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -200,6 +211,32 @@ describe("FrontPage", () => {
         "Summary: A broken moon hangs over the **capital**.",
       ),
     );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Create atmospheric portrait cover art for "Moonfall".',
+      ),
+    );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining("Sky-market politics and drone wars."),
+    );
+    expect(mocks.retrieveContext).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Moonfall Neon Night setting world campaign overview premise tone central conflict",
+      ),
+      expect.any(Set),
+      expect.anything(),
+      "front-1",
+      true,
+    );
+    expect(mocks.retrieveContext).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Moonfall Neon Night major players factions antagonists allies plot hooks current threats",
+      ),
+      expect.any(Set),
+      expect.anything(),
+      "front-1",
+      true,
+    );
     const cards = screen.getAllByTestId("entity-card");
     expect(within(cards[0]).getByText("Front Page Chronicle")).toBeTruthy();
     expect(
@@ -207,6 +244,12 @@ describe("FrontPage", () => {
     ).toBeTruthy();
     expect(
       within(cards[0]).getByTestId("entity-card-category-icon"),
+    ).toBeTruthy();
+    expect(
+      within(cards[1]).getByTestId("entity-card-placeholder"),
+    ).toBeTruthy();
+    expect(
+      within(cards[1]).getByTestId("entity-card-placeholder-icon"),
     ).toBeTruthy();
     expect(within(cards[0]).getByText("moon").tagName).toBe("STRONG");
     const cardButton = within(cards[0]).getByRole("button");
@@ -217,21 +260,6 @@ describe("FrontPage", () => {
     expect(uiStore.dismissedCampaignPage).toBe(true);
     expect(uiStore.openZenMode).not.toHaveBeenCalled();
     vi.useRealTimers();
-    await fireEvent.click(screen.getByText("Edit Title"));
-    await waitFor(() =>
-      expect(screen.getByPlaceholderText("Campaign title")).toBeTruthy(),
-    );
-    const titleInput = screen.getByPlaceholderText("Campaign title");
-    await fireEvent.input(titleInput, { target: { value: "Moonfall Prime" } });
-    expect(screen.getByText("Save Title")).toBeTruthy();
-    screen.getByText("Save Title").click();
-    await waitFor(() =>
-      expect(mocks.saveTitle).toHaveBeenCalledWith("Moonfall Prime"),
-    );
-    expect(screen.getByText("Moonfall")).toBeTruthy();
-    expect(
-      screen.getByText("A city caught between collapse and light."),
-    ).toBeTruthy();
     screen.getByLabelText("Edit summary").click();
     await waitFor(() =>
       expect(
@@ -261,11 +289,23 @@ describe("FrontPage", () => {
     expect(screen.getByText("Captain Ril")).toBeTruthy();
   });
 
+  it("places relevant entities before the world brief", async () => {
+    render(FrontPage);
+
+    await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
+
+    const entitiesSection = screen.getByTestId("entities-section");
+    const summarySection = screen.getByTestId("summary-section");
+
+    expect(entitiesSection.compareDocumentPosition(summarySection)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   it("keeps summary actions visible even when the summary is empty and being edited", async () => {
     Object.assign(campaignMock.metadata, {
       id: "vault-1",
       name: "Moonfall",
-      tagline: "A city caught between collapse and light.",
       description: "",
       coverImage: "images/cover.webp",
     });
@@ -289,7 +329,6 @@ describe("FrontPage", () => {
     Object.assign(campaignMock.metadata, {
       id: "vault-1",
       name: "Moonfall",
-      tagline: "A city caught between collapse and light.",
       description: "",
       coverImage: "images/cover.webp",
     });
@@ -419,7 +458,7 @@ describe("FrontPage", () => {
     );
     await fireEvent.click(screen.getByText("Generate Art"));
 
-    expect(screen.getByText("Working...")).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("Working...")).toBeTruthy());
     expect(
       screen.getByRole("status", { name: "Image generation in progress" }),
     ).toBeTruthy();
@@ -427,29 +466,6 @@ describe("FrontPage", () => {
     resolveGenerateCover?.();
 
     await waitFor(() => expect(screen.getByText("Generate Art")).toBeTruthy());
-  });
-
-  it("lets the user edit the campaign tagline", async () => {
-    render(FrontPage);
-
-    await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-
-    await fireEvent.click(screen.getByLabelText("Edit tagline"));
-    await waitFor(() =>
-      expect(screen.getByPlaceholderText("Campaign tagline")).toBeTruthy(),
-    );
-
-    const taglineInput = screen.getByPlaceholderText("Campaign tagline");
-    await fireEvent.input(taglineInput, {
-      target: { value: "A city balanced on the edge of collapse." },
-    });
-    screen.getByText("Save Tagline").click();
-
-    await waitFor(() =>
-      expect(mocks.saveTagline).toHaveBeenCalledWith(
-        "A city balanced on the edge of collapse.",
-      ),
-    );
   });
 
   it("opens zen mode on double click before the single-click action runs", async () => {
@@ -482,11 +498,11 @@ describe("FrontPage", () => {
     render(FrontPage);
 
     expect(screen.getByText("Loading front page")).toBeTruthy();
-    expect(screen.queryByText("Moonfall")).toBeNull();
+    expect(screen.queryByText("Front Page")).toBeNull();
 
     resolveLoad?.();
 
-    await waitFor(() => expect(screen.getByText("Moonfall")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Front Page")).toBeTruthy());
     expect(screen.queryByText("Loading front page")).toBeNull();
   });
 
@@ -512,10 +528,43 @@ describe("FrontPage", () => {
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
     await fireEvent.click(screen.getByLabelText("Generate summary"));
 
+    await waitFor(() =>
+      expect(mocks.generateDescription).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Description: Cyberpunk, neon-noir, corporate control",
+        ),
+      ),
+    );
     expect(mocks.generateDescription).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Description: Cyberpunk, neon-noir, corporate control",
+        'Write a front-page campaign summary for "Moonfall".',
       ),
+    );
+    expect(mocks.generateDescription).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Follow with 3 to 5 markdown bullet points using bold labels",
+      ),
+    );
+    expect(mocks.generateDescription).toHaveBeenCalledWith(
+      expect.stringContaining("Sky-market politics and drone wars."),
+    );
+    expect(mocks.retrieveContext).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Moonfall Neon Night setting world campaign overview premise tone central conflict",
+      ),
+      expect.any(Set),
+      expect.anything(),
+      "front-1",
+      false,
+    );
+    expect(mocks.retrieveContext).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Moonfall Neon Night major players factions antagonists allies plot hooks current threats",
+      ),
+      expect.any(Set),
+      expect.anything(),
+      "front-1",
+      false,
     );
   });
 
@@ -540,27 +589,6 @@ describe("FrontPage", () => {
     ).toBeNull();
     expect(campaignStoreMock.error).toBe(
       "Failed to generate campaign summary.",
-    );
-  });
-
-  it("seeds a tagline when generating a new summary without one", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
-    mocks.saveTagline.mockClear();
-    Object.assign(campaignMock.metadata, {
-      id: "vault-1",
-      name: "Moonfall",
-      tagline: "",
-      description: "A broken moon hangs over the **capital**.",
-      coverImage: "images/cover.webp",
-    });
-
-    render(FrontPage);
-
-    await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-    await fireEvent.click(screen.getByLabelText("Generate summary"));
-
-    await waitFor(() =>
-      expect(mocks.saveTagline).toHaveBeenCalledWith("Generated summary"),
     );
   });
 
@@ -608,13 +636,13 @@ describe("FrontPage", () => {
     vi.useFakeTimers();
 
     await fireEvent.mouseEnter(summaryPreview);
-    expect(summaryPreview.className).toContain("max-h-[11rem]");
+    expect(summaryPreview.className).toContain("max-h-[14rem]");
 
     await vi.advanceTimersByTimeAsync(800);
     expect(summaryPreview.className).toContain("max-h-[48rem]");
 
     await fireEvent.mouseLeave(summaryPreview);
-    expect(summaryPreview.className).toContain("max-h-[11rem]");
+    expect(summaryPreview.className).toContain("max-h-[14rem]");
     vi.useRealTimers();
   });
 });

--- a/apps/web/src/lib/components/dialogs/MergeNodesDialog.svelte
+++ b/apps/web/src/lib/components/dialogs/MergeNodesDialog.svelte
@@ -5,6 +5,7 @@
   } from "$lib/services/node-merge.service";
   import { vault } from "$lib/stores/vault.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
 
   let {
     isOpen = false,
@@ -60,9 +61,12 @@
     // Check for unsaved changes (T011)
     if (nodeMergeService.checkUnsavedChanges(sourceNodeIds)) {
       if (
-        !confirm(
-          "Some nodes might be open in the editor with unsaved changes. Proceeding might lose recent edits. Continue?",
-        )
+        !(await uiStore.confirm({
+          title: "Unsaved Changes",
+          message:
+            "Some nodes might be open in the editor with unsaved changes. Proceeding might lose recent edits. Continue?",
+          isDangerous: false,
+        }))
       ) {
         return;
       }

--- a/apps/web/src/lib/components/entity-detail/DetailMapTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailMapTab.svelte
@@ -44,9 +44,12 @@
   async function handleDeleteMap() {
     if (!linkedMap) return;
     if (
-      confirm(
-        "Are you sure you want to delete this map? This action cannot be undone.",
-      )
+      await uiStore.confirm({
+        title: "Clear Points",
+        message:
+          "Are you sure you want to delete this map? This action cannot be undone.",
+        isDangerous: true,
+      })
     ) {
       try {
         await vault.deleteMap(linkedMap.id);

--- a/apps/web/src/lib/components/explorer/EntityList.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityList.test.ts
@@ -41,6 +41,6 @@ describe("EntityList Filtering Logic Performance", () => {
     const duration = end - start;
 
     // In node/vitest, 10ms is a safe bet for pure logic
-    expect(duration).toBeLessThan(50);
+    expect(duration).toBeLessThan(100);
   });
 });

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -212,7 +212,14 @@
         ? `Are you sure you want to delete ${count} nodes and all their connections? This cannot be undone.`
         : "Are you sure you want to delete this node and all its connections? This cannot be undone.";
 
-    if (window.confirm(message)) {
+    if (
+      await ui.confirm({
+        title: "Confirm Action",
+        message,
+        confirmLabel: "Delete",
+        isDangerous: true,
+      })
+    ) {
       contextMenuOpen = false;
       canvasPickerOpen = false;
       try {

--- a/apps/web/src/lib/components/layout/app-header-actions.test.ts
+++ b/apps/web/src/lib/components/layout/app-header-actions.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     dismissedLandingPage: false,
-    dismissedCampaignPage: true,
+    dismissedWorldPage: true,
     closeSidebar: mocks.closeSidebar,
     closeZenMode: mocks.closeZenMode,
     toggleWelcomeScreen: mocks.toggleWelcomeScreen,
@@ -28,7 +28,7 @@ vi.mock("$lib/stores/vault.svelte", () => ({
 describe("openFrontPage", () => {
   beforeEach(() => {
     uiStore.dismissedLandingPage = false;
-    uiStore.dismissedCampaignPage = true;
+    uiStore.dismissedWorldPage = true;
     mocks.closeSidebar.mockClear();
     mocks.closeZenMode.mockClear();
     mocks.toggleWelcomeScreen.mockClear();
@@ -42,7 +42,7 @@ describe("openFrontPage", () => {
     expect(uiStore.closeZenMode).toHaveBeenCalled();
     expect(uiStore.toggleWelcomeScreen).toHaveBeenCalledWith(true);
     expect(uiStore.dismissedLandingPage).toBe(true);
-    expect(uiStore.dismissedCampaignPage).toBe(false);
+    expect(uiStore.dismissedWorldPage).toBe(false);
     expect(vault.selectedEntityId).toBe(null);
   });
 });

--- a/apps/web/src/lib/components/layout/app-header-actions.ts
+++ b/apps/web/src/lib/components/layout/app-header-actions.ts
@@ -7,5 +7,5 @@ export const openFrontPage = () => {
   vault.selectedEntityId = null;
   uiStore.toggleWelcomeScreen(true);
   uiStore.dismissedLandingPage = true;
-  uiStore.dismissedCampaignPage = false;
+  uiStore.dismissedWorldPage = false;
 };

--- a/apps/web/src/lib/components/modals/ConfirmationModal.svelte
+++ b/apps/web/src/lib/components/modals/ConfirmationModal.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { uiStore } from "$lib/stores/ui.svelte";
+  import { fade, scale } from "svelte/transition";
+
+  const dialog = $derived(uiStore.confirmationDialog);
+
+  const handleCancel = () => {
+    uiStore.resolveConfirmation(false);
+  };
+
+  const handleConfirm = () => {
+    uiStore.resolveConfirmation(true);
+  };
+
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (!dialog.open) return;
+    if (e.key === "Escape") {
+      handleCancel();
+    } else if (e.key === "Enter") {
+      handleConfirm();
+    }
+  };
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if dialog.open}
+  <!-- Backdrop -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-[200] flex items-center justify-center bg-black/85 backdrop-blur-md p-4"
+    transition:fade={{ duration: 200 }}
+    onclick={handleCancel}
+  >
+    <!-- Modal -->
+    <div
+      class="relative w-full max-w-md overflow-hidden rounded-[2rem] border border-theme-border bg-theme-surface shadow-2xl"
+      transition:scale={{ duration: 250, start: 0.95 }}
+      onclick={(e) => e.stopPropagation()}
+    >
+      <!-- Decorative Background Glow -->
+      <div
+        class="absolute -top-24 -left-24 h-48 w-48 rounded-full bg-theme-primary/10 blur-[80px]"
+      ></div>
+      <div
+        class="absolute -bottom-24 -right-24 h-48 w-48 rounded-full bg-theme-primary/5 blur-[80px]"
+      ></div>
+
+      <!-- Header -->
+      <div class="relative px-6 pt-8 pb-4 text-center">
+        <div
+          class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-theme-primary/30 bg-theme-primary/10 text-theme-primary"
+        >
+          {#if dialog.isDangerous}
+            <span class="icon-[lucide--triangle-alert] h-6 w-6 text-red-400"
+            ></span>
+          {:else}
+            <span class="icon-[lucide--help-circle] h-6 w-6"></span>
+          {/if}
+        </div>
+        <h3
+          class="font-header text-xl font-bold uppercase tracking-widest text-theme-text"
+        >
+          {dialog.title}
+        </h3>
+      </div>
+
+      <!-- Content -->
+      <div class="px-8 py-4 text-center">
+        <p class="text-sm leading-relaxed text-theme-muted">
+          {dialog.message}
+        </p>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex flex-col gap-3 p-8">
+        <button
+          class={`w-full rounded-xl px-6 py-3 text-xs font-bold uppercase tracking-widest transition-all ${
+            dialog.isDangerous
+              ? "bg-red-600 text-white border border-red-600 hover:bg-red-700 shadow-[0_0_20px_rgba(220,38,38,0.25)]"
+              : "bg-theme-primary text-theme-bg border border-theme-primary hover:bg-theme-secondary hover:border-theme-secondary shadow-[0_0_20px_rgba(var(--color-theme-primary-rgb),0.25)]"
+          }`}
+          onclick={handleConfirm}
+        >
+          {dialog.confirmLabel || "Confirm"}
+        </button>
+        <button
+          class="w-full rounded-xl border border-theme-border bg-theme-bg/50 px-6 py-3 text-xs font-bold uppercase tracking-widest text-theme-muted transition-all hover:bg-theme-bg hover:text-theme-text"
+          onclick={handleCancel}
+        >
+          {dialog.cancelLabel || "Cancel"}
+        </button>
+      </div>
+
+      <!-- Decorative Corners -->
+      <div
+        class="pointer-events-none absolute top-0 left-0 h-8 w-8 border-t-2 border-l-2 border-theme-primary/40 rounded-tl-[2rem]"
+      ></div>
+      <div
+        class="pointer-events-none absolute bottom-0 right-0 h-8 w-8 border-b-2 border-r-2 border-theme-primary/40 rounded-br-[2rem]"
+      ></div>
+    </div>
+  </div>
+{/if}

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -65,6 +65,14 @@
 
     <MobileMenu bind:isOpen={isMobileMenuOpen} />
 
+    {#if uiStore.confirmationDialog.open}
+      {#await loadModal(() => import("./ConfirmationModal.svelte"), "ConfirmationModal") then ConfirmationModal}
+        {#if ConfirmationModal}
+          <ConfirmationModal />
+        {/if}
+      {/await}
+    {/if}
+
     {#if uiStore.mergeDialog.open}
       {#await loadModal(() => import("$lib/components/dialogs/MergeNodesDialog.svelte"), "MergeNodesDialog") then MergeNodesDialog}
         {#if MergeNodesDialog}

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -96,9 +96,17 @@
     });
   };
 
-  const navigateTo = (id: string) => {
+  const navigateTo = async (id: string) => {
     if (editState.isEditing) {
-      if (!confirm("Discard unsaved changes to navigate?")) return;
+      if (
+        !(await uiStore.confirm({
+          title: "Unsaved Changes",
+          message: "Discard unsaved changes to navigate?",
+          confirmLabel: "Discard",
+          isDangerous: true,
+        }))
+      )
+        return;
       editState.cancel();
     }
     uiStore.zenModeEntityId = id;

--- a/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
+++ b/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
@@ -76,11 +76,15 @@
       {#if oracle.messages.length > 0}
         <button
           class="w-8 h-8 flex items-center justify-center text-theme-muted hover:text-red-400 transition-colors"
-          onclick={() => {
+          onclick={async () => {
             if (
-              confirm(
-                "Are you sure you want to clear the conversation history?",
-              )
+              await uiStore.confirm({
+                title: "Clear History",
+                message:
+                  "Are you sure you want to clear the conversation history?",
+                confirmLabel: "Clear",
+                isDangerous: true,
+              })
             ) {
               oracle.clearMessages();
             }
@@ -176,7 +180,7 @@
       <button
         onclick={async () => {
           try {
-            const _id = await demoService.convertToCampaign();
+            const _id = await demoService.convertToWorld();
             const url = new URL(page.url.href);
             url.searchParams.delete("demo");
             goto(url.toString(), { replaceState: true });

--- a/apps/web/src/lib/components/oracle/OracleWindow.svelte
+++ b/apps/web/src/lib/components/oracle/OracleWindow.svelte
@@ -92,11 +92,15 @@
         {#if oracle.messages.length > 0}
           <button
             class="w-8 h-8 flex items-center justify-center text-theme-muted hover:text-red-400 transition-colors"
-            onclick={() => {
+            onclick={async () => {
               if (
-                confirm(
-                  "Are you sure you want to clear the conversation history?",
-                )
+                await uiStore.confirm({
+                  title: "Clear History",
+                  message:
+                    "Are you sure you want to clear the conversation history?",
+                  confirmLabel: "Clear",
+                  isDangerous: true,
+                })
               ) {
                 oracle.clearMessages();
               }
@@ -161,7 +165,7 @@
         <button
           onclick={async () => {
             try {
-              const _id = await demoService.convertToCampaign();
+              const _id = await demoService.convertToWorld();
               const url = new URL(page.url.href);
               url.searchParams.delete("demo");
               goto(url.toString(), { replaceState: true });

--- a/apps/web/src/lib/components/settings/AISettings.svelte
+++ b/apps/web/src/lib/components/settings/AISettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { oracle } from "$lib/stores/oracle.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import { onMount } from "svelte";
   import InlineKeySetup from "../oracle/InlineKeySetup.svelte";
 
@@ -9,9 +10,13 @@
 
   const handleClear = async () => {
     if (
-      confirm(
-        "Are you sure you want to remove your API key? The Oracle will continue working via the system proxy.",
-      )
+      await uiStore.confirm({
+        title: "Reset Settings",
+        message:
+          "Are you sure you want to remove your API key? The Oracle will continue working via the system proxy.",
+        confirmLabel: "Remove Key",
+        isDangerous: true,
+      })
     ) {
       await oracle.clearKey();
     }

--- a/apps/web/src/lib/components/settings/CategorySettings.svelte
+++ b/apps/web/src/lib/components/settings/CategorySettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { categories } from "$lib/stores/categories.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import { sanitizeId } from "$lib/utils/markdown";
   import { getIconClass } from "$lib/utils/icon";
   import { fade, scale } from "svelte/transition";
@@ -144,11 +145,14 @@
 
         <!-- Delete -->
         <button
-          onclick={() => {
+          onclick={async () => {
             if (
-              confirm(
-                `Delete category "${cat.label}"? Entities using this category will fallback to default style.`,
-              )
+              await uiStore.confirm({
+                title: "Delete Category",
+                message: `Delete category "${cat.label}"? Entities using this category will fallback to default style.`,
+                confirmLabel: "Delete",
+                isDangerous: true,
+              })
             ) {
               categories.removeCategory(cat.id);
             }

--- a/apps/web/src/lib/components/settings/LabelSettings.svelte
+++ b/apps/web/src/lib/components/settings/LabelSettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { vault } from "$lib/stores/vault.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
 
   let editingLabel = $state<string | null>(null);
   let renameValue = $state("");
@@ -17,11 +18,13 @@
   };
 
   const handleDelete = async (label: string) => {
-    if (
-      confirm(
-        `Are you sure you want to delete the label "${label}" from ALL entities?`,
-      )
-    ) {
+    const confirmed = await uiStore.confirm({
+      title: "Delete Label",
+      message: `Are you sure you want to delete the label "${label}" from ALL entities?`,
+      confirmLabel: "Delete",
+      isDangerous: true,
+    });
+    if (confirmed) {
       // Logic disabled
     }
   };

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -29,12 +29,16 @@
     { id: "about", label: "About", icon: "icon-[lucide--info]" },
   ];
 
-  const close = () => {
+  const close = async () => {
     if (uiStore.isImporting) {
       if (
-        confirm(
-          "An import is in progress or pending review. Closing now will cancel the process and you may lose identified entities. Are you sure you want to abort?",
-        )
+        await uiStore.confirm({
+          title: "Confirm Change",
+          message:
+            "An import is in progress or pending review. Closing now will cancel the process and you may lose identified entities. Are you sure you want to abort?",
+          confirmLabel: "Abort",
+          isDangerous: false,
+        })
       ) {
         uiStore.abortActiveOperations();
         uiStore.closeSettings();

--- a/apps/web/src/lib/components/settings/VaultSettings.svelte
+++ b/apps/web/src/lib/components/settings/VaultSettings.svelte
@@ -81,7 +81,7 @@
       <button
         onclick={async () => {
           try {
-            await demoService.convertToCampaign();
+            await demoService.convertToWorld();
             const url = new URL(page.url.href);
             url.searchParams.delete("demo");
             goto(url.toString(), { replaceState: true });
@@ -150,11 +150,15 @@
             <button
               class="px-4 py-2 border border-amber-500/50 text-amber-500 hover:bg-amber-500/10 rounded transition-colors text-xs font-bold uppercase tracking-wider flex items-center gap-2"
               onclick={async () => {
-                if (
-                  confirm(
+                const confirmed = await uiStore.confirm({
+                  title: "Squash History",
+                  message:
                     "This will scan for .conflict files, keep only the newest version of each file, and remove the rest. Continue?",
-                  )
-                ) {
+                  confirmLabel: "Squash",
+                  cancelLabel: "Cancel",
+                  isDangerous: true,
+                });
+                if (confirmed) {
                   await vault.cleanupConflictFiles();
                 }
               }}

--- a/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
+++ b/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { vault } from "$lib/stores/vault.svelte";
   import { vaultRegistry } from "$lib/stores/vault-registry.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import { fade, scale } from "svelte/transition";
   import type { VaultRecord } from "$lib/utils/idb";
 
@@ -11,7 +12,6 @@
   let newVaultName = $state("");
   let editingId = $state<string | null>(null);
   let editName = $state("");
-  let deletingId = $state<string | null>(null);
 
   const handleLoadFromFolder = async () => {
     isLoading = true;
@@ -58,16 +58,27 @@
     }
   };
 
-  const handleDelete = async () => {
-    if (!deletingId) return;
-    isLoading = true;
-    try {
-      await vaultRegistry.deleteVault(deletingId);
-      deletingId = null;
-    } catch (e) {
-      console.error(e);
-    } finally {
-      isLoading = false;
+  const handleDelete = async (id: string) => {
+    const v = vaultRegistry.availableVaults.find((v) => v.id === id);
+    if (!v) return;
+
+    const confirmed = await uiStore.confirm({
+      title: "Delete Vault",
+      message: `Are you sure you want to permanently delete "${v.name}" and all its files? This action cannot be undone.`,
+      confirmLabel: "Delete Forever",
+      cancelLabel: "Cancel",
+      isDangerous: true,
+    });
+
+    if (confirmed) {
+      isLoading = true;
+      try {
+        await vaultRegistry.deleteVault(id);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        isLoading = false;
+      }
     }
   };
 
@@ -243,7 +254,7 @@
             <button
               class="flex-1 text-left disabled:opacity-50"
               onclick={() => handleSwitch(v.id)}
-              disabled={isLoading || !!deletingId || !!editingId}
+              disabled={isLoading || !!editingId}
             >
               <div class="font-bold text-sm flex items-center gap-2">
                 {v.name}
@@ -271,7 +282,7 @@
                 onclick={() => handleImportToVault(v)}
                 title="Restore from Folder"
                 aria-label="Restore from Folder"
-                disabled={isLoading || !!deletingId || !!editingId}
+                disabled={isLoading || !!editingId}
               >
                 <span class="icon-[lucide--folder-up] w-3.5 h-3.5"></span>
               </button>
@@ -281,7 +292,7 @@
                 onclick={() => startRename(v)}
                 title="Rename"
                 aria-label="Rename"
-                disabled={isLoading || !!deletingId || !!editingId}
+                disabled={isLoading || !!editingId}
               >
                 <span class="icon-[lucide--edit-2] w-3.5 h-3.5"></span>
               </button>
@@ -289,10 +300,10 @@
               {#if v.id !== vaultRegistry.activeVaultId}
                 <button
                   class="p-1.5 hover:bg-red-900/20 rounded text-theme-muted hover:text-red-500 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
-                  onclick={() => (deletingId = v.id)}
+                  onclick={() => handleDelete(v.id)}
                   title="Delete"
                   aria-label="Delete"
-                  disabled={isLoading || !!deletingId || !!editingId}
+                  disabled={isLoading || !!editingId}
                 >
                   <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
                 </button>
@@ -301,42 +312,6 @@
           {/if}
         </div>
       {/each}
-
-      {#if deletingId}
-        <div
-          class="absolute inset-0 bg-black/60 flex items-center justify-center backdrop-blur-[1px] z-50 p-4 rounded"
-          transition:fade={{ duration: 100 }}
-        >
-          <div
-            class="bg-theme-surface border border-red-500/50 rounded-lg p-4 shadow-2xl max-w-xs w-full animate-in zoom-in-95"
-          >
-            <h3
-              class="text-red-500 font-bold mb-2 flex items-center gap-2 text-sm tracking-wider"
-            >
-              <span class="icon-[lucide--alert-triangle] w-4 h-4"></span> DELETE VAULT?
-            </h3>
-            <p class="text-xs text-theme-text mb-4 leading-relaxed">
-              This will permanently delete "<strong
-                >{vaultRegistry.availableVaults.find((v) => v.id === deletingId)
-                  ?.name}</strong
-              >" and all its files. This action cannot be undone.
-            </p>
-            <div class="flex justify-end gap-2">
-              <button
-                class="px-3 py-1.5 rounded text-xs border border-theme-border hover:bg-theme-bg text-theme-text font-bold"
-                onclick={() => (deletingId = null)}>CANCEL</button
-              >
-              <button
-                class="px-3 py-1.5 rounded text-xs bg-red-600 text-white hover:bg-red-700 font-bold"
-                onclick={handleDelete}
-                disabled={isLoading}
-              >
-                {isLoading ? "DELETING..." : "DELETE FOREVER"}
-              </button>
-            </div>
-          </div>
-        </div>
-      {/if}
     </div>
 
     <div

--- a/apps/web/src/lib/components/world/CoverImage.svelte
+++ b/apps/web/src/lib/components/world/CoverImage.svelte
@@ -54,13 +54,13 @@
       <h3
         class="font-header text-xs uppercase tracking-[0.25em] text-theme-muted"
       >
-        Campaign Image
+        World Image
       </h3>
       <p class="mt-1 text-sm text-theme-text/70">
         {#if hasImage}
           Drop a new image to replace the current cover.
         {:else}
-          Drop an image to set the campaign cover.
+          Drop an image to set the world cover.
         {/if}
       </p>
     </div>
@@ -79,7 +79,7 @@
   <div
     class={`flex min-h-[240px] flex-col items-center justify-center rounded-2xl border border-dashed px-6 text-center transition-colors border-theme-border bg-theme-bg/70 ${isDragging ? "border-theme-primary bg-theme-primary/5" : ""}`}
     role="region"
-    aria-label="Campaign image drop zone"
+    aria-label="World image drop zone"
     ondragover={handleDragOver}
     ondragleave={handleDragLeave}
     ondrop={handleDrop}
@@ -94,7 +94,7 @@
       {#if hasImage}
         Drag a fresh cover image onto this zone to replace the current one.
       {:else}
-        Drag a cover image here to give the campaign a stronger identity.
+        Drag a cover image here to give your world a stronger identity.
       {/if}
     </p>
 

--- a/apps/web/src/lib/components/world/EntityCard.svelte
+++ b/apps/web/src/lib/components/world/EntityCard.svelte
@@ -36,12 +36,12 @@
   );
 
   const openInGraph = () => {
-    uiStore.dismissedCampaignPage = true;
+    uiStore.dismissedWorldPage = true;
     vault.selectedEntityId = activity.id;
   };
 
   const openInZenMode = () => {
-    uiStore.dismissedCampaignPage = true;
+    uiStore.dismissedWorldPage = true;
     vault.selectedEntityId = activity.id;
     uiStore.openZenMode(activity.id);
   };

--- a/apps/web/src/lib/components/world/FrontPage.svelte
+++ b/apps/web/src/lib/components/world/FrontPage.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
   import { vault } from "$lib/stores/vault.svelte";
-  import { campaignStore } from "$lib/stores/campaign.svelte";
+  import { worldStore } from "$lib/stores/world.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import ArticleRenderer from "$lib/components/blog/ArticleRenderer.svelte";
   import { contextRetrievalService } from "$lib/services/ai/context-retrieval.service";
   import CoverImage from "./CoverImage.svelte";
@@ -11,17 +12,17 @@
 
   let { onClose }: { onClose?: () => void } = $props();
 
-  const createCampaignCoverPrompt = (
-    campaignName: string,
+  const createWorldCoverPrompt = (
+    worldName: string,
     themeName: string,
     themeDescription: string,
-    summary: string,
+    briefing: string,
     worldContext: string,
   ) => {
-    const safeSummary = summary.trim() || "An unexplored campaign setting.";
-    const safeName = campaignName.trim() || "this campaign world";
+    const safeBriefing = briefing.trim() || "An unexplored setting.";
+    const safeName = worldName.trim() || "this world";
     const safeWorldContext =
-      worldContext.trim() || "No additional world context was retrieved.";
+      worldContext.trim() || "No additional context was retrieved.";
 
     return `Create atmospheric portrait cover art for "${safeName}".
 
@@ -30,8 +31,8 @@ Theme:
 - Thematic scope: ${themeDescription}
 
 World cues:
-- Summary: ${safeSummary}
-- Retrieved world context:
+- Briefing: ${safeBriefing}
+- Retrieved context:
 ${safeWorldContext}
 
 Art direction:
@@ -39,7 +40,7 @@ Art direction:
 - Focus on the tone, mood, and symbolic atmosphere of the setting.
 - Depict the world itself more than a single action scene.
 - Emphasize place, tension, and identity through lighting, silhouette, color, and environment.
-- Make it feel like the frontispiece to a living campaign world.
+- Make it feel like the frontispiece to a living world.
 - No text, no title lettering, no UI, no borders.`;
   };
 
@@ -48,14 +49,14 @@ Art direction:
   let isDraftDirty = $state(false);
 
   const activeVaultId = $derived(vault.activeVaultId);
-  const metadata = $derived(campaignStore.metadata);
-  const summarySource = $derived(
+  const metadata = $derived(worldStore.metadata);
+  const briefingSource = $derived(
     metadata?.description?.trim() ||
-      campaignStore.frontPageEntity?.chronicle?.trim() ||
-      campaignStore.frontPageEntity?.content?.trim() ||
+      worldStore.frontPageEntity?.chronicle?.trim() ||
+      worldStore.frontPageEntity?.content?.trim() ||
       "",
   );
-  const recentActivity = $derived(campaignStore.recentActivity);
+  const recentActivity = $derived(worldStore.recentActivity);
   const displayedRecentActivity = $derived.by(() => {
     const isPinned = (
       tags: string[] | undefined,
@@ -75,25 +76,25 @@ Art direction:
     return [...pinned, ...unpinned].slice(0, recentLimit);
   });
   const coverImage = $derived(metadata?.coverImage || "");
-  const campaignName = $derived(
-    metadata?.name?.trim() || vault.vaultName || "",
-  );
-  const hasSummary = $derived(!!draftDescription.trim());
-  const summaryPreview = $derived(draftDescription.trim());
+  const worldName = $derived(metadata?.name?.trim() || vault.vaultName || "");
+  const hasBriefing = $derived(!!draftDescription.trim());
+  const briefingPreview = $derived(draftDescription.trim());
 
-  let isEditingSummary = $state(false);
+  let isEditingBriefing = $state(false);
   let showCoverEditor = $state(false);
   let coverImageUrl = $state("");
   let lastCoverImage = "";
-  let isCampaignReady = $state(false);
-  let summaryTextarea = $state<HTMLTextAreaElement | null>(null);
+  let isWorldReady = $state(false);
+  let briefingTextarea = $state<HTMLTextAreaElement | null>(null);
   let recentLimit = $state(6);
   let isEditingRecentLimit = $state(false);
   let recentLimitInput = $state("6");
   let lastLoadedRecentLimit = 6;
-  let isSummaryExpanded = $state(false);
-  let summaryHoverTimer: ReturnType<typeof setTimeout> | null = null;
+  let isBriefingExpanded = $state(false);
+  let briefingHoverTimer: ReturnType<typeof setTimeout> | null = null;
   let showCoverLightbox = $state(false);
+  const FRONTPAGE_CONTEXT_MAX_CHARS = 2400;
+  const FRONTPAGE_ENTITY_SNIPPET_MAX_CHARS = 900;
 
   const getRecentLimitStorageKey = (vaultId: string) =>
     `codex_front_page_recent_limit:${vaultId}`;
@@ -124,27 +125,25 @@ Art direction:
 
   $effect(() => {
     if (!activeVaultId) {
-      isCampaignReady = false;
+      isWorldReady = false;
       return;
     }
 
     if (
       lastLoadedVaultId === activeVaultId &&
       lastLoadedRecentLimit === recentLimit &&
-      isCampaignReady
+      isWorldReady
     )
       return;
 
     let stale = false;
-    isCampaignReady = false;
+    isWorldReady = false;
     lastLoadedVaultId = activeVaultId;
     lastLoadedRecentLimit = recentLimit;
 
-    Promise.resolve(campaignStore.load(activeVaultId, recentLimit)).finally(
-      () => {
-        if (!stale) isCampaignReady = true;
-      },
-    );
+    Promise.resolve(worldStore.load(activeVaultId, recentLimit)).finally(() => {
+      if (!stale) isWorldReady = true;
+    });
 
     return () => {
       stale = true;
@@ -152,10 +151,10 @@ Art direction:
   });
 
   $effect(() => {
-    if (!isEditingSummary && !isDraftDirty) {
-      draftDescription = summarySource;
+    if (!isEditingBriefing && !isDraftDirty) {
+      draftDescription = briefingSource;
     }
-    if (!isEditingSummary && summarySource) isDraftDirty = false;
+    if (!isEditingBriefing && briefingSource) isDraftDirty = false;
     if (coverImage !== lastCoverImage) {
       lastCoverImage = coverImage;
       showCoverEditor = !coverImage;
@@ -179,95 +178,167 @@ Art direction:
   });
 
   $effect(() => {
-    if (!summaryTextarea || (!isEditingSummary && hasSummary)) return;
+    if (!briefingTextarea || (!isEditingBriefing && hasBriefing)) return;
 
-    summaryTextarea.style.height = "auto";
-    summaryTextarea.style.height = `${summaryTextarea.scrollHeight}px`;
+    briefingTextarea.style.height = "auto";
+    briefingTextarea.style.height = `${briefingTextarea.scrollHeight}px`;
   });
 
   const handleSaveDescription = async () => {
-    await campaignStore.saveDescription(draftDescription);
-    if (!campaignStore.error) {
+    await worldStore.saveDescription(draftDescription);
+    if (!worldStore.error) {
       isDraftDirty = false;
-      isEditingSummary = false;
+      isEditingBriefing = false;
     }
   };
 
+  const isFrontpageEntity = (entity: { tags?: string[]; labels?: string[] }) =>
+    [...(entity.tags || []), ...(entity.labels || [])].some(
+      (tag) => tag?.trim().toLowerCase() === "frontpage",
+    );
+
+  const buildFrontpageEntityContext = async () => {
+    const frontpageEntities = vault.allEntities
+      .filter(isFrontpageEntity)
+      .sort(
+        (a, b) =>
+          ((b as any).lastModified || 0) - ((a as any).lastModified || 0),
+      );
+    if (frontpageEntities.length === 0) return "";
+
+    if (vault.loadEntityContent) {
+      await Promise.all(
+        frontpageEntities.map((entity) => vault.loadEntityContent(entity.id)),
+      );
+    }
+
+    const sections: string[] = [];
+    let currentLength = 0;
+    let omittedCount = 0;
+
+    for (const entity of frontpageEntities) {
+      const loadedEntity = vault.entities[entity.id] || entity;
+      if (!loadedEntity?.title) continue;
+      const content = (
+        (loadedEntity as any).chronicle?.trim() ||
+        loadedEntity.content?.trim() ||
+        ""
+      ).trim();
+      if (!content) continue;
+
+      const header = `--- FRONTPAGE ENTITY: ${loadedEntity.title} ---\n`;
+      const remainingBudget = FRONTPAGE_CONTEXT_MAX_CHARS - currentLength;
+      if (remainingBudget <= header.length + 40) {
+        omittedCount += 1;
+        continue;
+      }
+
+      const bodyBudget = Math.min(
+        FRONTPAGE_ENTITY_SNIPPET_MAX_CHARS,
+        remainingBudget - header.length,
+      );
+      let body = content;
+      if (body.length > bodyBudget) {
+        body =
+          body.slice(0, Math.max(0, bodyBudget - 16)).trimEnd() +
+          "... [truncated]";
+      }
+
+      const snippet = `${header}${body}`;
+      sections.push(snippet);
+      currentLength += snippet.length + 2;
+    }
+
+    const joined = sections.join("\n\n");
+    if (!omittedCount) return joined;
+
+    const suffix = `\n\n[${omittedCount} additional frontpage ${
+      omittedCount === 1 ? "entity" : "entities"
+    } omitted for brevity.]`;
+    return `${joined}${suffix}`;
+  };
+
   const buildRetrievedWorldContext = async (isImage = false) => {
-    const campaignRef = campaignName.trim();
+    const worldRef = worldName.trim();
     const themeRef = themeStore.activeTheme.name.trim();
-    const baseTerms = [campaignRef, themeRef].filter(Boolean).join(" ").trim();
+    const baseTerms = [worldRef, themeRef].filter(Boolean).join(" ").trim();
     const queries = [
-      `${baseTerms} setting world campaign overview premise tone central conflict`,
+      `${baseTerms} setting world overview premise tone central conflict`,
       `${baseTerms} major players factions antagonists allies plot hooks current threats`,
     ];
 
     try {
-      const retrievedParts = await Promise.all(
-        queries.map(async (query) => {
-          const retrieved = await contextRetrievalService.retrieveContext(
-            query,
-            new Set<string>(),
-            vault,
-            campaignStore.frontPageEntity?.id,
-            isImage,
-          );
-          return retrieved.content.trim();
-        }),
-      );
+      const [retrievedParts, frontpageContext] = await Promise.all([
+        Promise.all(
+          queries.map(async (query) => {
+            const retrieved = await contextRetrievalService.retrieveContext(
+              query,
+              new Set<string>(),
+              vault,
+              worldStore.frontPageEntity?.id,
+              isImage,
+            );
+            return retrieved.content.trim();
+          }),
+        ),
+        buildFrontpageEntityContext(),
+      ]);
 
-      const uniqueParts = [...new Set(retrievedParts.filter(Boolean))];
+      const uniqueParts = [
+        ...new Set([...retrievedParts, frontpageContext].filter(Boolean)),
+      ];
       return uniqueParts.join("\n\n");
     } catch {
       return "";
     }
   };
 
-  const handleGenerateSummary = async () => {
-    if (hasSummary) {
-      const confirmed = window.confirm(
-        "Generate a new summary and replace the existing one?",
-      );
+  const handleGenerateBriefing = async () => {
+    if (hasBriefing) {
+      const confirmed = await uiStore.confirm({
+        title: "Regenerate Briefing",
+        message:
+          "This will replace your current world briefing with a new one generated from your notes. Continue?",
+        confirmLabel: "Regenerate",
+        cancelLabel: "Keep Existing",
+      });
       if (!confirmed) return;
     }
 
     const activeTheme = themeStore.activeTheme;
     const themeDescription = activeTheme.description.trim();
     const retrievedWorldContext = await buildRetrievedWorldContext();
-    const generated = await campaignStore.generateDescription(
-      `Write a front-page campaign summary for "${
-        campaignName.trim() || "this campaign world"
-      }".
+    const generated = await worldStore.generateBriefing(
+      `Write a high-level briefing for "${worldName.trim() || "this world"}".
 
 Theme:
 - Name: ${activeTheme.name}
 - Description: ${themeDescription}
-- Mood colors: primary ${activeTheme.tokens.primary}, accent ${activeTheme.tokens.accent}, background ${activeTheme.tokens.background}
 
 Requirements:
 - Start with 1 short atmospheric intro paragraph.
-- Follow with 3 to 5 markdown bullet points using bold labels such as **Current Conflict:**, **Key Players:**, **Immediate Hook:**, or **Threat Level:** when they fit the setting.
+- Follow with 3 to 5 markdown bullet points using bold labels such as **The Setting:**, **Current Conflict:**, **Key Players:**, or **Immediate Hook:** when they fit the world.
 - Clearly explain the setting, mood, and immediate premise.
-- Use specific details from the campaign instead of generic fantasy language.
+- Use specific details from the world instead of generic language.
 - Keep it readable, welcoming, and easy to scan.
 - Keep each bullet to one compact sentence.
 - Avoid headings and meta commentary.
 - Do not mention that you are an AI.
 
-Retrieved world context:
-${retrievedWorldContext || "No additional world context was retrieved."}
+Retrieved context:
+${retrievedWorldContext || "No additional context was retrieved."} 
 
-Match the summary to the theme's atmosphere and visual identity, and focus on what a new player or returning GM needs to know at a glance.`,
+Match the briefing to the theme atmosphere and visual identity, and focus on what a player or GM needs to know at a glance.`,
     );
-    if (generated.trim() && !campaignStore.error) {
+    if (generated.trim() && !worldStore.error) {
       draftDescription = generated;
       isDraftDirty = false;
-      isEditingSummary = false;
+      isEditingBriefing = false;
     }
   };
 
-  const startEditingSummary = async () => {
-    isEditingSummary = true;
+  const startEditingBriefing = async () => {
+    isEditingBriefing = true;
   };
 
   const openCoverEditor = () => {
@@ -278,10 +349,10 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
     showCoverLightbox = true;
   };
 
-  const cancelEditingSummary = () => {
-    draftDescription = summarySource;
+  const cancelEditingBriefing = () => {
+    draftDescription = briefingSource;
     isDraftDirty = false;
-    isEditingSummary = false;
+    isEditingBriefing = false;
   };
 
   const closeCoverEditor = () => {
@@ -292,24 +363,24 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
     if (!activeVaultId) return;
     const saved = await vault.saveImageToVault(
       file,
-      `campaign-${activeVaultId}`,
+      `world-${activeVaultId}`,
       file.name,
     );
-    await campaignStore.setCoverImage(saved.image);
+    await worldStore.setCoverImage(saved.image);
   };
 
   const handleGenerateCover = async () => {
     const themeName = themeStore.activeTheme.name;
     const themeDescription = themeStore.activeTheme.description.trim();
-    const summaryText = summaryPreview || "No campaign summary provided yet.";
+    const briefingText = briefingPreview || "No world briefing provided yet.";
     const retrievedWorldContext = await buildRetrievedWorldContext(true);
     try {
-      await campaignStore.generateCoverImage(
-        createCampaignCoverPrompt(
-          campaignName,
+      await worldStore.generateCoverImage(
+        createWorldCoverPrompt(
+          worldName,
           themeName,
           themeDescription,
-          summaryText,
+          briefingText,
           retrievedWorldContext,
         ),
       );
@@ -340,34 +411,34 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
     isEditingRecentLimit = false;
   };
 
-  const clearSummaryHoverTimer = () => {
-    if (summaryHoverTimer) {
-      clearTimeout(summaryHoverTimer);
-      summaryHoverTimer = null;
+  const clearBriefingHoverTimer = () => {
+    if (briefingHoverTimer) {
+      clearTimeout(briefingHoverTimer);
+      briefingHoverTimer = null;
     }
   };
 
-  const beginSummaryPreviewHover = () => {
-    if (!hasSummary || isEditingSummary) return;
-    clearSummaryHoverTimer();
-    summaryHoverTimer = setTimeout(() => {
-      isSummaryExpanded = true;
-      summaryHoverTimer = null;
+  const beginBriefingPreviewHover = () => {
+    if (!hasBriefing || isEditingBriefing) return;
+    clearBriefingHoverTimer();
+    briefingHoverTimer = setTimeout(() => {
+      isBriefingExpanded = true;
+      briefingHoverTimer = null;
     }, 800);
   };
 
-  const endSummaryPreviewHover = () => {
-    clearSummaryHoverTimer();
-    isSummaryExpanded = false;
+  const endBriefingPreviewHover = () => {
+    clearBriefingHoverTimer();
+    isBriefingExpanded = false;
   };
 
   onDestroy(() => {
-    clearSummaryHoverTimer();
+    clearBriefingHoverTimer();
   });
 
   $effect(() => {
-    if (!hasSummary || isEditingSummary) {
-      isSummaryExpanded = false;
+    if (!hasBriefing || isEditingBriefing) {
+      isBriefingExpanded = false;
     }
   });
 </script>
@@ -376,7 +447,7 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
   data-testid="front-page-shell"
   class="relative isolate min-h-[calc(100vh-var(--header-height,65px)-2rem)] overflow-hidden rounded-[2rem] border border-theme-border bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_48%),linear-gradient(180deg,rgba(10,10,10,0.92),rgba(5,5,8,0.98))] p-4 sm:p-5 md:p-8 xl:p-10 shadow-[0_30px_120px_rgba(0,0,0,0.35)]"
 >
-  {#if !isCampaignReady}
+  {#if !isWorldReady}
     <div
       class="relative z-10 flex min-h-[inherit] items-center justify-center py-20"
     >
@@ -390,7 +461,7 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
           >
             Loading front page
           </p>
-          <p class="mt-2 text-sm text-theme-muted">Preparing campaign data…</p>
+          <p class="mt-2 text-sm text-theme-muted">Preparing data…</p>
         </div>
       </div>
     </div>
@@ -428,7 +499,7 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
           <ZenImageLightbox
             bind:show={showCoverLightbox}
             imageUrl={coverImageUrl}
-            title="Campaign cover"
+            title="World cover"
           />
         </div>
 
@@ -439,7 +510,7 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
             <button
               class="rounded-full border border-theme-primary/45 bg-theme-surface/80 px-3 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-primary shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-theme-primary)_12%,transparent)] transition-colors hover:bg-theme-primary/12 hover:border-theme-primary/60"
               onclick={openCoverEditor}
-              disabled={campaignStore.isSaving}
+              disabled={worldStore.isSaving}
             >
               Change Image
             </button>
@@ -472,18 +543,18 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
         {#if showCoverEditor || !coverImage}
           <CoverImage
             hasImage={!!coverImage}
-            isSaving={campaignStore.isSaving}
+            isSaving={worldStore.isSaving}
             onDrop={handleUploadCover}
             onGenerate={handleGenerateCover}
             onCancel={coverImage ? closeCoverEditor : undefined}
           />
         {/if}
 
-        {#if campaignStore.error}
+        {#if worldStore.error}
           <p
             class="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200"
           >
-            {campaignStore.error}
+            {worldStore.error}
           </p>
         {/if}
 
@@ -492,11 +563,34 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
           class="flex flex-1 flex-col rounded-3xl border border-theme-border bg-theme-surface/80 p-4 sm:p-5 md:p-6"
         >
           <div class="mb-4 flex items-center justify-between">
-            <h2
-              class="font-header text-xs uppercase tracking-[0.22em] text-theme-muted"
-            >
-              Relevant Entities
-            </h2>
+            <div class="flex items-center gap-2">
+              <h2
+                class="font-header text-xs uppercase tracking-[0.22em] text-theme-muted"
+              >
+                Relevant Entities
+              </h2>
+              <div class="group relative flex items-center">
+                <span
+                  class="icon-[lucide--info] h-3.5 w-3.5 text-theme-muted/60 transition-colors hover:text-theme-primary cursor-help"
+                ></span>
+                <div
+                  class="absolute bottom-full left-0 mb-2 w-56 p-3 bg-theme-surface/95 backdrop-blur-md border border-theme-primary/30 rounded-xl text-[10px] leading-relaxed text-theme-text shadow-2xl opacity-0 group-hover:opacity-100 transition-all duration-200 pointer-events-none z-50 translate-y-1 group-hover:translate-y-0"
+                >
+                  <p>
+                    Entities tagged or labeled with <strong
+                      class="text-theme-primary">frontpage</strong
+                    > will be pinned to the top of this section.
+                  </p>
+                  <!-- Decorative Corner -->
+                  <div
+                    class="absolute -top-px -left-px w-2 h-2 border-t border-l border-theme-primary/40 rounded-tl-lg"
+                  ></div>
+                  <div
+                    class="absolute -bottom-px -right-px w-2 h-2 border-b border-r border-theme-primary/40 rounded-br-lg"
+                  ></div>
+                </div>
+              </div>
+            </div>
             <div class="flex items-center gap-2">
               {#if isEditingRecentLimit}
                 <input
@@ -532,7 +626,7 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
             </div>
           </div>
 
-          {#if campaignStore.isLoading}
+          {#if worldStore.isLoading}
             <div class="py-10 text-center text-sm text-theme-muted">
               Loading front page…
             </div>
@@ -552,34 +646,34 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
         </section>
 
         <section
-          data-testid="summary-section"
+          data-testid="briefing-content-section"
           class="flex flex-col overflow-hidden rounded-3xl border border-theme-border bg-theme-surface/80"
         >
           <div class="relative overflow-hidden bg-theme-bg/80">
-            {#if isEditingSummary}
+            {#if isEditingBriefing}
               <textarea
-                bind:this={summaryTextarea}
+                bind:this={briefingTextarea}
                 bind:value={draftDescription}
                 oninput={() => (isDraftDirty = true)}
                 rows="1"
                 class="min-h-[12rem] w-full resize-none border-0 bg-transparent px-5 py-5 pb-16 text-sm leading-relaxed text-theme-text placeholder:text-theme-muted/60 focus:outline-none sm:px-6 sm:py-6 sm:text-base overflow-hidden"
-                placeholder="Write a short campaign summary..."
+                placeholder="Write a short world briefing…"
               ></textarea>
             {:else}
               <div class="relative w-full px-5 py-5 sm:px-6 sm:py-6">
                 <div
-                  data-testid="summary-preview"
+                  data-testid="briefing-preview"
                   role="region"
-                  aria-label="Campaign summary preview"
-                  class={`relative flex-1 overflow-hidden prose prose-invert max-w-none prose-p:my-0 prose-p:leading-relaxed prose-ul:my-4 prose-ul:list-disc prose-ul:pl-5 prose-li:my-1 prose-li:marker:text-theme-primary prose-strong:text-theme-primary prose-a:text-theme-primary transition-[max-height] duration-300 ease-out ${isSummaryExpanded ? "max-h-[48rem]" : "max-h-[14rem]"}`}
-                  onmouseenter={beginSummaryPreviewHover}
-                  onmouseleave={endSummaryPreviewHover}
-                  onfocusin={beginSummaryPreviewHover}
-                  onfocusout={endSummaryPreviewHover}
+                  aria-label="World briefing preview"
+                  class={`relative flex-1 overflow-hidden prose prose-invert max-w-none prose-p:my-0 prose-p:leading-relaxed prose-ul:my-4 prose-ul:list-disc prose-ul:pl-5 prose-li:my-1 prose-li:marker:text-theme-primary prose-strong:text-theme-primary prose-a:text-theme-primary transition-[max-height] duration-300 ease-out ${isBriefingExpanded ? "max-h-[48rem]" : "max-h-[14rem]"}`}
+                  onmouseenter={beginBriefingPreviewHover}
+                  onmouseleave={endBriefingPreviewHover}
+                  onfocusin={beginBriefingPreviewHover}
+                  onfocusout={endBriefingPreviewHover}
                 >
-                  {#if hasSummary}
-                    <ArticleRenderer content={summaryPreview} />
-                    {#if !isSummaryExpanded}
+                  {#if hasBriefing}
+                    <ArticleRenderer content={briefingPreview} />
+                    {#if !isBriefingExpanded}
                       <div
                         class="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-b from-transparent to-theme-bg/95"
                       ></div>
@@ -588,8 +682,8 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
                     <div
                       class="flex min-h-[12rem] items-center justify-center px-4 py-8 text-center text-sm text-theme-muted/70"
                     >
-                      No world brief yet. Use the edit or generate button to add
-                      one.
+                      No world briefing yet. Use the edit or generate button to
+                      add one.
                     </div>
                   {/if}
                 </div>
@@ -598,19 +692,19 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
                 >
                   <button
                     class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-border/80 bg-theme-bg/75 text-theme-muted backdrop-blur-sm transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
-                    onclick={startEditingSummary}
-                    disabled={campaignStore.isSaving}
-                    title="Edit summary"
-                    aria-label="Edit summary"
+                    onclick={startEditingBriefing}
+                    disabled={worldStore.isSaving}
+                    title="Edit briefing"
+                    aria-label="Edit briefing"
                   >
                     <span class="icon-[lucide--pencil] h-4 w-4"></span>
                   </button>
                   <button
                     class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-primary/30 bg-theme-bg/75 text-theme-primary backdrop-blur-sm transition-colors hover:bg-theme-primary/15 disabled:opacity-50"
-                    onclick={handleGenerateSummary}
-                    disabled={campaignStore.isSaving}
-                    title="Generate summary"
-                    aria-label="Generate summary"
+                    onclick={handleGenerateBriefing}
+                    disabled={worldStore.isSaving}
+                    title="Generate briefing"
+                    aria-label="Generate briefing"
                   >
                     <span class="icon-[lucide--sparkles] h-4 w-4"></span>
                   </button>
@@ -619,21 +713,21 @@ Match the summary to the theme's atmosphere and visual identity, and focus on wh
             {/if}
           </div>
 
-          {#if isEditingSummary}
+          {#if isEditingBriefing}
             <div
               class="flex flex-wrap gap-2 border-t border-theme-border/60 px-5 py-4 sm:px-6"
             >
               <button
                 class="rounded-lg bg-theme-primary px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-bg disabled:opacity-50"
                 onclick={handleSaveDescription}
-                disabled={campaignStore.isSaving || !isDraftDirty}
+                disabled={worldStore.isSaving || !isDraftDirty}
               >
-                Save Summary
+                Save Briefing
               </button>
               <button
                 class="rounded-lg px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-theme-muted hover:text-theme-text disabled:opacity-50"
-                onclick={cancelEditingSummary}
-                disabled={campaignStore.isSaving}
+                onclick={cancelEditingBriefing}
+                disabled={worldStore.isSaving}
               >
                 Cancel
               </button>

--- a/apps/web/src/lib/components/world/FrontPage.test.ts
+++ b/apps/web/src/lib/components/world/FrontPage.test.ts
@@ -17,16 +17,17 @@ vi.mock("svelte", async () => {
 const mocks = vi.hoisted(() => ({
   load: vi.fn(),
   saveDescription: vi.fn(),
-  generateDescription: vi.fn().mockResolvedValue("Generated summary"),
+  generateBriefing: vi.fn().mockResolvedValue("Generated briefing"),
   generateCoverImage: vi.fn().mockResolvedValue("images/cover.webp"),
   setCoverImage: vi.fn(),
+  loadEntityContent: vi.fn().mockResolvedValue(undefined),
   retrieveContext: vi.fn().mockResolvedValue({
     content: "--- File: World Primer ---\nSky-market politics and drone wars.",
     sourceIds: ["front-1"],
   }),
 }));
 
-const campaignMock = vi.hoisted(() => ({
+const worldMock = vi.hoisted(() => ({
   metadata: {
     id: "vault-1",
     name: "Moonfall",
@@ -39,6 +40,32 @@ const campaignMock = vi.hoisted(() => ({
     chronicle: "# The Chronicle\nThe city watches the sky.",
     image: "images/frontpage.webp",
     thumbnail: "images/frontpage-thumb.webp",
+  },
+  frontpageEntity: {
+    id: "front-2",
+    title: "Moonlit Treaties",
+    lore: "Hidden lore for Moonlit Treaties should not be sent.",
+    content:
+      "# Moonlit Treaties\nThe frontier councils meet by moonlight to settle debts and treaties.",
+    chronicle:
+      "# Moonlit Treaties\nThe frontier councils meet by moonlight to settle debts and treaties.",
+    tags: ["frontpage"],
+    labels: [],
+    type: "location",
+    lastModified: Date.now() + 2,
+  },
+  labeledFrontpageEntity: {
+    id: "front-3",
+    title: "The Front Hall Ledger",
+    lore: "Hidden lore for the ledger should not be sent.",
+    content:
+      "# The Front Hall Ledger\nEvery decree, visitor, and whispered deal is entered here by the steward.",
+    chronicle:
+      "# The Front Hall Ledger\nEvery decree, visitor, and whispered deal is entered here by the steward.",
+    tags: [],
+    labels: ["frontpage"],
+    type: "document",
+    lastModified: Date.now() + 3,
   },
   recentActivity: [
     {
@@ -66,10 +93,10 @@ const campaignMock = vi.hoisted(() => ({
   ],
 }));
 
-const campaignStoreMock = vi.hoisted(() => ({
-  metadata: campaignMock.metadata,
-  frontPageEntity: campaignMock.frontPageEntity,
-  recentActivity: campaignMock.recentActivity,
+const worldStoreMock = vi.hoisted(() => ({
+  metadata: worldMock.metadata,
+  frontPageEntity: worldMock.frontPageEntity,
+  recentActivity: worldMock.recentActivity,
   isLoading: false,
   isSaving: false,
   error: null as string | null,
@@ -100,6 +127,9 @@ vi.mock("$lib/stores/theme.svelte", () => ({
 vi.mock("$lib/services/ai/context-retrieval.service", () => ({
   contextRetrievalService: {
     retrieveContext: mocks.retrieveContext,
+    getConsolidatedContext: vi.fn((entity: any) =>
+      [entity.chronicle, entity.content].filter(Boolean).join("\n\n"),
+    ),
   },
 }));
 
@@ -107,7 +137,21 @@ vi.mock("$lib/stores/vault.svelte", () => ({
   vault: {
     activeVaultId: "vault-1",
     vaultName: "Moonfall",
+    entities: {
+      "front-1": worldMock.frontPageEntity,
+      "front-2": worldMock.frontpageEntity,
+      "front-3": worldMock.labeledFrontpageEntity,
+      "entity-1": worldMock.recentActivity[0],
+    },
+    allEntities: [
+      worldMock.frontPageEntity,
+      worldMock.frontpageEntity,
+      worldMock.labeledFrontpageEntity,
+      worldMock.recentActivity[0],
+      worldMock.recentActivity[1],
+    ],
     getActiveVaultHandle: vi.fn().mockResolvedValue({}),
+    loadEntityContent: mocks.loadEntityContent,
     saveImageToVault: vi.fn().mockResolvedValue({ image: "images/local.webp" }),
     resolveImageUrl: vi.fn().mockResolvedValue("resolved://image"),
     switchVault: vi.fn(),
@@ -117,25 +161,27 @@ vi.mock("$lib/stores/vault.svelte", () => ({
 vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     dismissedLandingPage: false,
-    dismissedCampaignPage: false,
+    dismissedWorldPage: false,
     toggleWelcomeScreen: vi.fn(),
     toggleSidebarTool: vi.fn(),
     openZenMode: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
   },
   ui: {
     dismissedLandingPage: false,
-    dismissedCampaignPage: false,
+    dismissedWorldPage: false,
     toggleWelcomeScreen: vi.fn(),
     toggleSidebarTool: vi.fn(),
     openZenMode: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
   },
 }));
 
-vi.mock("$lib/stores/campaign.svelte", () => ({
-  campaignStore: Object.assign(campaignStoreMock, {
+vi.mock("$lib/stores/world.svelte", () => ({
+  worldStore: Object.assign(worldStoreMock, {
     load: mocks.load,
     saveDescription: mocks.saveDescription,
-    generateDescription: mocks.generateDescription,
+    generateBriefing: mocks.generateBriefing,
     generateCoverImage: mocks.generateCoverImage,
     setCoverImage: mocks.setCoverImage,
   }),
@@ -150,18 +196,44 @@ describe("FrontPage", () => {
       sourceIds: ["front-1"],
     });
     uiStore.dismissedLandingPage = false;
-    uiStore.dismissedCampaignPage = false;
-    campaignStoreMock.error = null;
+    uiStore.dismissedWorldPage = false;
+    worldStoreMock.error = null;
     window.localStorage.removeItem("codex_front_page_recent_limit:vault-1");
-    Object.assign(campaignMock.metadata, {
+    Object.assign(worldMock.metadata, {
       id: "vault-1",
       name: "Moonfall",
       description: "A broken moon hangs over the **capital**.",
       coverImage: "images/cover.webp",
     });
+    Object.assign(worldMock.frontpageEntity, {
+      id: "front-2",
+      title: "Moonlit Treaties",
+      lore: "Hidden lore for Moonlit Treaties should not be sent.",
+      content:
+        "# Moonlit Treaties\nThe frontier councils meet by moonlight to settle debts and treaties.",
+      chronicle:
+        "# Moonlit Treaties\nThe frontier councils meet by moonlight to settle debts and treaties.",
+      tags: ["frontpage"],
+      labels: [],
+      type: "location",
+      lastModified: Date.now() + 2,
+    });
+    Object.assign(worldMock.labeledFrontpageEntity, {
+      id: "front-3",
+      title: "The Front Hall Ledger",
+      lore: "Hidden lore for the ledger should not be sent.",
+      content:
+        "# The Front Hall Ledger\nEvery decree, visitor, and whispered deal is entered here by the steward.",
+      chronicle:
+        "# The Front Hall Ledger\nEvery decree, visitor, and whispered deal is entered here by the steward.",
+      tags: [],
+      labels: ["frontpage"],
+      type: "document",
+      lastModified: Date.now() + 3,
+    });
   });
 
-  it("renders campaign metadata, content, and cards", async () => {
+  it("renders world metadata, content, and cards", async () => {
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
@@ -177,16 +249,14 @@ describe("FrontPage", () => {
     await waitFor(() =>
       expect(screen.getByRole("dialog", { name: "Image View" })).toBeTruthy(),
     );
-    expect(screen.getByAltText("Campaign cover")).toBeTruthy();
+    expect(screen.getByAltText("World cover")).toBeTruthy();
     await fireEvent.click(screen.getByLabelText("Close image view"));
     expect(
       (screen.getByTestId("front-page-hero-background") as HTMLElement).style
         .backgroundImage,
     ).toContain("resolved://image");
     await fireEvent.click(screen.getByRole("button", { name: "Change Image" }));
-    await waitFor(() =>
-      expect(screen.getByText("Campaign Image")).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByText("World Image")).toBeTruthy());
     expect(
       screen.getByText("Drop a new image to replace the current cover."),
     ).toBeTruthy();
@@ -208,7 +278,7 @@ describe("FrontPage", () => {
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Summary: A broken moon hangs over the **capital**.",
+        "Briefing: A broken moon hangs over the **capital**.",
       ),
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
@@ -219,9 +289,25 @@ describe("FrontPage", () => {
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining("Sky-market politics and drone wars."),
     );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining("Moonlit Treaties"),
+    );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "The frontier councils meet by moonlight to settle debts and treaties.",
+      ),
+    );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining("The Front Hall Ledger"),
+    );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Every decree, visitor, and whispered deal is entered here by the steward.",
+      ),
+    );
     expect(mocks.retrieveContext).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Moonfall Neon Night setting world campaign overview premise tone central conflict",
+        "Moonfall Neon Night setting world overview premise tone central conflict",
       ),
       expect.any(Set),
       expect.anything(),
@@ -255,36 +341,36 @@ describe("FrontPage", () => {
     const cardButton = within(cards[0]).getByRole("button");
     vi.useFakeTimers();
     await fireEvent.click(cardButton);
-    expect(uiStore.dismissedCampaignPage).toBe(false);
+    expect(uiStore.dismissedWorldPage).toBe(false);
     await vi.advanceTimersByTimeAsync(320);
-    expect(uiStore.dismissedCampaignPage).toBe(true);
+    expect(uiStore.dismissedWorldPage).toBe(true);
     expect(uiStore.openZenMode).not.toHaveBeenCalled();
     vi.useRealTimers();
-    screen.getByLabelText("Edit summary").click();
+    screen.getByLabelText("Edit briefing").click();
     await waitFor(() =>
       expect(
-        screen.getByPlaceholderText("Write a short campaign summary..."),
+        screen.getByPlaceholderText("Write a short world briefing…"),
       ).toBeTruthy(),
     );
     expect(
       (
         screen.getByPlaceholderText(
-          "Write a short campaign summary...",
+          "Write a short world briefing…",
         ) as HTMLTextAreaElement
       ).value,
     ).toBe("A broken moon hangs over the **capital**.");
-    const summarySection = screen
-      .getByPlaceholderText("Write a short campaign summary...")
+    const briefingSection = screen
+      .getByPlaceholderText("Write a short world briefing…")
       .closest("section");
-    expect(summarySection).toBeTruthy();
-    within(summarySection as HTMLElement)
+    expect(briefingSection).toBeTruthy();
+    within(briefingSection as HTMLElement)
       .getByRole("button", { name: "Cancel" })
       .click();
     await waitFor(() =>
       expect(screen.getByText("capital").tagName).toBe("STRONG"),
     );
     expect(
-      screen.queryByPlaceholderText("Write a short campaign summary..."),
+      screen.queryByPlaceholderText("Write a short world briefing…"),
     ).toBeNull();
     expect(screen.getByText("Captain Ril")).toBeTruthy();
   });
@@ -295,15 +381,15 @@ describe("FrontPage", () => {
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
 
     const entitiesSection = screen.getByTestId("entities-section");
-    const summarySection = screen.getByTestId("summary-section");
+    const briefingSection = screen.getByTestId("briefing-content-section");
 
-    expect(entitiesSection.compareDocumentPosition(summarySection)).toBe(
+    expect(entitiesSection.compareDocumentPosition(briefingSection)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
 
-  it("keeps summary actions visible even when the summary is empty and being edited", async () => {
-    Object.assign(campaignMock.metadata, {
+  it("keeps briefing actions visible even when the briefing is empty and being edited", async () => {
+    Object.assign(worldMock.metadata, {
       id: "vault-1",
       name: "Moonfall",
       description: "",
@@ -314,25 +400,25 @@ describe("FrontPage", () => {
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
 
-    await fireEvent.click(screen.getByLabelText("Edit summary"));
+    await fireEvent.click(screen.getByLabelText("Edit briefing"));
     await waitFor(() =>
       expect(
-        screen.getByPlaceholderText("Write a short campaign summary..."),
+        screen.getByPlaceholderText("Write a short world briefing…"),
       ).toBeTruthy(),
     );
 
-    expect(screen.getByRole("button", { name: "Save Summary" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save Briefing" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
   });
 
-  it("falls back to the tagged front page entity when no summary metadata exists", async () => {
-    Object.assign(campaignMock.metadata, {
+  it("falls back to the tagged front page entity when no briefing metadata exists", async () => {
+    Object.assign(worldMock.metadata, {
       id: "vault-1",
       name: "Moonfall",
       description: "",
       coverImage: "images/cover.webp",
     });
-    Object.assign(campaignMock.frontPageEntity, {
+    Object.assign(worldMock.frontPageEntity, {
       id: "front-1",
       content: "# The Chronicle\nThe city watches the sky.",
       chronicle: "# The Chronicle\nThe city watches the sky.",
@@ -343,25 +429,25 @@ describe("FrontPage", () => {
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
 
     expect(
-      screen.queryByPlaceholderText("Write a short campaign summary..."),
+      screen.queryByPlaceholderText("Write a short world briefing…"),
     ).toBeNull();
-    expect(screen.getByTestId("summary-preview")).toBeTruthy();
+    expect(screen.getByTestId("briefing-preview")).toBeTruthy();
     expect(screen.getByText("The city watches the sky.")).toBeTruthy();
   });
 
-  it("keeps the summary in edit mode while typing", async () => {
+  it("keeps the briefing in edit mode while typing", async () => {
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-    await fireEvent.click(screen.getByLabelText("Edit summary"));
+    await fireEvent.click(screen.getByLabelText("Edit briefing"));
     await waitFor(() =>
       expect(
-        screen.getByPlaceholderText("Write a short campaign summary..."),
+        screen.getByPlaceholderText("Write a short world briefing…"),
       ).toBeTruthy(),
     );
 
     const textarea = screen.getByPlaceholderText(
-      "Write a short campaign summary...",
+      "Write a short world briefing…",
     ) as HTMLTextAreaElement;
     await fireEvent.input(textarea, {
       target: {
@@ -370,25 +456,25 @@ describe("FrontPage", () => {
     });
 
     expect(
-      screen.getByPlaceholderText("Write a short campaign summary..."),
+      screen.getByPlaceholderText("Write a short world briefing…"),
     ).toBeTruthy();
-    expect(screen.queryByTestId("summary-preview")).toBeNull();
+    expect(screen.queryByTestId("briefing-preview")).toBeNull();
     expect(textarea.value).toContain("unrest");
   });
 
-  it("returns to preview mode after saving the summary", async () => {
+  it("returns to preview mode after saving the briefing", async () => {
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-    await fireEvent.click(screen.getByLabelText("Edit summary"));
+    await fireEvent.click(screen.getByLabelText("Edit briefing"));
     await waitFor(() =>
       expect(
-        screen.getByPlaceholderText("Write a short campaign summary..."),
+        screen.getByPlaceholderText("Write a short world briefing…"),
       ).toBeTruthy(),
     );
 
     const textarea = screen.getByPlaceholderText(
-      "Write a short campaign summary...",
+      "Write a short world briefing…",
     ) as HTMLTextAreaElement;
     await fireEvent.input(textarea, {
       target: {
@@ -396,32 +482,34 @@ describe("FrontPage", () => {
       },
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Save Summary" }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Save Briefing" }),
+    );
 
     await waitFor(() => expect(mocks.saveDescription).toHaveBeenCalled());
     expect(
-      screen.queryByPlaceholderText("Write a short campaign summary..."),
+      screen.queryByPlaceholderText("Write a short world briefing…"),
     ).toBeNull();
-    expect(screen.getByTestId("summary-preview")).toBeTruthy();
+    expect(screen.getByTestId("briefing-preview")).toBeTruthy();
   });
 
-  it("keeps the summary editor open when saving fails", async () => {
+  it("keeps the briefing editor open when saving fails", async () => {
     mocks.saveDescription.mockImplementationOnce(async () => {
-      campaignStoreMock.error = "Failed to save campaign summary.";
+      worldStoreMock.error = "Failed to save world briefing.";
     });
 
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-    await fireEvent.click(screen.getByLabelText("Edit summary"));
+    await fireEvent.click(screen.getByLabelText("Edit briefing"));
     await waitFor(() =>
       expect(
-        screen.getByPlaceholderText("Write a short campaign summary..."),
+        screen.getByPlaceholderText("Write a short world briefing…"),
       ).toBeTruthy(),
     );
 
     const textarea = screen.getByPlaceholderText(
-      "Write a short campaign summary...",
+      "Write a short world briefing…",
     ) as HTMLTextAreaElement;
     await fireEvent.input(textarea, {
       target: {
@@ -429,15 +517,17 @@ describe("FrontPage", () => {
       },
     });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Save Summary" }));
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Save Briefing" }),
+    );
 
     await waitFor(() =>
       expect(
-        screen.getByPlaceholderText("Write a short campaign summary..."),
+        screen.getByPlaceholderText("Write a short world briefing…"),
       ).toBeTruthy(),
     );
-    expect(screen.queryByTestId("summary-preview")).toBeNull();
-    expect(campaignStoreMock.error).toBe("Failed to save campaign summary.");
+    expect(screen.queryByTestId("briefing-preview")).toBeNull();
+    expect(worldStoreMock.error).toBe("Failed to save world briefing.");
   });
 
   it("shows a working state while cover art is generating", async () => {
@@ -453,9 +543,7 @@ describe("FrontPage", () => {
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
     await fireEvent.click(screen.getByRole("button", { name: "Change Image" }));
-    await waitFor(() =>
-      expect(screen.getByText("Campaign Image")).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByText("World Image")).toBeTruthy());
     await fireEvent.click(screen.getByText("Generate Art"));
 
     await waitFor(() => expect(screen.getByText("Working...")).toBeTruthy());
@@ -482,11 +570,11 @@ describe("FrontPage", () => {
     await vi.advanceTimersByTimeAsync(320);
 
     expect(uiStore.openZenMode).toHaveBeenCalledWith("front-1");
-    expect(uiStore.dismissedCampaignPage).toBe(true);
+    expect(uiStore.dismissedWorldPage).toBe(true);
     vi.useRealTimers();
   });
 
-  it("keeps the loading state visible until the campaign load resolves", async () => {
+  it("keeps the loading state visible until the world load resolves", async () => {
     let resolveLoad: (() => void) | undefined;
     mocks.load.mockImplementationOnce(
       () =>
@@ -506,51 +594,73 @@ describe("FrontPage", () => {
     expect(screen.queryByText("Loading front page")).toBeNull();
   });
 
-  it("asks before replacing an existing summary", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(false);
-
+  it("asks before replacing an existing briefing", async () => {
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-    await fireEvent.click(screen.getByLabelText("Generate summary"));
+    await fireEvent.click(screen.getByLabelText("Generate briefing"));
 
-    expect(window.confirm).toHaveBeenCalledWith(
-      "Generate a new summary and replace the existing one?",
+    expect(uiStore.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Regenerate Briefing",
+      }),
     );
-    expect(mocks.generateDescription).not.toHaveBeenCalled();
+    expect(mocks.generateBriefing).not.toHaveBeenCalled();
   });
 
-  it("includes the theme description when generating a summary", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+  it("includes the theme description when generating a briefing", async () => {
+    (uiStore.confirm as any).mockResolvedValueOnce(true);
 
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-    await fireEvent.click(screen.getByLabelText("Generate summary"));
+    await fireEvent.click(screen.getByLabelText("Generate briefing"));
 
     await waitFor(() =>
-      expect(mocks.generateDescription).toHaveBeenCalledWith(
+      expect(mocks.generateBriefing).toHaveBeenCalledWith(
         expect.stringContaining(
           "Description: Cyberpunk, neon-noir, corporate control",
         ),
       ),
     );
-    expect(mocks.generateDescription).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Write a front-page campaign summary for "Moonfall".',
-      ),
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
+      expect.stringContaining('Write a high-level briefing for "Moonfall".'),
     );
-    expect(mocks.generateDescription).toHaveBeenCalledWith(
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
       expect.stringContaining(
         "Follow with 3 to 5 markdown bullet points using bold labels",
       ),
     );
-    expect(mocks.generateDescription).toHaveBeenCalledWith(
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
       expect.stringContaining("Sky-market politics and drone wars."),
+    );
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
+      expect.stringContaining("Moonlit Treaties"),
+    );
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "The frontier councils meet by moonlight to settle debts and treaties.",
+      ),
+    );
+    expect(mocks.generateBriefing).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Hidden lore for Moonlit Treaties should not be sent.",
+      ),
+    );
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
+      expect.stringContaining("The Front Hall Ledger"),
+    );
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Every decree, visitor, and whispered deal is entered here by the steward.",
+      ),
+    );
+    expect(mocks.generateBriefing).not.toHaveBeenCalledWith(
+      expect.stringContaining("Hidden lore for the ledger should not be sent."),
     );
     expect(mocks.retrieveContext).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Moonfall Neon Night setting world campaign overview premise tone central conflict",
+        "Moonfall Neon Night setting world overview premise tone central conflict",
       ),
       expect.any(Set),
       expect.anything(),
@@ -566,30 +676,52 @@ describe("FrontPage", () => {
       "front-1",
       false,
     );
+    expect(mocks.loadEntityContent).toHaveBeenCalledWith("front-2");
+    expect(mocks.loadEntityContent).toHaveBeenCalledWith("front-3");
   });
 
-  it("keeps the current summary when generation fails", async () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
-    mocks.generateDescription.mockImplementationOnce(async () => {
-      campaignStoreMock.error = "Failed to generate campaign summary.";
-      return "";
+  it("caps extra frontpage entity context before generating a briefing", async () => {
+    (uiStore.confirm as any).mockResolvedValueOnce(true);
+    Object.assign(worldMock.frontpageEntity, {
+      content: "Frontpage alpha ".repeat(250),
+      chronicle: "Frontpage alpha ".repeat(250),
+    });
+    Object.assign(worldMock.labeledFrontpageEntity, {
+      content: "Frontpage beta ".repeat(250),
+      chronicle: "Frontpage beta ".repeat(250),
     });
 
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
-    await fireEvent.click(screen.getByLabelText("Generate summary"));
+    await fireEvent.click(screen.getByLabelText("Generate briefing"));
 
     await waitFor(() =>
-      expect(screen.getByTestId("summary-preview")).toBeTruthy(),
+      expect(mocks.generateBriefing).toHaveBeenCalledWith(
+        expect.stringContaining("Frontpage alpha"),
+      ),
+    );
+    expect(mocks.generateBriefing).toHaveBeenCalledWith(
+      expect.stringContaining("[truncated]"),
+    );
+  });
+
+  it("keeps the current briefing when generation fails", async () => {
+    (uiStore.confirm as any).mockResolvedValueOnce(true);
+    mocks.generateBriefing.mockResolvedValueOnce("");
+
+    render(FrontPage);
+
+    await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
+    await fireEvent.click(screen.getByLabelText("Generate briefing"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("briefing-preview")).toBeTruthy(),
     );
     expect(screen.getByText("capital").tagName).toBe("STRONG");
     expect(
-      screen.queryByPlaceholderText("Write a short campaign summary..."),
+      screen.queryByPlaceholderText("Write a short world briefing…"),
     ).toBeNull();
-    expect(campaignStoreMock.error).toBe(
-      "Failed to generate campaign summary.",
-    );
   });
 
   it("lets the user change how many recent entities are shown", async () => {
@@ -627,22 +759,22 @@ describe("FrontPage", () => {
     expect(screen.getAllByTestId("entity-card")).toHaveLength(2);
   });
 
-  it("expands the summary preview after hovering for a moment", async () => {
+  it("expands the briefing preview after hovering for a moment", async () => {
     render(FrontPage);
 
     await waitFor(() => expect(mocks.load).toHaveBeenCalledWith("vault-1", 6));
 
-    const summaryPreview = screen.getByTestId("summary-preview");
+    const briefingPreview = screen.getByTestId("briefing-preview");
     vi.useFakeTimers();
 
-    await fireEvent.mouseEnter(summaryPreview);
-    expect(summaryPreview.className).toContain("max-h-[14rem]");
+    await fireEvent.mouseEnter(briefingPreview);
+    expect(briefingPreview.className).toContain("max-h-[14rem]");
 
     await vi.advanceTimersByTimeAsync(800);
-    expect(summaryPreview.className).toContain("max-h-[48rem]");
+    expect(briefingPreview.className).toContain("max-h-[48rem]");
 
-    await fireEvent.mouseLeave(summaryPreview);
-    expect(summaryPreview.className).toContain("max-h-[14rem]");
+    await fireEvent.mouseLeave(briefingPreview);
+    expect(briefingPreview.className).toContain("max-h-[14rem]");
     vi.useRealTimers();
   });
 });

--- a/apps/web/src/lib/config/chat-commands.test.ts
+++ b/apps/web/src/lib/config/chat-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { chatCommands } from "./chat-commands";
 import { oracle } from "../stores/oracle.svelte";
+import { uiStore } from "../stores/ui.svelte";
 
 // Mock the oracle store
 vi.mock("../stores/oracle.svelte", () => ({
@@ -8,6 +9,13 @@ vi.mock("../stores/oracle.svelte", () => ({
     ask: vi.fn(),
     startWizard: vi.fn(),
     clearMessages: vi.fn(),
+  },
+}));
+
+// Mock uiStore
+vi.mock("../stores/ui.svelte", () => ({
+  uiStore: {
+    confirm: vi.fn(),
   },
 }));
 
@@ -83,17 +91,17 @@ describe("chatCommands", () => {
   });
 
   describe("/clear", () => {
-    it("should clear messages if confirmed", () => {
-      vi.stubGlobal("confirm", vi.fn().mockReturnValue(true));
+    it("should clear messages if confirmed", async () => {
+      vi.mocked(uiStore.confirm).mockResolvedValue(true);
       const cmd = chatCommands.find((c) => c.name === "/clear");
-      cmd?.handler("");
+      await cmd?.handler("");
       expect(oracle.clearMessages).toHaveBeenCalled();
     });
 
-    it("should NOT clear messages if cancelled", () => {
-      vi.stubGlobal("confirm", vi.fn().mockReturnValue(false));
+    it("should NOT clear messages if cancelled", async () => {
+      vi.mocked(uiStore.confirm).mockResolvedValue(false);
       const cmd = chatCommands.find((c) => c.name === "/clear");
-      cmd?.handler("");
+      await cmd?.handler("");
       expect(oracle.clearMessages).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/src/lib/config/chat-commands.ts
+++ b/apps/web/src/lib/config/chat-commands.ts
@@ -1,4 +1,5 @@
 import { oracle } from "../stores/oracle.svelte";
+import { uiStore } from "../stores/ui.svelte";
 
 export interface ChatCommand {
   name: string;
@@ -63,8 +64,14 @@ export const chatCommands: ChatCommand[] = [
   {
     name: "/clear",
     description: "Clear conversation history",
-    handler: () => {
-      if (confirm("Are you sure you want to clear the conversation history?")) {
+    handler: async () => {
+      if (
+        await uiStore.confirm({
+          title: "Clear History",
+          message: "Are you sure you want to clear the conversation history?",
+          isDangerous: true,
+        })
+      ) {
         oracle.clearMessages();
       }
     },

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -37,7 +37,7 @@ export const ONBOARDING_TOUR: GuideStep[] = [
     targetSelector: "body",
     title: "Welcome to Codex Cryptica",
     content:
-      "This tool gives you absolute control over your campaign notes. Everything stays on your computer for total privacy.",
+      "This tool gives you absolute control over your world notes. Everything stays on your computer for total privacy.",
     position: "bottom",
   },
   {
@@ -45,7 +45,7 @@ export const ONBOARDING_TOUR: GuideStep[] = [
     targetSelector: '[data-testid="open-vault-button"]',
     title: "Vault Management",
     content:
-      "This is your active story. Click here to switch between different campaigns or create a new vault.",
+      "This is your active story. Click here to switch between different worlds or create a new vault.",
     position: "bottom",
   },
   {
@@ -61,7 +61,7 @@ export const ONBOARDING_TOUR: GuideStep[] = [
     targetSelector: '[data-testid="nav-map"]',
     title: "Tactical Maps",
     content:
-      "Plot your campaign data onto geographic or tactical canvases with persistent pins and Fog of War.",
+      "Plot your world data onto geographic or tactical canvases with persistent pins and Fog of War.",
     position: "bottom",
   },
   {
@@ -146,16 +146,16 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
   },
   "front-page": {
     id: "front-page",
-    title: "Campaign Front Page",
+    title: "World Front Page",
     content:
-      "Use the summary field to edit the campaign blurb directly. If it is empty, the Generate Summary button appears inside the field; if it already has text, the generate action moves to the bottom next to Save Summary. Tagged `frontpage` entities stay pinned at the top of recent entities and show their chronicle/body preview there.",
+      "Use the briefing field to edit the world blurb directly. If it is empty, the Generate Briefing button appears inside the field; if it already has text, the generate action moves to the bottom next to Save Briefing. Tagged `frontpage` entities stay pinned at the top of recent entities and show their chronicle/body preview there.",
     icon: "icon-[lucide--house]",
   },
   "local-folder-sync": {
     id: "local-folder-sync",
     title: "Local Folder Sync",
     content:
-      "Keep your internal archive in sync with a folder on your machine. This allows you to use external tools like Obsidian to edit your campaign data seamlessly.",
+      "Keep your internal archive in sync with a folder on your machine. This allows you to use external tools like Obsidian to edit your world data seamlessly.",
     icon: "icon-[lucide--folder-sync]",
   },
   "total-privacy": {
@@ -204,7 +204,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "vault-switcher",
     title: "Switching Stories",
     content:
-      "Change your campaign. Click the folder name at the top to switch to a different story.",
+      "Change your world. Click the folder name at the top to switch to a different story.",
     icon: "icon-[lucide--folder-sync]",
   },
   "era-date-picker": {
@@ -239,7 +239,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "demo-mode",
     title: "Demo Mode",
     content:
-      "Explore the tool with pre-loaded sample data. Any changes you make are transient. Click 'Save as Campaign' in Settings or the Oracle to keep your work.",
+      "Explore the tool with pre-loaded sample data. Any changes you make are transient. Click 'Save as World' in Settings or the Oracle to keep your work.",
     icon: "icon-[lucide--play-circle]",
   },
   "lite-mode": {
@@ -260,7 +260,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "map-mode",
     title: "Map Mode",
     content:
-      "Plot your campaign data onto custom geographic or tactical canvases with persistent pins and Fog of War.",
+      "Plot your world data onto custom geographic or tactical canvases with persistent pins and Fog of War.",
     icon: "icon-[lucide--map]",
   },
   "spatial-canvas": {
@@ -288,7 +288,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "entity-explorer",
     title: "Entity Explorer",
     content:
-      "Quickly browse and filter all your campaign entities via the persistent sidebar. Clicking an entity opens it in Focus Mode, replacing the main view with a spacious detail panel.",
+      "Quickly browse and filter all your world entities via the persistent sidebar. Clicking an entity opens it in Focus Mode, replacing the main view with a spacious detail panel.",
     icon: "icon-[lucide--database]",
   },
   "activity-bar": {

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -148,7 +148,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "front-page",
     title: "Campaign Front Page",
     content:
-      "Use the title field to rename the campaign, and use the summary field to edit the campaign blurb directly. If it is empty, the Generate Summary button appears inside the field; if it already has text, the generate action moves to the bottom next to Save Summary. Tagged `frontpage` entities stay pinned at the top of recent entities and show their chronicle/body preview there.",
+      "Use the summary field to edit the campaign blurb directly. If it is empty, the Generate Summary button appears inside the field; if it already has text, the generate action moves to the bottom next to Save Summary. Tagged `frontpage` entities stay pinned at the top of recent entities and show their chronicle/body preview there.",
     icon: "icon-[lucide--house]",
   },
   "local-folder-sync": {

--- a/apps/web/src/lib/content/blog/front-page.md
+++ b/apps/web/src/lib/content/blog/front-page.md
@@ -1,0 +1,94 @@
+---
+id: front-page
+slug: front-page
+title: "The Front Page: Your World's Living Briefing Room"
+description: "See your world at a glance with a front page that brings together the briefing, pinned notes, recent activity, and cover art in one place."
+keywords:
+  [
+    "World Front Page",
+    "RPG World Briefing",
+    "Pinned Notes",
+    "World Summary",
+    "Frontpage Notes",
+    "Local-First World Building",
+  ]
+publishedAt: 2026-04-04T12:00:00Z
+---
+
+![The Front Page](https://assets.codexchronica.com/images/blog/front-page/front-page-hero.png)
+
+Your archive can hold a lot of lore, but the front page is where the shape of the world becomes readable again.
+
+When you open a world in Codex Cryptica, the front page is the first thing you see: a briefing, a visual cover, recent activity, and the notes the system thinks matter most right now. It is not just a dashboard. It is the place where a setting stops feeling like a pile of files and starts feeling like a living world.
+
+## What the Front Page Does
+
+The front page pulls together the details you need fastest:
+
+- **World Briefing** — A compact world summary you can write by hand or generate from your notes.
+- **Cover Image** — A visual anchor that matches the mood of the setting.
+- **Relevant Entities** — Cards for notable people, places, and things from the vault.
+- **Recent Activity** — The latest edits and additions, so the world stays legible as it changes.
+
+That combination matters because world-building is rarely static. A setting evolves one note at a time. The front page gives you a place to see that movement without digging through the whole archive.
+
+![Briefing and Cover](https://assets.codexchronica.com/images/blog/front-page/front-page-theme.png)
+
+## Theme Comes First
+
+The front page should respect the theme of the world, not flatten it.
+
+If your setting is neon-noir, the briefing should feel sharp, compressed, and urban. If it is high fantasy, it should sound a little more mythic and spacious. If it is horror, the page should leave room for tension and silence. The front page works best when the visual language and the text are pulling in the same direction.
+
+That is why the generated briefing and cover art both use the setting's theme as a compass. The page should feel like an honest reflection of the world you are building, not a generic template pasted over your notes.
+
+## Why It Exists
+
+Most worlds do not fail because they lack detail. They fail because the important detail gets buried.
+
+The front page is designed to answer the quick questions:
+
+- What is this world about?
+- What is happening right now?
+- Which notes should I keep in view?
+- What does the setting feel like at a glance?
+
+That makes it useful for both ends of the session loop. Before play, it gives you a quick refresher. After play, it helps you turn new discoveries into something visible and permanent.
+
+## The Briefing Workflow
+
+You can write the briefing yourself, or let Codex generate a starting draft from your archive and theme.
+
+When generation is used, the Oracle gathers context from the world, then shapes it into a short briefing that focuses on the setting, the current premise, major players, and immediate hooks. The point is not to replace your voice. The point is to compress the world into something readable enough that you can edit it quickly.
+
+That is why the front page works best when the briefing is short, specific, and easy to scan. It should feel like the first page of a living world notebook, not an encyclopedic dump.
+
+## Pinned Frontpage Notes
+
+Some notes deserve to live at the top of the front page.
+
+Anything tagged or labeled `frontpage` is treated as important enough to surface directly in the briefing context. That gives you a simple way to pin core world facts, session summaries, faction overviews, house rules, or any other note you want the front page to remember.
+
+This is useful when a note is:
+
+- too important to bury in the archive
+- too specific to replace the main briefing
+- meant to shape the world's immediate presentation
+
+The front page does not try to guess what matters most by title alone. You tell it by tagging or labeling the note, and it gets included.
+
+## Recent Activity at a Glance
+
+The recent activity section keeps the world moving.
+
+It shows what changed most recently, with `frontpage` notes pinned to the top so they remain visible even as new work comes in. That gives you a practical balance between stability and motion: the front page keeps the world oriented, while recent activity shows where the world is changing.
+
+## A Better Starting Point
+
+The front page is not the whole world. It is the starting point that helps the rest of the setting make sense.
+
+If the archive is the library, the front page is the reading desk. It gives you the map, the current weather, and the notes worth carrying into the next scene.
+
+### Ready to put your world on display?
+
+Open your world and shape the front page into the briefing room your setting deserves.

--- a/apps/web/src/lib/content/help/front-page.md
+++ b/apps/web/src/lib/content/help/front-page.md
@@ -1,23 +1,23 @@
 ---
 id: front-page
-title: Campaign Front Page
-tags: [campaign, landing, vault]
+title: World Front Page
+tags: [world, landing, vault]
 rank: 18
 ---
 
-## Your Campaign Landing Page
+## Your World Landing Page
 
-The front page is the first thing you see when a vault opens. It gives you a campaign summary, a quick way to jump to the graph or tools, and a space for recent activity cards.
+The front page is the first thing you see when a vault opens. It gives you a world briefing, a quick way to jump to the graph or tools, and a space for recent activity cards.
 
 ### What You Can Do
 
-- Edit the campaign summary directly from the page.
+- Edit the world briefing directly from the page.
 - Upload a cover image, paste an image URL, or ask the Oracle to generate one.
 - Tag any markdown entity with `frontpage` to pin it to the top of recent entities and use its chronicle/body text in the card preview.
 - Use the navigation buttons to move into the Graph view, open the map, or open the canvas.
 
 ### Tips
 
-- Keep the summary short and useful. You can always expand it later.
+- Keep the briefing short and useful. You can always expand it later.
 - If you add more than one `frontpage` tag, the most recently edited entity wins.
 - Recent cards update automatically from the vault’s latest edits, and any `frontpage` entity stays pinned at the top.

--- a/apps/web/src/lib/content/help/front-page.md
+++ b/apps/web/src/lib/content/help/front-page.md
@@ -11,7 +11,6 @@ The front page is the first thing you see when a vault opens. It gives you a cam
 
 ### What You Can Do
 
-- Rename the campaign/world/setting from the title field.
 - Edit the campaign summary directly from the page.
 - Upload a cover image, paste an image URL, or ask the Oracle to generate one.
 - Tag any markdown entity with `frontpage` to pin it to the top of recent entities and use its chronicle/body text in the card preview.

--- a/apps/web/src/lib/hooks/useZenModeActions.svelte.test.ts
+++ b/apps/web/src/lib/hooks/useZenModeActions.svelte.test.ts
@@ -13,6 +13,7 @@ describe("useZenModeActions", () => {
     // Mock stores
     mockUiStore = {
       notify: vi.fn(),
+      confirm: vi.fn().mockResolvedValue(true),
     };
     mockVault = {
       updateEntity: vi.fn().mockResolvedValue(undefined),
@@ -102,7 +103,7 @@ describe("useZenModeActions", () => {
     const mockEntity = { id: "e1", title: "Target" } as any;
 
     it("should do nothing if confirm is cancelled", async () => {
-      (global.confirm as any).mockReturnValue(false);
+      mockUiStore.confirm.mockResolvedValue(false);
       const onDeleted = vi.fn();
       const actions = createZenModeActions(mockEditState, {
         uiStore: mockUiStore,
@@ -116,7 +117,7 @@ describe("useZenModeActions", () => {
     });
 
     it("should delete entity and notify on success", async () => {
-      (global.confirm as any).mockReturnValue(true);
+      mockUiStore.confirm.mockResolvedValue(true);
       const onDeleted = vi.fn();
       const actions = createZenModeActions(mockEditState, {
         uiStore: mockUiStore,
@@ -135,7 +136,7 @@ describe("useZenModeActions", () => {
     });
 
     it("should notify error on failure", async () => {
-      (global.confirm as any).mockReturnValue(true);
+      mockUiStore.confirm.mockResolvedValue(true);
       const consoleSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
@@ -158,7 +159,7 @@ describe("useZenModeActions", () => {
   });
 
   describe("handleClose", () => {
-    it("should call onClose immediately if not editing", () => {
+    it("should call onClose immediately if not editing", async () => {
       mockEditState.isEditing = false;
       const onClose = vi.fn();
       const actions = createZenModeActions(mockEditState, {
@@ -166,34 +167,34 @@ describe("useZenModeActions", () => {
         vault: mockVault,
       });
 
-      actions.handleClose(onClose);
+      await actions.handleClose(onClose);
       expect(onClose).toHaveBeenCalled();
     });
 
-    it("should ask for confirmation if editing", () => {
+    it("should ask for confirmation if editing", async () => {
       mockEditState.isEditing = true;
-      (global.confirm as any).mockReturnValue(false); // User says "Keep editing"
+      mockUiStore.confirm.mockResolvedValue(false); // User says "Keep editing"
       const onClose = vi.fn();
       const actions = createZenModeActions(mockEditState, {
         uiStore: mockUiStore,
         vault: mockVault,
       });
 
-      actions.handleClose(onClose);
+      await actions.handleClose(onClose);
       expect(onClose).not.toHaveBeenCalled();
       expect(mockEditState.isEditing).toBe(true);
     });
 
-    it("should close and stop editing if user confirms discard", () => {
+    it("should close and stop editing if user confirms discard", async () => {
       mockEditState.isEditing = true;
-      (global.confirm as any).mockReturnValue(true); // User says "Discard"
+      mockUiStore.confirm.mockResolvedValue(true); // User says "Discard"
       const onClose = vi.fn();
       const actions = createZenModeActions(mockEditState, {
         uiStore: mockUiStore,
         vault: mockVault,
       });
 
-      actions.handleClose(onClose);
+      await actions.handleClose(onClose);
       expect(onClose).toHaveBeenCalled();
       expect(mockEditState.isEditing).toBe(false);
     });

--- a/apps/web/src/lib/hooks/useZenModeActions.svelte.ts
+++ b/apps/web/src/lib/hooks/useZenModeActions.svelte.ts
@@ -45,9 +45,11 @@ export function createZenModeActions(
 
   const handleDelete = async (entity: Entity, onDeleted: () => void) => {
     if (
-      confirm(
-        `Are you sure you want to permanently delete "${entity.title}"? This cannot be undone.`,
-      )
+      await uiStore.confirm({
+        title: "Delete Entity",
+        message: `Are you sure you want to permanently delete "${entity.title}"? This cannot be undone.`,
+        isDangerous: true,
+      })
     ) {
       try {
         await vault.deleteEntity(entity.id);
@@ -61,10 +63,18 @@ export function createZenModeActions(
     }
   };
 
-  const handleClose = (onClose: () => void) => {
+  const handleClose = async (onClose: () => void) => {
     const editState = getEditState();
     if (editState.isEditing) {
-      if (!confirm("Discard unsaved changes?")) return;
+      if (
+        !(await uiStore.confirm({
+          title: "Discard Changes",
+          message: "Discard unsaved changes?",
+          isDangerous: true,
+        }))
+      ) {
+        return;
+      }
     }
     onClose();
     editState.isEditing = false;

--- a/apps/web/src/lib/services/ai/prompts/context-distillation.ts
+++ b/apps/web/src/lib/services/ai/prompts/context-distillation.ts
@@ -1,0 +1,17 @@
+export function buildContextDistillationPrompt(context: string): string {
+  return `You are a campaign archivist. Condense the following vault excerpts into a concise, factual world digest for a front-page briefing.
+
+Rules:
+- Preserve concrete facts only.
+- Do not invent details.
+- Remove repetition and keep the most useful campaign signals.
+- Focus on setting, tone, major factions, notable entities, current conflicts, and immediate hooks.
+- Use at most 6 short bullet points.
+- Keep each bullet to one sentence.
+- Do not include an introduction, conclusion, or meta commentary.
+
+Vault excerpts:
+${context}
+
+Concise world digest:`;
+}

--- a/apps/web/src/lib/services/ai/text-generation.service.test.ts
+++ b/apps/web/src/lib/services/ai/text-generation.service.test.ts
@@ -23,6 +23,9 @@ vi.mock("./prompts/merge-proposal", () => ({
 vi.mock("./prompts/plot-analysis", () => ({
   buildPlotAnalysisPrompt: vi.fn((s, c, q) => `plot:${s}:${c}:${q}`),
 }));
+vi.mock("./prompts/context-distillation", () => ({
+  buildContextDistillationPrompt: vi.fn((context) => `distill:${context}`),
+}));
 
 describe("DefaultTextGenerationService", () => {
   let service: DefaultTextGenerationService;
@@ -87,6 +90,37 @@ describe("DefaultTextGenerationService", () => {
       const result = await service.expandQuery("key", "Original query", []);
 
       expect(result).toBe("Original query");
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("distillContext", () => {
+    it("should distill a long context block", async () => {
+      const result = await service.distillContext(
+        "key",
+        "Raw campaign context",
+        "model",
+      );
+
+      expect(result).toBe("Generated content");
+      expect(mockAiClientManager.getModel).toHaveBeenCalledWith("key", "model");
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        "distill:Raw campaign context",
+      );
+    });
+
+    it("should return the original context if distillation fails", async () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockModel.generateContent.mockRejectedValue(new Error("AI error"));
+
+      const result = await service.distillContext(
+        "key",
+        "Raw campaign context",
+        "model",
+      );
+
+      expect(result).toBe("Raw campaign context");
       expect(consoleSpy).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });

--- a/apps/web/src/lib/services/ai/text-generation.service.ts
+++ b/apps/web/src/lib/services/ai/text-generation.service.ts
@@ -4,6 +4,7 @@ import { buildQueryExpansionPrompt } from "./prompts/query-expansion";
 import { buildSystemInstruction } from "./prompts/system-instructions";
 import { buildMergeProposalPrompt } from "./prompts/merge-proposal";
 import { buildPlotAnalysisPrompt } from "./prompts/plot-analysis";
+import { buildContextDistillationPrompt } from "./prompts/context-distillation";
 import { contextRetrievalService as defaultContextRetrievalService } from "./context-retrieval.service";
 import { isAIEnabled, assertAIEnabled } from "./capability-guard";
 
@@ -41,6 +42,30 @@ export class DefaultTextGenerationService implements TextGenerationService {
         err,
       );
       return query;
+    }
+  }
+
+  async distillContext(
+    apiKey: string,
+    context: string,
+    modelName: string,
+  ): Promise<string> {
+    if (!isAIEnabled()) return context;
+    if (!context.trim()) return context;
+
+    const model = this.aiClientManager.getModel(apiKey, modelName);
+    const prompt = buildContextDistillationPrompt(context);
+
+    try {
+      const result = await model.generateContent(prompt);
+      const distilled = result.response.text().trim();
+      return distilled || context;
+    } catch (err) {
+      console.warn(
+        "[TextGenerationService] Context distillation failed, using raw context.",
+        err,
+      );
+      return context;
     }
   }
 

--- a/apps/web/src/lib/services/demo.ts
+++ b/apps/web/src/lib/services/demo.ts
@@ -62,7 +62,7 @@ class DemoService implements IDemoActions {
   async convertToWorld(): Promise<string> {
     try {
       const theme = uiStore.activeDemoTheme || "fantasy";
-      const name = `My ${theme.charAt(0).toUpperCase() + theme.slice(1)} Campaign`;
+      const name = `My ${theme.charAt(0).toUpperCase() + theme.slice(1)} World`;
 
       // 1. Create a real vault
       const vaultId = await vaultRegistry.createVault(name);

--- a/apps/web/src/lib/services/demo.ts
+++ b/apps/web/src/lib/services/demo.ts
@@ -59,7 +59,7 @@ class DemoService implements IDemoActions {
     }
   }
 
-  async convertToCampaign(): Promise<string> {
+  async convertToWorld(): Promise<string> {
     try {
       const theme = uiStore.activeDemoTheme || "fantasy";
       const name = `My ${theme.charAt(0).toUpperCase() + theme.slice(1)} Campaign`;

--- a/apps/web/src/lib/stores/calendar.svelte.ts
+++ b/apps/web/src/lib/stores/calendar.svelte.ts
@@ -1,10 +1,10 @@
 import { DEFAULT_CALENDAR } from "chronology-engine";
-import type { CampaignCalendar } from "chronology-engine";
+import type { WorldCalendar } from "chronology-engine";
 import { vault } from "./vault.svelte";
 import { getDB } from "../utils/idb";
 
 class CalendarStore {
-  config = $state<CampaignCalendar>(DEFAULT_CALENDAR);
+  config = $state<WorldCalendar>(DEFAULT_CALENDAR);
 
   constructor() {
     // Initialized by vault switch
@@ -31,7 +31,7 @@ class CalendarStore {
     }
   }
 
-  async setConfig(newConfig: CampaignCalendar) {
+  async setConfig(newConfig: WorldCalendar) {
     const previousConfig = this.config;
     this.config = newConfig;
     try {

--- a/apps/web/src/lib/stores/campaign.svelte.ts
+++ b/apps/web/src/lib/stores/campaign.svelte.ts
@@ -106,38 +106,6 @@ export class CampaignStore {
     }
   }
 
-  async saveTitle(name: string) {
-    if (!this.activeVaultId) return;
-    this.isSaving = true;
-    this.error = null;
-    try {
-      await this.campaignServiceImpl.updateMetadata(this.activeVaultId, {
-        name: name.trim(),
-      });
-      await this.refresh();
-    } catch (err: any) {
-      this.error = err?.message || "Failed to save campaign title.";
-    } finally {
-      this.isSaving = false;
-    }
-  }
-
-  async saveTagline(tagline: string) {
-    if (!this.activeVaultId) return;
-    this.isSaving = true;
-    this.error = null;
-    try {
-      await this.campaignServiceImpl.updateMetadata(this.activeVaultId, {
-        tagline: tagline.trim(),
-      });
-      await this.refresh();
-    } catch (err: any) {
-      this.error = err?.message || "Failed to save campaign tagline.";
-    } finally {
-      this.isSaving = false;
-    }
-  }
-
   async setCoverImage(coverImage: string) {
     if (!this.activeVaultId) return;
     this.isSaving = true;

--- a/apps/web/src/lib/stores/canvas-registry.svelte.ts
+++ b/apps/web/src/lib/stores/canvas-registry.svelte.ts
@@ -121,7 +121,14 @@ class CanvasRegistryStore {
       return;
     }
 
-    if (!confirm(`Are you sure you want to delete canvas "${data.name}"?`)) {
+    if (
+      !(await uiStore.confirm({
+        title: "Delete Canvas",
+        message: `Are you sure you want to delete canvas "${data.name}"?`,
+        confirmLabel: "Delete",
+        isDangerous: true,
+      }))
+    ) {
       return;
     }
 

--- a/apps/web/src/lib/stores/canvas-registry.test.ts
+++ b/apps/web/src/lib/stores/canvas-registry.test.ts
@@ -14,6 +14,7 @@ vi.mock("./vault-registry.svelte", () => ({
 vi.mock("./ui.svelte", () => ({
   uiStore: {
     notify: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(true),
   },
 }));
 

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -37,7 +37,7 @@ describe("UIStore", () => {
     uiStore.activeSettingsTab = "vault";
     uiStore.skipWelcomeScreen = false;
     uiStore.dismissedLandingPage = false;
-    uiStore.dismissedCampaignPage = false;
+    uiStore.dismissedWorldPage = false;
     uiStore.closeSidebar();
     uiStore.showCanvasPalette = true;
   });

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -16,7 +16,7 @@ class UIStore {
   isImporting = $state(false);
   skipWelcomeScreen = $state(false);
   dismissedLandingPage = $state(false);
-  dismissedCampaignPage = $state(false);
+  dismissedWorldPage = $state(false);
   liteMode = $state(false);
   showDiceModal = $state(false);
 
@@ -297,6 +297,56 @@ class UIStore {
   /** @deprecated Use showZenMode */
   get showReadModal() {
     return this.showZenMode;
+  }
+
+  // Confirmation Dialog State
+  confirmationDialog = $state<{
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    isDangerous?: boolean;
+    resolve: ((result: boolean) => void) | null;
+  }>({
+    open: false,
+    title: "",
+    message: "",
+    resolve: null,
+  });
+
+  async confirm(options: {
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    isDangerous?: boolean;
+  }): Promise<boolean> {
+    if (this.confirmationDialog.open) {
+      return false;
+    }
+
+    this.confirmationDialog = {
+      open: true,
+      ...options,
+      resolve: null,
+    };
+
+    return new Promise<boolean>((resolve) => {
+      this.confirmationDialog.resolve = resolve;
+    });
+  }
+
+  resolveConfirmation(result: boolean) {
+    if (this.confirmationDialog.resolve) {
+      this.confirmationDialog.resolve(result);
+    }
+    this.confirmationDialog = {
+      open: false,
+      title: "",
+      message: "",
+      resolve: null,
+    };
   }
 
   setGlobalError(message: string, stack?: string) {

--- a/apps/web/src/lib/stores/world.svelte.test.ts
+++ b/apps/web/src/lib/stores/world.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { CampaignStore } from "./campaign.svelte";
+import { WorldStore } from "./world.svelte";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -11,7 +11,7 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-describe("CampaignStore", () => {
+describe("WorldStore", () => {
   it("ignores stale load results when a newer vault load finishes first", async () => {
     const firstMetadata = deferred<any>();
     const firstFrontPage = deferred<any>();
@@ -20,7 +20,7 @@ describe("CampaignStore", () => {
     const secondFrontPage = deferred<any>();
     const secondRecent = deferred<any>();
 
-    const store = new CampaignStore(
+    const store = new WorldStore(
       {
         getMetadata: vi.fn((vaultId: string) =>
           vaultId === "vault-1"

--- a/apps/web/src/lib/stores/world.svelte.ts
+++ b/apps/web/src/lib/stores/world.svelte.ts
@@ -1,7 +1,7 @@
 import {
   ActivityServiceImplementation,
-  CampaignServiceImplementation,
-  type CampaignMetadata,
+  WorldServiceImplementation,
+  type WorldMetadata,
   type FrontPageEntity,
   type RecentActivity,
 } from "@codex/vault-engine";
@@ -11,9 +11,9 @@ import { oracle } from "$lib/stores/oracle.svelte";
 import { imageGenerationService } from "$lib/services/ai/image-generation.service";
 import { textGenerationService } from "$lib/services/ai/text-generation.service";
 
-const CAMPAIGN_IMAGE_MODEL = "gemini-3.1-flash-image-preview";
+const WORLD_IMAGE_MODEL = "gemini-3.1-flash-image-preview";
 
-const campaignService = new CampaignServiceImplementation({
+const worldService = new WorldServiceImplementation({
   db: entityDb,
   imageGenerator: imageGenerationService,
   assetManager: {
@@ -22,7 +22,7 @@ const campaignService = new CampaignServiceImplementation({
     },
   },
   getApiKey: () => oracle.effectiveApiKey || "",
-  getImageModel: () => CAMPAIGN_IMAGE_MODEL,
+  getImageModel: () => WORLD_IMAGE_MODEL,
   getSummaryModel: () => oracle.modelName,
   getSummaryGenerator: () => textGenerationService,
 });
@@ -31,9 +31,9 @@ const activityService = new ActivityServiceImplementation({
   db: entityDb,
 });
 
-export class CampaignStore {
+export class WorldStore {
   activeVaultId = $state<string | null>(null);
-  metadata = $state<CampaignMetadata | null>(null);
+  metadata = $state<WorldMetadata | null>(null);
   frontPageEntity = $state<FrontPageEntity | null>(null);
   recentActivity = $state<RecentActivity[]>([]);
   isLoading = $state(false);
@@ -41,7 +41,7 @@ export class CampaignStore {
   error = $state<string | null>(null);
 
   constructor(
-    private campaignServiceImpl: CampaignServiceImplementation = campaignService,
+    private worldServiceImpl: WorldServiceImplementation = worldService,
     private activityServiceImpl: ActivityServiceImplementation = activityService,
   ) {}
 
@@ -62,8 +62,8 @@ export class CampaignStore {
     this.error = null;
     try {
       const [metadata, frontPageEntity, recentActivity] = await Promise.all([
-        this.campaignServiceImpl.getMetadata(vaultId),
-        this.campaignServiceImpl.getFrontPageEntity(vaultId),
+        this.worldServiceImpl.getMetadata(vaultId),
+        this.worldServiceImpl.getFrontPageEntity(vaultId),
         this.activityServiceImpl.getRecentActivity(vaultId, limit),
       ]);
 
@@ -78,7 +78,7 @@ export class CampaignStore {
       if (loadId !== this.loadSequence || this.activeVaultId !== vaultId) {
         return;
       }
-      this.error = err?.message || "Failed to load campaign front page.";
+      this.error = err?.message || "Failed to load world front page.";
     } finally {
       if (loadId === this.loadSequence && this.activeVaultId === vaultId) {
         this.isLoading = false;
@@ -95,12 +95,12 @@ export class CampaignStore {
     this.isSaving = true;
     this.error = null;
     try {
-      await this.campaignServiceImpl.updateMetadata(this.activeVaultId, {
+      await this.worldServiceImpl.updateMetadata(this.activeVaultId, {
         description,
       });
       await this.refresh();
     } catch (err: any) {
-      this.error = err?.message || "Failed to save campaign summary.";
+      this.error = err?.message || "Failed to save world briefing.";
     } finally {
       this.isSaving = false;
     }
@@ -111,31 +111,30 @@ export class CampaignStore {
     this.isSaving = true;
     this.error = null;
     try {
-      await this.campaignServiceImpl.updateMetadata(this.activeVaultId, {
+      await this.worldServiceImpl.updateMetadata(this.activeVaultId, {
         coverImage,
       });
       await this.refresh();
     } catch (err: any) {
-      this.error = err?.message || "Failed to save campaign image.";
+      this.error = err?.message || "Failed to save world image.";
     } finally {
       this.isSaving = false;
     }
   }
 
-  async generateDescription(promptBase: string) {
+  async generateBriefing(promptBase: string) {
     if (!this.activeVaultId) return "";
     this.isSaving = true;
     this.error = null;
     try {
-      const generated =
-        await this.campaignServiceImpl.generateCampaignDescription(
-          this.activeVaultId,
-          promptBase,
-        );
+      const generated = await this.worldServiceImpl.generateWorldBriefing(
+        this.activeVaultId,
+        promptBase,
+      );
       await this.refresh();
       return generated;
     } catch (err: any) {
-      this.error = err?.message || "Failed to generate campaign summary.";
+      this.error = err?.message || "Failed to generate world briefing.";
       return "";
     } finally {
       this.isSaving = false;
@@ -147,14 +146,14 @@ export class CampaignStore {
     this.isSaving = true;
     this.error = null;
     try {
-      const image = await this.campaignServiceImpl.generateCoverImage(
+      const image = await this.worldServiceImpl.generateCoverImage(
         this.activeVaultId,
         promptBase,
       );
       await this.refresh();
       return image;
     } catch (err: any) {
-      this.error = err?.message || "Failed to generate cover image.";
+      this.error = err?.message || "Failed to generate world image.";
       return "";
     } finally {
       this.isSaving = false;
@@ -162,7 +161,7 @@ export class CampaignStore {
   }
 }
 
-const CAMPAIGN_KEY = "__codex_campaign_store_instance__";
-export const campaignStore: CampaignStore =
-  (globalThis as any)[CAMPAIGN_KEY] ??
-  ((globalThis as any)[CAMPAIGN_KEY] = new CampaignStore());
+const WORLD_KEY = "__codex_world_store_instance__";
+export const worldStore: WorldStore =
+  (globalThis as any)[WORLD_KEY] ??
+  ((globalThis as any)[WORLD_KEY] = new WorldStore());

--- a/apps/web/src/lib/stores/world.svelte.ts
+++ b/apps/web/src/lib/stores/world.svelte.ts
@@ -131,6 +131,9 @@ export class WorldStore {
         this.activeVaultId,
         promptBase,
       );
+      if (!generated) {
+        throw new Error("AI returned an empty world briefing.");
+      }
       await this.refresh();
       return generated;
     } catch (err: any) {

--- a/apps/web/src/lib/types/demo.ts
+++ b/apps/web/src/lib/types/demo.ts
@@ -12,7 +12,7 @@ export interface IDemoActions {
    * Persists the current transient demo state to IndexedDB.
    * Returns the new vault ID.
    */
-  convertToCampaign(): Promise<string>;
+  convertToWorld(): Promise<string>;
 
   /**
    * Exits demo mode and reloads the previous campaign or returns to landing.

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -59,7 +59,7 @@
         .catch((err) => logChunkError("GraphView", err));
     }
     if (!FrontPage) {
-      import("../../lib/components/campaign/FrontPage.svelte")
+      import("../../lib/components/world/FrontPage.svelte")
         .then((m) => (FrontPage = m?.default))
         .catch((err) => logChunkError("FrontPage", err));
     }
@@ -87,7 +87,7 @@
   });
 
   const dismissFrontPageOverlay = () => {
-    uiStore.dismissedCampaignPage = true;
+    uiStore.dismissedWorldPage = true;
   };
 
   const handleFrontPageOverlayKeydown = (event: KeyboardEvent) => {
@@ -110,7 +110,7 @@
       // 3. If the front page is visible, dismiss it
       if (
         !uiStore.isLandingPageVisible &&
-        !uiStore.dismissedCampaignPage &&
+        !uiStore.dismissedWorldPage &&
         !selectedEntity
       ) {
         dismissFrontPageOverlay();
@@ -301,7 +301,7 @@
   {/if}
 
   <!-- Vault Front Page Overlay -->
-  {#if FrontPage && vault.isInitialized && !uiStore.isLandingPageVisible && !uiStore.dismissedCampaignPage && !selectedEntity}
+  {#if FrontPage && vault.isInitialized && !uiStore.isLandingPageVisible && !uiStore.dismissedWorldPage && !selectedEntity}
     <div
       data-testid="front-page-overlay"
       class={`absolute inset-0 z-40 overflow-y-auto p-4 md:p-6 bg-theme-bg/96 backdrop-blur-sm ${selectedEntity ? "pointer-events-none" : ""}`}

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -113,9 +113,12 @@
           class="px-3 py-1.5 bg-theme-surface border border-theme-border text-red-500/70 text-[10px] font-bold rounded-lg hover:text-red-400 hover:border-red-400 transition-colors flex items-center gap-2"
           onclick={async () => {
             if (
-              confirm(
-                "Are you sure you want to delete this map? This action cannot be undone.",
-              )
+              await uiStore.confirm({
+                title: "Clear Map",
+                message:
+                  "Are you sure you want to delete this map? This action cannot be undone.",
+                isDangerous: true,
+              })
             ) {
               await vault.deleteMap(mapStore.activeMapId!);
             }

--- a/apps/web/src/routes/(app)/oracle/+page.svelte
+++ b/apps/web/src/routes/(app)/oracle/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import OracleChat from "$lib/components/oracle/OracleChat.svelte";
   import { oracle } from "$lib/stores/oracle.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import { onMount } from "svelte";
 
   onMount(() => {
@@ -36,11 +37,14 @@
       {#if oracle.messages.length > 0}
         <button
           class="px-3 py-1 flex items-center gap-2 text-[10px] font-bold text-oracle-primary hover:text-red-400 border border-oracle-dim/30 hover:border-red-500/50 transition-all uppercase font-header tracking-widest bg-oracle-dark/20"
-          onclick={() => {
+          onclick={async () => {
             if (
-              confirm(
-                "Are you sure you want to clear the conversation history?",
-              )
+              await uiStore.confirm({
+                title: "Clear Chat",
+                message:
+                  "Are you sure you want to clear the conversation history?",
+                isDangerous: true,
+              })
             ) {
               oracle.clearMessages();
             }

--- a/apps/web/src/routes/(app)/vault/[id]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import { vault } from "$lib/stores/vault.svelte";
-  import FrontPage from "$lib/components/campaign/FrontPage.svelte";
+  import FrontPage from "$lib/components/world/FrontPage.svelte";
   import EntityDetailPanel from "$lib/components/EntityDetailPanel.svelte";
 
   const vaultId = $derived(page.params.id);

--- a/apps/web/tests/e2e.spec.ts
+++ b/apps/web/tests/e2e.spec.ts
@@ -128,7 +128,7 @@ test.describe("Vault E2E", () => {
       const uiStore = (window as any).uiStore;
       uiStore.toggleWelcomeScreen(false);
       uiStore.dismissedLandingPage = false;
-      uiStore.dismissedCampaignPage = false;
+      uiStore.dismissedWorldPage = false;
       document.documentElement.classList.remove("skip-landing");
       localStorage.removeItem("codex_skip_landing");
     });

--- a/apps/web/tests/explorer-sidebar.spec.ts
+++ b/apps/web/tests/explorer-sidebar.spec.ts
@@ -34,7 +34,7 @@ test.describe("Entity Explorer Sidebar", () => {
           };
           v.isInitialized = true;
           v.status = "idle";
-          ui.dismissedCampaignPage = true;
+          ui.dismissedWorldPage = true;
         } else {
           setTimeout(checkVaultAndUI, 20);
         }

--- a/check_full.cjs
+++ b/check_full.cjs
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const content = fs.readFileSync('apps/web/src/lib/components/campaign/FrontPage.svelte', 'utf8');
+
+const scriptMatch = content.match(/<script.*?>([\s\S]*?)<\/script>/);
+
+function check(text, name) {
+  let openBraces = 0;
+  let openParens = 0;
+  let inString = null;
+  let inComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const nextChar = text[i+1];
+
+    if (inBlockComment) {
+      if (char === '*' && nextChar === '/') { inBlockComment = false; i++; }
+      continue;
+    }
+    if (inComment) {
+      if (char === '\n') inComment = false;
+      continue;
+    }
+
+    if (inString) {
+      if (char === '\\') { i++; continue; }
+      if (char === inString) inString = null;
+      continue;
+    }
+
+    if (char === '/' && nextChar === '/') { inComment = true; i++; continue; }
+    if (char === '/' && nextChar === '*') { inBlockComment = true; i++; continue; }
+
+    if (char === '"' || char === "'" || char === '`') { inString = char; continue; }
+    
+    if (char === '{') openBraces++;
+    if (char === '}') openBraces--;
+    if (char === '(') openParens++;
+    if (char === ')') openParens--;
+    
+    if (openBraces < 0 || openParens < 0) {
+      const start = Math.max(0, i - 50);
+      const end = Math.min(text.length, i + 50);
+      console.log(`Negative count in ${name} at index ${i} (char: ${char}):\n...${text.substring(start, end)}...`);
+      return false;
+    }
+  }
+  console.log(`${name} final - Braces: ${openBraces}, Parens: ${openParens}`);
+  return openBraces === 0 && openParens === 0;
+}
+
+const scriptOk = check(scriptMatch[1], 'Script');
+
+if (!scriptOk) process.exit(1);

--- a/check_script.cjs
+++ b/check_script.cjs
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const content = fs.readFileSync('apps/web/src/lib/components/campaign/FrontPage.svelte', 'utf8');
+
+const scriptMatch = content.match(/<script.*?>([\s\S]*?)<\/script>/);
+const script = scriptMatch[1];
+const scriptOffset = content.indexOf(script);
+
+function check(text, name) {
+  let openBraces = 0;
+  let inString = null;
+  let inComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    const nextChar = text[i+1];
+
+    if (inBlockComment) {
+      if (char === '*' && nextChar === '/') { inBlockComment = false; i++; }
+      continue;
+    }
+    if (inComment) {
+      if (char === '\n') inComment = false;
+      continue;
+    }
+
+    if (inString) {
+      if (char === '\\') { i++; continue; }
+      if (char === inString) inString = null;
+      continue;
+    }
+
+    if (char === '/' && nextChar === '/') { inComment = true; i++; continue; }
+    if (char === '/' && nextChar === '*') { inBlockComment = true; i++; continue; }
+
+    if (char === '"' || char === "'" || char === '`') { inString = char; continue; }
+    
+    if (char === '{') openBraces++;
+    if (char === '}') {
+      openBraces--;
+      if (openBraces < 0) {
+        console.log(`Negative braces in ${name} at absolute index ${scriptOffset + i} (char: ${char})`);
+        const start = Math.max(0, i - 50);
+        const end = Math.min(text.length, i + 50);
+        console.log(`Context:\n...${text.substring(start, end)}...`);
+      }
+    }
+  }
+  console.log(`${name} final braces: ${openBraces}`);
+}
+
+check(script, 'Script');

--- a/check_syntax.cjs
+++ b/check_syntax.cjs
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const content = fs.readFileSync('apps/web/src/lib/components/campaign/FrontPage.svelte', 'utf8');
+
+const scriptMatch = content.match(/<script.*?>([\s\S]*?)<\/script>/);
+if (!scriptMatch) {
+  console.log('No script block found');
+  process.exit(1);
+}
+
+const script = scriptMatch[1];
+const lines = script.split('\n');
+
+let openBraces = 0;
+let openParens = 0;
+let inString = null;
+let inComment = false;
+let inBlockComment = false;
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  inComment = false;
+  for (let j = 0; j < line.length; j++) {
+    const char = line[j];
+    const nextChar = line[j+1];
+
+    if (inBlockComment) {
+      if (char === '*' && nextChar === '/') {
+        inBlockComment = false;
+        j++;
+      }
+      continue;
+    }
+
+    if (inComment) break;
+
+    if (inString) {
+      if (char === '\\') {
+        j++;
+        continue;
+      }
+      if (char === inString) {
+        inString = null;
+      }
+      continue;
+    }
+
+    if (char === '/' && nextChar === '/') {
+      inComment = true;
+      continue;
+    }
+    if (char === '/' && nextChar === '*') {
+      inBlockComment = true;
+      j++;
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      inString = char;
+      continue;
+    }
+
+    if (char === '{') openBraces++;
+    if (char === '}') openBraces--;
+    if (char === '(') openParens++;
+    if (char === ')') openParens--;
+
+    if (openBraces < 0 || openParens < 0) {
+      console.log(`Negative count at line ${i + 1}, char ${j + 1}: ${char}. Braces: ${openBraces}, Parens: ${openParens}`);
+    }
+  }
+}
+
+console.log(`Final counts - Braces: ${openBraces}, Parens: ${openParens}`);
+if (openBraces !== 0 || openParens !== 0) {
+  process.exit(1);
+}

--- a/check_template.cjs
+++ b/check_template.cjs
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const content = fs.readFileSync('apps/web/src/lib/components/campaign/FrontPage.svelte', 'utf8');
+
+const template = content.replace(/<script.*?>[\s\S]*?<\/script>/, '');
+
+let openBraces = 0;
+let inString = null;
+
+for (let i = 0; i < template.length; i++) {
+  const char = template[i];
+  if (inString) {
+    if (char === '\\') { i++; continue; }
+    if (char === inString) inString = null;
+    continue;
+  }
+  if (char === '"' || char === "'") { inString = char; continue; }
+  
+  if (char === '{') openBraces++;
+  if (char === '}') openBraces--;
+  
+  if (openBraces < 0) {
+    console.log(`Negative braces at index ${i}: ${template.substring(i-20, i+20)}`);
+  }
+}
+
+console.log(`Final template braces: ${openBraces}`);
+if (openBraces !== 0) process.exit(1);

--- a/packages/chronology-engine/src/engine.ts
+++ b/packages/chronology-engine/src/engine.ts
@@ -1,8 +1,4 @@
-import type {
-  TemporalMetadata,
-  CampaignCalendar,
-  CalendarMonth,
-} from "./types";
+import type { TemporalMetadata, WorldCalendar, CalendarMonth } from "./types";
 
 export const GREGORIAN_MONTHS: CalendarMonth[] = [
   { id: "january", name: "January", days: 31 },
@@ -19,19 +15,19 @@ export const GREGORIAN_MONTHS: CalendarMonth[] = [
   { id: "december", name: "December", days: 31 },
 ];
 
-export const DEFAULT_CALENDAR: CampaignCalendar = {
+export const DEFAULT_CALENDAR: WorldCalendar = {
   useGregorian: true,
   months: GREGORIAN_MONTHS,
   daysPerWeek: 7,
 };
 
-const daysInYearCache = new WeakMap<CampaignCalendar, number>();
+const daysInYearCache = new WeakMap<WorldCalendar, number>();
 
 export class CalendarEngine {
   /**
    * Get the active month list for a configuration.
    */
-  getMonths(config: CampaignCalendar): CalendarMonth[] {
+  getMonths(config: WorldCalendar): CalendarMonth[] {
     return config.useGregorian ? GREGORIAN_MONTHS : config.months;
   }
 
@@ -39,7 +35,7 @@ export class CalendarEngine {
    * Get the total days in a year for the given configuration.
    * Results are cached to avoid redundant reductions in performance-critical loops.
    */
-  getDaysInYear(config: CampaignCalendar): number {
+  getDaysInYear(config: WorldCalendar): number {
     if (daysInYearCache.has(config)) {
       return daysInYearCache.get(config)!;
     }
@@ -51,7 +47,7 @@ export class CalendarEngine {
   /**
    * Validate if a date structure is valid under the given calendar rules.
    */
-  isValid(date: TemporalMetadata, config: CampaignCalendar): boolean {
+  isValid(date: TemporalMetadata, config: WorldCalendar): boolean {
     if (date.year === undefined || date.year === null) return false;
 
     const months = this.getMonths(config);
@@ -74,7 +70,7 @@ export class CalendarEngine {
   /**
    * Format a date for human readability.
    */
-  format(date: TemporalMetadata, config: CampaignCalendar): string {
+  format(date: TemporalMetadata, config: WorldCalendar): string {
     if (date.label) return date.label;
 
     const months = this.getMonths(config);
@@ -104,7 +100,7 @@ export class CalendarEngine {
    *
    * Note: This uses ISO 8601 style numbering (including Year 0).
    */
-  getTimelineValue(date: TemporalMetadata, config: CampaignCalendar): number {
+  getTimelineValue(date: TemporalMetadata, config: WorldCalendar): number {
     const months = this.getMonths(config);
     const daysInYear = this.getDaysInYear(config);
 

--- a/packages/chronology-engine/src/types.ts
+++ b/packages/chronology-engine/src/types.ts
@@ -20,7 +20,7 @@ export interface CalendarMonth {
 /**
  * Rules for how time is structured in a campaign vault.
  */
-export interface CampaignCalendar {
+export interface WorldCalendar {
   useGregorian: boolean;
   months: CalendarMonth[];
   daysPerWeek: number;

--- a/packages/chronology-engine/tests/engine.test.ts
+++ b/packages/chronology-engine/tests/engine.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { calendarEngine, DEFAULT_CALENDAR } from "../src/engine";
-import type { CampaignCalendar } from "../src/types";
+import type { WorldCalendar } from "../src/types";
 
 describe("CalendarEngine", () => {
-  const customCalendar: CampaignCalendar = {
+  const customCalendar: WorldCalendar = {
     useGregorian: false,
     months: [
       { id: "month1", name: "Alpha", days: 20 },

--- a/packages/schema/src/ai.ts
+++ b/packages/schema/src/ai.ts
@@ -45,6 +45,11 @@ export interface TextGenerationService {
     query: string,
     history: ChatHistoryMessage[],
   ): Promise<string>;
+  distillContext?(
+    apiKey: string,
+    context: string,
+    modelName: string,
+  ): Promise<string>;
   generateResponse(
     apiKey: string,
     query: string,

--- a/packages/vault-engine/src/index.ts
+++ b/packages/vault-engine/src/index.ts
@@ -3,5 +3,5 @@ export * from "./queue";
 export * from "./repository.svelte";
 export * from "./sync-coordinator";
 export * from "./asset-manager";
-export * from "./services/CampaignService";
+export * from "./services/WorldService";
 export * from "./services/ActivityService";

--- a/packages/vault-engine/src/services/ActivityService.ts
+++ b/packages/vault-engine/src/services/ActivityService.ts
@@ -1,5 +1,5 @@
 import Dexie from "dexie";
-import type { RecentActivity } from "./CampaignService";
+import type { RecentActivity } from "./WorldService";
 
 interface GraphEntityRecord {
   id: string;

--- a/packages/vault-engine/src/services/WorldService.test.ts
+++ b/packages/vault-engine/src/services/WorldService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { CampaignServiceImplementation } from "./CampaignService";
+import { WorldServiceImplementation } from "./WorldService";
 
 const createGraphEntitiesMock = ({
   tagRecords = [],
@@ -48,7 +48,7 @@ const createGraphEntitiesMock = ({
   orderBy: vi.fn(),
 });
 
-describe("CampaignServiceImplementation", () => {
+describe("WorldServiceImplementation", () => {
   it("returns vault metadata with fallbacks", async () => {
     const get = vi.fn().mockResolvedValue({
       id: "vault-1",
@@ -59,7 +59,7 @@ describe("CampaignServiceImplementation", () => {
       lastModified: 123,
     });
     const put = vi.fn().mockResolvedValue(undefined);
-    const service = new CampaignServiceImplementation({
+    const service = new WorldServiceImplementation({
       db: {
         vaultMetadata: { get, put } as any,
         graphEntities: { where: vi.fn() } as any,
@@ -79,7 +79,7 @@ describe("CampaignServiceImplementation", () => {
 
   it("returns an empty name when vault metadata is missing", async () => {
     const get = vi.fn().mockResolvedValue(undefined);
-    const service = new CampaignServiceImplementation({
+    const service = new WorldServiceImplementation({
       db: {
         vaultMetadata: { get, put: vi.fn() } as any,
         graphEntities: createGraphEntitiesMock() as any,
@@ -116,7 +116,7 @@ describe("CampaignServiceImplementation", () => {
         lastModified: 10,
       });
     const put = vi.fn().mockResolvedValue(undefined);
-    const service = new CampaignServiceImplementation({
+    const service = new WorldServiceImplementation({
       db: {
         vaultMetadata: { get, put } as any,
         graphEntities: createGraphEntitiesMock() as any,
@@ -155,7 +155,7 @@ describe("CampaignServiceImplementation", () => {
         lastModified: 20,
       },
     ];
-    const service = new CampaignServiceImplementation({
+    const service = new WorldServiceImplementation({
       db: {
         vaultMetadata: { get: vi.fn(), put: vi.fn() } as any,
         graphEntities: createGraphEntitiesMock({
@@ -178,7 +178,7 @@ describe("CampaignServiceImplementation", () => {
   });
 
   it("returns recent activity cards from graph data and entity content", async () => {
-    const service = new CampaignServiceImplementation({
+    const service = new WorldServiceImplementation({
       db: {
         vaultMetadata: { get: vi.fn(), put: vi.fn() } as any,
         graphEntities: createGraphEntitiesMock({

--- a/packages/vault-engine/src/services/WorldService.ts
+++ b/packages/vault-engine/src/services/WorldService.ts
@@ -22,7 +22,7 @@ export interface VaultMetadataRecord {
   lastModified: number;
 }
 
-export interface CampaignMetadata {
+export interface WorldMetadata {
   id: string;
   name: string;
   tagline?: string;
@@ -51,7 +51,7 @@ export interface FrontPageEntity {
   thumbnail?: string;
 }
 
-export interface CampaignServiceDependencies {
+export interface WorldServiceDependencies {
   db?: {
     vaultMetadata: {
       get(id: string): Promise<VaultMetadataRecord | undefined>;
@@ -101,10 +101,10 @@ export interface CampaignServiceDependencies {
   } | null;
 }
 
-const createMissingDb = (): CampaignServiceDependencies["db"] => {
+const createMissingDb = (): WorldServiceDependencies["db"] => {
   const fail = (method: string) => () => {
     throw new Error(
-      `CampaignService requires an EntityDb instance with ${method} support`,
+      `WorldService requires an EntityDb instance with ${method} support`,
     );
   };
 
@@ -136,7 +136,7 @@ function getExcerpt(content: string, max = 150): string {
 }
 
 async function fetchFrontpageRecords(
-  db: NonNullable<CampaignServiceDependencies["db"]>,
+  db: NonNullable<WorldServiceDependencies["db"]>,
   vaultId: string,
 ) {
   const [tagged, labeled] = await Promise.all([
@@ -162,14 +162,14 @@ async function fetchFrontpageRecords(
   );
 }
 
-export class CampaignServiceImplementation {
-  constructor(private deps: CampaignServiceDependencies = {}) {}
+export class WorldServiceImplementation {
+  constructor(private deps: WorldServiceDependencies = {}) {}
 
   private get db() {
     return this.deps.db ?? createMissingDb()!;
   }
 
-  async getMetadata(vaultId: string): Promise<CampaignMetadata> {
+  async getMetadata(vaultId: string): Promise<WorldMetadata> {
     const record = (await this.db.vaultMetadata.get(vaultId)) as
       | VaultMetadataRecord
       | undefined;
@@ -185,7 +185,7 @@ export class CampaignServiceImplementation {
 
   async updateMetadata(
     vaultId: string,
-    metadata: Partial<CampaignMetadata>,
+    metadata: Partial<WorldMetadata>,
   ): Promise<void> {
     const existing = (await this.db.vaultMetadata.get(vaultId)) as
       | VaultMetadataRecord
@@ -289,7 +289,7 @@ export class CampaignServiceImplementation {
     const assetManager = this.deps.assetManager;
     if (!imageGenerator || !assetManager) {
       throw new Error(
-        "CampaignService.generateCoverImage requires imageGenerator and assetManager dependencies",
+        "WorldService.generateCoverImage requires imageGenerator and assetManager dependencies",
       );
     }
 
@@ -301,7 +301,7 @@ export class CampaignServiceImplementation {
       promptBase,
       modelName,
     );
-    const assetName = `campaign-${vaultId}-${Date.now()}`;
+    const assetName = `world-${vaultId}-${Date.now()}`;
     const saved = await assetManager.saveImageToVault(
       blob,
       assetName,
@@ -312,32 +312,24 @@ export class CampaignServiceImplementation {
     return saved.image;
   }
 
-  async generateCampaignDescription(
+  async generateWorldBriefing(
     vaultId: string,
     promptBase: string,
   ): Promise<string> {
     const generator = this.deps.getSummaryGenerator?.();
     if (!generator) {
       throw new Error(
-        "CampaignService.generateCampaignDescription requires getSummaryGenerator dependency",
+        "WorldService.generateWorldBriefing requires getSummaryGenerator dependency",
       );
     }
-
-    const recent = await this.getRecentActivity(vaultId, 10);
-    const context = recent
-      .map(
-        (item) =>
-          `- ${item.title} (${item.tags.join(", ") || "untagged"}): ${item.excerpt}`,
-      )
-      .join("\n");
 
     let result = "";
     await generator.generateResponse(
       this.deps.getApiKey?.() ?? "",
       promptBase,
       [],
-      context,
-      this.deps.getSummaryModel?.() ?? "gemini-2.0-flash",
+      "",
+      this.deps.getSummaryModel?.() || "gemini-2.0-flash",
       (partial) => {
         result = partial;
       },
@@ -350,4 +342,4 @@ export class CampaignServiceImplementation {
   }
 }
 
-export const campaignService = new CampaignServiceImplementation();
+export const worldService = new WorldServiceImplementation();

--- a/packages/vault-engine/src/services/WorldService.ts
+++ b/packages/vault-engine/src/services/WorldService.ts
@@ -337,7 +337,9 @@ export class WorldServiceImplementation {
     );
 
     const description = result.trim();
-    await this.updateMetadata(vaultId, { description });
+    if (description) {
+      await this.updateMetadata(vaultId, { description });
+    }
     return description;
   }
 }

--- a/scripts/blog-screenshots/front-page.spec.ts
+++ b/scripts/blog-screenshots/front-page.spec.ts
@@ -1,0 +1,190 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+test.describe("Blog Screenshots: Front Page", () => {
+  const outputDir = path.join(process.cwd(), "../../blogPics/front-page");
+  const briefingText = `# Moonfall Atlas
+
+The frontier city of Valdris balances on a cracked moonlit coast, where treaty halls, harbor lanterns, and old vows keep the peace from collapsing.
+
+- **The Setting:** A dusk-soaked city-state built around archives, trade routes, and the fragile authority of sworn houses.
+- **Current Conflict:** The harbor council and the moonward factions are one bad night away from open break.
+- **Key Players:** The archivists, the lantern captains, and the oathbound envoys all claim to protect the city.
+- **Immediate Hook:** A sealed decree has resurfaced, and every faction believes it changes who owns the future.
+`;
+
+  const uploadGeneratedCover = async (page: any) => {
+    await page.evaluate(async () => {
+      const zone = document.querySelector(
+        '[role="region"][aria-label="World image drop zone"]',
+      ) as HTMLElement | null;
+      if (!zone) throw new Error("World image drop zone not found");
+
+      const canvas = document.createElement("canvas");
+      canvas.width = 1600;
+      canvas.height = 900;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Canvas context unavailable");
+
+      const background = ctx.createLinearGradient(0, 0, 1600, 900);
+      background.addColorStop(0, "#241712");
+      background.addColorStop(0.48, "#5a3420");
+      background.addColorStop(1, "#0f1017");
+      ctx.fillStyle = background;
+      ctx.fillRect(0, 0, 1600, 900);
+
+      const glow = ctx.createRadialGradient(1120, 250, 40, 1120, 250, 420);
+      glow.addColorStop(0, "rgba(248, 196, 106, 0.95)");
+      glow.addColorStop(0.35, "rgba(248, 196, 106, 0.35)");
+      glow.addColorStop(1, "rgba(248, 196, 106, 0)");
+      ctx.fillStyle = glow;
+      ctx.fillRect(0, 0, 1600, 900);
+
+      const moon = ctx.createRadialGradient(360, 240, 10, 360, 240, 170);
+      moon.addColorStop(0, "rgba(255, 246, 212, 0.95)");
+      moon.addColorStop(0.55, "rgba(255, 231, 178, 0.48)");
+      moon.addColorStop(1, "rgba(255, 231, 178, 0)");
+      ctx.fillStyle = moon;
+      ctx.beginPath();
+      ctx.arc(360, 240, 160, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = "rgba(8, 8, 14, 0.28)";
+      ctx.beginPath();
+      ctx.moveTo(0, 780);
+      ctx.lineTo(120, 690);
+      ctx.lineTo(260, 740);
+      ctx.lineTo(430, 610);
+      ctx.lineTo(620, 680);
+      ctx.lineTo(860, 540);
+      ctx.lineTo(1080, 680);
+      ctx.lineTo(1290, 600);
+      ctx.lineTo(1600, 720);
+      ctx.lineTo(1600, 900);
+      ctx.lineTo(0, 900);
+      ctx.closePath();
+      ctx.fill();
+
+      ctx.strokeStyle = "rgba(248, 196, 106, 0.42)";
+      ctx.lineWidth = 3;
+      for (const y of [660, 710, 760]) {
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(1600, y - 40);
+        ctx.stroke();
+      }
+
+      ctx.fillStyle = "rgba(255, 238, 200, 0.95)";
+      ctx.font = '700 72px "Georgia", serif';
+      ctx.fillText("Moonfall Atlas", 110, 150);
+      ctx.fillStyle = "rgba(255, 238, 200, 0.78)";
+      ctx.font = '400 28px "Georgia", serif';
+      ctx.fillText(
+        "A frontier setting of treaties, lantern law, and a moonlit archive.",
+        112,
+        205,
+      );
+
+      const blob = await (await fetch(canvas.toDataURL("image/png"))).blob();
+      const file = new File([blob], "front-page-cover.png", {
+        type: "image/png",
+      });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      zone.dispatchEvent(
+        new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      );
+    });
+  };
+
+  const fillBriefing = async (page: any) => {
+    await page.getByRole("button", { name: "Edit briefing" }).click();
+    const editor = page.locator(
+      'textarea[placeholder="Write a short world briefing…"]',
+    );
+    await expect(editor).toBeVisible({ timeout: 15000 });
+    await editor.fill(briefingText);
+    await page.getByRole("button", { name: "Save Briefing" }).click();
+    await expect(page.getByTestId("briefing-preview")).toContainText(
+      "Moonfall Atlas",
+      { timeout: 15000 },
+    );
+  };
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      (window as any).__SHARED_GEMINI_KEY__ = "fake-test-key";
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.removeItem("codex_active_vault_id");
+      localStorage.removeItem("codex_was_converted");
+    });
+  });
+
+  test("01 - Front Page Hero", async ({ page }) => {
+    await page.goto("/?demo=fantasy&s=" + Date.now());
+    await page.waitForFunction(
+      () =>
+        (window as any).uiStore !== undefined &&
+        (window as any).vault !== undefined,
+    );
+    await page.waitForFunction(
+      () =>
+        (window as any).vault?.status === "idle" &&
+        (window as any).uiStore?.isDemoMode,
+      { timeout: 15000 },
+    );
+
+    await page.getByTestId("header-front-page-button").click();
+    await uploadGeneratedCover(page);
+    await expect(page.getByTestId("front-page-hero-background")).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForTimeout(400);
+
+    await page.getByTestId("front-page-hero-background").screenshot({
+      path: path.join(outputDir, "front-page-hero.png"),
+    });
+  });
+
+  test("02 - Briefing And Context", async ({ page }) => {
+    await page.goto("/?demo=fantasy&s=" + Date.now());
+    await page.waitForFunction(
+      () =>
+        (window as any).uiStore !== undefined &&
+        (window as any).vault !== undefined,
+    );
+    await page.waitForFunction(
+      () =>
+        (window as any).vault?.status === "idle" &&
+        (window as any).uiStore?.isDemoMode,
+      { timeout: 15000 },
+    );
+
+    await page.getByTestId("header-front-page-button").click();
+    await uploadGeneratedCover(page);
+    await expect(page.getByTestId("front-page-hero-background")).toBeVisible({
+      timeout: 15000,
+    });
+    await fillBriefing(page);
+    const briefingSection = page.getByTestId("briefing-content-section");
+    await expect(briefingSection).toBeVisible({ timeout: 15000 });
+    await page.waitForTimeout(400);
+
+    await briefingSection.screenshot({
+      path: path.join(outputDir, "front-page-theme.png"),
+    });
+  });
+});

--- a/scripts/blog-screenshots/playwright.config.ts
+++ b/scripts/blog-screenshots/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /.*\.spec\.ts/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev -- --port 5173",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/specs/021-share-campaigns/data-model.md
+++ b/specs/021-share-campaigns/data-model.md
@@ -7,7 +7,7 @@
 The `Campaign` (or `Vault`) metadata entity needs extension to support sharing.
 
 ```typescript
-interface CampaignMetadata {
+interface WorldMetadata {
   id: string;
   name: string;
   // ... existing fields

--- a/specs/021-share-campaigns/tasks.md
+++ b/specs/021-share-campaigns/tasks.md
@@ -12,7 +12,7 @@
 
 - [x] T001 Create `specs/021-share-campaigns/checklists/` directory for validation
 - [x] T002 Ensure `VITE_GOOGLE_API_KEY` is added to `.env.example`
-- [x] T003 [P] Define `CampaignMetadata` extensions in `packages/schema/src/campaign.ts` (if applicable, or `apps/web/src/lib/types/`)
+- [x] T003 [P] Define `WorldMetadata` extensions in `packages/schema/src/campaign.ts` (if applicable, or `apps/web/src/lib/types/`)
 
 ---
 

--- a/specs/045-campaign-date-picker/contracts/calendar-service.ts
+++ b/specs/045-campaign-date-picker/contracts/calendar-service.ts
@@ -1,6 +1,6 @@
 import type {
   TemporalMetadata,
-  CampaignCalendar,
+  WorldCalendar,
   CalendarMonth,
 } from "../../../packages/chronology-engine/src/types";
 
@@ -8,21 +8,21 @@ export interface ICalendarEngine {
   /**
    * Validates if a partial or full date is valid within the current calendar rules.
    */
-  isValid(date: TemporalMetadata, config: CampaignCalendar): boolean;
+  isValid(date: TemporalMetadata, config: WorldCalendar): boolean;
 
   /**
    * Formats a date for display based on campaign settings.
    * e.g. "12th of Hammer, 1240 AF"
    */
-  format(date: TemporalMetadata, config: CampaignCalendar): string;
+  format(date: TemporalMetadata, config: WorldCalendar): string;
 
   /**
    * Gets the list of available months.
    */
-  getMonths(config: CampaignCalendar): CalendarMonth[];
+  getMonths(config: WorldCalendar): CalendarMonth[];
 
   /**
    * Calculates the relative position of a date on a linear timeline (for graph engine).
    */
-  getTimelineValue(date: TemporalMetadata, config: CampaignCalendar): number;
+  getTimelineValue(date: TemporalMetadata, config: WorldCalendar): number;
 }

--- a/specs/045-campaign-date-picker/data-model.md
+++ b/specs/045-campaign-date-picker/data-model.md
@@ -2,7 +2,7 @@
 
 ## Entities
 
-### CampaignCalendar
+### WorldCalendar
 
 Represents the rules for time in the specific campaign vault.
 
@@ -23,8 +23,8 @@ Represents the rules for time in the specific campaign vault.
 
 ## Relationships
 
-- **Campaign** (Vault Metadata) `1 -- 1` **CampaignCalendar**
-- **TemporalMetadata** (Entity Field) `N -- 1` **CampaignCalendar** (via validation logic)
+- **Campaign** (Vault Metadata) `1 -- 1` **WorldCalendar**
+- **TemporalMetadata** (Entity Field) `N -- 1` **WorldCalendar** (via validation logic)
 
 ## State Transitions
 

--- a/specs/045-campaign-date-picker/plan.md
+++ b/specs/045-campaign-date-picker/plan.md
@@ -39,7 +39,7 @@ _GATE: Passed on 2026-02-17._
 specs/045-campaign-date-picker/
 ├── plan.md              # This file
 ├── research.md          # Decision log for Positioning and Engine
-├── data-model.md        # CampaignCalendar and Month entities
+├── data-model.md        # WorldCalendar and Month entities
 ├── quickstart.md        # Setup guide for chronology-engine
 ├── contracts/           # ICalendarEngine interface
 └── tasks.md             # Implementation breakdown

--- a/specs/045-campaign-date-picker/spec.md
+++ b/specs/045-campaign-date-picker/spec.md
@@ -74,7 +74,7 @@ As a user, I want to decide if an event needs a specific day/month or just a yea
 
 ### Key Entities
 
-- **CampaignCalendar**: Represents the chronological rules of the world (Month names, days per month, etc).
+- **WorldCalendar**: Represents the chronological rules of the world (Month names, days per month, etc).
 - **WorldEra**: Existing entity; used as a grouping mechanism for years in the picker.
 - **TemporalMetadata**: The data structure being edited (Year, Month, Day, Label).
 

--- a/specs/045-campaign-date-picker/tasks.md
+++ b/specs/045-campaign-date-picker/tasks.md
@@ -9,7 +9,7 @@
 
 ## Phase 2: Foundational (Chronology Engine)
 
-- [x] T005 [P] Define `TemporalMetadata`, `CampaignCalendar`, and `CalendarMonth` types in `packages/chronology-engine/src/types.ts`
+- [x] T005 [P] Define `TemporalMetadata`, `WorldCalendar`, and `CalendarMonth` types in `packages/chronology-engine/src/types.ts`
 - [x] T006 Implement `CalendarEngine` class with `isValid` and `format` methods in `packages/chronology-engine/src/engine.ts`
 - [x] T007 Implement Gregorian template constants and toggle logic in `CalendarEngine`
 - [x] T008 Implement `getTimelineValue` in `packages/chronology-engine/src/engine.ts` for linear timeline mapping

--- a/specs/051-demo-mode/contracts/demo-service.ts
+++ b/specs/051-demo-mode/contracts/demo-service.ts
@@ -12,7 +12,7 @@ export interface IDemoActions {
    * Persists the current transient demo state to IndexedDB.
    * Returns the new vault ID.
    */
-  convertToCampaign(): Promise<string>;
+  convertToWorld(): Promise<string>;
 
   /**
    * Exits demo mode and reloads the previous campaign or returns to landing.

--- a/specs/077-vault-front-page/contracts/campaign-service.md
+++ b/specs/077-vault-front-page/contracts/campaign-service.md
@@ -1,9 +1,9 @@
-# Contract: CampaignService
+# Contract: WorldService
 
-The `CampaignService` and `ActivityService` MUST be implemented as **classes** that accept their dependencies via the constructor, allowing for unit tests to pass in mock databases or other mocked services.
+The `WorldService` and `ActivityService` MUST be implemented as **classes** that accept their dependencies via the constructor, allowing for unit tests to pass in mock databases or other mocked services.
 
 ```typescript
-export interface CampaignMetadata {
+export interface WorldMetadata {
   id: string;
   name: string;
   tagline?: string;
@@ -32,23 +32,23 @@ export interface FrontPageEntity {
 }
 
 /**
- * Interface definition for CampaignService.
+ * Interface definition for WorldService.
  * Implementation class must be exported alongside a default singleton instance.
  */
-export interface CampaignService {
+export interface WorldService {
   /**
    * Fetches the primary metadata for the campaign.
    * Returns an empty `name` when no saved vault title exists so the UI can
    * fall back to the readable vault name.
    */
-  getMetadata(vaultId: string): Promise<CampaignMetadata>;
+  getMetadata(vaultId: string): Promise<WorldMetadata>;
 
   /**
    * Updates vault-level metadata (description, cover image).
    */
   updateMetadata(
     vaultId: string,
-    metadata: Partial<CampaignMetadata>,
+    metadata: Partial<WorldMetadata>,
   ): Promise<void>;
 
   /**
@@ -74,14 +74,14 @@ export interface CampaignService {
 ## Implementation Example (with DI)
 
 ```typescript
-export class CampaignServiceImplementation implements CampaignService {
+export class WorldServiceImplementation implements WorldService {
   constructor(private db: EntityDb = entityDb) {}
 
-  async getMetadata(vaultId: string): Promise<CampaignMetadata> {
+  async getMetadata(vaultId: string): Promise<WorldMetadata> {
     const record = await this.db.vaultMetadata.get(vaultId);
     // ... logic
   }
 }
 
-export const campaignService = new CampaignServiceImplementation();
+export const worldService = new WorldServiceImplementation();
 ```

--- a/specs/077-vault-front-page/plan.md
+++ b/specs/077-vault-front-page/plan.md
@@ -30,7 +30,7 @@ _GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 5. **Privacy**: All images and metadata stored locally via OPFS and Dexie. [PASS]
 6. **Clean Implementation**: Adhere to Dexie schema versioning (Version 4). [PASS]
 7. **Documentation**: Update `help-content.ts`. [PASS]
-8. **Dependency Injection**: **CRITICAL**. All new services (`CampaignService`, `ActivityService`) and stores (`CampaignStore`) MUST use constructor-based DI to ensure unit-testability with mocked databases and services. [PASS]
+8. **Dependency Injection**: **CRITICAL**. All new services (`WorldService`, `ActivityService`) and stores (`WorldStore`) MUST use constructor-based DI to ensure unit-testability with mocked databases and services. [PASS]
 
 ## Project Structure
 
@@ -57,7 +57,7 @@ apps/web/src/
 │   │   │   ├── EntityCard.svelte    # Card for relevant recent items
 │   │   │   └── CoverImage.svelte    # Cover art drop zone / generator
 │   ├── stores/
-│   │   └── campaign.svelte.ts       # UI state for front page (Uses DI for Services)
+│   │   └── world.svelte.ts       # UI state for front page (Uses DI for Services)
 │   ├── utils/
 │   │   └── entity-db.ts             # UPDATED: Dexie Schema Version 4
 └── routes/
@@ -68,7 +68,7 @@ packages/
 ├── vault-engine/
 │   ├── src/
 │   │   ├── services/
-│   │   │   ├── CampaignService.ts   # Metadata and frontpage tag logic (Uses DI for EntityDb)
+│   │   │   ├── WorldService.ts   # Metadata and frontpage tag logic (Uses DI for EntityDb)
 │   │   │   └── ActivityService.ts   # Tracking recent changes (Uses DI for EntityDb)
 ```
 

--- a/specs/077-vault-front-page/quickstart.md
+++ b/specs/077-vault-front-page/quickstart.md
@@ -10,7 +10,7 @@
 1.  **Dexie Update**: Modify `apps/web/src/lib/utils/entity-db.ts`.
     - Add `vaultMetadata` table to the schema.
     - Bump to `version(4)`.
-2.  **CampaignService**: Implement in `packages/vault-engine/src/services/CampaignService.ts`.
+2.  **WorldService**: Implement in `packages/vault-engine/src/services/WorldService.ts`.
     - `getRecentActivity`: query recent entities, pin any `frontpage`-marked records, and include title/type/image metadata.
     - `getFrontPageEntity`: query `entityDb.graphEntities` for `frontpage` markers in both tags and labels, then use the newest match.
     - `generateCoverImage`: feed the current summary and theme context into the image prompt, then persist the generated asset locally.

--- a/specs/077-vault-front-page/research.md
+++ b/specs/077-vault-front-page/research.md
@@ -16,7 +16,7 @@
 
 ### 3. Frontpage Tag Resolution
 
-- **Decision**: Implement a search in `CampaignService` and `ActivityService` that queries the `graphEntities` table in Dexie for `frontpage` markers in both tags and labels.
+- **Decision**: Implement a search in `WorldService` and `ActivityService` that queries the `graphEntities` table in Dexie for `frontpage` markers in both tags and labels.
 - **Rationale**: Consistent with how categories and connections are handled via structured Dexie queries, while still remaining tolerant of older content shapes.
 
 ### 4. Cover Image Storage

--- a/specs/077-vault-front-page/tasks.md
+++ b/specs/077-vault-front-page/tasks.md
@@ -23,9 +23,9 @@
 
 **Purpose**: Core logic and service interfaces with **Constructor DI**
 
-- [x] T004 [P] Create `CampaignService.ts` as a class with **Constructor DI** for `EntityDb` in `packages/vault-engine/src/services/CampaignService.ts`
+- [x] T004 [P] Create `WorldService.ts` as a class with **Constructor DI** for `EntityDb` in `packages/vault-engine/src/services/WorldService.ts`
 - [x] T005 [P] Create `ActivityService.ts` as a class with **Constructor DI** for `EntityDb` in `packages/vault-engine/src/services/ActivityService.ts`
-- [x] T006 Create `CampaignStore` class in `apps/web/src/lib/stores/campaign.svelte.ts` using **Constructor DI** for `CampaignService` and `ActivityService`
+- [x] T006 Create `WorldStore` class in `apps/web/src/lib/stores/world.svelte.ts` using **Constructor DI** for `WorldService` and `ActivityService`
 
 **Checkpoint**: Core services and stores initialized with clean DI patterns.
 
@@ -39,12 +39,12 @@
 
 ### Tests for User Story 1 (TDD with Mocks)
 
-- [x] T007 [P] [US1] Unit test for `CampaignService.getMetadata` using a mocked `EntityDb` in `packages/vault-engine/src/services/CampaignService.test.ts`
-- [x] T008 [P] [US1] Component test for `FrontPage.svelte` using a mocked `CampaignStore` in `apps/web/src/lib/components/campaign/FrontPage.test.ts`
+- [x] T007 [P] [US1] Unit test for `WorldService.getMetadata` using a mocked `EntityDb` in `packages/vault-engine/src/services/WorldService.test.ts`
+- [x] T008 [P] [US1] Component test for `FrontPage.svelte` using a mocked `WorldStore` in `apps/web/src/lib/components/campaign/FrontPage.test.ts`
 
 ### Implementation for User Story 1
 
-- [x] T009 [US1] Implement `getMetadata` using `this.db.vaultMetadata` in `packages/vault-engine/src/services/CampaignService.ts`
+- [x] T009 [US1] Implement `getMetadata` using `this.db.vaultMetadata` in `packages/vault-engine/src/services/WorldService.ts`
 - [x] T010 [US1] Create `FrontPage.svelte` in `apps/web/src/lib/components/campaign/FrontPage.svelte` with Markdown rendering for the summary and frontpage entity fallback
 - [x] T011 [US1] Implement title, tagline, and summary editing UI and save logic in `FrontPage.svelte`
 - [x] T012 [US1] Update `apps/web/src/routes/(app)/+page.svelte` and `apps/web/src/routes/(app)/vault/[id]/+page.svelte` to render the front page overlay and entity detail shell
@@ -59,11 +59,11 @@
 
 ### Tests for User Story 2
 
-- [x] T013 [P] [US2] Unit test for `CampaignService.getFrontPageEntity` using mocked `EntityDb` in `packages/vault-engine/src/services/CampaignService.test.ts`
+- [x] T013 [P] [US2] Unit test for `WorldService.getFrontPageEntity` using mocked `EntityDb` in `packages/vault-engine/src/services/WorldService.test.ts`
 
 ### Implementation for User Story 2
 
-- [x] T014 [US2] Implement `getFrontPageEntity` using `this.db.graphEntities` queries in `packages/vault-engine/src/services/CampaignService.ts`
+- [x] T014 [US2] Implement `getFrontPageEntity` using `this.db.graphEntities` queries in `packages/vault-engine/src/services/WorldService.ts`
 - [x] T015 [US2] Update `FrontPage.svelte` to fetch and render the marked entity content using `ArticleRenderer`
 
 ---
@@ -106,7 +106,7 @@
 
 ### Implementation for User Story 5
 
-- [x] T021 [US5] Implement `generateCoverImage` using Oracle and Dexie persistence in `packages/vault-engine/src/services/CampaignService.ts`
+- [x] T021 [US5] Implement `generateCoverImage` using Oracle and Dexie persistence in `packages/vault-engine/src/services/WorldService.ts`
 - [x] T022 [P] [US5] Create `CoverImage.svelte` component in `apps/web/src/lib/components/campaign/CoverImage.svelte`
 - [x] T023 [US5] Add inline cover image management, lightbox, and generator controls to `FrontPage.svelte`
 
@@ -120,7 +120,7 @@
 
 ### Implementation for User Story 6
 
-- [x] T024 [US6] Implement AI description generation logic in `CampaignService.ts` (Deriving prompt from existing entities)
+- [x] T024 [US6] Implement AI description generation logic in `WorldService.ts` (Deriving prompt from existing entities)
 - [x] T025 [US6] Add summary/tagline generation controls and loading state to `FrontPage.svelte`
 
 ---


### PR DESCRIPTION
This PR introduces a significant terminology shift and a new UX pattern:

- **Generalized Terminology**: Refactored all 'Campaign' terminology (e.g., `CampaignStore`, `CampaignService`) to 'World' (`WorldStore`, `WorldService`) across the codebase to support broader, setting-agnostic worldbuilding contexts.
- **Improved AI Prompts**: Replaced 'summary' with 'briefing' and removed specific genre biases (like 'fantasy') from the Oracle generation prompts.
- **Custom Confirmation Modal**: Implemented an async, theme-aligned `uiStore.confirm()` modal to replace all instances of the standard browser `window.confirm()`. This provides a cohesive, immersive experience for dangerous actions like deletion and file generation.
- **Accessibility Improvements**: The new modal uses `<svelte:window>` to correctly capture `Enter` and `Esc` key events.
- **Contrast Fixes**: Dangerous buttons within the confirmation modal now use a high-contrast solid red styling to ensure readability on lighter themes.