### PR TITLE
🔒 [security fix] Use textContent to clear editor

### DIFF
--- a/apps/web/src/lib/features/importer/ImportDropzone.svelte
+++ b/apps/web/src/lib/features/importer/ImportDropzone.svelte
@@ -52,7 +52,7 @@
     onFileSelect([file]);
 
     // Clear
-    if (editorRef) editorRef.innerHTML = "";
+    if (editorRef) editorRef.textContent = "";
     content = "";
   };
 </script>


### PR DESCRIPTION
🎯 **What:** Potential logic flaw / XSS risk via `innerHTML` reset in `ImportDropzone.svelte`.
⚠️ **Risk:** Using `innerHTML` to clear content unnecessarily invokes the HTML parser. While clearing with an empty string is low risk, it's a security best practice to use `textContent` to avoid the parser entirely and reduce the attack surface.
🛡️ **Solution:** Replaced `editorRef.innerHTML = ""` with `editorRef.textContent = ""` to safely and efficiently clear the editor's content.

---
*PR created automatically by Jules for task [2754817988105103656](https://jules.google.com/task/2754817988105103656) started by @eserlan*