### PR TITLE
⚡ Bolt: optimize Cytoscape node projection in Minimap

### DIFF
--- a/apps/web/src/lib/components/graph/Minimap.svelte
+++ b/apps/web/src/lib/components/graph/Minimap.svelte
@@ -51,7 +51,9 @@
 
   const updateProjection = () => {
     if (!cy) return;
-    const eles = cy.elements().filter((el) => el.isNode()); // Only nodes for projection
+    // ⚡ Bolt Optimization: Use cy.nodes() directly instead of cy.elements().filter()
+    // to avoid allocating a full collection of nodes + edges and the overhead of filtering.
+    const eles = cy.nodes();
 
     // If there are no nodes, avoid calling boundingBox and reset to safe defaults
     if (!eles || eles.length === 0) {


### PR DESCRIPTION
💡 What: Replaced `cy.elements().filter(...)` with `cy.nodes()` in `apps/web/src/lib/components/graph/Minimap.svelte` when calculating graph bounds.
🎯 Why: `cy.elements()` allocates an unnecessary Cytoscape collection containing all nodes and edges in the graph. In large graphs, filtering this massive array is an unnecessary overhead when Cytoscape provides a native `cy.nodes()` method to fetch just the nodes directly.
📊 Impact: Eliminates O(N + E) element collection allocation and filtering during graph updates/resizes/layout completions. Provides a faster and cleaner projection for the minimap.
🔬 Measurement: Verify tests run completely (`npm run test`), and inspect the `Minimap.svelte` changes to confirm native `.nodes()` method usage.

---
*PR created automatically by Jules for task [9181343886717745825](https://jules.google.com/task/9181343886717745825) started by @eserlan*