### PR TITLE
feat(web): make dice roller detachable into standalone window

### DIFF
--- a/apps/web/src/lib/components/dice/DiceModal.svelte
+++ b/apps/web/src/lib/components/dice/DiceModal.svelte
@@ -1,119 +1,7 @@
 <script lang="ts">
   import { uiStore } from "$lib/stores/ui.svelte";
-  import { diceHistory } from "$lib/stores/dice-history.svelte";
-  import { diceEngine, diceParser } from "dice-engine";
-  import { fly, fade, slide } from "svelte/transition";
-  import RollLog from "./RollLog.svelte";
-  import { tick } from "svelte";
-  import { getDiceIcon } from "$lib/utils/dice-icons";
-
-  let formula = $state("");
-  let error = $state("");
-  let showHelp = $state(false);
-  let formulaInput = $state<HTMLInputElement>();
-  let rollLogComponent = $state<ReturnType<typeof RollLog>>();
-
-  // History Navigation
-  let historyIndex = $state(-1);
-  let originalFormula = "";
-
-  const executeRoll = async (f: string) => {
-    try {
-      error = "";
-      const command = diceParser.parse(f);
-      const result = diceEngine.execute(command);
-      await diceHistory.addResult(result, "modal");
-      // Reset history navigation
-      historyIndex = -1;
-      // Scroll to top to see new result
-      await tick();
-      rollLogComponent?.scrollToTop();
-    } catch (e: any) {
-      error = e.message;
-    }
-  };
-
-  const roll = (customFormula?: string) => {
-    const f = customFormula || formula;
-    if (!f) return;
-    executeRoll(f);
-    if (!customFormula) {
-      formula = "";
-      formulaInput?.focus();
-    }
-  };
-
-  const quickAdd = (sides: number) => {
-    if (!formula) {
-      formula = `1d${sides}`;
-    } else {
-      // Global increment: find if the formula contains this die type anywhere
-      // Match "XdSide" where X is a number
-      const diePattern = new RegExp(`(\\d+)d${sides}\\b`, "i");
-      const match = formula.match(diePattern);
-
-      if (match) {
-        // Increment the existing count
-        const count = parseInt(match[1]) + 1;
-        formula = formula.replace(diePattern, `${count}d${sides}`);
-      } else {
-        // Append as a new part
-        const trimmed = formula.trim();
-        const lastChar = trimmed.slice(-1);
-        if (/[0-9a-z]/i.test(lastChar)) {
-          formula = `${trimmed} + 1d${sides}`;
-        } else {
-          formula = `${trimmed} 1d${sides}`;
-        }
-      }
-    }
-    formulaInput?.focus();
-  };
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    const history = diceHistory.modalHistory;
-    // Get unique formulas in reverse chronological order (most recent first)
-    const uniqueFormulas = Array.from(
-      new Set(history.map((h) => h.formula)),
-    ).reverse();
-
-    if (e.key === "ArrowUp") {
-      e.preventDefault();
-      if (uniqueFormulas.length === 0) return;
-
-      if (historyIndex === -1) {
-        originalFormula = formula;
-      }
-
-      if (historyIndex < uniqueFormulas.length - 1) {
-        historyIndex++;
-        formula = uniqueFormulas[historyIndex];
-      }
-    } else if (e.key === "ArrowDown") {
-      e.preventDefault();
-      if (historyIndex > 0) {
-        historyIndex--;
-        formula = uniqueFormulas[historyIndex];
-      } else if (historyIndex === 0) {
-        historyIndex = -1;
-        formula = originalFormula;
-      }
-    }
-  };
-
-  const reroll = (f: string) => {
-    executeRoll(f);
-  };
-
-  const diceTypes = [
-    { sides: 4 },
-    { sides: 6 },
-    { sides: 8 },
-    { sides: 10 },
-    { sides: 12 },
-    { sides: 20 },
-    { sides: 100 },
-  ];
+  import { fly, fade } from "svelte/transition";
+  import DiceVault from "./DiceVault.svelte";
 </script>
 
 {#if uiStore.showDiceModal}
@@ -150,118 +38,31 @@
             Die Roller
           </h2>
         </div>
-        <button
-          class="p-1 hover:bg-theme-primary/10 rounded-md transition-colors text-theme-muted hover:text-theme-primary"
-          onclick={() => {
-            uiStore.showDiceModal = false;
-          }}
-          aria-label="Close"
-        >
-          <span class="icon-[lucide--x] w-5 h-5"></span>
-        </button>
-      </div>
-
-      <!-- Quick Roll Buttons -->
-      <div class="p-4 border-b border-theme-border/50 bg-theme-bg/20">
-        <div class="flex flex-wrap gap-2 justify-center mb-2">
-          {#each diceTypes as die}
-            <button
-              class="flex flex-col items-center justify-center w-12 h-14 rounded-lg border border-theme-border bg-theme-bg hover:border-theme-primary hover:text-theme-primary transition-all active:scale-90 group relative"
-              onclick={() => quickAdd(die.sides)}
-              title="Add {die.sides}-sided die to formula"
-            >
-              <span
-                class="text-[9px] font-bold opacity-50 group-hover:opacity-100 mb-1"
-                >d{die.sides}</span
-              >
-              <span class="{getDiceIcon(die.sides)} w-5 h-5"></span>
-            </button>
-          {/each}
-        </div>
-        <p class="text-[9px] text-center text-theme-muted italic opacity-60">
-          Click dice to build your formula
-        </p>
-      </div>
-
-      <!-- Custom Formula -->
-      <div class="p-4 space-y-3 border-b border-theme-border/30 bg-theme-bg/10">
-        <form
-          onsubmit={(e) => {
-            e.preventDefault();
-            roll();
-          }}
-          class="flex gap-2"
-        >
-          <div class="relative flex-1 group">
-            <input
-              bind:this={formulaInput}
-              type="text"
-              bind:value={formula}
-              onkeydown={handleKeyDown}
-              placeholder="Enter formula (e.g. 2d20kh1 + 5)"
-              class="w-full bg-theme-bg border border-theme-border rounded-xl pl-4 pr-10 py-3 text-sm focus:border-theme-primary focus:ring-2 focus:ring-theme-primary/20 outline-none font-body transition-all placeholder:opacity-40"
-            />
-            <button
-              type="button"
-              class="absolute right-3 top-1/2 -translate-y-1/2 text-theme-muted hover:text-theme-primary transition-colors p-1"
-              onclick={() => (showHelp = !showHelp)}
-              title="Formula Help"
-            >
-              <span class="icon-[lucide--info] w-4 h-4"></span>
-            </button>
-          </div>
+        <div class="flex items-center gap-1">
+          <!-- Detach Button -->
           <button
-            type="submit"
-            class="bg-theme-primary text-theme-bg font-bold px-6 py-2 rounded-xl text-xs tracking-[0.2em] hover:brightness-110 active:scale-95 transition-all shadow-lg shadow-theme-primary/20"
+            class="p-1.5 hover:bg-theme-primary/10 rounded-md transition-colors text-theme-muted hover:text-theme-primary"
+            onclick={() => uiStore.openDiceWindow()}
+            title="Pop out into new window"
+            aria-label="Pop out into new window"
           >
-            ROLL
+            <span class="icon-[lucide--external-link] w-4 h-4"></span>
           </button>
-        </form>
-
-        {#if showHelp}
-          <div
-            class="bg-theme-bg/50 border border-theme-border/50 rounded-lg p-3 text-[10px] space-y-2"
-            transition:slide
-          >
-            <div class="grid grid-cols-2 gap-x-4 gap-y-1">
-              <span class="text-theme-primary font-bold">2d20kh1</span>
-              <span class="text-theme-muted">Keep Highest (Advantage)</span>
-              <span class="text-theme-primary font-bold">2d20kl1</span>
-              <span class="text-theme-muted">Keep Lowest (Disadvantage)</span>
-              <span class="text-theme-primary font-bold">4d6!</span>
-              <span class="text-theme-muted">Exploding (Max rolls again)</span>
-              <span class="text-theme-primary font-bold">1d10 + 5</span>
-              <span class="text-theme-muted">Standard Modifier</span>
-            </div>
-          </div>
-        {/if}
-
-        {#if error}
-          <p class="text-red-500 text-[10px] italic ml-1">{error}</p>
-        {/if}
-      </div>
-
-      <!-- Roll Log -->
-      <div class="flex-1 min-h-0 bg-theme-bg/30">
-        <div
-          class="px-4 py-2 flex justify-between items-center border-b border-theme-border/30"
-        >
-          <span
-            class="text-[11px] font-bold text-theme-muted uppercase tracking-tighter"
-            >Session History</span
-          >
           <button
-            class="text-[11px] font-bold text-theme-muted hover:text-red-500 uppercase transition-colors"
-            onclick={() => diceHistory.clearHistory("modal")}
+            class="p-1.5 hover:bg-theme-primary/10 rounded-md transition-colors text-theme-muted hover:text-theme-primary"
+            onclick={() => {
+              uiStore.showDiceModal = false;
+            }}
+            aria-label="Close"
           >
-            Clear
+            <span class="icon-[lucide--x] w-5 h-5"></span>
           </button>
         </div>
-        <RollLog
-          bind:this={rollLogComponent}
-          rolls={diceHistory.modalHistory}
-          onReroll={reroll}
-        />
+      </div>
+
+      <!-- Main Dice Content -->
+      <div class="flex-1 overflow-hidden">
+        <DiceVault />
       </div>
     </div>
   </div>

--- a/apps/web/src/lib/components/dice/DiceVault.svelte
+++ b/apps/web/src/lib/components/dice/DiceVault.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  import { diceHistory } from "$lib/stores/dice-history.svelte";
+  import { diceEngine, diceParser } from "dice-engine";
+  import { slide } from "svelte/transition";
+  import RollLog from "./RollLog.svelte";
+  import { tick } from "svelte";
+  import { getDiceIcon } from "$lib/utils/dice-icons";
+
+  let { isStandalone = false } = $props<{ isStandalone?: boolean }>();
+
+  let formula = $state("");
+  let error = $state("");
+  let showHelp = $state(false);
+  let formulaInput = $state<HTMLInputElement>();
+  let rollLogComponent = $state<ReturnType<typeof RollLog>>();
+
+  // History Navigation
+  let historyIndex = $state(-1);
+  let originalFormula = "";
+
+  const executeRoll = async (f: string) => {
+    try {
+      error = "";
+      const command = diceParser.parse(f);
+      const result = diceEngine.execute(command);
+      await diceHistory.addResult(result, "modal");
+      // Reset history navigation
+      historyIndex = -1;
+      // Scroll to top to see new result
+      await tick();
+      rollLogComponent?.scrollToTop();
+    } catch (e: any) {
+      error = e.message;
+    }
+  };
+
+  const roll = (customFormula?: string) => {
+    const f = customFormula || formula;
+    if (!f) return;
+    executeRoll(f);
+    if (!customFormula) {
+      formula = "";
+      formulaInput?.focus();
+    }
+  };
+
+  const quickAdd = (sides: number) => {
+    if (!formula) {
+      formula = `1d${sides}`;
+    } else {
+      const diePattern = new RegExp(`(\\d+)d${sides}\\b`, "i");
+      const match = formula.match(diePattern);
+
+      if (match) {
+        const count = parseInt(match[1]) + 1;
+        formula = formula.replace(diePattern, `${count}d${sides}`);
+      } else {
+        const trimmed = formula.trim();
+        const lastChar = trimmed.slice(-1);
+        if (/[0-9a-z]/i.test(lastChar)) {
+          formula = `${trimmed} + 1d${sides}`;
+        } else {
+          formula = `${trimmed} 1d${sides}`;
+        }
+      }
+    }
+    formulaInput?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const history = diceHistory.modalHistory;
+    const uniqueFormulas = Array.from(
+      new Set(history.map((h) => h.formula)),
+    ).reverse();
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (uniqueFormulas.length === 0) return;
+
+      if (historyIndex === -1) {
+        originalFormula = formula;
+      }
+
+      if (historyIndex < uniqueFormulas.length - 1) {
+        historyIndex++;
+        formula = uniqueFormulas[historyIndex];
+      }
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (historyIndex > 0) {
+        historyIndex--;
+        formula = uniqueFormulas[historyIndex];
+      } else if (historyIndex === 0) {
+        historyIndex = -1;
+        formula = originalFormula;
+      }
+    }
+  };
+
+  const reroll = (f: string) => {
+    executeRoll(f);
+  };
+
+  const diceTypes = [
+    { sides: 4 },
+    { sides: 6 },
+    { sides: 8 },
+    { sides: 10 },
+    { sides: 12 },
+    { sides: 20 },
+    { sides: 100 },
+  ];
+</script>
+
+<div
+  class="flex flex-col h-full {isStandalone
+    ? 'bg-theme-bg'
+    : 'bg-theme-surface'}"
+>
+  <!-- Quick Roll Buttons -->
+  <div class="p-4 border-b border-theme-border/50 bg-theme-bg/20">
+    <div class="flex flex-wrap gap-2 justify-center mb-2">
+      {#each diceTypes as die}
+        <button
+          class="flex flex-col items-center justify-center w-12 h-14 rounded-lg border border-theme-border bg-theme-bg hover:border-theme-primary hover:text-theme-primary transition-all active:scale-90 group relative"
+          onclick={() => quickAdd(die.sides)}
+          title="Add {die.sides}-sided die to formula"
+        >
+          <span class="text-[9px] font-bold opacity-50 group-hover:opacity-100 mb-1"
+            >d{die.sides}</span
+          >
+          <span class="{getDiceIcon(die.sides)} w-5 h-5"></span>
+        </button>
+      {/each}
+    </div>
+    <p class="text-[9px] text-center text-theme-muted italic opacity-60">
+      Click dice to build your formula
+    </p>
+  </div>
+
+  <!-- Custom Formula -->
+  <div class="p-4 space-y-3 border-b border-theme-border/30 bg-theme-bg/10">
+    <form
+      onsubmit={(e) => {
+        e.preventDefault();
+        roll();
+      }}
+      class="flex gap-2"
+    >
+      <div class="relative flex-1 group">
+        <input
+          bind:this={formulaInput}
+          type="text"
+          bind:value={formula}
+          onkeydown={handleKeyDown}
+          placeholder="Enter formula (e.g. 2d20kh1 + 5)"
+          class="w-full bg-theme-bg border border-theme-border rounded-xl pl-4 pr-10 py-3 text-sm focus:border-theme-primary focus:ring-2 focus:ring-theme-primary/20 outline-none font-body transition-all placeholder:opacity-40"
+        />
+        <button
+          type="button"
+          class="absolute right-3 top-1/2 -translate-y-1/2 text-theme-muted hover:text-theme-primary transition-colors p-1"
+          onclick={() => (showHelp = !showHelp)}
+          title="Formula Help"
+        >
+          <span class="icon-[lucide--info] w-4 h-4"></span>
+        </button>
+      </div>
+      <button
+        type="submit"
+        class="bg-theme-primary text-theme-bg font-bold px-6 py-2 rounded-xl text-xs tracking-[0.2em] hover:brightness-110 active:scale-95 transition-all shadow-lg shadow-theme-primary/20"
+      >
+        ROLL
+      </button>
+    </form>
+
+    {#if showHelp}
+      <div
+        class="bg-theme-bg/50 border border-theme-border/50 rounded-lg p-3 text-[10px] space-y-2"
+        transition:slide
+      >
+        <div class="grid grid-cols-2 gap-x-4 gap-y-1">
+          <span class="text-theme-primary font-bold">2d20kh1</span>
+          <span class="text-theme-muted">Keep Highest (Advantage)</span>
+          <span class="text-theme-primary font-bold">2d20kl1</span>
+          <span class="text-theme-muted">Keep Lowest (Disadvantage)</span>
+          <span class="text-theme-primary font-bold">4d6!</span>
+          <span class="text-theme-muted">Exploding (Max rolls again)</span>
+          <span class="text-theme-primary font-bold">1d10 + 5</span>
+          <span class="text-theme-muted">Standard Modifier</span>
+        </div>
+      </div>
+    {/if}
+
+    {#if error}
+      <p class="text-red-500 text-[10px] italic ml-1">{error}</p>
+    {/if}
+  </div>
+
+  <!-- Roll Log -->
+  <div class="flex-1 min-h-0 bg-theme-bg/30">
+    <div
+      class="px-4 py-2 flex justify-between items-center border-b border-theme-border/30"
+    >
+      <span class="text-[11px] font-bold text-theme-muted uppercase tracking-tighter"
+        >Session History</span
+      >
+      <button
+        class="text-[11px] font-bold text-theme-muted hover:text-red-500 uppercase transition-colors"
+        onclick={() => diceHistory.clearHistory("modal")}
+      >
+        Clear
+      </button>
+    </div>
+    <RollLog
+      bind:this={rollLogComponent}
+      rolls={diceHistory.modalHistory}
+      onReroll={reroll}
+    />
+  </div>
+</div>

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -398,6 +398,22 @@ class UIStore {
     if (newWin) newWin.opener = null;
   }
 
+  openDiceWindow() {
+    if (typeof window === "undefined") return;
+
+    const width = 450;
+    const height = 800;
+    const left = window.screenX + (window.outerWidth - width) / 2;
+    const top = window.screenY + (window.outerHeight - height) / 2;
+
+    const url = `${window.location.origin}${base}/dice`;
+    const features = `width=${width},height=${height},left=${left},top=${top},toolbar=0,location=0,menubar=0,noopener,noreferrer`;
+
+    const newWin = window.open(url, "CodexCrypticaDice", features);
+    if (newWin) newWin.opener = null;
+    this.showDiceModal = false;
+  }
+
   toggleSettings(tab: SettingsTab = "vault") {
     if (this.showSettings && this.activeSettingsTab === tab) {
       this.showSettings = false;

--- a/apps/web/src/routes/(app)/dice/+page.svelte
+++ b/apps/web/src/routes/(app)/dice/+page.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import DiceVault from "$lib/components/dice/DiceVault.svelte";
+</script>
+
+<svelte:head>
+  <title>Codex Cryptica | Die Roller</title>
+</svelte:head>
+
+<div class="h-screen bg-theme-bg flex flex-col overflow-hidden font-body">
+  <!-- Header (Standalone Version) -->
+  <div
+    class="p-4 border-b border-theme-border flex justify-between items-center bg-theme-surface shrink-0"
+  >
+    <div class="flex items-center gap-2">
+      <span class="icon-[lucide--dices] w-5 h-5 text-theme-primary"></span>
+      <h1
+        class="text-sm font-bold font-header tracking-widest text-theme-text uppercase"
+      >
+        Die Roller
+      </h1>
+    </div>
+    <div
+      class="text-[9px] text-theme-muted uppercase font-mono tracking-widest opacity-60"
+    >
+      Standalone Mode
+    </div>
+  </div>
+
+  <div class="flex-1 min-h-0">
+    <DiceVault isStandalone={true} />
+  </div>
+
+  <footer
+    class="p-2 text-center text-[9px] text-theme-muted/40 uppercase font-header tracking-widest bg-theme-surface border-t border-theme-border shrink-0"
+  >
+    Codex Cryptica // Local Dice Vault
+  </footer>
+</div>
+
+<style>
+  @reference "../../../app.css";
+</style>

--- a/specs/079-modal-dice-roller-refinement.md
+++ b/specs/079-modal-dice-roller-refinement.md
@@ -1,0 +1,54 @@
+# Feature Specification: Modal Dice Roller Refinement (079)
+
+**Branch**: `modal-dice-roller`
+**Status**: Planning
+**Objective**: Transform the existing basic dice modal into a premium, tactile, and highly functional "Dice Vault" that supports saved presets, advanced formula building, and immersive visual feedback.
+
+## Core Vision
+The dice roller should not just be a utility but a part of the "ritual" of play. It needs to feel responsive, remember the user's favorite rolls, and handle complex systems with ease.
+
+## Proposed Enhancements
+
+### 1. Saved Presets (The "Spellbook")
+- **Named Rolls**: Save formulas with labels (e.g., "Longsword Attack", "Fireball").
+- **Persistence**: Store presets in IndexedDB so they survive sessions.
+- **Quick Access**: A dedicated tab or sidebar within the modal for presets.
+
+### 2. Immersive Visuals & Feedback
+- **Roll Animation**: Instead of instant results, add a brief "tumble" animation or a count-up effect to the total.
+- **Outcome Styling**: Color-code results (e.g., natural 20s glow gold, natural 1s pulse red).
+- **Tactile Buttons**: Enhance the "clickiness" of the UI with better active states and potentially sound effects (optional/toggleable).
+
+### 3. Advanced Formula Builder
+- **Visual Modifiers**: Buttons for "Advantage" (2d20kh1) and "Disadvantage" (2d20kl1) that modify the current formula.
+- **Exploding Toggle**: A global toggle to make the current formula "Exploding".
+- **Clearer Breakdown**: Hovering over a total in the history should show the exact math (e.g., `(12 + 4) + 5 = 21`).
+
+### 4. Layout Optimization
+- **Dual-Pane View**: On larger screens, show History and the Roller side-by-side.
+- **Mobile Comfort**: Ensure the "Roll" button is easily reachable by the thumb.
+
+---
+
+## Task List
+
+### Phase 1: Data & Storage
+- [ ] **T1.1**: Define `DicePreset` interface in `packages/dice-engine/src/types.ts`.
+- [ ] **T1.2**: Create `dice-presets.svelte.ts` store in `apps/web/src/lib/stores/`.
+- [ ] **T1.3**: Register `dice_presets` store in `apps/web/src/lib/utils/idb.ts`.
+
+### Phase 2: UI/UX Refinement
+- [ ] **T2.1**: Update `DiceModal.svelte` to include a "Presets" section.
+- [ ] **T2.2**: Add "Save Current Formula" button to the formula input bar.
+- [ ] **T2.3**: Implement "Advantage/Disadvantage" toggle buttons that wrap the current `1d20` in `2d20kh1`.
+- [ ] **T2.4**: Improve the `RollLog.svelte` with better result highlighting (Nat 20/Nat 1).
+
+### Phase 3: Animations & Polish
+- [ ] **T3.1**: Implement a "Counter" component for the total to animate from 0 to result.
+- [ ] **T3.2**: Add a "shake" animation to the modal on a heavy roll (many dice).
+- [ ] **T3.3**: Ensure keyboard shortcuts (Enter to roll, Esc to close, Arrow keys for history) are robust.
+
+### Phase 4: Validation
+- [ ] **T4.1**: Unit tests for preset saving/loading logic.
+- [ ] **T4.2**: E2E tests for the "Save Preset" workflow.
+- [ ] **T4.3**: Accessibility audit (Aria labels, focus trapping).


### PR DESCRIPTION
## Summary
This PR makes the Dice Roller 'detachable,' allowing users to open it in a standalone browser window. This is achieved by refactoring the dice UI into a reusable component and adding a dedicated route for the popped-out view.

## Changes
- **New Component**: DiceVault.svelte encapsulates the core dice rolling logic and history, extracted from DiceModal.svelte.
- **UI Store Update**: Added openDiceWindow() to uiStore to handle window.open logic and state synchronization.
- **Standalone Route**: Added apps/web/src/routes/(app)/dice/+page.svelte to provide the standalone experience.
- **Modal Enhancement**: Updated DiceModal.svelte with a 'Detach' button in the header.
- **Future Planning**: Added specs/079-modal-dice-roller-refinement.md to track planned UX improvements (presets, animations).

## Verification Results
- [x] Dice Modal still functions correctly as a modal.
- [x] Clicking the detach button opens a new window at /dice.
- [x] The standalone window correctly displays the dice roller and history.
- [x] State (history) is shared between the main app and the standalone window via IndexedDB.