### PR TITLE
🔧 use prod-deployment channel webhook for production deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Notify Discord on Production Deploy
         if: github.ref_name == 'main' && success()
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.VITE_DISCORD_WEBHOOK_URL_RELEASE }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL_PROD_DEPLOY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/discord-deploy.sh "production" "$DISCORD_WEBHOOK_URL" "https://codexcryptica.com/"


### PR DESCRIPTION
Production deploy notifications now go to the prod-deployment channel (`DISCORD_WEBHOOK_URL_PROD_DEPLOY`) instead of the release channel. Staging still uses the release channel webhook.