### PR TITLE
🔧 split CI workflow and fix deploy for workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, staging]
+    paths-ignore:
+      - "apps/web/src/lib/content/blog/**"
+      - "scripts/publish-blog-content.mjs"
+      - ".github/workflows/deploy-blog-content.yml"
+      - "docs/**"
+
+concurrency:
+  group: "ci-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install Dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test:coverage
+
+      - name: Upload Coverage Reports
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage
+          path: |
+            apps/*/coverage/
+            packages/*/coverage/
+          retention-days: 7
+
+      - name: Build
+        env:
+          VITE_PUBLIC_APP_URL: "https://codexcryptica.com"
+          VITE_ROBOTS_DIRECTIVE: "index, follow"
+        run: npm run build --workspace=web

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,17 +8,10 @@ on:
       - "scripts/publish-blog-content.mjs"
       - ".github/workflows/deploy-blog-content.yml"
       - "docs/**"
-  pull_request:
-    branches: [main, staging]
-    paths-ignore:
-      - "apps/web/src/lib/content/blog/**"
-      - "scripts/publish-blog-content.mjs"
-      - ".github/workflows/deploy-blog-content.yml"
-      - "docs/**"
   workflow_dispatch:
 
 concurrency:
-  group: "cloudflare-pages-${{ github.event_name }}-${{ github.ref }}"
+  group: "cloudflare-pages"
   cancel-in-progress: true
 
 permissions:
@@ -87,7 +80,7 @@ jobs:
           retention-days: 30
 
   deploy:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Splits CI into a dedicated `ci.yml` workflow (lint, test, build on PRs) and fixes `deploy.yml` to run the deploy step on `workflow_dispatch` events. This ensures PR status checks appear correctly and manual staging deploys actually deploy.