### PR TITLE
feat: change fantasy font to Alegreya

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -110,11 +110,10 @@
 
     --color-theme-accent: #991b1b;
 
-    --font-header-val: 'Zilla Slab', serif;
-    --font-body-val: 'Zilla Slab', serif;
+    --font-header-val: 'Alegreya', serif;
+    --font-body-val: 'Alegreya', serif;
 
     --bg-texture: none;
-
     --color-warning: #eab308;
     --color-danger: #ef4444;
 

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -9,11 +9,11 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 			<link rel="preload" as="style"
-			href="https://fonts.googleapis.com/css2?family=Zilla+Slab:wght@400;700&family=IM+Fell+English:ital@0;1&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Inter:wght@300;400;700&family=Orbitron:wght@400;700&family=Spectral:ital,wght@0,400;0,700;1,400&display=swap"
+			href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Inter:wght@300;400;700&family=Orbitron:wght@400;700&family=Spectral:ital,wght@0,400;0,700;1,400&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&display=swap"
 			onload="this.onload=null;this.rel='stylesheet'" />
 		<noscript>
 			<link rel="stylesheet"
-				href="https://fonts.googleapis.com/css2?family=Zilla+Slab:wght@400;700&family=IM+Fell+English:ital@0;1&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Inter:wght@300;400;700&family=Orbitron:wght@400;700&family=Spectral:ital,wght@0,400;0,700;1,400&display=swap" />	</noscript>
+				href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Inter:wght@300;400;700&family=Orbitron:wght@400;700&family=Spectral:ital,wght@0,400;0,700;1,400&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&display=swap" />	</noscript>
 	<script src="https://accounts.google.com/gsi/client" async defer></script>
 	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 	<link rel="llms" href="%sveltekit.assets%/llms.txt" />

--- a/apps/web/tests/themes.spec.ts
+++ b/apps/web/tests/themes.spec.ts
@@ -35,13 +35,13 @@ test.describe("Visual Styling Templates", () => {
     // Close settings via explicit button
     await page.getByLabel("Close Settings").click();
 
-    // 5. Verify typography overhaul (Zilla Slab header font)
+    // 5. Verify typography overhaul (Alegreya header font)
     const fontHeader = await page.evaluate(() =>
       getComputedStyle(document.documentElement)
         .getPropertyValue("--font-header-val")
         .trim(),
     );
-    expect(fontHeader).toContain("Zilla Slab");
+    expect(fontHeader).toContain("Alegreya");
 
     // 6. Verify texture integration
     const textureOverlay = await page.evaluate(() =>

--- a/packages/schema/src/theme.ts
+++ b/packages/schema/src/theme.ts
@@ -134,8 +134,8 @@ export const THEMES: Record<string, StylingTemplate> = {
       text: "#2d241e", // Inked Text
       border: "rgba(120, 53, 15, 0.3)",
       accent: "#991b1b", // Dried Blood / Crimson
-      fontHeader: "'Zilla Slab', serif",
-      fontBody: "'Zilla Slab', serif",
+      fontHeader: "'Alegreya', serif",
+      fontBody: "'Alegreya', serif",
       texture: "parchment.svg",
     },
     graph: {


### PR DESCRIPTION
Replaces 'Zilla Slab' with 'Alegreya' for the Ancient Parchment (fantasy) theme. 

### Changes
- Updated `packages/schema/src/theme.ts` to use 'Alegreya' for both header and body fonts.
- Updated `apps/web/src/app.html` to include the Alegreya Google Font import and remove the unused Zilla Slab import.
- Updated `apps/web/src/app.css` to reflect the new default font for the fantasy theme.
- Updated `apps/web/tests/themes.spec.ts` to verify the font change in E2E tests.

### Rationale
Alegreya offers a more organic, calligraphic rhythm that better fits the 'Ancient Parchment' aesthetic compared to the more mechanical feel of Zilla Slab.