### PR TITLE
🐛 fix: address feedback on mobile entity focus

### DIFF
--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -264,6 +264,23 @@ describe("UIStore", () => {
     expect(uiStore.focusedEntityId).toBe("hero-123");
   });
 
+  it("should close the sidebar even when re-focusing the same entity on mobile", () => {
+    // 1. Setup mobile state with an entity already focused
+    uiStore.isMobile = true;
+    uiStore.focusEntity("hero-123");
+    uiStore.toggleSidebarTool("explorer");
+    expect(uiStore.leftSidebarOpen).toBe(true);
+    expect(uiStore.focusedEntityId).toBe("hero-123");
+
+    // 2. Focus the SAME entity again
+    uiStore.focusEntity("hero-123");
+
+    // 3. Verify sidebar is closed even if the entity didn't change
+    expect(uiStore.leftSidebarOpen).toBe(false);
+    expect(uiStore.activeSidebarTool).toBe("none");
+    expect(uiStore.focusedEntityId).toBe("hero-123");
+  });
+
   it("should NOT close the sidebar when focusing an entity on desktop", () => {
     // 1. Setup desktop state
     uiStore.isMobile = false;

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -119,29 +119,28 @@ class UIStore {
 
   focusEntity(entityId: string | null) {
     if (entityId) {
+      // On mobile, close the sidebar when focusing an entity to ensure the view is visible.
+      // We do this BEFORE the early return to ensure selecting an already-focused entity still closes the drawer.
+      if (this.isMobile) {
+        this.closeSidebar();
+      }
+
       if (this.focusedEntityId === entityId && this.mainViewMode === "focus")
         return;
 
       this.focusedEntityId = entityId;
       this.mainViewMode = "focus";
 
-      // On mobile, close the sidebar when focusing an entity to ensure the view is visible
-      if (this.isMobile) {
-        this.closeSidebar();
-      }
-
-      // Close the right-side entity sidebar if it was open
-      if (this.mainViewMode === "focus") {
-        void import("./vault.svelte").then((m) => {
-          if (
-            m?.vault &&
-            this.mainViewMode === "focus" &&
-            this.focusedEntityId === entityId
-          ) {
-            m.vault.selectedEntityId = null;
-          }
-        });
-      }
+      // Close the right-side entity sidebar if it was open (mutually exclusive with focus mode)
+      void import("./vault.svelte").then((m) => {
+        if (
+          m?.vault &&
+          this.mainViewMode === "focus" &&
+          this.focusedEntityId === entityId
+        ) {
+          m.vault.selectedEntityId = null;
+        }
+      });
     } else {
       if (this.mainViewMode !== "focus") return;
 


### PR DESCRIPTION
Addresses feedback from PR #569:
- Ensures the mobile sidebar closes even if the entity being selected is already focused.
- Removes a redundant `mainViewMode` check in `focusEntity`.
- Adds a unit test for the re-focusing scenario on mobile.