### PR TITLE
fix(ci): fix auto-merge workflow permissions

### DIFF
--- a/.github/workflows/auto-merge-staging.yml
+++ b/.github/workflows/auto-merge-staging.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   enable-auto-merge:
@@ -19,72 +20,18 @@ jobs:
 
     steps:
       - name: Enable auto-merge for staging PRs
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const sameRepo =
-              pr.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`;
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Check if the PR is from the same repository
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          BASE_REPO="${{ github.repository }}"
+          
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "Skipping PR #$PR_NUMBER because it comes from a fork ($HEAD_REPO)."
+            exit 0
+          fi
 
-            if (!sameRepo) {
-              core.info(
-                `Skipping PR #${pr.number} because it comes from a fork.`,
-              );
-              return;
-            }
-
-            const { repository } = await github.graphql(
-              `
-                query($owner: String!, $repo: String!, $number: Int!) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $number) {
-                      id
-                      isDraft
-                      autoMergeRequest {
-                        enabledAt
-                      }
-                    }
-                  }
-                }
-              `,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                number: pr.number,
-              },
-            );
-
-            const pullRequest = repository?.pullRequest;
-            if (!pullRequest) {
-              throw new Error(`Pull request #${pr.number} could not be found.`);
-            }
-
-            if (pullRequest.isDraft) {
-              core.info(`PR #${pr.number} is still a draft; skipping auto-merge.`);
-              return;
-            }
-
-            if (pullRequest.autoMergeRequest) {
-              core.info(`Auto-merge is already enabled for PR #${pr.number}.`);
-              return;
-            }
-
-            await github.graphql(
-              `
-                mutation($pullRequestId: ID!) {
-                  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
-                    pullRequest {
-                      number
-                      autoMergeRequest {
-                        enabledAt
-                      }
-                    }
-                  }
-                }
-              `,
-              {
-                pullRequestId: pullRequest.id,
-              },
-            );
-
-            core.info(`Enabled auto-merge for PR #${pr.number}.`);
+          echo "Enabling auto-merge for PR #$PR_NUMBER..."
+          gh pr merge "$PR_NUMBER" --auto --squash


### PR DESCRIPTION
Switches from GraphQL mutation to `gh pr merge --auto` which is more reliable and adds `contents: write` permission.