### PR TITLE
🔧 fix(ci): add checkout to auto-merge

### DIFF
--- a/.github/workflows/auto-merge-staging.yml
+++ b/.github/workflows/auto-merge-staging.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
       - name: Enable auto-merge for staging PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `gh pr merge --auto` command requires a git repository to be present. This PR adds the missing `actions/checkout` step.