### PR TITLE
🔧 Enable scrolling for sidebar list view

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.17.29",
+  "version": "0.17.30",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.17.32",
+  "version": "0.17.33",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.17.31",
+  "version": "0.17.32",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.17.30",
+  "version": "0.17.31",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.17.33",
+  "version": "0.17.34",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/src/lib/components/layout/SidebarPanelHost.svelte
+++ b/apps/web/src/lib/components/layout/SidebarPanelHost.svelte
@@ -36,7 +36,7 @@
 {#if uiStore.leftSidebarOpen}
   <aside
     class="bg-theme-surface border-theme-border flex flex-col z-[75] shadow-xl relative shrink-0
-           fixed inset-0 top-[var(--header-height,65px)] bottom-14 md:static md:w-96 md:border-r md:bottom-0"
+           fixed inset-0 top-[var(--header-height,65px)] bottom-14 md:static md:w-96 md:border-r md:bottom-0 md:h-full"
     data-testid="sidebar-panel-host"
   >
     {#if uiStore.activeSidebarTool === "oracle" && OracleSidebarPanel}

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -8,7 +8,7 @@ const versionFromBuild =
     : undefined;
 
 export const VERSION =
-  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.30";
+  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.31";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -8,7 +8,7 @@ const versionFromBuild =
     : undefined;
 
 export const VERSION =
-  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.31";
+  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.32";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -8,7 +8,7 @@ const versionFromBuild =
     : undefined;
 
 export const VERSION =
-  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.32";
+  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.33";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -8,7 +8,7 @@ const versionFromBuild =
     : undefined;
 
 export const VERSION =
-  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.29";
+  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.30";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -8,7 +8,7 @@ const versionFromBuild =
     : undefined;
 
 export const VERSION =
-  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.33";
+  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.34";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";

--- a/apps/web/src/service-worker.ts
+++ b/apps/web/src/service-worker.ts
@@ -5,7 +5,7 @@
 
 import { build, files, version } from "$service-worker";
 
-const CACHE_VERSION = "310";
+const CACHE_VERSION = "311";
 const CACHE = `cache-${version}-${CACHE_VERSION}`;
 
 const ASSETS = [

--- a/apps/web/src/service-worker.ts
+++ b/apps/web/src/service-worker.ts
@@ -5,7 +5,7 @@
 
 import { build, files, version } from "$service-worker";
 
-const CACHE_VERSION = "311";
+const CACHE_VERSION = "312";
 const CACHE = `cache-${version}-${CACHE_VERSION}`;
 
 const ASSETS = [

--- a/apps/web/src/service-worker.ts
+++ b/apps/web/src/service-worker.ts
@@ -5,7 +5,7 @@
 
 import { build, files, version } from "$service-worker";
 
-const CACHE_VERSION = "309";
+const CACHE_VERSION = "310";
 const CACHE = `cache-${version}-${CACHE_VERSION}`;
 
 const ASSETS = [

--- a/apps/web/src/service-worker.ts
+++ b/apps/web/src/service-worker.ts
@@ -5,7 +5,7 @@
 
 import { build, files, version } from "$service-worker";
 
-const CACHE_VERSION = "312";
+const CACHE_VERSION = "313";
 const CACHE = `cache-${version}-${CACHE_VERSION}`;
 
 const ASSETS = [

--- a/apps/web/src/service-worker.ts
+++ b/apps/web/src/service-worker.ts
@@ -5,7 +5,7 @@
 
 import { build, files, version } from "$service-worker";
 
-const CACHE_VERSION = "313";
+const CACHE_VERSION = "314";
 const CACHE = `cache-${version}-${CACHE_VERSION}`;
 
 const ASSETS = [


### PR DESCRIPTION
## Summary

Enable scrolling in the left sidebar (Entity Explorer list view) when there are more entries than the screen can show.

## Changes

- Added `md:h-full` to sidebar panel to use full flex container height
- This ensures the flex container has a bounded height, allowing `overflow-y-auto` on the entity list to work properly

## Technical Details

The issue was that on desktop, the sidebar panel (`SidebarPanelHost`) was using `md:static` positioning without an explicit height constraint. While the entity list had `overflow-y-auto` defined, it couldn't scroll because its parent container didn't have a bounded height.

The fix uses `md:h-full` to make the sidebar take the full height of its flex container parent. This is a cleaner solution than hardcoding a calc() value, as it leverages the existing flex layout structure where:
- The parent container has `flex-1` and `min-h-0`
- The sidebar uses `md:h-full` to fill available height
- Child components already have proper `flex-1 min-h-0` and `overflow-y-auto` constraints

This allows the sidebar to fill the available vertical space while enabling proper scrolling for overflow content.

## Testing

- [x] Lint passes (0 errors)
- [x] All 738 unit tests pass
- [x] Manual testing recommended to verify scroll behavior on desktop with many entities