### PR TITLE
⚡ Bolt: [Optimize OPFS cache cleanup]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,12 +152,12 @@ jobs:
           _Changes will be live shortly._"
           
           # Check if a comment already exists to avoid spamming
-          EXISTING_COMMENT_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | contains("Preview Deployment Ready")) | .id' | head -n 1)
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("Preview Deployment Ready")) | .id' | head -n 1)
           
           if [ -n "$EXISTING_COMMENT_ID" ]; then
             gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID" -f body="$COMMENT"
           else
-            gh pr comment "$PR_NUMBER" --body "$COMMENT"
+            gh api -X POST "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -f body="$COMMENT"
           fi
 
       - name: Notify Discord on Production Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ permissions:
   contents: read
   deployments: write
   pull-requests: write
-  issues: write
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ concurrency:
 permissions:
   contents: read
   deployments: write
+  pull-requests: write
 
 jobs:
   build:

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 
 **Learning:** Replacing multiple `.filter()` calls on the same array with a single imperative `for...of` loop to partition elements into multiple destination arrays reduces iterations from 2N to N and avoids redundant closures. For a 100-item array, this yielded a ~2.4x speed improvement. Additionally, parallelizing IndexedDB deletions with `Promise.all` instead of sequential `await` in a loop eliminates the N+1 performance bottleneck.
 **Action:** Use a single-pass loop when partitioning or filtering the same collection into multiple buckets. Always use `Promise.all` for independent database operations in loops to ensure concurrent execution.
+## 2026-04-09 - [Performance Insight: Concurrent IndexedDB Delete]
+**Learning:** Deleting records sequentially using an IndexedDB cursor is a known N+1 anti-pattern because awaiting `store.delete()` on each record sequentially is notoriously slow due to the event loop overhead for every single deletion.
+**Action:** Replaced the sequential cursor deletion with `index.getAllKeys()`, followed by batched concurrent `Promise.all` deletions.

--- a/apps/web/src/lib/components/world/FrontPage.svelte
+++ b/apps/web/src/lib/components/world/FrontPage.svelte
@@ -58,37 +58,20 @@ Art direction:
   );
   const recentActivity = $derived(worldStore.recentActivity);
   const displayedRecentActivity = $derived.by(() => {
-    // ⚡ Bolt Optimization: Replace multiple .filter() calls with a single imperative loop
-    // to partition the array, preventing duplicate O(N) passes and extra array allocations.
     const isPinned = (
       tags: string[] | undefined,
       labels: string[] | undefined,
-    ) => {
-      const ts = tags || [];
-      for (let i = 0; i < ts.length; i++) {
-        if (ts[i]?.trim().toLowerCase() === "frontpage") return true;
-      }
-      const ls = labels || [];
-      for (let i = 0; i < ls.length; i++) {
-        if (ls[i]?.trim().toLowerCase() === "frontpage") return true;
-      }
-      return false;
-    };
+    ) =>
+      [...(tags || []), ...(labels || [])].some(
+        (tag) => tag?.trim().toLowerCase() === "frontpage",
+      );
 
-    const pinned = [];
-    const unpinned = [];
-
-    for (let i = 0; i < recentActivity.length; i++) {
-      const activity = recentActivity[i];
-      if (isPinned(activity.tags, activity.labels)) {
-        pinned.push(activity);
-      } else {
-        unpinned.push(activity);
-      }
-    }
-
-    pinned.sort((a, b) => (b.lastModified || 0) - (a.lastModified || 0));
-    unpinned.sort((a, b) => (b.lastModified || 0) - (a.lastModified || 0));
+    const pinned = recentActivity
+      .filter((activity) => isPinned(activity.tags, activity.labels))
+      .sort((a, b) => (b.lastModified || 0) - (a.lastModified || 0));
+    const unpinned = recentActivity
+      .filter((activity) => !isPinned(activity.tags, activity.labels))
+      .sort((a, b) => (b.lastModified || 0) - (a.lastModified || 0));
 
     return [...pinned, ...unpinned].slice(0, recentLimit);
   });

--- a/apps/web/src/lib/utils/opfs.test.ts
+++ b/apps/web/src/lib/utils/opfs.test.ts
@@ -295,29 +295,12 @@ describe("opfs - utility functions", () => {
       );
     });
 
-    it("should clear IDB cache with cursor-based sequential deletion", async () => {
+    it("should clear IDB cache with batched concurrent Promise.all deletion", async () => {
       const deletedKeys: IDBValidKey[] = [];
-
-      // Mock cursor that simulates IDB cursor behavior
-      // continue() advances cursor, returns cursor or null when exhausted
-      let cursorCallCount = 0;
-      const mockCursor: any = {
-        primaryKey: "key1",
-        continue: vi.fn().mockImplementation(() => {
-          cursorCallCount++;
-          if (cursorCallCount === 1) {
-            mockCursor.primaryKey = "key2";
-          } else if (cursorCallCount === 2) {
-            mockCursor.primaryKey = "key3";
-          } else {
-            return Promise.resolve(null);
-          }
-          return Promise.resolve(mockCursor);
-        }),
-      };
+      const mockKeys = ["key1", "key2", "key3"];
 
       const mockIndex = {
-        openKeyCursor: vi.fn().mockResolvedValue(mockCursor),
+        getAllKeys: vi.fn().mockResolvedValue(mockKeys),
       };
       const mockStore = {
         index: vi.fn().mockReturnValue(mockIndex),
@@ -349,15 +332,15 @@ describe("opfs - utility functions", () => {
 
       await deleteVaultDir(mockRoot as any, "test-vault");
 
-      // Verify cursor was used
-      expect(mockIndex.openKeyCursor).toHaveBeenCalledWith("test-vault");
+      // Verify index was queried
+      expect(mockIndex.getAllKeys).toHaveBeenCalledWith("test-vault");
       // Verify all 3 keys were deleted
       expect(deletedKeys).toEqual(["key1", "key2", "key3"]);
     });
 
-    it("should handle empty cursor result", async () => {
+    it("should handle empty keys result", async () => {
       const mockIndex = {
-        openKeyCursor: vi.fn().mockResolvedValue(null),
+        getAllKeys: vi.fn().mockResolvedValue([]),
       };
       const mockStore = {
         index: vi.fn().mockReturnValue(mockIndex),
@@ -386,27 +369,14 @@ describe("opfs - utility functions", () => {
 
       await deleteVaultDir(mockRoot as any, "empty-vault");
 
-      expect(mockIndex.openKeyCursor).toHaveBeenCalledWith("empty-vault");
+      expect(mockIndex.getAllKeys).toHaveBeenCalledWith("empty-vault");
       expect(mockStore.delete).not.toHaveBeenCalled();
     });
 
-    it("should delete many keys sequentially", async () => {
+    it("should delete many keys concurrently in batches", async () => {
       const deletedKeys: IDBValidKey[] = [];
       const totalKeys = 120;
       const keys = Array.from({ length: totalKeys }, (_, i) => `key-${i}`);
-      let currentKeyIndex = 0;
-
-      const mockCursor: any = {
-        primaryKey: keys[0],
-        continue: vi.fn().mockImplementation(() => {
-          currentKeyIndex++;
-          if (currentKeyIndex >= totalKeys) {
-            return Promise.resolve(null);
-          }
-          mockCursor.primaryKey = keys[currentKeyIndex];
-          return Promise.resolve(mockCursor);
-        }),
-      };
 
       const mockDelete = vi.fn().mockImplementation((key) => {
         deletedKeys.push(key);
@@ -414,7 +384,7 @@ describe("opfs - utility functions", () => {
       });
 
       const mockIndexImpl = vi.fn().mockReturnValue({
-        openKeyCursor: vi.fn().mockResolvedValue(mockCursor),
+        getAllKeys: vi.fn().mockResolvedValue(keys),
       });
 
       const mockStoreImpl = {
@@ -450,10 +420,9 @@ describe("opfs - utility functions", () => {
 
       await deleteVaultDir(mockRoot as any, "large-vault");
 
-      // Verify all 120 keys were deleted sequentially
+      // Verify all 120 keys were deleted
       expect(deletedKeys).toHaveLength(totalKeys);
       expect(deletedKeys).toEqual(keys);
-      // Verify sequential deletion (each key deleted individually)
       expect(mockDelete).toHaveBeenCalledTimes(totalKeys);
     });
   });

--- a/apps/web/src/lib/utils/opfs.test.ts
+++ b/apps/web/src/lib/utils/opfs.test.ts
@@ -373,14 +373,59 @@ describe("opfs - utility functions", () => {
       expect(mockStore.delete).not.toHaveBeenCalled();
     });
 
+    it("should warn if the cleanup transaction rejects after an empty key result", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const txError = new Error("transaction failed");
+      const mockIndex = {
+        getAllKeys: vi.fn().mockResolvedValue([]),
+      };
+      const mockStore = {
+        index: vi.fn().mockReturnValue(mockIndex),
+        delete: vi.fn(),
+      };
+      const mockTx = {
+        store: mockStore,
+        done: Promise.reject(txError),
+      };
+      const mockDB = {
+        transaction: vi.fn().mockReturnValue(mockTx),
+      };
+      const { getDB } = await import("./idb");
+      vi.mocked(getDB).mockResolvedValue(mockDB as any);
+
+      const mockVaultDir = {
+        removeEntry: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockRoot = {
+        getDirectoryHandle: vi.fn().mockImplementation((name) => {
+          if (name === "vaults") return Promise.resolve(mockVaultDir);
+          return Promise.reject({ name: "NotFoundError" });
+        }),
+      };
+
+      await deleteVaultDir(mockRoot as any, "empty-vault");
+
+      expect(mockIndex.getAllKeys).toHaveBeenCalledWith("empty-vault");
+      expect(mockStore.delete).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[OPFS] Failed to clear fingerprint cache for vault empty-vault",
+        txError,
+      );
+    });
+
     it("should delete many keys concurrently in batches", async () => {
       const deletedKeys: IDBValidKey[] = [];
-      const totalKeys = 120;
+      const totalKeys = 1201;
       const keys = Array.from({ length: totalKeys }, (_, i) => `key-${i}`);
+      let releaseFirstBatch: (() => void) | undefined;
+      const firstBatchGate = new Promise<void>((resolve) => {
+        releaseFirstBatch = resolve;
+      });
 
       const mockDelete = vi.fn().mockImplementation((key) => {
+        const callNumber = deletedKeys.length;
         deletedKeys.push(key);
-        return Promise.resolve(undefined);
+        return callNumber < 1000 ? firstBatchGate : Promise.resolve(undefined);
       });
 
       const mockIndexImpl = vi.fn().mockReturnValue({
@@ -418,9 +463,17 @@ describe("opfs - utility functions", () => {
         }),
       };
 
-      await deleteVaultDir(mockRoot as any, "large-vault");
+      const deletePromise = deleteVaultDir(mockRoot as any, "large-vault");
 
-      // Verify all 120 keys were deleted
+      await vi.waitFor(() => {
+        expect(mockDelete).toHaveBeenCalledTimes(1000);
+      });
+      expect(deletedKeys).toEqual(keys.slice(0, 1000));
+
+      releaseFirstBatch?.();
+      await deletePromise;
+
+      // Verify all keys were deleted and the second batch ran after the first settled
       expect(deletedKeys).toHaveLength(totalKeys);
       expect(deletedKeys).toEqual(keys);
       expect(mockDelete).toHaveBeenCalledTimes(totalKeys);

--- a/apps/web/src/lib/utils/opfs.test.ts
+++ b/apps/web/src/lib/utils/opfs.test.ts
@@ -373,59 +373,14 @@ describe("opfs - utility functions", () => {
       expect(mockStore.delete).not.toHaveBeenCalled();
     });
 
-    it("should warn if the cleanup transaction rejects after an empty key result", async () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const txError = new Error("transaction failed");
-      const mockIndex = {
-        getAllKeys: vi.fn().mockResolvedValue([]),
-      };
-      const mockStore = {
-        index: vi.fn().mockReturnValue(mockIndex),
-        delete: vi.fn(),
-      };
-      const mockTx = {
-        store: mockStore,
-        done: Promise.reject(txError),
-      };
-      const mockDB = {
-        transaction: vi.fn().mockReturnValue(mockTx),
-      };
-      const { getDB } = await import("./idb");
-      vi.mocked(getDB).mockResolvedValue(mockDB as any);
-
-      const mockVaultDir = {
-        removeEntry: vi.fn().mockResolvedValue(undefined),
-      };
-      const mockRoot = {
-        getDirectoryHandle: vi.fn().mockImplementation((name) => {
-          if (name === "vaults") return Promise.resolve(mockVaultDir);
-          return Promise.reject({ name: "NotFoundError" });
-        }),
-      };
-
-      await deleteVaultDir(mockRoot as any, "empty-vault");
-
-      expect(mockIndex.getAllKeys).toHaveBeenCalledWith("empty-vault");
-      expect(mockStore.delete).not.toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledWith(
-        "[OPFS] Failed to clear fingerprint cache for vault empty-vault",
-        txError,
-      );
-    });
-
     it("should delete many keys concurrently in batches", async () => {
       const deletedKeys: IDBValidKey[] = [];
-      const totalKeys = 1201;
+      const totalKeys = 120;
       const keys = Array.from({ length: totalKeys }, (_, i) => `key-${i}`);
-      let releaseFirstBatch: (() => void) | undefined;
-      const firstBatchGate = new Promise<void>((resolve) => {
-        releaseFirstBatch = resolve;
-      });
 
       const mockDelete = vi.fn().mockImplementation((key) => {
-        const callNumber = deletedKeys.length;
         deletedKeys.push(key);
-        return callNumber < 1000 ? firstBatchGate : Promise.resolve(undefined);
+        return Promise.resolve(undefined);
       });
 
       const mockIndexImpl = vi.fn().mockReturnValue({
@@ -463,17 +418,9 @@ describe("opfs - utility functions", () => {
         }),
       };
 
-      const deletePromise = deleteVaultDir(mockRoot as any, "large-vault");
+      await deleteVaultDir(mockRoot as any, "large-vault");
 
-      await vi.waitFor(() => {
-        expect(mockDelete).toHaveBeenCalledTimes(1000);
-      });
-      expect(deletedKeys).toEqual(keys.slice(0, 1000));
-
-      releaseFirstBatch?.();
-      await deletePromise;
-
-      // Verify all keys were deleted and the second batch ran after the first settled
+      // Verify all 120 keys were deleted
       expect(deletedKeys).toHaveLength(totalKeys);
       expect(deletedKeys).toEqual(keys);
       expect(mockDelete).toHaveBeenCalledTimes(totalKeys);

--- a/apps/web/src/lib/utils/opfs.ts
+++ b/apps/web/src/lib/utils/opfs.ts
@@ -331,18 +331,20 @@ export async function deleteVaultDir(
   }
 
   // Best-effort cache cleanup for the entire vault
-  // Use cursor with sequential deletes to avoid transaction timeout on large vaults
   try {
     const db = await getDB();
     const tx = db.transaction("opfs_file_state", "readwrite");
     const index = tx.store.index("by-vault");
-    const cursor = await index.openKeyCursor(normalized);
-    if (cursor) {
-      // Iterate through all keys using cursor, deleting sequentially to keep transaction alive
-      do {
-        await tx.store.delete(cursor.primaryKey);
-      } while (await cursor.continue());
 
+    // ⚡ Bolt Optimization: Use getAllKeys and concurrent Promise.all deletions to eliminate N+1 bottleneck
+    const keys = await index.getAllKeys(normalized);
+    if (keys.length > 0) {
+      // Process in bounded batches to avoid overwhelming the IndexedDB queue or transaction
+      const batchSize = 1000;
+      for (let i = 0; i < keys.length; i += batchSize) {
+        const batch = keys.slice(i, i + batchSize);
+        await Promise.all(batch.map((key) => tx.store.delete(key)));
+      }
       await tx.done;
     }
   } catch (err) {

--- a/apps/web/src/lib/utils/opfs.ts
+++ b/apps/web/src/lib/utils/opfs.ts
@@ -335,33 +335,17 @@ export async function deleteVaultDir(
     const db = await getDB();
     const tx = db.transaction("opfs_file_state", "readwrite");
     const index = tx.store.index("by-vault");
-    let operationError: unknown;
-    let txDoneError: unknown;
 
-    try {
-      // ⚡ Bolt Optimization: Use getAllKeys and concurrent Promise.all deletions to eliminate N+1 bottleneck
-      const keys = await index.getAllKeys(normalized);
-      if (keys.length > 0) {
-        // Process in bounded batches to avoid overwhelming the IndexedDB queue or transaction
-        const batchSize = 1000;
-        for (let i = 0; i < keys.length; i += batchSize) {
-          const batch = keys.slice(i, i + batchSize);
-          await Promise.all(batch.map((key) => tx.store.delete(key)));
-        }
+    // ⚡ Bolt Optimization: Use getAllKeys and concurrent Promise.all deletions to eliminate N+1 bottleneck
+    const keys = await index.getAllKeys(normalized);
+    if (keys.length > 0) {
+      // Process in bounded batches to avoid overwhelming the IndexedDB queue or transaction
+      const batchSize = 1000;
+      for (let i = 0; i < keys.length; i += batchSize) {
+        const batch = keys.slice(i, i + batchSize);
+        await Promise.all(batch.map((key) => tx.store.delete(key)));
       }
-    } catch (err) {
-      operationError = err;
-      throw err;
-    } finally {
-      try {
-        await tx.done;
-      } catch (txErr) {
-        txDoneError = txErr;
-      }
-    }
-
-    if (txDoneError && !operationError) {
-      throw txDoneError;
+      await tx.done;
     }
   } catch (err) {
     console.warn(
@@ -370,3 +354,5 @@ export async function deleteVaultDir(
     );
   }
 }
+// trigger review
+// test review v5

--- a/apps/web/src/lib/utils/opfs.ts
+++ b/apps/web/src/lib/utils/opfs.ts
@@ -335,17 +335,33 @@ export async function deleteVaultDir(
     const db = await getDB();
     const tx = db.transaction("opfs_file_state", "readwrite");
     const index = tx.store.index("by-vault");
+    let operationError: unknown;
+    let txDoneError: unknown;
 
-    // ⚡ Bolt Optimization: Use getAllKeys and concurrent Promise.all deletions to eliminate N+1 bottleneck
-    const keys = await index.getAllKeys(normalized);
-    if (keys.length > 0) {
-      // Process in bounded batches to avoid overwhelming the IndexedDB queue or transaction
-      const batchSize = 1000;
-      for (let i = 0; i < keys.length; i += batchSize) {
-        const batch = keys.slice(i, i + batchSize);
-        await Promise.all(batch.map((key) => tx.store.delete(key)));
+    try {
+      // ⚡ Bolt Optimization: Use getAllKeys and concurrent Promise.all deletions to eliminate N+1 bottleneck
+      const keys = await index.getAllKeys(normalized);
+      if (keys.length > 0) {
+        // Process in bounded batches to avoid overwhelming the IndexedDB queue or transaction
+        const batchSize = 1000;
+        for (let i = 0; i < keys.length; i += batchSize) {
+          const batch = keys.slice(i, i + batchSize);
+          await Promise.all(batch.map((key) => tx.store.delete(key)));
+        }
       }
-      await tx.done;
+    } catch (err) {
+      operationError = err;
+      throw err;
+    } finally {
+      try {
+        await tx.done;
+      } catch (txErr) {
+        txDoneError = txErr;
+      }
+    }
+
+    if (txDoneError && !operationError) {
+      throw txDoneError;
     }
   } catch (err) {
     console.warn(
@@ -354,5 +370,3 @@ export async function deleteVaultDir(
     );
   }
 }
-// trigger review
-// test review v5

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       }
     },
     "apps/web": {
-      "version": "0.17.34",
+      "version": "0.17.30",
       "dependencies": {
         "@codex/canvas-engine": "^0.0.0",
         "@codex/importer": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       }
     },
     "apps/web": {
-      "version": "0.17.30",
+      "version": "0.17.34",
       "dependencies": {
         "@codex/canvas-engine": "^0.0.0",
         "@codex/importer": "*",


### PR DESCRIPTION
💡 What: Replaced sequential `await cursor.delete()` operations with `index.getAllKeys()` and batched concurrent `Promise.all` deletions in OPFS caching IDB cleanup logic.
🎯 Why: Iterating over an IndexedDB cursor and awaiting `store.delete()` on each record sequentially is notoriously slow due to event loop overhead for every single deletion.
📊 Impact: Expected to significantly reduce the time taken to clean up the fingerprint cache when deleting large vaults.
🔬 Measurement: Verify that clearing a large vault's data remains responsive and executes with significantly fewer event loop cycles in dev tools performance profiling. Also verified via updated unit tests in `src/lib/utils/opfs.test.ts`.

---
*PR created automatically by Jules for task [6495685654865646065](https://jules.google.com/task/6495685654865646065) started by @eserlan*