### PR TITLE
🧪 follow-up: CI deploy fix and mobile explorer E2E test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,10 +142,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Construct the preview URL directly
-          # Cloudflare Pages transforms branch names: "/" → "-", truncated to 28 chars
+          # Construct the preview URL using Cloudflare Pages branch slugging rules:
+          # lowercase, replace non [a-z0-9-] with "-", trim edge "-", then truncate.
           BRANCH="${{ github.head_ref }}"
-          CF_BRANCH=$(echo "$BRANCH" | sed 's/\//-/g' | cut -c1-28)
+          CF_BRANCH=$(printf '%s' "$BRANCH" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//' \
+            | cut -c1-28 \
+            | sed -E 's/-+$//')
           DEPLOYMENT_URL="https://${CF_BRANCH}.codex-cryptica.pages.dev"
 
           COMMENT="🚀 **Preview Deployment Ready!**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Deploy Preview to Cloudflare Pages
         if: github.event_name == 'pull_request'
+        id: deploy_preview
         uses: cloudflare/wrangler-action@v3
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -140,18 +141,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          DEPLOYMENT_URL: ${{ steps.deploy_preview.outputs.deployment-url }}
-          ALIAS_URL: ${{ steps.deploy_preview.outputs.deployment-alias-url }}
         run: |
+          # Construct the preview URL directly
+          # Cloudflare Pages transforms branch names: "/" → "-", truncated to 28 chars
+          BRANCH="${{ github.head_ref }}"
+          CF_BRANCH=$(echo "$BRANCH" | sed 's/\//-/g' | cut -c1-28)
+          DEPLOYMENT_URL="https://${CF_BRANCH}.codex-cryptica.pages.dev"
+
           COMMENT="🚀 **Preview Deployment Ready!**
 
-          **URL:** $DEPLOYMENT_URL
-          **Alias:** $ALIAS_URL
+          **URL:** ${DEPLOYMENT_URL}
+          **Branch:** \`${BRANCH}\`
 
           _Changes will be live shortly._"
 
           # Check if a comment already exists to avoid spamming
-          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("Preview Deployment Ready")) | .id' | head -n 1)
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("Preview Deployment Ready!")) | .id' | head -n 1)
 
           if [ -n "$EXISTING_COMMENT_ID" ]; then
             gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID" -f body="$COMMENT"

--- a/apps/web/tests/mobile-explorer-scrolling.spec.ts
+++ b/apps/web/tests/mobile-explorer-scrolling.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Mobile Explorer Scrolling", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      try {
+        localStorage.setItem("codex_skip_landing", "true");
+      } catch {
+        /* ignore */
+      }
+    });
+
+    await page.goto("/");
+    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
+      timeout: 15000,
+    });
+    await expect(page.getByTestId("graph-canvas")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("explorer header stays fixed while list scrolls on mobile", async ({
+    page,
+  }) => {
+    // Set mobile viewport
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    // Create multiple entities to enable scrolling
+    for (let i = 0; i < 10; i++) {
+      await page.getByTestId("new-entity-button").click();
+      await page.getByPlaceholder("Chronicle Title...").fill(`Entity ${i}`);
+      await page.getByRole("button", { name: "ADD" }).click();
+    }
+
+    // Open the explorer sidebar
+    await page.getByTitle("Entity Explorer").click();
+    await page.waitForTimeout(300);
+
+    // Verify header search is visible initially
+    const searchInput = page.getByPlaceholder("Search entities...");
+    await expect(searchInput).toBeVisible();
+
+    // Get the list container and scroll it
+    const listContainer = page.locator(
+      '[style*="touch-action"], .flex-1.overflow-y-auto',
+    );
+    await listContainer
+      .first()
+      .evaluate((el: HTMLElement) => el.scrollTo({ top: 200 }));
+    await page.waitForTimeout(100);
+
+    // Header with search should still be visible after scroll (fixed position)
+    await expect(searchInput).toBeVisible();
+  });
+});

--- a/apps/web/tests/mobile-explorer-scrolling.spec.ts
+++ b/apps/web/tests/mobile-explorer-scrolling.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Mobile Explorer Scrolling", () => {
   test.beforeEach(async ({ page }) => {
+    // Set mobile viewport BEFORE navigation so responsive layout initializes correctly
+    await page.setViewportSize({ width: 375, height: 667 });
+
     await page.addInitScript(() => {
       (window as any).DISABLE_ONBOARDING = true;
       (window as any).__E2E__ = true;
@@ -24,9 +27,6 @@ test.describe("Mobile Explorer Scrolling", () => {
   test("explorer header stays fixed while list scrolls on mobile", async ({
     page,
   }) => {
-    // Set mobile viewport
-    await page.setViewportSize({ width: 375, height: 667 });
-
     // Create multiple entities to enable scrolling
     for (let i = 0; i < 10; i++) {
       await page.getByTestId("new-entity-button").click();
@@ -34,24 +34,56 @@ test.describe("Mobile Explorer Scrolling", () => {
       await page.getByRole("button", { name: "ADD" }).click();
     }
 
-    // Open the explorer sidebar
-    await page.getByTitle("Entity Explorer").click();
-    await page.waitForTimeout(300);
+    // Open the explorer sidebar using the activity bar testid
+    await page.getByTestId("activity-bar-explorer").click();
+    const explorerPanel = page.getByTestId("entity-explorer-panel");
+    await expect(explorerPanel).toBeVisible();
 
-    // Verify header search is visible initially
     const searchInput = page.getByPlaceholder("Search entities...");
     await expect(searchInput).toBeVisible();
 
-    // Get the list container and scroll it
-    const listContainer = page.locator(
-      '[style*="touch-action"], .flex-1.overflow-y-auto',
-    );
-    await listContainer
-      .first()
-      .evaluate((el: HTMLElement) => el.scrollTo({ top: 200 }));
-    await page.waitForTimeout(100);
+    // Record header position before scroll
+    const headerBoxBefore = await searchInput.boundingBox();
+    expect(headerBoxBefore).not.toBeNull();
 
-    // Header with search should still be visible after scroll (fixed position)
+    // Get the list container inside the explorer panel and verify it can scroll
+    const listContainer = explorerPanel
+      .locator('[style*="touch-action"], .flex-1.overflow-y-auto')
+      .first();
+    await expect(listContainer).toBeVisible();
+
+    // Verify the container is actually scrollable
+    const scrollMetricsBefore = await listContainer.evaluate(
+      (el: HTMLElement) => ({
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      }),
+    );
+    expect(scrollMetricsBefore.scrollHeight).toBeGreaterThan(
+      scrollMetricsBefore.clientHeight,
+    );
+
+    // Scroll the list and assert that the scroll position changes
+    await listContainer.evaluate((el: HTMLElement) =>
+      el.scrollTo({
+        top: Math.min(200, Math.max(0, el.scrollHeight - el.clientHeight)),
+      }),
+    );
+
+    await expect
+      .poll(async () =>
+        listContainer.evaluate((el: HTMLElement) => el.scrollTop),
+      )
+      .toBeGreaterThan(scrollMetricsBefore.scrollTop);
+
+    // Header with search should still be visible after list scroll
     await expect(searchInput).toBeVisible();
+    const headerBoxAfter = await searchInput.boundingBox();
+    expect(headerBoxAfter).not.toBeNull();
+    // Header position should not have moved (fixed position)
+    expect(
+      Math.abs(headerBoxAfter!.y - headerBoxBefore!.y),
+    ).toBeLessThanOrEqual(1);
   });
 });


### PR DESCRIPTION
Follow-up fixes and tests for PR #586 (mobile explorer scrolling).

## Changes

### CI Fix
- **Deploy workflow**: Added missing step ID to Cloudflare Pages deploy step
- Construct preview URL directly instead of relying on missing `wrangler-action` outputs
- Update existing PR comment instead of spamming new ones (matches on `"Preview Deployment Ready!"`)

### E2E Test
- **`mobile-explorer-scrolling.spec.ts`**: New test verifying:
  - Explorer header (search + filters) remains visible on mobile viewport (375x667)
  - Entity list scrolls independently without losing header
  - Tests with 10 entities to ensure scrollable content

## Test Results
```
✓ Mobile Explorer Scrolling › explorer header stays fixed while list scrolls on mobile
```