### PR TITLE
Patch payload targetId hallucination in ProposerService

### DIFF
--- a/packages/proposer/src/service.ts
+++ b/packages/proposer/src/service.ts
@@ -6,6 +6,15 @@ const DB_NAME = "CodexCryptica";
 const DB_VERSION = 7;
 const PROPOSAL_STORE = "proposals";
 
+function normalizeTargetId(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 export class ProposerService implements IProposerService {
   private dbPromise: Promise<IDBPDatabase<any>> | undefined;
   private config: ProposerConfig = {
@@ -152,10 +161,7 @@ Only return the JSON. If no connections are found, return empty array [].`;
         availableTargets.map((t) => [t.name.toLowerCase(), t.id]),
       );
       const slugToIdMap = new Map(
-        availableTargets.map((t) => [
-          t.name.toLowerCase().replace(/[^a-z0-9]/g, "-"),
-          t.id,
-        ]),
+        availableTargets.map((t) => [normalizeTargetId(t.name), t.id]),
       );
 
       // Deduplicate proposals to only suggest one connection per target entity (highest confidence)
@@ -169,7 +175,7 @@ Only return the JSON. If no connections are found, return empty array [].`;
         let resolvedId = p.targetId;
         if (!validTargetIds.has(resolvedId)) {
           const normalized = String(resolvedId).trim().toLowerCase();
-          const slugified = normalized.replace(/[^a-z0-9]/g, "-");
+          const slugified = normalizeTargetId(normalized);
           const matchId =
             idToIdMap.get(normalized) ||
             nameToIdMap.get(normalized) ||

--- a/packages/proposer/src/service.ts
+++ b/packages/proposer/src/service.ts
@@ -145,6 +145,9 @@ Only return the JSON. If no connections are found, return empty array [].`;
 
       const proposals: Proposal[] = [];
       const validTargetIds = new Set(availableTargets.map((t) => t.id));
+      const idToIdMap = new Map(
+        availableTargets.map((t) => [t.id.toLowerCase(), t.id]),
+      );
       const nameToIdMap = new Map(
         availableTargets.map((t) => [t.name.toLowerCase(), t.id]),
       );
@@ -165,9 +168,13 @@ Only return the JSON. If no connections are found, return empty array [].`;
         // Robust ID Matching: AI sometimes hallucinates the 'name' as the ID or slugs it.
         let resolvedId = p.targetId;
         if (!validTargetIds.has(resolvedId)) {
-          const normalized = String(resolvedId).toLowerCase();
+          const normalized = String(resolvedId).trim().toLowerCase();
+          const slugified = normalized.replace(/[^a-z0-9]/g, "-");
           const matchId =
-            nameToIdMap.get(normalized) || slugToIdMap.get(normalized);
+            idToIdMap.get(normalized) ||
+            nameToIdMap.get(normalized) ||
+            slugToIdMap.get(normalized) ||
+            slugToIdMap.get(slugified);
 
           if (matchId) {
             resolvedId = matchId;

--- a/packages/proposer/tests/service.test.ts
+++ b/packages/proposer/tests/service.test.ts
@@ -190,6 +190,48 @@ describe("ProposerService", () => {
               type: "related",
               reason: "test",
             },
+            {
+              targetId: " TARGET_ONE ",
+              confidence: 0.8,
+              type: "related",
+              reason: "test",
+            },
+            {
+              targetId: "Target One.",
+              confidence: 0.7,
+              type: "related",
+              reason: "test",
+            },
+          ]),
+      },
+    });
+    const mockModel = { generateContent };
+    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
+      .fn()
+      .mockReturnValue(mockModel);
+    const proposals = await service.analyzeEntity(
+      "fake-key",
+      "gemini-1.5-flash",
+      "source1",
+      "content",
+      [{ id: "target1", name: "Target One" }],
+    );
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].targetId).toBe("target1");
+    expect(proposals[0].confidence).toBe(0.9);
+  });
+
+  it("should match canonical IDs case-insensitively after trimming", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      response: {
+        text: () =>
+          JSON.stringify([
+            {
+              targetId: " TARGET1 ",
+              confidence: 0.9,
+              type: "related",
+              reason: "test",
+            },
           ]),
       },
     });


### PR DESCRIPTION
This patch resolves an issue where AI models hallucinate the `targetId` in connection proposals. It introduces a more robust matching strategy that handles common AI errors like wrong casing, leading/trailing whitespace, and variations in slug formats (e.g., using underscores instead of hyphens). By resolving these to the canonical ID, the service ensures consistent behavior and data integrity between the AI output and the application UI.

---
*PR created automatically by Jules for task [16544995058149630084](https://jules.google.com/task/16544995058149630084) started by @eserlan*