### PR TITLE
fix: reload on stale chunk fetch failure in oracle

### DIFF
--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -160,6 +160,26 @@ export class OracleStore {
       );
     } catch (err: any) {
       console.error("[OracleStore] Ask failed:", err);
+
+      // Stale chunk: browser has old HTML referencing a chunk hash that no
+      // longer exists on the server (happens after a deployment while the
+      // previous page is still open).  Force a full reload so the user gets
+      // fresh HTML + matching chunks.
+      if (
+        typeof err?.message === "string" &&
+        err.message.includes("Failed to fetch dynamically imported module")
+      ) {
+        await this.chatHistory.addMessage({
+          id: crypto.randomUUID(),
+          role: "system",
+          content:
+            "⟳ A new version of the app was deployed. Reloading to apply the update…",
+        });
+        this.settings.setLoading(false);
+        setTimeout(() => location.reload(), 1500);
+        return;
+      }
+
       await this.chatHistory.addMessage({
         id: crypto.randomUUID(),
         role: "system",


### PR DESCRIPTION
## Summary

- Detects `Failed to fetch dynamically imported module` errors in `oracle.ask()` catch block
- Shows a user-friendly reload message in the chat before refreshing
- Root cause: after a new deployment the service worker deletes old caches, leaving users with stale HTML referencing chunk hashes that no longer exist on the server

## Test plan

- [ ] Verify existing oracle store tests still pass (88 test files, 811 tests — all green)
- [ ] Manual: open the app, deploy a new build, attempt to use oracle — should see reload message instead of silent ❌ error

🤖 Generated with [Claude Code](https://claude.com/claude-code)