### PR TITLE
⚡ Bolt: Optimize VTT token rendering in MapView

### DIFF
--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -159,16 +159,23 @@
     const peerId = mapSession.myPeerId;
     const selected = mapSession.selectedTokens;
 
-    return Object.values(mapSession.tokens)
-      .filter((token) => mapSession.canViewToken(token.id, peerId, isHost))
-      .map((token) => ({
-        ...token,
-        label: token.name,
-        image: tokenImageCache[token.id] ?? null,
-        selected: mapSession.selection === token.id || selected.has(token.id),
-        active: mapSession.activeTokenId === token.id,
-        visible: true,
-      }));
+    // ⚡ Bolt Optimization: Use an imperative loop instead of chaining .filter().map()
+    // to avoid intermediate array allocations and reduce GC pressure.
+    const result = [];
+    const tokens = Object.values(mapSession.tokens);
+    for (const token of tokens) {
+      if (mapSession.canViewToken(token.id, peerId, isHost)) {
+        result.push({
+          ...token,
+          label: token.name,
+          image: tokenImageCache[token.id] ?? null,
+          selected: mapSession.selection === token.id || selected.has(token.id),
+          active: mapSession.activeTokenId === token.id,
+          visible: true,
+        });
+      }
+    }
+    return result;
   });
 
   $effect(() => {


### PR DESCRIPTION
💡 What: Replaced `.filter().map()` chain with an imperative loop in `MapView.svelte`'s `vttTokens` derived state.
🎯 Why: To reduce intermediate array allocations and garbage collection overhead in a frequently re-evaluated reactive statement.
📊 Impact: Prevents allocating an extra array per token update, improving rendering performance during map interactions.
🔬 Measurement: Observe memory usage and CPU profiling during rapid token updates in the VTT.

---
*PR created automatically by Jules for task [9527625355396969749](https://jules.google.com/task/9527625355396969749) started by @eserlan*