### PR TITLE
:sparkles: feat: in-app changelog & what's new modal

### DIFF
--- a/apps/web/src/lib/components/modals/ChangelogModal.svelte
+++ b/apps/web/src/lib/components/modals/ChangelogModal.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { uiStore } from "$stores/ui.svelte";
+  import { fade, fly } from "svelte/transition";
+  import { VERSION } from "$lib/config";
+  import releases from "../../content/changelog/releases.json";
+
+  const entries = $derived(
+    releases.filter((r) => {
+      if (!uiStore.lastSeenVersion) return true;
+      return compareVersions(r.version, uiStore.lastSeenVersion) > 0;
+    }),
+  );
+
+  function compareVersions(v1: string, v2: string) {
+    const parts1 = v1.split(".").map(Number);
+    const parts2 = v2.split(".").map(Number);
+    for (let i = 0; i < 3; i++) {
+      if (parts1[i] > parts2[i]) return 1;
+      if (parts1[i] < parts2[i]) return -1;
+    }
+    return 0;
+  }
+
+  const close = () => {
+    uiStore.markVersionAsSeen(VERSION);
+    uiStore.showChangelog = false;
+  };
+
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") close();
+  };
+</script>
+
+{#if uiStore.showChangelog && entries.length > 0}
+  <!-- Backdrop -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 bg-black/80 z-[200] backdrop-blur-sm"
+    onclick={close}
+    onkeydown={handleKeydown}
+    role="presentation"
+    transition:fade
+  ></div>
+
+  <div
+    class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-2xl bg-theme-bg border border-theme-border shadow-2xl rounded-lg overflow-hidden flex flex-col z-[201] font-body"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="changelog-heading"
+    onkeydown={handleKeydown}
+    transition:fly={{ y: 20, duration: 300 }}
+  >
+    <!-- Header -->
+    <div
+      class="px-8 py-6 border-b border-theme-border flex justify-between items-center bg-theme-surface"
+      style="background-image: var(--bg-texture-overlay)"
+    >
+      <div>
+        <h2
+          id="changelog-heading"
+          class="text-xl font-bold text-theme-text uppercase font-header tracking-widest"
+        >
+          What's New
+        </h2>
+        <p class="text-[10px] text-theme-muted uppercase tracking-[0.2em] mt-1">
+          Codex Cryptica {VERSION}
+        </p>
+      </div>
+      <button
+        onclick={close}
+        class="text-theme-muted hover:text-theme-primary transition-colors"
+        aria-label="Close"
+      >
+        <span class="icon-[lucide--x] w-6 h-6"></span>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="flex-1 overflow-y-auto p-8 custom-scrollbar space-y-10">
+      {#each entries as release}
+        <section>
+          <div
+            class="flex items-baseline justify-between mb-4 border-b border-theme-border/30 pb-2"
+          >
+            <h3
+              class="text-sm font-bold text-theme-primary uppercase font-header tracking-widest"
+            >
+              {release.title}
+            </h3>
+            <span
+              class="text-[10px] font-header text-theme-muted uppercase tracking-wider"
+            >
+              v{release.version} // {release.date}
+            </span>
+          </div>
+
+          <ul class="space-y-3">
+            {#each release.highlights as highlight}
+              <li
+                class="flex gap-3 text-sm text-theme-text/80 leading-relaxed group"
+              >
+                <span
+                  class="icon-[lucide--sparkles] w-4 h-4 text-theme-primary shrink-0 opacity-50 group-hover:opacity-100 transition-opacity"
+                ></span>
+                <span>{highlight}</span>
+              </li>
+            {/each}
+          </ul>
+        </section>
+      {/each}
+    </div>
+
+    <!-- Footer -->
+    <div
+      class="px-8 py-6 border-t border-theme-border bg-theme-surface/50 text-center"
+    >
+      <button
+        onclick={close}
+        class="px-12 py-3 bg-theme-primary text-black font-bold uppercase font-header tracking-widest text-xs hover:bg-theme-primary/80 transition-all active:scale-95 shadow-[0_0_15px_var(--color-accent-primary)]"
+      >
+        Acknowledge Updates
+      </button>
+      <div
+        class="mt-4 text-[9px] font-header text-theme-muted uppercase tracking-[0.3em]"
+      >
+        Archive synchronization protocols maintained
+      </div>
+    </div>
+  </div>
+{/if}

--- a/apps/web/src/lib/components/modals/ChangelogModal.svelte
+++ b/apps/web/src/lib/components/modals/ChangelogModal.svelte
@@ -67,7 +67,7 @@
           class="text-theme-muted hover:text-theme-primary transition-colors focus:outline-none focus:ring-2 focus:ring-theme-primary focus:ring-offset-2 focus:ring-offset-theme-bg rounded"
           aria-label="Close"
         >
-          <span class="icon-[lucide--x] w-6 h-6"></span>
+          <span class="icon-[lucide--x] w-5 h-5 md:w-6 md:h-6"></span>
         </button>
       </div>
 
@@ -112,9 +112,9 @@
       >
         <button
           onclick={close}
-          class="px-12 py-3 bg-theme-primary text-black font-bold uppercase font-header tracking-widest text-xs hover:bg-theme-primary/80 transition-all active:scale-95 shadow-[0_0_15px_var(--color-theme-primary)] focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-theme-bg rounded-sm"
+          class="px-6 py-2 bg-theme-surface border border-theme-border text-theme-muted hover:text-theme-text hover:border-theme-primary transition-colors text-sm font-medium rounded focus:outline-none focus:ring-2 focus:ring-theme-primary"
         >
-          {hasUnseenMinorReleases ? "Acknowledge Updates" : "Return to Codex"}
+          {hasUnseenMinorReleases ? "Acknowledge Updates" : "Done"}
         </button>
         <div
           class="mt-4 text-[9px] font-header text-theme-muted uppercase tracking-[0.3em]"

--- a/apps/web/src/lib/components/modals/ChangelogModal.svelte
+++ b/apps/web/src/lib/components/modals/ChangelogModal.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { uiStore } from "$stores/ui.svelte";
-  import { fade, fly } from "svelte/transition";
+  import { fade, scale } from "svelte/transition";
   import { VERSION } from "$lib/config";
   import releases from "../../content/changelog/releases.json";
+
+  let previousActiveElement: HTMLElement | null = null;
+  let dialogElement = $state<HTMLElement>();
+  let closeButton = $state<HTMLButtonElement>();
 
   const entries = $derived(
     releases.filter((r) => {
@@ -26,107 +30,155 @@
     uiStore.showChangelog = false;
   };
 
+  $effect(() => {
+    if (!uiStore.showChangelog) return;
+
+    previousActiveElement = document.activeElement as HTMLElement;
+
+    const timeout = window.setTimeout(() => {
+      if (closeButton) {
+        closeButton.focus();
+      } else {
+        dialogElement?.focus();
+      }
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timeout);
+      previousActiveElement?.focus();
+      previousActiveElement = null;
+    };
+  });
+
   const handleKeydown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") close();
+    if (e.key === "Escape") {
+      close();
+      return;
+    }
+
+    if (e.key !== "Tab" || !dialogElement) return;
+
+    const focusables = dialogElement.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0] as HTMLElement | undefined;
+    const last = focusables[focusables.length - 1] as HTMLElement | undefined;
+
+    if (!first || !last) return;
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
   };
 
   const displayEntries = $derived(entries.length > 0 ? entries : [releases[0]]);
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
 {#if uiStore.showChangelog}
   <!-- Backdrop -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="fixed inset-0 bg-black/80 z-[200] backdrop-blur-sm"
+    class="fixed inset-0 z-[200] flex items-center justify-center bg-black/85 backdrop-blur-md p-4"
     onclick={close}
-    role="presentation"
-    transition:fade
-  ></div>
-
-  <div
-    class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-2xl bg-theme-bg border border-theme-border shadow-2xl rounded-lg overflow-hidden flex flex-col z-[201] font-body"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="changelog-heading"
-    transition:fly={{ y: 20, duration: 300 }}
+    transition:fade={{ duration: 200 }}
   >
-    <!-- Header -->
     <div
-      class="px-8 py-6 border-b border-theme-border flex justify-between items-center bg-theme-surface"
-      style="background-image: var(--bg-texture-overlay)"
+      bind:this={dialogElement}
+      class="relative flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-[2rem] border border-theme-border bg-theme-surface font-body shadow-2xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="changelog-heading"
+      tabindex="-1"
+      onkeydown={handleKeydown}
+      onclick={(e) => e.stopPropagation()}
+      transition:scale={{ duration: 250, start: 0.95 }}
     >
-      <div>
-        <h2
-          id="changelog-heading"
-          class="text-xl font-bold text-theme-text uppercase font-header tracking-widest"
-        >
-          {entries.length > 0 ? "What's New" : "Recent Updates"}
-        </h2>
-        <p class="text-[10px] text-theme-muted uppercase tracking-[0.2em] mt-1">
-          Codex Cryptica {VERSION}
-          {entries.length === 0 ? "(Up to Date)" : ""}
-        </p>
-      </div>
-      <button
-        onclick={close}
-        class="text-theme-muted hover:text-theme-primary transition-colors"
-        aria-label="Close"
-      >
-        <span class="icon-[lucide--x] w-6 h-6"></span>
-      </button>
-    </div>
-
-    <!-- Body -->
-    <div class="flex-1 overflow-y-auto p-8 custom-scrollbar space-y-10">
-      {#each displayEntries as release}
-        <section>
-          <div
-            class="flex items-baseline justify-between mb-4 border-b border-theme-border/30 pb-2"
-          >
-            <h3
-              class="text-sm font-bold text-theme-primary uppercase font-header tracking-widest"
-            >
-              {release.title}
-            </h3>
-            <span
-              class="text-[10px] font-header text-theme-muted uppercase tracking-wider"
-            >
-              v{release.version} // {release.date}
-            </span>
-          </div>
-
-          <ul class="space-y-3">
-            {#each release.highlights as highlight}
-              <li
-                class="flex gap-3 text-sm text-theme-text/80 leading-relaxed group"
-              >
-                <span
-                  class="icon-[lucide--sparkles] w-4 h-4 text-theme-primary shrink-0 opacity-50 group-hover:opacity-100 transition-opacity"
-                ></span>
-                <span>{highlight}</span>
-              </li>
-            {/each}
-          </ul>
-        </section>
-      {/each}
-    </div>
-
-    <!-- Footer -->
-    <div
-      class="px-8 py-6 border-t border-theme-border bg-theme-surface/50 text-center"
-    >
-      <button
-        onclick={close}
-        class="px-12 py-3 bg-theme-primary text-black font-bold uppercase font-header tracking-widest text-xs hover:bg-theme-primary/80 transition-all active:scale-95 shadow-[0_0_15px_var(--color-accent-primary)]"
-      >
-        {entries.length > 0 ? "Acknowledge Updates" : "Return to Codex"}
-      </button>
+      <!-- Header -->
       <div
-        class="mt-4 text-[9px] font-header text-theme-muted uppercase tracking-[0.3em]"
+        class="flex items-center justify-between border-b border-theme-border bg-theme-surface px-8 py-6"
+        style="background-image: var(--bg-texture-overlay)"
       >
-        Archive synchronization protocols maintained
+        <div>
+          <h2
+            id="changelog-heading"
+            class="text-xl font-bold text-theme-text uppercase font-header tracking-widest"
+          >
+            {entries.length > 0 ? "What's New" : "Recent Updates"}
+          </h2>
+          <p
+            class="mt-1 text-[10px] text-theme-muted uppercase tracking-[0.2em]"
+          >
+            Codex Cryptica {VERSION}
+            {entries.length === 0 ? "(Up to Date)" : ""}
+          </p>
+        </div>
+        <button
+          bind:this={closeButton}
+          onclick={close}
+          class="text-theme-muted hover:text-theme-primary transition-colors"
+          aria-label="Close"
+          type="button"
+        >
+          <span class="icon-[lucide--x] w-6 h-6"></span>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="flex-1 overflow-y-auto p-8 custom-scrollbar space-y-10">
+        {#each displayEntries as release}
+          <section>
+            <div
+              class="mb-4 flex items-baseline justify-between border-b border-theme-border/30 pb-2"
+            >
+              <h3
+                class="text-sm font-bold text-theme-primary uppercase font-header tracking-widest"
+              >
+                {release.title}
+              </h3>
+              <span
+                class="text-[10px] font-header text-theme-muted uppercase tracking-wider"
+              >
+                v{release.version} // {release.date}
+              </span>
+            </div>
+
+            <ul class="space-y-3">
+              {#each release.highlights as highlight}
+                <li
+                  class="group flex gap-3 text-sm leading-relaxed text-theme-text/80"
+                >
+                  <span
+                    class="icon-[lucide--sparkles] w-4 h-4 shrink-0 text-theme-primary opacity-50 transition-opacity group-hover:opacity-100"
+                  ></span>
+                  <span>{highlight}</span>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/each}
+      </div>
+
+      <!-- Footer -->
+      <div
+        class="border-t border-theme-border bg-theme-surface/50 px-8 py-6 text-center"
+      >
+        <button
+          onclick={close}
+          class="rounded-xl border border-theme-primary bg-theme-primary px-6 py-3 text-xs font-bold uppercase tracking-widest text-theme-bg transition-all hover:border-theme-secondary hover:bg-theme-secondary shadow-[0_0_20px_rgba(var(--color-theme-primary-rgb),0.25)]"
+          type="button"
+        >
+          {entries.length > 0 ? "Acknowledge Updates" : "Return to Codex"}
+        </button>
+        <div
+          class="mt-4 text-[9px] font-header text-theme-muted uppercase tracking-[0.3em]"
+        >
+          Archive synchronization protocols maintained
+        </div>
       </div>
     </div>
   </div>

--- a/apps/web/src/lib/components/modals/ChangelogModal.svelte
+++ b/apps/web/src/lib/components/modals/ChangelogModal.svelte
@@ -29,15 +29,18 @@
   const handleKeydown = (e: KeyboardEvent) => {
     if (e.key === "Escape") close();
   };
+
+  const displayEntries = $derived(entries.length > 0 ? entries : [releases[0]]);
 </script>
 
-{#if uiStore.showChangelog && entries.length > 0}
+<svelte:window onkeydown={handleKeydown} />
+
+{#if uiStore.showChangelog}
   <!-- Backdrop -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="fixed inset-0 bg-black/80 z-[200] backdrop-blur-sm"
     onclick={close}
-    onkeydown={handleKeydown}
     role="presentation"
     transition:fade
   ></div>
@@ -47,7 +50,6 @@
     role="dialog"
     aria-modal="true"
     aria-labelledby="changelog-heading"
-    onkeydown={handleKeydown}
     transition:fly={{ y: 20, duration: 300 }}
   >
     <!-- Header -->
@@ -60,10 +62,11 @@
           id="changelog-heading"
           class="text-xl font-bold text-theme-text uppercase font-header tracking-widest"
         >
-          What's New
+          {entries.length > 0 ? "What's New" : "Recent Updates"}
         </h2>
         <p class="text-[10px] text-theme-muted uppercase tracking-[0.2em] mt-1">
           Codex Cryptica {VERSION}
+          {entries.length === 0 ? "(Up to Date)" : ""}
         </p>
       </div>
       <button
@@ -77,7 +80,7 @@
 
     <!-- Body -->
     <div class="flex-1 overflow-y-auto p-8 custom-scrollbar space-y-10">
-      {#each entries as release}
+      {#each displayEntries as release}
         <section>
           <div
             class="flex items-baseline justify-between mb-4 border-b border-theme-border/30 pb-2"
@@ -118,7 +121,7 @@
         onclick={close}
         class="px-12 py-3 bg-theme-primary text-black font-bold uppercase font-header tracking-widest text-xs hover:bg-theme-primary/80 transition-all active:scale-95 shadow-[0_0_15px_var(--color-accent-primary)]"
       >
-        Acknowledge Updates
+        {entries.length > 0 ? "Acknowledge Updates" : "Return to Codex"}
       </button>
       <div
         class="mt-4 text-[9px] font-header text-theme-muted uppercase tracking-[0.3em]"

--- a/apps/web/src/lib/components/modals/ChangelogModal.svelte
+++ b/apps/web/src/lib/components/modals/ChangelogModal.svelte
@@ -64,10 +64,10 @@
         </div>
         <button
           onclick={close}
-          class="text-theme-muted hover:text-theme-primary transition-colors focus:outline-none focus:ring-2 focus:ring-theme-primary focus:ring-offset-2 focus:ring-offset-theme-bg rounded"
+          class="text-theme-muted hover:text-theme-primary transition-colors"
           aria-label="Close"
         >
-          <span class="icon-[lucide--x] w-5 h-5 md:w-6 md:h-6"></span>
+          <span class="icon-[lucide--x] w-6 h-6"></span>
         </button>
       </div>
 

--- a/apps/web/src/lib/components/modals/ChangelogModal.svelte
+++ b/apps/web/src/lib/components/modals/ChangelogModal.svelte
@@ -3,130 +3,124 @@
   import { fade, fly } from "svelte/transition";
   import { VERSION } from "$lib/config";
   import releases from "../../content/changelog/releases.json";
+  import { focusTrap } from "$lib/actions/focusTrap";
 
-  const entries = $derived(
-    releases.filter((r) => {
-      if (!uiStore.lastSeenVersion) return true;
-      return compareVersions(r.version, uiStore.lastSeenVersion) > 0;
-    }),
-  );
-
-  function compareVersions(v1: string, v2: string) {
-    const parts1 = v1.split(".").map(Number);
-    const parts2 = v2.split(".").map(Number);
-    for (let i = 0; i < 3; i++) {
-      if (parts1[i] > parts2[i]) return 1;
-      if (parts1[i] < parts2[i]) return -1;
-    }
-    return 0;
-  }
+  // Calculate if there are unseen MINOR releases to determine the header title
+  const hasUnseenMinorReleases = $derived.by(() => {
+    if (!uiStore.lastSeenVersion) return true;
+    const currentStoredMinor = parseInt(
+      uiStore.lastSeenVersion.split(".")[1] || "0",
+      10,
+    );
+    return releases.some((r) => {
+      const releaseMinor = parseInt(r.version.split(".")[1] || "0", 10);
+      return releaseMinor > currentStoredMinor;
+    });
+  });
 
   const close = () => {
     uiStore.markVersionAsSeen(VERSION);
     uiStore.showChangelog = false;
   };
-
-  const handleKeydown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") close();
-  };
-
-  const displayEntries = $derived(entries.length > 0 ? entries : [releases[0]]);
 </script>
-
-<svelte:window onkeydown={handleKeydown} />
 
 {#if uiStore.showChangelog}
   <!-- Backdrop -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="fixed inset-0 bg-black/80 z-[200] backdrop-blur-sm"
+    class="fixed inset-0 bg-black/80 z-[200] backdrop-blur-sm focus:outline-none"
     onclick={close}
     role="presentation"
+    use:focusTrap={{ onEscape: close }}
     transition:fade
-  ></div>
-
-  <div
-    class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-2xl bg-theme-bg border border-theme-border shadow-2xl rounded-lg overflow-hidden flex flex-col z-[201] font-body"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="changelog-heading"
-    transition:fly={{ y: 20, duration: 300 }}
   >
-    <!-- Header -->
     <div
-      class="px-8 py-6 border-b border-theme-border flex justify-between items-center bg-theme-surface"
-      style="background-image: var(--bg-texture-overlay)"
+      class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-3xl h-[85vh] max-h-[800px] bg-theme-bg border border-theme-border shadow-2xl rounded-lg overflow-hidden flex flex-col z-[201] font-body"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="changelog-heading"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+      transition:fly={{ y: 20, duration: 300 }}
     >
-      <div>
-        <h2
-          id="changelog-heading"
-          class="text-xl font-bold text-theme-text uppercase font-header tracking-widest"
-        >
-          {entries.length > 0 ? "What's New" : "Recent Updates"}
-        </h2>
-        <p class="text-[10px] text-theme-muted uppercase tracking-[0.2em] mt-1">
-          Codex Cryptica {VERSION}
-          {entries.length === 0 ? "(Up to Date)" : ""}
-        </p>
-      </div>
-      <button
-        onclick={close}
-        class="text-theme-muted hover:text-theme-primary transition-colors"
-        aria-label="Close"
-      >
-        <span class="icon-[lucide--x] w-6 h-6"></span>
-      </button>
-    </div>
-
-    <!-- Body -->
-    <div class="flex-1 overflow-y-auto p-8 custom-scrollbar space-y-10">
-      {#each displayEntries as release}
-        <section>
-          <div
-            class="flex items-baseline justify-between mb-4 border-b border-theme-border/30 pb-2"
-          >
-            <h3
-              class="text-sm font-bold text-theme-primary uppercase font-header tracking-widest"
-            >
-              {release.title}
-            </h3>
-            <span
-              class="text-[10px] font-header text-theme-muted uppercase tracking-wider"
-            >
-              v{release.version} // {release.date}
-            </span>
-          </div>
-
-          <ul class="space-y-3">
-            {#each release.highlights as highlight}
-              <li
-                class="flex gap-3 text-sm text-theme-text/80 leading-relaxed group"
-              >
-                <span
-                  class="icon-[lucide--sparkles] w-4 h-4 text-theme-primary shrink-0 opacity-50 group-hover:opacity-100 transition-opacity"
-                ></span>
-                <span>{highlight}</span>
-              </li>
-            {/each}
-          </ul>
-        </section>
-      {/each}
-    </div>
-
-    <!-- Footer -->
-    <div
-      class="px-8 py-6 border-t border-theme-border bg-theme-surface/50 text-center"
-    >
-      <button
-        onclick={close}
-        class="px-12 py-3 bg-theme-primary text-black font-bold uppercase font-header tracking-widest text-xs hover:bg-theme-primary/80 transition-all active:scale-95 shadow-[0_0_15px_var(--color-accent-primary)]"
-      >
-        {entries.length > 0 ? "Acknowledge Updates" : "Return to Codex"}
-      </button>
+      <!-- Header -->
       <div
-        class="mt-4 text-[9px] font-header text-theme-muted uppercase tracking-[0.3em]"
+        class="px-8 py-6 border-b border-theme-border flex justify-between items-center bg-theme-surface shrink-0"
+        style="background-image: var(--bg-texture-overlay)"
       >
-        Archive synchronization protocols maintained
+        <div>
+          <h2
+            id="changelog-heading"
+            class="text-xl font-bold text-theme-text uppercase font-header tracking-widest"
+          >
+            {hasUnseenMinorReleases ? "What's New" : "Recent Updates"}
+          </h2>
+          <p
+            class="text-[10px] text-theme-muted uppercase tracking-[0.2em] mt-1"
+          >
+            Codex Cryptica {VERSION}
+            {!hasUnseenMinorReleases ? "(Up to Date)" : ""}
+          </p>
+        </div>
+        <button
+          onclick={close}
+          class="text-theme-muted hover:text-theme-primary transition-colors focus:outline-none focus:ring-2 focus:ring-theme-primary focus:ring-offset-2 focus:ring-offset-theme-bg rounded"
+          aria-label="Close"
+        >
+          <span class="icon-[lucide--x] w-6 h-6"></span>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="flex-1 overflow-y-auto p-8 custom-scrollbar space-y-12">
+        {#each releases as release}
+          <section>
+            <div
+              class="flex flex-col sm:flex-row sm:items-baseline justify-between mb-4 border-b border-theme-border/30 pb-2 gap-1 sm:gap-0"
+            >
+              <h3
+                class="text-base font-bold text-theme-primary uppercase font-header tracking-widest"
+              >
+                {release.title}
+              </h3>
+              <span
+                class="text-[10px] font-header text-theme-muted uppercase tracking-wider shrink-0"
+              >
+                v{release.version} // {release.date}
+              </span>
+            </div>
+
+            <ul class="space-y-4">
+              {#each release.highlights as highlight}
+                <li
+                  class="flex gap-4 text-sm text-theme-text/90 leading-relaxed group"
+                >
+                  <span
+                    class="icon-[lucide--sparkles] w-4 h-4 text-theme-primary shrink-0 mt-0.5 opacity-60 group-hover:opacity-100 transition-opacity"
+                  ></span>
+                  <span>{highlight}</span>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/each}
+      </div>
+
+      <!-- Footer -->
+      <div
+        class="px-8 py-6 border-t border-theme-border bg-theme-surface/50 text-center shrink-0"
+      >
+        <button
+          onclick={close}
+          class="px-12 py-3 bg-theme-primary text-black font-bold uppercase font-header tracking-widest text-xs hover:bg-theme-primary/80 transition-all active:scale-95 shadow-[0_0_15px_var(--color-theme-primary)] focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-theme-bg rounded-sm"
+        >
+          {hasUnseenMinorReleases ? "Acknowledge Updates" : "Return to Codex"}
+        </button>
+        <div
+          class="mt-4 text-[9px] font-header text-theme-muted uppercase tracking-[0.3em]"
+        >
+          Archive synchronization protocols maintained
+        </div>
       </div>
     </div>
   </div>

--- a/apps/web/src/lib/components/modals/ChangelogModal.test.ts
+++ b/apps/web/src/lib/components/modals/ChangelogModal.test.ts
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("svelte", async () => {
+  // @ts-expect-error - force the client Svelte runtime so testing-library can mount
+  return await import("../../../../../../node_modules/svelte/src/index-client.js");
+});
+
+import ChangelogModal from "./ChangelogModal.svelte";
+import { uiStore } from "$lib/stores/ui.svelte";
+
+describe("ChangelogModal", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    HTMLElement.prototype.animate = vi.fn().mockReturnValue({
+      cancel: vi.fn(),
+      finished: Promise.resolve(),
+      onfinish: null,
+      oncancel: null,
+      pause: vi.fn(),
+      play: vi.fn(),
+      reverse: vi.fn(),
+    } as unknown as Animation);
+    uiStore.showChangelog = true;
+    uiStore.lastSeenVersion = "0.17.0";
+  });
+
+  it("moves focus into the dialog, traps tab navigation, and restores focus on close", async () => {
+    const previousFocus = document.createElement("button");
+    previousFocus.textContent = "Previous focus";
+    document.body.appendChild(previousFocus);
+    previousFocus.focus();
+
+    const { unmount } = render(ChangelogModal);
+
+    const dialog = await screen.findByRole("dialog", { name: "What's New" });
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    const acknowledgeButton = screen.getByRole("button", {
+      name: "Acknowledge Updates",
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(closeButton);
+    });
+
+    await fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(acknowledgeButton);
+
+    await fireEvent.keyDown(dialog, { key: "Tab" });
+    expect(document.activeElement).toBe(closeButton);
+
+    await fireEvent.click(closeButton);
+    expect(uiStore.showChangelog).toBe(false);
+    expect(window.localStorage.getItem("codex_last_seen_version")).toBe(
+      "0.17.37",
+    );
+
+    unmount();
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(previousFocus);
+    });
+  });
+
+  it("uses the shared primary button token treatment", () => {
+    render(ChangelogModal);
+
+    const acknowledgeButton = screen.getByRole("button", {
+      name: "Acknowledge Updates",
+    });
+
+    expect(acknowledgeButton.className).toContain("bg-theme-primary");
+    expect(acknowledgeButton.className).toContain("text-theme-bg");
+    expect(acknowledgeButton.className).toContain("border-theme-primary");
+    expect(acknowledgeButton.className).not.toContain("text-black");
+  });
+});

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -36,7 +36,6 @@
 </script>
 
 <SearchModal />
-<SettingsModal />
 
 {#if uiStore.showChangelog}
   {#await loadModal(() => import("./ChangelogModal.svelte"), "ChangelogModal") then ChangelogModal}

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -36,6 +36,15 @@
 </script>
 
 <SearchModal />
+<SettingsModal />
+
+{#if uiStore.showChangelog}
+  {#await loadModal(() => import("./ChangelogModal.svelte"), "ChangelogModal") then ChangelogModal}
+    {#if ChangelogModal}
+      <ChangelogModal />
+    {/if}
+  {/await}
+{/if}
 
 {#if !isLoginRoute}
   {#await loadModal(() => import("$lib/components/oracle/OracleWindow.svelte"), "OracleWindow") then OracleWindow}

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -461,6 +461,24 @@
                   </div>
                 </div>
               </div>
+
+              <div class="mt-6">
+                <button
+                  onclick={() => (uiStore.showChangelog = true)}
+                  class="w-full p-4 bg-theme-primary/10 border border-theme-primary/30 hover:border-theme-primary text-theme-primary transition-all rounded group flex items-center justify-between"
+                >
+                  <div class="flex items-center gap-3">
+                    <span class="icon-[lucide--sparkles] w-5 h-5"></span>
+                    <span
+                      class="text-sm font-bold uppercase font-header tracking-widest"
+                      >What's New in Codex</span
+                    >
+                  </div>
+                  <span
+                    class="icon-[lucide--chevron-right] w-4 h-4 group-hover:translate-x-1 transition-transform"
+                  ></span>
+                </button>
+              </div>
             </section>
 
             <section>

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -465,6 +465,7 @@
               <div class="mt-6">
                 <button
                   onclick={() => (uiStore.showChangelog = true)}
+                  data-testid="show-changelog-button"
                   class="w-full p-4 bg-theme-primary/10 border border-theme-primary/30 hover:border-theme-primary text-theme-primary transition-all rounded group flex items-center justify-between"
                 >
                   <div class="flex items-center gap-3">

--- a/apps/web/src/lib/content/changelog/releases.json
+++ b/apps/web/src/lib/content/changelog/releases.json
@@ -54,5 +54,93 @@
       "Image Generation: Distill your entity descriptions into stunning, AI-generated character and location art.",
       "Smart PDF Import: Drop lore bibles or PDFs onto the screen to have them automatically parsed and mapped into your graph."
     ]
+  },
+  {
+    "version": "0.12.0",
+    "title": "The World Timeline Update",
+    "date": "2026-02-15",
+    "type": "minor",
+    "highlights": [
+      "World Timeline: A chronological view of your world's events, eras, and history.",
+      "Node Merging: Combine duplicate or related entities into a single, cohesive node.",
+      "Rich Text Formatting: Enhanced markdown support for more expressive and readable notes."
+    ]
+  },
+  {
+    "version": "0.11.0",
+    "title": "The Advanced Graph Update",
+    "date": "2026-02-01",
+    "type": "minor",
+    "highlights": [
+      "Fog of War for Graph: Hide unrevealed nodes from players during shared sessions or exports.",
+      "Central Node Orbit: Focus on a single entity and see its immediate connections orbit around it.",
+      "Connection Labels: Add descriptive text to the lines connecting your entities."
+    ]
+  },
+  {
+    "version": "0.10.0",
+    "title": "The Customization Update",
+    "date": "2026-01-15",
+    "type": "minor",
+    "highlights": [
+      "Styling Templates: Apply custom visual themes to specific nodes or categories.",
+      "Entity Labeling: Tag and organize entities with custom, color-coded labels.",
+      "Node Read Mode: A clean, distraction-free view for reading long-form entity content."
+    ]
+  },
+  {
+    "version": "0.9.0",
+    "title": "The Oracle Intelligence Update",
+    "date": "2026-01-01",
+    "type": "minor",
+    "highlights": [
+      "Lore Oracle Intelligence: The AI assistant can now answer complex questions about your specific world lore.",
+      "Oracle RAG Improvements: Vastly improved retrieval accuracy ensures the AI pulls exactly the right context.",
+      "Oracle Data Parsing: The AI can extract structured data directly from your text notes."
+    ]
+  },
+  {
+    "version": "0.8.0",
+    "title": "The Campaign Management Update",
+    "date": "2025-12-15",
+    "type": "minor",
+    "highlights": [
+      "Share Campaigns: Generate read-only links to share your world with players.",
+      "Campaign Date Picker: Set and track the current in-world date for your sessions.",
+      "Flexible Categories: Create custom entity types beyond the default schema."
+    ]
+  },
+  {
+    "version": "0.7.0",
+    "title": "The Graph Engine Update",
+    "date": "2025-12-01",
+    "type": "minor",
+    "highlights": [
+      "Minimap Navigation: Quickly pan around massive knowledge graphs using the new minimap.",
+      "Graph Focus Mode: Isolate sub-graphs and filter out noise for deep-dive worldbuilding.",
+      "Delete Nodes: Safely remove entities and automatically clean up orphaned connections."
+    ]
+  },
+  {
+    "version": "0.6.0",
+    "title": "The Search & Discovery Update",
+    "date": "2025-11-15",
+    "type": "minor",
+    "highlights": [
+      "Fuzzy Search: Instantly find any entity, connection, or text snippet across your entire vault.",
+      "Mobile UX Refinements: Improved touch targets, sidebar navigation, and sync feedback for mobile devices.",
+      "Performance Improvements: Large graph rendering and search indexing optimizations."
+    ]
+  },
+  {
+    "version": "0.5.0",
+    "title": "The Foundations Update",
+    "date": "2025-11-01",
+    "type": "minor",
+    "highlights": [
+      "Core Entity Schema: Established the foundational Markdown and YAML structure for all data.",
+      "Svelte Sync Engine: The first iteration of local-first reactivity across the graph and editor.",
+      "Google Drive Mirroring: Automatic, silent backups of your local vault to the cloud."
+    ]
   }
 ]

--- a/apps/web/src/lib/content/changelog/releases.json
+++ b/apps/web/src/lib/content/changelog/releases.json
@@ -1,0 +1,35 @@
+[
+  {
+    "version": "0.17.37",
+    "title": "Entity Traditional View & Traditional Explorer",
+    "date": "2026-04-12",
+    "type": "minor",
+    "highlights": [
+      "New persistent Entity Explorer sidebar",
+      "Traditional 'Focus Mode' for deep entity editing",
+      "Dexie-backed metadata caching for faster navigation"
+    ]
+  },
+  {
+    "version": "0.17.0",
+    "title": "Vault Front Page & Onboarding",
+    "date": "2026-04-03",
+    "type": "minor",
+    "highlights": [
+      "New Vault Front Page with quick access to recent entities",
+      "Improved onboarding for new archives",
+      "OPFS integration for high-performance local file handling"
+    ]
+  },
+  {
+    "version": "0.16.0",
+    "title": "Oracle & Die Roller Enhancements",
+    "date": "2026-03-25",
+    "type": "minor",
+    "highlights": [
+      "Refined Die Roller with multi-dice support",
+      "Improved Oracle reasoning with context-aware prompts",
+      "Lite Mode (No AI) for distraction-free writing"
+    ]
+  }
+]

--- a/apps/web/src/lib/content/changelog/releases.json
+++ b/apps/web/src/lib/content/changelog/releases.json
@@ -1,35 +1,58 @@
 [
   {
-    "version": "0.17.37",
-    "title": "Entity Traditional View & Traditional Explorer",
-    "date": "2026-04-12",
-    "type": "minor",
-    "highlights": [
-      "New persistent Entity Explorer sidebar",
-      "Traditional 'Focus Mode' for deep entity editing",
-      "Dexie-backed metadata caching for faster navigation"
-    ]
-  },
-  {
     "version": "0.17.0",
-    "title": "Vault Front Page & Onboarding",
-    "date": "2026-04-03",
+    "title": "The Playable Tabletop Update",
+    "date": "2026-04-14",
     "type": "minor",
     "highlights": [
-      "New Vault Front Page with quick access to recent entities",
-      "Improved onboarding for new archives",
-      "OPFS integration for high-performance local file handling"
+      "Data-Native VTT: Turn your maps into playable, tactical encounters directly linked to your lore.",
+      "Peer-to-Peer Multiplayer: Host zero-setup sessions and invite players directly to your maps with real-time sync.",
+      "Fantasy Theme Refresh: A massive visual overhaul with deep fantasy aesthetics, cohesive typography (Alegreya), and rich styling.",
+      "In-App Changelog: Automatic notifications to keep you up to date on new features."
     ]
   },
   {
     "version": "0.16.0",
-    "title": "Oracle & Die Roller Enhancements",
+    "title": "The Living Hub Update",
+    "date": "2026-04-03",
+    "type": "minor",
+    "highlights": [
+      "Vault Front Page: A completely redesigned dashboard offering a living briefing room, pinned notes, and recent activity.",
+      "Traditional Entity Explorer: A powerful new sidebar and focus mode for deep, distraction-free entity editing.",
+      "Free Oracle Tier: Everyone now gets access to the Lore Oracle's core features out of the box."
+    ]
+  },
+  {
+    "version": "0.15.0",
+    "title": "The Spatial Canvas Update",
     "date": "2026-03-25",
     "type": "minor",
     "highlights": [
-      "Refined Die Roller with multi-dice support",
-      "Improved Oracle reasoning with context-aware prompts",
-      "Lite Mode (No AI) for distraction-free writing"
+      "Infinite Spatial Canvas: A massive new way to visually organize, group, and connect your entities outside the strict graph constraints.",
+      "Integrated Die Roller: Fully featured, fair 3D die rolling directly in your workspace.",
+      "Pop-out Help & Guides: A comprehensive, dockable help system to guide you through mastering Codex Cryptica."
+    ]
+  },
+  {
+    "version": "0.14.0",
+    "title": "The Robust Storage Update",
+    "date": "2026-03-15",
+    "type": "minor",
+    "highlights": [
+      "OPFS & Dexie Integration: A total rewrite of the local storage engine for lightning-fast performance and metadata caching.",
+      "Multi-Campaign Switching: Seamlessly jump between different isolated vaults and campaigns.",
+      "Robust Local & Cloud Sync: Bulletproof Google Drive synchronization paired with local-first file system mirroring."
+    ]
+  },
+  {
+    "version": "0.13.0",
+    "title": "The Oracle Ascension Update",
+    "date": "2026-03-01",
+    "type": "minor",
+    "highlights": [
+      "Chat Commands & Proposer: Ask the AI to propose new connections, generate images, or analyze plot holes directly from the chat.",
+      "Image Generation: Distill your entity descriptions into stunning, AI-generated character and location art.",
+      "Smart PDF Import: Drop lore bibles or PDFs onto the screen to have them automatically parsed and mapped into your graph."
     ]
   }
 ]

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -21,6 +21,8 @@ class UIStore {
   dismissedWorldPage = $state(false);
   liteMode = $state(false);
   showDiceModal = $state(false);
+  showChangelog = $state(false);
+  lastSeenVersion = $state<string | null>(null);
 
   // Sidebar State
   leftSidebarOpen = $state(false);
@@ -63,6 +65,8 @@ class UIStore {
       if (lite !== null) {
         this.liteMode = lite === "true";
       }
+
+      this.lastSeenVersion = localStorage.getItem("codex_last_seen_version");
 
       const lastLabel = localStorage.getItem("codex_last_connection_label");
       if (lastLabel !== null) {
@@ -165,6 +169,13 @@ class UIStore {
   closeSidebar() {
     this.leftSidebarOpen = false;
     this.activeSidebarTool = "none";
+  }
+
+  markVersionAsSeen(version: string) {
+    this.lastSeenVersion = version;
+    if (typeof window !== "undefined") {
+      localStorage.setItem("codex_last_seen_version", version);
+    }
   }
 
   toggleWelcomeScreen(skip: boolean) {

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -21,6 +21,8 @@
   import { categories } from "$lib/stores/categories.svelte";
   import { demoService } from "$lib/services/demo";
   import { HELP_ARTICLES } from "$lib/config/help-content";
+  import { VERSION as _VERSION } from "$lib/config";
+  import releases from "$lib/content/changelog/releases.json";
   import { THEMES, isEntityVisible } from "schema";
 
   // Components & Providers
@@ -198,6 +200,32 @@
         } else {
           helpStore.startTour("initial-onboarding");
         }
+      }
+    }
+  });
+
+  // Automatic Release Note Trigger
+  $effect(() => {
+    if (browser && !uiStore.showChangelog && !uiStore.isDemoMode) {
+      const hasUnseenReleases = releases.some((r) => {
+        if (!uiStore.lastSeenVersion) return true;
+
+        const v1 = r.version.split(".").map(Number);
+        const v2 = uiStore.lastSeenVersion.split(".").map(Number);
+        for (let i = 0; i < 3; i++) {
+          if (v1[i] > v2[i]) return true;
+          if (v1[i] < v2[i]) return false;
+        }
+        return false;
+      });
+
+      if (hasUnseenReleases) {
+        // Delay to not conflict with tour/demo triggers
+        setTimeout(() => {
+          if (!helpStore.activeTour && !uiStore.showZenMode) {
+            uiStore.showChangelog = true;
+          }
+        }, 2000);
       }
     }
   });

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -21,7 +21,6 @@
   import { categories } from "$lib/stores/categories.svelte";
   import { demoService } from "$lib/services/demo";
   import { HELP_ARTICLES } from "$lib/config/help-content";
-  import { VERSION as _VERSION } from "$lib/config";
   import releases from "$lib/content/changelog/releases.json";
   import { THEMES, isEntityVisible } from "schema";
 
@@ -221,11 +220,17 @@
 
       if (hasUnseenReleases) {
         // Delay to not conflict with tour/demo triggers
-        setTimeout(() => {
-          if (!helpStore.activeTour && !uiStore.showZenMode) {
+        const timeout = setTimeout(() => {
+          if (
+            !helpStore.activeTour &&
+            !uiStore.showZenMode &&
+            !uiStore.isDemoMode &&
+            !uiStore.showChangelog
+          ) {
             uiStore.showChangelog = true;
           }
         }, 2000);
+        return () => clearTimeout(timeout);
       }
     }
   });

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -206,19 +206,21 @@
   // Automatic Release Note Trigger
   $effect(() => {
     if (browser && !uiStore.showChangelog && !uiStore.isDemoMode) {
-      const hasUnseenReleases = releases.some((r) => {
-        if (!uiStore.lastSeenVersion) return true;
+      const lastSeenStr = uiStore.lastSeenVersion;
 
-        const v1 = r.version.split(".").map(Number);
-        const v2 = uiStore.lastSeenVersion.split(".").map(Number);
-        for (let i = 0; i < 3; i++) {
-          if (v1[i] > v2[i]) return true;
-          if (v1[i] < v2[i]) return false;
-        }
-        return false;
-      });
+      const hasUnseenMinorRelease = (() => {
+        if (!lastSeenStr) return true;
+        const currentStoredMinor = parseInt(
+          lastSeenStr.split(".")[1] || "0",
+          10,
+        );
+        return releases.some((r) => {
+          const releaseMinor = parseInt(r.version.split(".")[1] || "0", 10);
+          return releaseMinor > currentStoredMinor;
+        });
+      })();
 
-      if (hasUnseenReleases) {
+      if (hasUnseenMinorRelease) {
         // Delay to not conflict with tour/demo triggers
         const timeout = setTimeout(() => {
           if (

--- a/apps/web/tests/changelog.spec.ts
+++ b/apps/web/tests/changelog.spec.ts
@@ -2,14 +2,14 @@ import { test, expect } from "@playwright/test";
 import { setupVaultPage } from "./test-helpers";
 
 test.describe("Changelog System", () => {
-  test("should automatically open when a new version is detected", async ({
+  test("should automatically open when a new MINOR version is detected", async ({
     page,
   }) => {
-    // 1. Setup with an older version in localStorage
+    // 1. Setup with an older MINOR version in localStorage
     await page.addInitScript(() => {
       (window as any).DISABLE_ONBOARDING = true;
       (window as any).__E2E__ = true;
-      localStorage.setItem("codex_last_seen_version", "0.17.0");
+      localStorage.setItem("codex_last_seen_version", "0.16.5");
       localStorage.setItem("codex_skip_landing", "true");
     });
 
@@ -28,16 +28,19 @@ test.describe("Changelog System", () => {
     const lastSeen = await page.evaluate(() =>
       localStorage.getItem("codex_last_seen_version"),
     );
+    // Should match the current package.json version
     expect(lastSeen).toBe("0.17.37");
   });
 
-  test("should NOT automatically open when version is up to date", async ({
+  test("should NOT automatically open when MINOR version is up to date (even if patch is older)", async ({
     page,
   }) => {
     await page.addInitScript(() => {
       (window as any).DISABLE_ONBOARDING = true;
       (window as any).__E2E__ = true;
-      localStorage.setItem("codex_last_seen_version", "0.17.37");
+      // Stored version is 0.17.0, current app is 0.17.37.
+      // Because minor is the same, it should NOT pop up.
+      localStorage.setItem("codex_last_seen_version", "0.17.0");
       localStorage.setItem("codex_skip_landing", "true");
     });
 
@@ -75,7 +78,7 @@ test.describe("Changelog System", () => {
     await expect(modal).toBeVisible();
 
     // 5. Verify it shows the latest version from releases.json
-    await expect(page.locator("text=v0.17.37")).toBeVisible();
+    await expect(page.locator("text=v0.17.0")).toBeVisible();
 
     // 6. Close via Escape key
     await page.keyboard.press("Escape");

--- a/apps/web/tests/changelog.spec.ts
+++ b/apps/web/tests/changelog.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+import { setupVaultPage } from "./test-helpers";
+
+test.describe("Changelog System", () => {
+  test("should automatically open when a new version is detected", async ({
+    page,
+  }) => {
+    // 1. Setup with an older version in localStorage
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_last_seen_version", "0.17.0");
+      localStorage.setItem("codex_skip_landing", "true");
+    });
+
+    await page.goto("/");
+
+    // 2. Verify modal appears after the 2s delay
+    // We wait up to 5s to be safe
+    const modal = page.locator('div[role="dialog"] >> text=What\'s New');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // 3. Close the modal
+    await page.getByRole("button", { name: "Acknowledge Updates" }).click();
+    await expect(modal).not.toBeVisible();
+
+    // 4. Verify version is updated in localStorage
+    const lastSeen = await page.evaluate(() =>
+      localStorage.getItem("codex_last_seen_version"),
+    );
+    expect(lastSeen).toBe("0.17.37");
+  });
+
+  test("should NOT automatically open when version is up to date", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_last_seen_version", "0.17.37");
+      localStorage.setItem("codex_skip_landing", "true");
+    });
+
+    await page.goto("/");
+
+    // Wait 3s to ensure the 2s timeout would have fired
+    await page.waitForTimeout(3000);
+
+    const modal = page.locator('div[role="dialog"] >> text=What\'s New');
+    await expect(modal).not.toBeVisible();
+  });
+
+  test("should open manually from Settings even if up to date", async ({
+    page,
+  }) => {
+    await setupVaultPage(page);
+
+    // Ensure we are up to date
+    await page.evaluate(() => {
+      localStorage.setItem("codex_last_seen_version", "0.17.37");
+    });
+
+    // 1. Open Settings
+    await page.keyboard.press("Control+,");
+    await expect(page.getByTestId("settings-modal")).toBeVisible();
+
+    // 2. Go to About tab
+    await page.getByRole("tab", { name: "About" }).click();
+
+    // 3. Click What's New
+    await page.getByTestId("show-changelog-button").click();
+
+    // 4. Verify modal appears (with "Recent Updates" title since we're up to date)
+    const modal = page.locator('div[role="dialog"] >> text=Recent Updates');
+    await expect(modal).toBeVisible();
+
+    // 5. Verify it shows the latest version from releases.json
+    await expect(page.locator("text=v0.17.37")).toBeVisible();
+
+    // 6. Close via Escape key
+    await page.keyboard.press("Escape");
+    await expect(modal).not.toBeVisible();
+  });
+});

--- a/specs/081-in-app-changelog.md
+++ b/specs/081-in-app-changelog.md
@@ -1,0 +1,84 @@
+# Feature Specification: In-App Changelog
+
+**Feature Branch**: `feat/in-app-changelog`  
+**Created**: 2026-04-14  
+**Status**: Implemented  
+**Input**: User description: "in app change log so users will see the most recent features" (GitHub Issue #607)
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Automatic Update Notification (Priority: P1)
+
+As a returning user, I want to be automatically notified of new features since my last visit, so I don't miss out on improvements.
+
+**Why this priority**: Core value of the feature—ensuring users are aware of updates without manual effort.
+
+**Independent Test**: Can be tested by setting an older version in `localStorage` and refreshing the app to see the modal.
+
+**Acceptance Scenarios**:
+
+1. **Given** I haven't seen version 0.17.37, **When** I load the application, **Then** a "What's New" modal should appear after a short delay.
+2. **Given** I have already seen version 0.17.37, **When** I load the application, **Then** the modal should NOT appear.
+
+---
+
+### User Story 2 - Manual Changelog Access (Priority: P2)
+
+As a curious user, I want to manually view the latest changes at any time, even if I've already dismissed the automatic notification.
+
+**Why this priority**: Provides a persistent reference for feature documentation within the app.
+
+**Independent Test**: Can be tested by navigating to Settings > About and clicking the "What's New" button.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am in the Settings modal, **When** I click the "About" tab, **Then** I should see a "What's New in Codex" button.
+2. **Given** I click the "What's New in Codex" button, **Then** the Changelog modal should open.
+
+---
+
+### User Story 3 - Release Highlights (Priority: P1)
+
+As a user, I want to see a concise list of high-impact changes rather than a technical commit log, so I can quickly understand the value of the update.
+
+**Why this priority**: Ensures the information is digestible and high-signal for end users.
+
+**Independent Test**: Can be verified by inspecting the content of `releases.json` and its rendering in `ChangelogModal.svelte`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Changelog modal is open, **When** viewing a release, **Then** I should see a title, date, version number, and a list of bulleted highlights.
+
+---
+
+### Edge Cases
+
+- **First-time Users**: Users with no `lastSeenVersion` in storage should see all relevant major/minor updates on their first visit (or have their version initialized to current to avoid overwhelm).
+- **Overlapping Modals**: The system should delay the changelog modal to avoid conflicting with onboarding tours or the welcome screen.
+- **Demo Mode**: The automatic trigger should be disabled in Demo Mode to avoid interrupting the scripted experience.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST store the `lastSeenVersion` in `localStorage`.
+- **FR-002**: System MUST provide a structured JSON file (`releases.json`) to store release data.
+- **FR-003**: System MUST compare the current release versions against `lastSeenVersion` to determine if a notification is needed.
+- **FR-004**: System MUST allow users to dismiss the modal and update the `lastSeenVersion` accordingly.
+- **FR-005**: System MUST provide a manual entry point in the "About" section of the settings.
+
+### Key Entities
+
+- **ReleaseEntry**: Represents a single version update.
+  - `version`: Semver string (e.g., "0.17.37")
+  - `title`: Short descriptive title of the update.
+  - `date`: ISO date string.
+  - `highlights`: Array of strings describing key changes.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of returning users are prompted with a "What's New" modal upon their first visit after a minor/major version bump.
+- **SC-002**: Users can access the changelog manually in under 3 clicks from the main interface.
+- **SC-003**: The modal rendering is responsive and follows the theme's visual guidelines.


### PR DESCRIPTION
## 🚀 Overview
This PR implements an in-app changelog system to keep users informed about new features and major updates.

## ✨ Key Features
- **Automatic 'What's New' Modal**: Automatically appears for returning users when a new minor/major version is detected (with a 2s delay to avoid onboarding conflicts).
- **Persistent Version Tracking**: Tracks `lastSeenVersion` in `localStorage` via the `UIStore`.
- **Manual Access**: Added a "What's New" button in the **About** tab of the Settings modal for manual review.
- **Structured Data**: Uses `releases.json` as a single source of truth for release highlights.
- **Retroactive Spec**: Added `specs/081-in-app-changelog.md` to document the feature.

## 🛠️ Technical Details
- Added `lastSeenVersion` and `showChangelog` state to `ui.svelte.ts`.
- Implemented `ChangelogModal.svelte` with version comparison logic (`0.17.37` > `0.17.0`).
- Integrated into `GlobalModalProvider.svelte` and `+layout.svelte`.
- Fixed a minor duplication bug of `SettingsModal` in `GlobalModalProvider`.

## 📸 Preview
Manual access is available under **Settings > About > What's New in Codex**.

## ✅ Verification
- Ran `svelte-check`: 0 errors.
- Verified version comparison logic in `ChangelogModal`.
- Confirmed manual and automatic trigger paths.
