### PR TITLE
feat: Look at entity from VTT + zen popout tab

### DIFF
--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -9,6 +9,7 @@ import {
   deriveGuestPresenceStatus,
   normalizeGuestName,
   removeGuestFromRoster,
+  sanitizeEntityForGuestTransport,
   upsertGuestRoster,
 } from "./p2p-helpers";
 import { createPeer, type PeerFactory } from "./peer-factory";
@@ -703,9 +704,7 @@ export class P2PHostService {
   private broadcastEntityUpdate(entity: any) {
     if (this.connections.length === 0) return;
 
-    // Sanitize
-    const snap = $state.snapshot(entity);
-    const { _fsHandle, ...safeEntity } = snap;
+    const safeEntity = sanitizeEntityForGuestTransport($state.snapshot(entity));
 
     console.log("[P2P Host] Broadcasting update for:", safeEntity.title);
 
@@ -745,9 +744,7 @@ export class P2PHostService {
     const sanitizedUpdates: Record<string, any> = {};
     for (const [id, patch] of Object.entries(updates)) {
       const snap = $state.snapshot(patch);
-      // Remove runtime-only fields
-      const { _fsHandle, ...safePatch } = snap as any;
-      sanitizedUpdates[id] = safePatch;
+      sanitizedUpdates[id] = sanitizeEntityForGuestTransport(snap as Entity);
     }
 
     console.log(

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.test.ts
@@ -53,6 +53,7 @@ describe("p2p helpers", () => {
           id: "entity-1",
           title: "Entity 1",
           image: "images/a.png",
+          lore: "Host-only notes",
           _fsHandle: "runtime",
         } as any,
       },

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p-helpers.ts
@@ -4,6 +4,18 @@ import type { GuestPresenceStatus, GuestSession } from "../../stores/guest";
 
 type GuestRoster = Record<string, GuestSession>;
 
+export function sanitizeEntityForGuestTransport(entity: Entity): Entity {
+  const {
+    _fsHandle,
+    lore: _lore,
+    ...safeEntity
+  } = entity as Entity & {
+    _fsHandle?: unknown;
+    lore?: string;
+  };
+  return safeEntity as Entity;
+}
+
 export function normalizeGuestName(name: unknown, fallback: string) {
   if (typeof name !== "string") return fallback;
   const trimmed = name.trim();
@@ -68,7 +80,7 @@ export function buildSharedGraphPayload(
   const assets: Record<string, string> = {};
 
   for (const [id, localEntity] of Object.entries(rawEntities)) {
-    const { _fsHandle, ...safeEntity } = localEntity as any;
+    const safeEntity = sanitizeEntityForGuestTransport(localEntity);
     entities[id] = safeEntity;
 
     if (safeEntity.image && !safeEntity.image.startsWith("http")) {

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
@@ -258,6 +258,13 @@ describe("P2P Services", () => {
         expect(mockConn.send).toHaveBeenCalledWith(
           expect.objectContaining({
             type: "GRAPH_SYNC",
+            payload: expect.objectContaining({
+              entities: expect.objectContaining({
+                "entity-1": expect.not.objectContaining({
+                  lore: expect.anything(),
+                }),
+              }),
+            }),
           }),
         );
       });
@@ -750,12 +757,16 @@ describe("P2P Services", () => {
       const mockConn = new MockConnection("guest-1");
       (hostService as any).connections.push(mockConn);
 
-      const entity = { id: "entity-1", title: "Updated Entity" };
+      const entity = {
+        id: "entity-1",
+        title: "Updated Entity",
+        lore: "Host-only notes",
+      };
       (hostService as any).broadcastEntityUpdate(entity);
 
       expect(mockConn.send).toHaveBeenCalledWith({
         type: "ENTITY_UPDATE",
-        payload: expect.objectContaining({ id: "entity-1" }),
+        payload: expect.not.objectContaining({ lore: expect.anything() }),
       });
     });
 

--- a/apps/web/src/lib/components/debug/DebugConsole.svelte
+++ b/apps/web/src/lib/components/debug/DebugConsole.svelte
@@ -32,7 +32,7 @@
 
 {#if logs.length > 0}
   <div
-    class="fixed bottom-4 right-4 z-[9999] flex flex-col items-end gap-2 font-mono"
+    class="fixed bottom-4 right-[calc(1rem+100px)] z-[9999] flex flex-col items-end gap-2 font-mono"
   >
     <button
       class="bg-black/80 text-white px-3 py-1 rounded text-xs border border-white/20 hover:bg-white/10 transition-colors shadow-lg"

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1095,7 +1095,7 @@
               <span
                 class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary"
               ></span>
-              <span>View Entity</span>
+              <span>Look at {_ctxToken.name}</span>
             </button>
           {/if}
         {/if}

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, type Snippet } from "svelte";
   import { fade } from "svelte/transition";
+  import { base } from "$app/paths";
   import { mapStore } from "../../stores/map.svelte";
   import { vault } from "../../stores/vault.svelte";
   import { uiStore } from "../../stores/ui.svelte";
@@ -1096,6 +1097,24 @@
                 class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary"
               ></span>
               <span>Look at {_ctxToken.name}</span>
+            </button>
+            <button
+              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+              onclick={() => {
+                if (_ctxToken?.entityId && vault.activeVaultId) {
+                  window.open(
+                    `${base}/vault/${vault.activeVaultId}?zen=${_ctxToken.entityId}`,
+                    "_blank",
+                    "noopener,noreferrer",
+                  );
+                  contextMenu = null;
+                }
+              }}
+            >
+              <span
+                class="icon-[heroicons--arrow-top-right-on-square] w-3.5 h-3.5 text-theme-primary"
+              ></span>
+              <span>Open in new tab</span>
             </button>
           {/if}
         {/if}

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1103,7 +1103,7 @@
               onclick={() => {
                 if (_ctxToken?.entityId && vault.activeVaultId) {
                   window.open(
-                    `${base}/vault/${vault.activeVaultId}?zen=${_ctxToken.entityId}`,
+                    `${base}/vault/${vault.activeVaultId}/entity/${_ctxToken.entityId}`,
                     "_blank",
                     "noopener,noreferrer",
                   );

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1105,9 +1105,9 @@
                 const entity = _ctxToken?.entityId
                   ? vault.entities[_ctxToken.entityId]
                   : null;
-                if (entity && vault.activeVaultId) {
+                if (entity) {
                   openEntityPopout(
-                    vault.activeVaultId,
+                    vault.activeVaultId ?? "guest",
                     entity,
                     base,
                     uiStore.isGuestMode,

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -2,6 +2,7 @@
   import { onMount, type Snippet } from "svelte";
   import { fade } from "svelte/transition";
   import { base } from "$app/paths";
+  import { openEntityPopout } from "$lib/utils/zen-popout";
   import { mapStore } from "../../stores/map.svelte";
   import { vault } from "../../stores/vault.svelte";
   import { uiStore } from "../../stores/ui.svelte";
@@ -1098,26 +1099,28 @@
               ></span>
               <span>Look at {_ctxToken.name}</span>
             </button>
-            {#if !uiStore.isGuestMode}
-              <button
-                class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-                onclick={() => {
-                  if (_ctxToken?.entityId && vault.activeVaultId) {
-                    window.open(
-                      `${base}/vault/${vault.activeVaultId}/entity/${_ctxToken.entityId}`,
-                      "_blank",
-                      "noopener,noreferrer",
-                    );
-                    contextMenu = null;
-                  }
-                }}
-              >
-                <span
-                  class="icon-[heroicons--arrow-top-right-on-square] w-3.5 h-3.5 text-theme-primary"
-                ></span>
-                <span>Open in new tab</span>
-              </button>
-            {/if}
+            <button
+              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+              onclick={() => {
+                const entity = _ctxToken?.entityId
+                  ? vault.entities[_ctxToken.entityId]
+                  : null;
+                if (entity && vault.activeVaultId) {
+                  openEntityPopout(
+                    vault.activeVaultId,
+                    entity,
+                    base,
+                    uiStore.isGuestMode,
+                  );
+                  contextMenu = null;
+                }
+              }}
+            >
+              <span
+                class="icon-[heroicons--arrow-top-right-on-square] w-3.5 h-3.5 text-theme-primary"
+              ></span>
+              <span>Open in new tab</span>
+            </button>
           {/if}
         {/if}
 

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { onMount, type Snippet } from "svelte";
   import { fade } from "svelte/transition";
-  import { base } from "$app/paths";
-  import { openEntityPopout } from "$lib/utils/zen-popout";
   import { mapStore } from "../../stores/map.svelte";
   import { vault } from "../../stores/vault.svelte";
   import { uiStore } from "../../stores/ui.svelte";
@@ -1098,28 +1096,6 @@
                 class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary"
               ></span>
               <span>Look at {_ctxToken.name}</span>
-            </button>
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-              onclick={() => {
-                const entity = _ctxToken?.entityId
-                  ? vault.entities[_ctxToken.entityId]
-                  : null;
-                if (entity) {
-                  openEntityPopout(
-                    vault.activeVaultId ?? "guest",
-                    entity,
-                    base,
-                    uiStore.isGuestMode,
-                  );
-                  contextMenu = null;
-                }
-              }}
-            >
-              <span
-                class="icon-[heroicons--arrow-top-right-on-square] w-3.5 h-3.5 text-theme-primary"
-              ></span>
-              <span>Open in new tab</span>
             </button>
           {/if}
         {/if}

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1098,24 +1098,26 @@
               ></span>
               <span>Look at {_ctxToken.name}</span>
             </button>
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-              onclick={() => {
-                if (_ctxToken?.entityId && vault.activeVaultId) {
-                  window.open(
-                    `${base}/vault/${vault.activeVaultId}/entity/${_ctxToken.entityId}`,
-                    "_blank",
-                    "noopener,noreferrer",
-                  );
-                  contextMenu = null;
-                }
-              }}
-            >
-              <span
-                class="icon-[heroicons--arrow-top-right-on-square] w-3.5 h-3.5 text-theme-primary"
-              ></span>
-              <span>Open in new tab</span>
-            </button>
+            {#if !uiStore.isGuestMode}
+              <button
+                class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+                onclick={() => {
+                  if (_ctxToken?.entityId && vault.activeVaultId) {
+                    window.open(
+                      `${base}/vault/${vault.activeVaultId}/entity/${_ctxToken.entityId}`,
+                      "_blank",
+                      "noopener,noreferrer",
+                    );
+                    contextMenu = null;
+                  }
+                }}
+              >
+                <span
+                  class="icon-[heroicons--arrow-top-right-on-square] w-3.5 h-3.5 text-theme-primary"
+                ></span>
+                <span>Open in new tab</span>
+              </button>
+            {/if}
           {/if}
         {/if}
 

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1078,6 +1078,28 @@
           <span>Ping Token</span>
         </button>
 
+        <!-- View Entity (host always; guest only if token is not gm-only) -->
+        {#if contextMenu.tokenId}
+          {@const _ctxToken = mapSession.tokens[contextMenu.tokenId]}
+          {#if _ctxToken?.entityId && mapSession.canViewToken(contextMenu.tokenId, mapSession.myPeerId, mapStore.isGMMode)}
+            <div class="h-px bg-theme-border my-1 mx-2"></div>
+            <button
+              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+              onclick={() => {
+                if (_ctxToken?.entityId) {
+                  uiStore.openZenMode(_ctxToken.entityId);
+                  contextMenu = null;
+                }
+              }}
+            >
+              <span
+                class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary"
+              ></span>
+              <span>View Entity</span>
+            </button>
+          {/if}
+        {/if}
+
         <!-- Multi-select actions (GM only) -->
         {#if mapStore.isGMMode && !uiStore.isGuestMode}
           {#if contextMenu?.tokenId && mapSession.selectedTokens.size > 1 && mapSession.selectedTokens.has(contextMenu.tokenId)}

--- a/apps/web/src/lib/components/modals/GuestLoginModal.svelte
+++ b/apps/web/src/lib/components/modals/GuestLoginModal.svelte
@@ -45,6 +45,20 @@
   };
 </script>
 
+<svelte:window
+  onkeydown={(e) => {
+    if (
+      e.key === "Enter" &&
+      document.activeElement?.tagName !== "INPUT" &&
+      document.activeElement?.tagName !== "TEXTAREA"
+    ) {
+      e.preventDefault();
+      const form = document.querySelector("form");
+      if (form) form.requestSubmit();
+    }
+  }}
+/>
+
 <div
   class="fixed inset-0 bg-theme-bg/90 backdrop-blur-md flex items-center justify-center z-[100] p-4 font-mono text-theme-text"
 >

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -2,6 +2,7 @@
   import { uiStore } from "$lib/stores/ui.svelte";
   import { vault } from "$lib/stores/vault.svelte";
   import { fly, fade } from "svelte/transition";
+  import { base } from "$app/paths";
 
   import { clipboardService } from "$lib/services/ClipboardService";
   import ZenImageLightbox from "../zen/ZenImageLightbox.svelte";
@@ -94,6 +95,16 @@
     actions.handleClose(() => {
       uiStore.closeZenMode();
     });
+  };
+
+  const handlePopOut = () => {
+    if (!entity || !vault.activeVaultId) return;
+    window.open(
+      `${base}/vault/${vault.activeVaultId}?zen=${entity.id}`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    uiStore.closeZenMode();
   };
 
   const navigateTo = async (id: string) => {
@@ -220,6 +231,7 @@
         onCancelEdit={cancelEditing}
         onSave={saveChanges}
         onClose={handleClose}
+        onPopOut={handlePopOut}
       />
 
       <!-- Navigation Tabs -->

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -50,7 +50,7 @@
   // lazy-loaded entity content updates the active entity snapshot.
   $effect(() => {
     if (!uiStore.showZenMode || !entity || !vault.isGuest) return;
-    persistZenPopoutPayload(entity, true);
+    persistZenPopoutPayload(vault.activeVaultId ?? "guest", entity, true);
   });
 
   let activeTab = $derived(uiStore.zenModeActiveTab);

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -4,6 +4,7 @@
   import { fly, fade } from "svelte/transition";
   import { base } from "$app/paths";
   import { page } from "$app/state";
+  import { openEntityPopout } from "$lib/utils/zen-popout";
 
   import { clipboardService } from "$lib/services/ClipboardService";
   import ZenImageLightbox from "../zen/ZenImageLightbox.svelte";
@@ -113,11 +114,7 @@
 
   const handlePopOut = () => {
     if (!entity || !vault.activeVaultId) return;
-    window.open(
-      `${base}/vault/${vault.activeVaultId}/entity/${entity.id}`,
-      "_blank",
-      "noopener,noreferrer",
-    );
+    openEntityPopout(vault.activeVaultId, entity, base, vault.isGuest);
     uiStore.closeZenMode();
   };
 
@@ -245,7 +242,7 @@
         onCancelEdit={cancelEditing}
         onSave={saveChanges}
         onClose={handleClose}
-        onPopOut={isPopout || vault.isGuest ? undefined : handlePopOut}
+        onPopOut={isPopout ? undefined : handlePopOut}
       />
 
       <!-- Navigation Tabs -->

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -96,9 +96,14 @@
     }
   };
 
-  const handleClose = () => {
+  const handleClose = async () => {
     if (isPopout) {
-      window.close();
+      const confirmed = await uiStore.confirm({
+        title: "Close tab?",
+        message: `Close the tab for "${entity?.title ?? "this entity"}"?`,
+        confirmLabel: "Close tab",
+      });
+      if (confirmed) window.close();
       return;
     }
     actions.handleClose(() => {

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -132,11 +132,43 @@
         entityForPopout = vault.entities[entityId] ?? entityForPopout;
       }
 
+      // Convert blob URL → data URL so the image survives cross-tab (no P2P in popout)
+      if (resolvedImageUrl) {
+        try {
+          const resp = await fetch(resolvedImageUrl);
+          const blob = await resp.blob();
+          const dataUrl = await new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+          });
+          entityForPopout = { ...entityForPopout, image: dataUrl };
+        } catch {
+          // silently skip — image just won't appear in the popout
+        }
+      }
+
+      // Collect stubs for linked entities — needed for connection rendering in popout
+      const seen = new Set<string>();
+      const extraEntities: (typeof entity)[] = [];
+      const addStub = (id: string) => {
+        if (seen.has(id)) return;
+        seen.add(id);
+        const e = vault.entities[id];
+        if (e) extraEntities.push(e);
+      };
+      for (const conn of entityForPopout.connections ?? [])
+        addStub(conn.target);
+      for (const item of vault.inboundConnections[entityForPopout.id] ?? [])
+        addStub(item.sourceId);
+
       openEntityPopout(
         vault.activeVaultId ?? "guest",
         entityForPopout,
         base,
         vault.isGuest,
+        extraEntities.length > 0 ? extraEntities : undefined,
       );
       uiStore.closeZenMode();
     };

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -113,8 +113,13 @@
   };
 
   const handlePopOut = () => {
-    if (!entity || !vault.activeVaultId) return;
-    openEntityPopout(vault.activeVaultId, entity, base, vault.isGuest);
+    if (!entity) return;
+    openEntityPopout(
+      vault.activeVaultId ?? "guest",
+      entity,
+      base,
+      vault.isGuest,
+    );
     uiStore.closeZenMode();
   };
 

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -149,26 +149,11 @@
         }
       }
 
-      // Collect stubs for linked entities — needed for connection rendering in popout
-      const seen = new Set<string>();
-      const extraEntities: (typeof entity)[] = [];
-      const addStub = (id: string) => {
-        if (seen.has(id)) return;
-        seen.add(id);
-        const e = vault.entities[id];
-        if (e) extraEntities.push(e);
-      };
-      for (const conn of entityForPopout.connections ?? [])
-        addStub(conn.target);
-      for (const item of vault.inboundConnections[entityForPopout.id] ?? [])
-        addStub(item.sourceId);
-
       openEntityPopout(
         vault.activeVaultId ?? "guest",
         entityForPopout,
         base,
         vault.isGuest,
-        extraEntities.length > 0 ? extraEntities : undefined,
       );
       uiStore.closeZenMode();
     };
@@ -376,6 +361,7 @@
               {entity}
               bind:editState
               {resolvedImageUrl}
+              {isPopout}
               onShowLightbox={() => (showLightbox = true)}
               onNavigate={navigateTo}
               onDelete={handleDelete}

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -100,7 +100,7 @@
   const handlePopOut = () => {
     if (!entity || !vault.activeVaultId) return;
     window.open(
-      `${base}/vault/${vault.activeVaultId}?zen=${entity.id}`,
+      `${base}/vault/${vault.activeVaultId}/entity/${entity.id}`,
       "_blank",
       "noopener,noreferrer",
     );

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -4,7 +4,10 @@
   import { fly, fade } from "svelte/transition";
   import { base } from "$app/paths";
   import { page } from "$app/state";
-  import { openEntityPopout } from "$lib/utils/zen-popout";
+  import {
+    openEntityPopout,
+    persistZenPopoutPayload,
+  } from "$lib/utils/zen-popout";
 
   import { clipboardService } from "$lib/services/ClipboardService";
   import ZenImageLightbox from "../zen/ZenImageLightbox.svelte";
@@ -41,6 +44,13 @@
     if (uiStore.showZenMode && entityId && !entity) {
       uiStore.closeZenMode();
     }
+  });
+
+  // Keep the guest popout payload fresh after Zen Mode renders and after
+  // lazy-loaded entity content updates the active entity snapshot.
+  $effect(() => {
+    if (!uiStore.showZenMode || !entity || !vault.isGuest) return;
+    persistZenPopoutPayload(entity, true);
   });
 
   let activeTab = $derived(uiStore.zenModeActiveTab);
@@ -114,13 +124,24 @@
 
   const handlePopOut = () => {
     if (!entity) return;
-    openEntityPopout(
-      vault.activeVaultId ?? "guest",
-      entity,
-      base,
-      vault.isGuest,
-    );
-    uiStore.closeZenMode();
+    const popOutEntity = async () => {
+      let entityForPopout = entity;
+
+      if (vault.isGuest && entityId && !entity.content) {
+        await vault.loadEntityContent(entityId);
+        entityForPopout = vault.entities[entityId] ?? entityForPopout;
+      }
+
+      openEntityPopout(
+        vault.activeVaultId ?? "guest",
+        entityForPopout,
+        base,
+        vault.isGuest,
+      );
+      uiStore.closeZenMode();
+    };
+
+    void popOutEntity();
   };
 
   const navigateTo = async (id: string) => {

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -3,6 +3,7 @@
   import { vault } from "$lib/stores/vault.svelte";
   import { fly, fade } from "svelte/transition";
   import { base } from "$app/paths";
+  import { page } from "$app/state";
 
   import { clipboardService } from "$lib/services/ClipboardService";
   import ZenImageLightbox from "../zen/ZenImageLightbox.svelte";
@@ -12,6 +13,10 @@
   import ZenSidebar from "../zen/ZenSidebar.svelte";
   import ZenContent from "../zen/ZenContent.svelte";
   import DetailMapTab from "$lib/components/entity-detail/DetailMapTab.svelte";
+
+  const isPopout = $derived(
+    /\/vault\/[^/]+\/entity\/[^/]+$/.test(page.url.pathname),
+  );
 
   let entityId = $derived(uiStore.zenModeEntityId);
   let entity = $derived(entityId ? vault.entities[entityId] : null);
@@ -92,6 +97,10 @@
   };
 
   const handleClose = () => {
+    if (isPopout) {
+      window.close();
+      return;
+    }
     actions.handleClose(() => {
       uiStore.closeZenMode();
     });
@@ -167,7 +176,7 @@
       return;
 
     if (e.key === "Escape") {
-      handleClose();
+      if (!isPopout) handleClose();
     } else if (!isEditing) {
       const scroller =
         window.innerWidth < 768 ? mobileScroller : scrollContainer;
@@ -190,7 +199,7 @@
   <div
     class="fixed inset-0 z-[100] flex items-center justify-center p-0 md:p-8 bg-black/90 backdrop-blur-md"
     transition:fade={{ duration: 200 }}
-    onclick={handleClose}
+    onclick={isPopout ? undefined : handleClose}
     data-testid="zen-mode-modal"
   >
     <div
@@ -231,7 +240,7 @@
         onCancelEdit={cancelEditing}
         onSave={saveChanges}
         onClose={handleClose}
-        onPopOut={handlePopOut}
+        onPopOut={isPopout ? undefined : handlePopOut}
       />
 
       <!-- Navigation Tabs -->

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -245,7 +245,7 @@
         onCancelEdit={cancelEditing}
         onSave={saveChanges}
         onClose={handleClose}
-        onPopOut={isPopout ? undefined : handlePopOut}
+        onPopOut={isPopout || vault.isGuest ? undefined : handlePopOut}
       />
 
       <!-- Navigation Tabs -->

--- a/apps/web/src/lib/components/modals/ZenModeModal.test.ts
+++ b/apps/web/src/lib/components/modals/ZenModeModal.test.ts
@@ -1,0 +1,137 @@
+/** @vitest-environment jsdom */
+
+import { render, waitFor } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("svelte", async () => {
+  // @ts-expect-error - force the client Svelte runtime so testing-library can mount
+  return await import("../../../../../../node_modules/svelte/src/index-client.js");
+});
+
+vi.mock("$app/paths", () => ({
+  base: "",
+}));
+
+vi.mock("$app/state", () => ({
+  page: {
+    url: {
+      pathname: "/vault/guest/entity/entity-1",
+    },
+  },
+}));
+
+vi.mock("$lib/services/ClipboardService", () => ({
+  clipboardService: {
+    copyEntity: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock("$lib/hooks/useEditState.svelte", () => ({
+  createEditState: vi.fn(() => ({
+    isEditing: false,
+    cancel: vi.fn(),
+    start: vi.fn(),
+  })),
+}));
+
+vi.mock("$lib/hooks/useZenModeActions.svelte", () => ({
+  createZenModeActions: vi.fn(() => ({
+    isSaving: false,
+    saveChanges: vi.fn(),
+    handleDelete: vi.fn(),
+    handleClose: vi.fn(),
+  })),
+}));
+
+vi.mock("../zen/ZenImageLightbox.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
+vi.mock("../zen/ZenHeader.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
+vi.mock("../zen/ZenSidebar.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
+vi.mock("../zen/ZenContent.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
+vi.mock("$lib/components/entity-detail/DetailMapTab.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
+vi.mock("$lib/stores/ui.svelte", () => ({
+  uiStore: {
+    showZenMode: true,
+    zenModeEntityId: "entity-1",
+    zenModeActiveTab: "overview",
+    openZenMode: vi.fn(),
+    closeZenMode: vi.fn(),
+    confirm: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => {
+  const entities = {
+    "entity-1": {
+      id: "entity-1",
+      title: "Faerun",
+      content: "A realm of ancient forests and buried empires.",
+      _path: ["faerun.md"],
+    },
+  };
+
+  return {
+    vault: {
+      activeVaultId: null,
+      isGuest: true,
+      entities,
+      loadEntityContent: vi.fn(async (id: string) => {
+        entities[id] = {
+          ...entities[id],
+          content: "Hydrated content from host",
+        };
+      }),
+      resolveImageUrl: vi.fn().mockResolvedValue(""),
+    },
+  };
+});
+
+vi.mock("$lib/utils/zen-popout", async () => {
+  const actual = await import("../../utils/zen-popout");
+  return {
+    ...actual,
+    openEntityPopout: vi.fn(),
+  };
+});
+
+import ZenModeModal from "./ZenModeModal.svelte";
+
+describe("ZenModeModal", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("persists the guest entity snapshot after zen mode opens", async () => {
+    render(ZenModeModal);
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.sessionStorage.getItem("codex.zen-popout.entity-1") ?? "null",
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          isGuest: true,
+          entity: expect.objectContaining({
+            id: "entity-1",
+            content: "A realm of ancient forests and buried empires.",
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/web/src/lib/components/modals/ZenModeModal.test.ts
+++ b/apps/web/src/lib/components/modals/ZenModeModal.test.ts
@@ -121,7 +121,8 @@ describe("ZenModeModal", () => {
     await waitFor(() => {
       expect(
         JSON.parse(
-          window.sessionStorage.getItem("codex.zen-popout.entity-1") ?? "null",
+          window.sessionStorage.getItem("codex.zen-popout.guest.entity-1") ??
+            "null",
         ),
       ).toEqual(
         expect.objectContaining({

--- a/apps/web/src/lib/components/modals/ZenModeModal.test.ts
+++ b/apps/web/src/lib/components/modals/ZenModeModal.test.ts
@@ -75,7 +75,7 @@ vi.mock("$lib/stores/ui.svelte", () => ({
 }));
 
 vi.mock("$lib/stores/vault.svelte", () => {
-  const entities = {
+  const entities: Record<string, any> = {
     "entity-1": {
       id: "entity-1",
       title: "Faerun",

--- a/apps/web/src/lib/components/modals/__tests__/ModalStub.svelte
+++ b/apps/web/src/lib/components/modals/__tests__/ModalStub.svelte
@@ -1,0 +1,1 @@
+<div data-testid="modal-stub"></div>

--- a/apps/web/src/lib/components/vtt/GuestSessionBootstrap.svelte
+++ b/apps/web/src/lib/components/vtt/GuestSessionBootstrap.svelte
@@ -9,6 +9,7 @@
     buildGuestRoutePath,
     normalizeGuestView,
   } from "$lib/utils/guest-session";
+  import { mergeGuestEntityUpdate } from "$lib/utils/guest-entity-merge";
   import { buildGuestPresencePayload } from "$lib/cloud-bridge/p2p/p2p-helpers";
   import { themeStore } from "$lib/stores/theme.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
@@ -114,13 +115,10 @@
           syncGuestGraphPayload(graph);
         },
         (updatedEntity) => {
-          vault.repository.entities[updatedEntity.id] = {
-            ...updatedEntity,
-            _path:
-              typeof updatedEntity._path === "string"
-                ? [updatedEntity._path]
-                : updatedEntity._path,
-          };
+          vault.repository.entities[updatedEntity.id] = mergeGuestEntityUpdate(
+            vault.repository.entities[updatedEntity.id],
+            updatedEntity,
+          );
         },
         (deletedId) => {
           delete vault.repository.entities[deletedId];

--- a/apps/web/src/lib/components/vtt/InitiativePanel.svelte
+++ b/apps/web/src/lib/components/vtt/InitiativePanel.svelte
@@ -193,7 +193,7 @@
                     uiStore.openZenMode(token.entityId!);
                   }}
                   onmousedown={(e) => e.stopPropagation()}
-                  title="View entity"
+                  title="Look at {token.name}"
                   type="button"
                 >
                   <span class="icon-[lucide--book-open] w-3.5 h-3.5"></span>

--- a/apps/web/src/lib/components/vtt/InitiativePanel.svelte
+++ b/apps/web/src/lib/components/vtt/InitiativePanel.svelte
@@ -185,6 +185,20 @@
               >
                 <span class="icon-[lucide--radar] w-3.5 h-3.5"></span>
               </button>
+              {#if token?.entityId && mapSession.canViewToken(entry.tokenId, mapSession.myPeerId, mapStore.isGMMode)}
+                <button
+                  class="shrink-0 text-theme-muted hover:text-theme-primary transition-colors active:scale-90"
+                  onclick={(e) => {
+                    e.stopPropagation();
+                    uiStore.openZenMode(token.entityId!);
+                  }}
+                  onmousedown={(e) => e.stopPropagation()}
+                  title="View entity"
+                  type="button"
+                >
+                  <span class="icon-[lucide--book-open] w-3.5 h-3.5"></span>
+                </button>
+              {/if}
               <button
                 type="button"
                 class="min-w-0 text-left cursor-pointer"

--- a/apps/web/src/lib/components/vtt/VTTChatSidebar.svelte
+++ b/apps/web/src/lib/components/vtt/VTTChatSidebar.svelte
@@ -32,13 +32,16 @@
 </script>
 
 <aside
-  class="absolute top-0 left-0 bottom-0 z-[30] flex overflow-hidden border-r border-theme-border bg-theme-surface/95 shadow-[0_0_30px_rgba(0,0,0,0.25)] backdrop-blur transition-all duration-200 pointer-events-auto {collapsed
+  class="absolute top-0 left-0 bottom-0 z-[30] flex overflow-hidden border-r border-theme-primary/20 bg-theme-surface/95 shadow-[0_0_30px_rgba(0,0,0,0.25)] backdrop-blur transition-all duration-200 pointer-events-auto {collapsed
     ? 'w-12'
     : 'w-[20rem] max-w-[calc(100vw-3rem)]'}"
   aria-label="VTT Chat Sidebar"
 >
   {#if collapsed}
-    <div class="flex h-full w-full flex-col items-center justify-between p-2">
+    <div
+      class="flex h-full w-full flex-col items-center justify-between p-2"
+      style="background-image: var(--bg-texture-overlay)"
+    >
       <button
         class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
         onclick={() => (collapsed = false)}
@@ -58,13 +61,30 @@
       </div>
     </div>
   {:else}
-    <div class="flex h-full min-h-0 w-full flex-col">
+    <div
+      class="flex h-full min-h-0 w-full flex-col relative"
+      style="background-image: var(--bg-texture-overlay)"
+    >
+      <!-- Decorative Corners -->
       <div
-        class="flex items-center justify-between gap-3 border-b border-theme-border/70 px-3 py-3"
+        class="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-theme-primary/30 rounded-tl pointer-events-none hidden md:block"
+      ></div>
+      <div
+        class="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-theme-primary/30 rounded-tr pointer-events-none hidden md:block"
+      ></div>
+      <div
+        class="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-theme-primary/30 rounded-bl pointer-events-none hidden md:block"
+      ></div>
+      <div
+        class="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-theme-primary/30 rounded-br pointer-events-none hidden md:block"
+      ></div>
+
+      <div
+        class="flex items-center justify-between gap-3 border-b border-theme-primary/20 px-3 py-3"
       >
         <div>
           <div
-            class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-muted"
+            class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
           >
             VTT Chat
           </div>

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -14,6 +14,7 @@
     onCancelEdit,
     onSave,
     onClose,
+    onPopOut,
   } = $props<{
     entity: Entity;
     editState: any;
@@ -24,6 +25,7 @@
     onCancelEdit: () => void;
     onSave: () => Promise<void>;
     onClose: () => void;
+    onPopOut?: () => void;
   }>();
 </script>
 
@@ -121,6 +123,18 @@
           <span class="icon-[lucide--save] w-3 h-3"></span>
           <span class="hidden sm:inline">SAVE</span>
         {/if}
+      </button>
+    {/if}
+
+    {#if onPopOut && !editState.isEditing}
+      <button
+        onclick={onPopOut}
+        class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-xs font-bold tracking-widest"
+        title="Open in new tab"
+        aria-label="Open in new tab"
+      >
+        <span class="icon-[heroicons--arrow-top-right-on-square] w-4 h-4"
+        ></span>
       </button>
     {/if}
 

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -12,6 +12,7 @@
     onShowLightbox,
     onNavigate,
     onDelete,
+    isPopout = false,
   } = $props<{
     entity: Entity | null;
     editState: any;
@@ -19,6 +20,7 @@
     onShowLightbox: () => void;
     onNavigate: (id: string) => void;
     onDelete: () => Promise<void>;
+    isPopout?: boolean;
   }>();
 
   interface ConnectionListItem {
@@ -201,46 +203,50 @@
 
   <!-- Sidebar Content (Desktop) -->
   <div class="hidden md:block space-y-6">
-    <div
-      class="space-y-4 pt-8 border-t border-theme-border md:border-t-0 md:pt-0"
-    >
-      <h3
-        class="text-xs font-bold text-theme-secondary uppercase font-header tracking-widest border-b border-theme-border pb-2"
+    {#if !isPopout}
+      <div
+        class="space-y-4 pt-8 border-t border-theme-border md:border-t-0 md:pt-0"
       >
-        Connections
-      </h3>
-      {#if allConnections.length > 0}
-        <div class="space-y-2">
-          {#each allConnections as conn}
-            <button
-              onclick={() => onNavigate(conn.id)}
-              class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
-            >
-              <span
-                class="w-1.5 h-1.5 rounded-full {conn.isOutbound
-                  ? 'bg-theme-primary'
-                  : 'bg-blue-500'}"
-              ></span>
-              <div class="flex-1 min-w-0">
-                <div class="text-[11px] text-theme-muted uppercase font-header">
-                  {conn.label}
+        <h3
+          class="text-xs font-bold text-theme-secondary uppercase font-header tracking-widest border-b border-theme-border pb-2"
+        >
+          Connections
+        </h3>
+        {#if allConnections.length > 0}
+          <div class="space-y-2">
+            {#each allConnections as conn}
+              <button
+                onclick={() => onNavigate(conn.id)}
+                class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
+              >
+                <span
+                  class="w-1.5 h-1.5 rounded-full {conn.isOutbound
+                    ? 'bg-theme-primary'
+                    : 'bg-blue-500'}"
+                ></span>
+                <div class="flex-1 min-w-0">
+                  <div
+                    class="text-[11px] text-theme-muted uppercase font-header"
+                  >
+                    {conn.label}
+                  </div>
+                  <div
+                    class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"
+                  >
+                    {conn.title}
+                  </div>
                 </div>
-                <div
-                  class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"
-                >
-                  {conn.title}
-                </div>
-              </div>
-              <span
-                class="icon-[lucide--chevron-right] w-4 h-4 text-theme-muted group-hover:text-theme-primary opacity-0 group-hover:opacity-100 transition"
-              ></span>
-            </button>
-          {/each}
-        </div>
-      {:else}
-        <p class="text-xs text-theme-muted italic">No known connections.</p>
-      {/if}
-    </div>
+                <span
+                  class="icon-[lucide--chevron-right] w-4 h-4 text-theme-muted group-hover:text-theme-primary opacity-0 group-hover:opacity-100 transition"
+                ></span>
+              </button>
+            {/each}
+          </div>
+        {:else}
+          <p class="text-xs text-theme-muted italic">No known connections.</p>
+        {/if}
+      </div>
+    {/if}
 
     {#if editState.isEditing && !vault.isGuest}
       <div class="mt-8 pt-8 border-t border-theme-border">

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -203,7 +203,7 @@
 
   <!-- Sidebar Content (Desktop) -->
   <div class="hidden md:block space-y-6">
-    {#if !isPopout}
+    {#if !(isPopout && vault.isGuest)}
       <div
         class="space-y-4 pt-8 border-t border-theme-border md:border-t-0 md:pt-0"
       >

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -45,6 +45,8 @@ Object.defineProperty(window, "matchMedia", {
 import { uiStore } from "./ui.svelte";
 import { vault } from "./vault.svelte";
 
+const mockedVault = vault as any;
+
 describe("UIStore", () => {
   beforeEach(() => {
     // Reset state before each test
@@ -55,9 +57,9 @@ describe("UIStore", () => {
     uiStore.dismissedWorldPage = false;
     uiStore.closeSidebar();
     uiStore.showCanvasPalette = true;
-    vault.isGuest = false;
-    vault.entities = {};
-    vault.loadEntityContent.mockClear();
+    mockedVault.isGuest = false;
+    mockedVault.entities = {};
+    mockedVault.loadEntityContent.mockClear();
   });
 
   it("should make Entity Explorer and Canvas Palette mutually exclusive", () => {

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -10,7 +10,12 @@ vi.mock("$app/paths", () => ({
 }));
 
 vi.mock("./vault.svelte", () => ({
-  vault: { selectedEntityId: null },
+  vault: {
+    selectedEntityId: null,
+    isGuest: false,
+    entities: {},
+    loadEntityContent: vi.fn(),
+  },
 }));
 
 vi.mock("../utils/idb", () => ({
@@ -38,6 +43,7 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 import { uiStore } from "./ui.svelte";
+import { vault } from "./vault.svelte";
 
 describe("UIStore", () => {
   beforeEach(() => {
@@ -49,6 +55,9 @@ describe("UIStore", () => {
     uiStore.dismissedWorldPage = false;
     uiStore.closeSidebar();
     uiStore.showCanvasPalette = true;
+    vault.isGuest = false;
+    vault.entities = {};
+    vault.loadEntityContent.mockClear();
   });
 
   it("should make Entity Explorer and Canvas Palette mutually exclusive", () => {

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -463,6 +463,14 @@ class UIStore {
     entityId: string,
     tab: "overview" | "inventory" | "map" = "overview",
   ) {
+    if (typeof window !== "undefined") {
+      void import("./vault.svelte").then(({ vault }) => {
+        const entity = vault.entities?.[entityId];
+        if (vault.isGuest && !entity?.content) {
+          void vault.loadEntityContent(entityId);
+        }
+      });
+    }
     this.zenModeEntityId = entityId;
     this.zenModeActiveTab = tab;
     this.showZenMode = true;

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -209,6 +209,13 @@ export class VaultStore {
   // --- Core Lifecycle ---
 
   async init() {
+    // Guest popout tabs pre-populate the vault via applyGuestPayload before
+    // this runs — skip full init so loadFiles() doesn't overwrite that data.
+    if (uiStore.isGuestMode) {
+      this.isInitialized = true;
+      return;
+    }
+
     try {
       await vaultRegistry.init();
 

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -31,6 +31,7 @@ import { migrateStructure } from "./vault/migration";
 
 import { VaultMessenger } from "./vault/messenger";
 import { VaultStorageManager } from "./vault/storage";
+import { p2pGuestService } from "../cloud-bridge/p2p/guest-service";
 
 export class VaultStore {
   // Reactive State
@@ -127,6 +128,7 @@ export class VaultStore {
       repository: this.repository,
       activeVaultId: () => this.activeVaultId,
       isGuest: () => this.isGuest,
+      getGuestFile: (path) => p2pGuestService.getFile(path),
       getActiveVaultHandle: () => this.getActiveVaultHandle(),
       getSpecificVaultHandle: (vId) => this.getSpecificVaultHandle(vId),
       getActiveSyncHandle: () => this.getActiveSyncHandle(),

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -588,11 +588,18 @@ export class EntityStore {
 
   async loadEntityContent(id: string): Promise<void> {
     const activeVaultId = this.deps.activeVaultId();
-    if (!id || !activeVaultId) return;
+    if (!id) return;
     if (this._contentVerifiedIds.has(id)) return;
 
     const currentEntity = this.entities[id];
     if (!currentEntity) return;
+
+    // Guest/popout mode: no local vault — content arrives via P2P or postMessage.
+    // If the entity already carries content, treat it as verified and done.
+    if (!activeVaultId) {
+      if (currentEntity.content) this._contentVerifiedIds.add(id);
+      return;
+    }
 
     // PRIORITY 1: Cache
     let cached: { content: string; lore: string } | null = null;

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -13,6 +13,7 @@ export interface EntityStoreDependencies {
   repository: VaultRepository;
   activeVaultId: () => string | null;
   isGuest: () => boolean;
+  getGuestFile?: (path: string) => Promise<Blob>;
   getActiveVaultHandle: () => Promise<FileSystemDirectoryHandle | undefined>;
   getSpecificVaultHandle: (
     vaultId: string,
@@ -257,7 +258,12 @@ export class EntityStore {
       const merged = {
         ...current,
         ...patch,
-        content: patch.content !== undefined ? patch.content : current.content,
+        content:
+          patch.content !== undefined
+            ? this.deps.isGuest() && patch.content === "" && current.content
+              ? current.content
+              : patch.content
+            : current.content,
         lore: patch.lore !== undefined ? patch.lore : current.lore,
         updatedAt: Date.now(),
       } as LocalEntity;
@@ -587,19 +593,60 @@ export class EntityStore {
   // --- Content Loading ---
 
   async loadEntityContent(id: string): Promise<void> {
-    const activeVaultId = this.deps.activeVaultId();
     if (!id) return;
-    if (this._contentVerifiedIds.has(id)) return;
-
     const currentEntity = this.entities[id];
     if (!currentEntity) return;
 
-    // Guest/popout mode: no local vault — content arrives via P2P or postMessage.
-    // If the entity already carries content, treat it as verified and done.
-    if (!activeVaultId) {
-      if (currentEntity.content) this._contentVerifiedIds.add(id);
+    const isGuest = this.deps.isGuest();
+    if (
+      this._contentVerifiedIds.has(id) &&
+      (!isGuest || !!currentEntity.content)
+    )
+      return;
+
+    const activeVaultId = this.deps.activeVaultId();
+    const guestFileFetcher = this.deps.getGuestFile;
+    const parseMarkdown =
+      this._helpers.parseMarkdown ||
+      (await import("../../utils/markdown")).parseMarkdown;
+
+    if (isGuest) {
+      if (currentEntity.content) {
+        this._contentLoadedIds.add(id);
+        this._contentVerifiedIds.add(id);
+        return;
+      }
+
+      const path = currentEntity._path || [`${id}.md`];
+      const requestPath = path.join("/");
+      if (!guestFileFetcher || !requestPath) return;
+
+      try {
+        const file = await guestFileFetcher(requestPath);
+        const text = await file.text();
+        if (!text) {
+          this._contentVerifiedIds.add(id);
+          return;
+        }
+
+        const { content: freshContent } = parseMarkdown(text);
+        this.deps.repository.entities[id] = {
+          ...currentEntity,
+          content: freshContent || currentEntity.content || "",
+          lore: "",
+        };
+        this._contentLoadedIds.add(id);
+        this._contentVerifiedIds.add(id);
+      } catch (err) {
+        debugStore.warn(
+          `[EntityStore] Guest content fetch failed for ${id}`,
+          err,
+        );
+      }
       return;
     }
+
+    if (!activeVaultId) return;
 
     // PRIORITY 1: Cache
     let cached: { content: string; lore: string } | null = null;
@@ -636,9 +683,6 @@ export class EntityStore {
       const readFileAsText =
         this._helpers.readFileAsText ||
         (await import("../../utils/opfs")).readFileAsText;
-      const parseMarkdown =
-        this._helpers.parseMarkdown ||
-        (await import("../../utils/markdown")).parseMarkdown;
 
       let text = "";
       const vaultDir = await this.deps.getActiveVaultHandle();

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -108,6 +108,7 @@ describe("EntityStore", () => {
       repository: repository as any,
       activeVaultId: () => "vault-1",
       isGuest: () => false,
+      getGuestFile: vi.fn(),
       setStatus: vi.fn(),
       setErrorMessage: vi.fn(),
       getActiveVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
@@ -797,6 +798,7 @@ describe("EntityStore", () => {
         repository: repository as any,
         activeVaultId: () => null,
         isGuest: () => false,
+        getGuestFile: vi.fn(),
         setStatus: vi.fn(),
         setErrorMessage: vi.fn(),
         getActiveVaultHandle: vi.fn().mockResolvedValue({}),
@@ -806,6 +808,110 @@ describe("EntityStore", () => {
       });
 
       await storeNoVault.loadEntityContent("hero");
+    });
+
+    it("fetches guest chronicle content from the host when no local vault is available", async () => {
+      const getGuestFile = vi.fn().mockResolvedValue(
+        new Blob(["---\nlore: Hidden host notes\n---\nShared chronicle body"], {
+          type: "text/markdown",
+        }),
+      );
+      vi.mocked(
+        (await import("../../utils/markdown")).parseMarkdown,
+      ).mockReturnValue({
+        metadata: { lore: "Hidden host notes" },
+        content: "Shared chronicle body",
+      } as any);
+
+      const guestStore = new EntityStore({
+        repository: repository as any,
+        activeVaultId: () => null,
+        isGuest: () => true,
+        getGuestFile,
+        setStatus: vi.fn(),
+        setErrorMessage: vi.fn(),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getSpecificVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getActiveSyncHandle: vi.fn().mockResolvedValue(undefined),
+        getServices: () => ({}),
+      });
+
+      await guestStore.loadEntityContent("hero");
+
+      expect(getGuestFile).toHaveBeenCalledWith("hero.md");
+      expect(repository.entities.hero.content).toBe("Shared chronicle body");
+      expect(repository.entities.hero.lore).toBe("");
+      expect(guestStore.isContentLoaded("hero")).toBe(true);
+    });
+
+    it("retries guest host fetch when the entity was verified earlier but still has no content", async () => {
+      const getGuestFile = vi.fn().mockResolvedValue(
+        new Blob(["---\n---\nRetried chronicle"], {
+          type: "text/markdown",
+        }),
+      );
+      vi.mocked(
+        (await import("../../utils/markdown")).parseMarkdown,
+      ).mockReturnValue({
+        metadata: {},
+        content: "Retried chronicle",
+      } as any);
+
+      const guestStore = new EntityStore({
+        repository: repository as any,
+        activeVaultId: () => null,
+        isGuest: () => true,
+        getGuestFile,
+        setStatus: vi.fn(),
+        setErrorMessage: vi.fn(),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getSpecificVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getActiveSyncHandle: vi.fn().mockResolvedValue(undefined),
+        getServices: () => ({}),
+      });
+
+      guestStore.markContentLoaded("hero");
+      repository.entities.hero = {
+        ...repository.entities.hero,
+        content: "",
+      };
+
+      await guestStore.loadEntityContent("hero");
+
+      expect(getGuestFile).toHaveBeenCalledWith("hero.md");
+      expect(repository.entities.hero.content).toContain("Retried chronicle");
+    });
+
+    it("uses the guest host-fetch path even when a local activeVaultId is still present", async () => {
+      const getGuestFile = vi.fn().mockResolvedValue(
+        new Blob(["---\n---\nGuest chronicle"], {
+          type: "text/markdown",
+        }),
+      );
+      vi.mocked(
+        (await import("../../utils/markdown")).parseMarkdown,
+      ).mockReturnValue({
+        metadata: {},
+        content: "Guest chronicle",
+      } as any);
+
+      const guestStore = new EntityStore({
+        repository: repository as any,
+        activeVaultId: () => "default-vault",
+        isGuest: () => true,
+        getGuestFile,
+        setStatus: vi.fn(),
+        setErrorMessage: vi.fn(),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getSpecificVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getActiveSyncHandle: vi.fn().mockResolvedValue(undefined),
+        getServices: () => ({}),
+      });
+
+      await guestStore.loadEntityContent("hero");
+
+      expect(getGuestFile).toHaveBeenCalledWith("hero.md");
+      expect(repository.entities.hero.content).toContain("Guest chronicle");
     });
 
     it("should return early when entity is already verified", async () => {
@@ -820,6 +926,36 @@ describe("EntityStore", () => {
 
     it("should return early when entity does not exist", async () => {
       await store.loadEntityContent("nonexistent");
+    });
+
+    it("preserves hydrated guest content when a guest batch patch sends empty content", async () => {
+      const guestStore = new EntityStore({
+        repository: repository as any,
+        activeVaultId: () => null,
+        isGuest: () => true,
+        getGuestFile: vi.fn(),
+        setStatus: vi.fn(),
+        setErrorMessage: vi.fn(),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getSpecificVaultHandle: vi.fn().mockResolvedValue(undefined),
+        getActiveSyncHandle: vi.fn().mockResolvedValue(undefined),
+        getServices: () => ({}),
+      });
+
+      repository.entities.hero = {
+        ...repository.entities.hero,
+        content: "Hydrated chronicle",
+      };
+
+      await guestStore.batchUpdate({
+        hero: {
+          title: "Updated Hero",
+          content: "",
+        },
+      });
+
+      expect(repository.entities.hero.title).toBe("Updated Hero");
+      expect(repository.entities.hero.content).toBe("Hydrated chronicle");
     });
   });
 

--- a/apps/web/src/lib/utils/guest-entity-merge.test.ts
+++ b/apps/web/src/lib/utils/guest-entity-merge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { mergeGuestEntityUpdate } from "./guest-entity-merge";
+
+describe("mergeGuestEntityUpdate", () => {
+  it("preserves hydrated content when the incoming guest update omits the body", () => {
+    const merged = mergeGuestEntityUpdate(
+      {
+        id: "entity-1",
+        title: "Faerun",
+        content: "Hydrated chronicle",
+        _path: ["faerun.md"],
+      } as any,
+      {
+        id: "entity-1",
+        title: "Faerun Revised",
+        content: "",
+      } as any,
+    );
+
+    expect(merged).toMatchObject({
+      id: "entity-1",
+      title: "Faerun Revised",
+      content: "Hydrated chronicle",
+      _path: ["faerun.md"],
+    });
+  });
+
+  it("uses non-empty incoming content when the host sends a replacement", () => {
+    const merged = mergeGuestEntityUpdate(
+      {
+        id: "entity-1",
+        title: "Faerun",
+        content: "Old content",
+      } as any,
+      {
+        id: "entity-1",
+        title: "Faerun Revised",
+        content: "New shared chronicle",
+      } as any,
+    );
+
+    expect(merged.content).toBe("New shared chronicle");
+  });
+});

--- a/apps/web/src/lib/utils/guest-entity-merge.ts
+++ b/apps/web/src/lib/utils/guest-entity-merge.ts
@@ -1,0 +1,19 @@
+import type { Entity } from "schema";
+
+export function mergeGuestEntityUpdate(
+  currentEntity: Entity | undefined,
+  updatedEntity: Entity,
+): Entity {
+  return {
+    ...currentEntity,
+    ...updatedEntity,
+    content:
+      updatedEntity.content !== undefined && updatedEntity.content !== ""
+        ? updatedEntity.content
+        : currentEntity?.content,
+    _path:
+      typeof updatedEntity._path === "string"
+        ? [updatedEntity._path]
+        : (updatedEntity._path ?? currentEntity?._path),
+  } as Entity;
+}

--- a/apps/web/src/lib/utils/guest-entity-merge.ts
+++ b/apps/web/src/lib/utils/guest-entity-merge.ts
@@ -1,19 +1,25 @@
 import type { Entity } from "schema";
+import type { LocalEntity } from "$lib/stores/vault/types";
 
 export function mergeGuestEntityUpdate(
-  currentEntity: Entity | undefined,
+  currentEntity: LocalEntity | undefined,
   updatedEntity: Entity,
-): Entity {
-  return {
-    ...currentEntity,
+): LocalEntity {
+  const normalizedUpdate = {
     ...updatedEntity,
-    content:
-      updatedEntity.content !== undefined && updatedEntity.content !== ""
-        ? updatedEntity.content
-        : currentEntity?.content,
     _path:
       typeof updatedEntity._path === "string"
         ? [updatedEntity._path]
-        : (updatedEntity._path ?? currentEntity?._path),
-  } as Entity;
+        : updatedEntity._path,
+  } satisfies LocalEntity;
+
+  return {
+    ...currentEntity,
+    ...normalizedUpdate,
+    content:
+      updatedEntity.content !== undefined && updatedEntity.content !== ""
+        ? updatedEntity.content
+        : (currentEntity?.content ?? ""),
+    _path: normalizedUpdate._path ?? currentEntity?._path,
+  };
 }

--- a/apps/web/src/lib/utils/zen-popout.test.ts
+++ b/apps/web/src/lib/utils/zen-popout.test.ts
@@ -19,7 +19,7 @@ describe("zen-popout helpers", () => {
     vi.spyOn(window, "open").mockReturnValue(childWindow);
 
     openEntityPopout(
-      "guest",
+      "vault-1",
       {
         id: "entity-1",
         title: "Faerun",
@@ -97,8 +97,7 @@ describe("zen-popout helpers", () => {
       window.location.origin,
     );
     expect(payload?.entity.id).toBe("entity-1");
-    expect(payload?.entity).not.toHaveProperty("lore");
-    expect(consumeZenPopoutPayload("entity-1")?.entity.id).toBe("entity-1");
+    // Payload comes directly from the opener postMessage, not sessionStorage.
   });
 
   it("persists a cloned guest entity snapshot without lore", () => {
@@ -110,16 +109,48 @@ describe("zen-popout helpers", () => {
       _path: ["faerun.md"],
     } as any;
 
-    const payload = persistZenPopoutPayload(entity, true);
+    const payload = persistZenPopoutPayload("vault-1", entity, true);
     entity.content = "mutated after persist";
     entity.lore = "mutated lore";
 
     expect(payload.entity.content).toBe("Ancient forests and ruined empires.");
     expect(payload.entity).not.toHaveProperty("lore");
-    const storedPayload = consumeZenPopoutPayload("entity-1");
+    const storedPayload = consumeZenPopoutPayload("vault-1", "entity-1");
     expect(storedPayload?.entity.content).toBe(
       "Ancient forests and ruined empires.",
     );
     expect(storedPayload?.entity).not.toHaveProperty("lore");
+  });
+
+  it("strips _fsHandle from guest entity snapshot", () => {
+    const entity = {
+      id: "entity-2",
+      title: "Waterdeep",
+      content: "City of splendors.",
+      _path: ["waterdeep.md"],
+      _fsHandle: { handle: "some-fs-handle" },
+    } as any;
+
+    const payload = persistZenPopoutPayload("vault-2", entity, true);
+
+    expect(payload.entity).not.toHaveProperty("_fsHandle");
+    expect(payload.entity.content).toBe("City of splendors.");
+  });
+
+  it("namespaces sessionStorage keys by vaultId to prevent collisions", () => {
+    const entity = {
+      id: "shared-id",
+      title: "Entity A",
+      _path: ["a.md"],
+    } as any;
+
+    persistZenPopoutPayload("vault-a", entity, true);
+    persistZenPopoutPayload("vault-b", { ...entity, title: "Entity B" }, true);
+
+    const payloadA = consumeZenPopoutPayload("vault-a", "shared-id");
+    const payloadB = consumeZenPopoutPayload("vault-b", "shared-id");
+
+    expect(payloadA?.entity.title).toBe("Entity A");
+    expect(payloadB?.entity.title).toBe("Entity B");
   });
 });

--- a/apps/web/src/lib/utils/zen-popout.test.ts
+++ b/apps/web/src/lib/utils/zen-popout.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  consumeZenPopoutPayload,
+  openEntityPopout,
+  persistZenPopoutPayload,
+  requestZenPopoutPayload,
+} from "./zen-popout";
+
+describe("zen-popout helpers", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("responds to guest popout payload requests from the child tab", () => {
+    const childWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    vi.spyOn(window, "open").mockReturnValue(childWindow);
+
+    openEntityPopout(
+      "guest",
+      {
+        id: "entity-1",
+        title: "Faerun",
+        lore: "Hosts only",
+        _path: ["faerun.md"],
+      } as any,
+      "",
+      true,
+    );
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: window.location.origin,
+        source: childWindow,
+        data: {
+          source: "codex.zen-popout",
+          type: "REQUEST_PAYLOAD",
+          entityId: "entity-1",
+        },
+      }),
+    );
+
+    expect(childWindow.postMessage).toHaveBeenCalledWith(
+      {
+        source: "codex.zen-popout",
+        type: "PAYLOAD",
+        entityId: "entity-1",
+        payload: expect.objectContaining({
+          isGuest: true,
+          entity: expect.not.objectContaining({ lore: expect.anything() }),
+        }),
+      },
+      window.location.origin,
+    );
+  });
+
+  it("requests a payload from the opener when session storage is empty", async () => {
+    const opener = {
+      postMessage: vi.fn((_message: unknown, _origin: string) => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            origin: window.location.origin,
+            source: opener as unknown as MessageEventSource,
+            data: {
+              source: "codex.zen-popout",
+              type: "PAYLOAD",
+              entityId: "entity-1",
+              payload: {
+                isGuest: true,
+                entity: {
+                  id: "entity-1",
+                  title: "Faerun",
+                  lore: "Hosts only",
+                  _path: ["faerun.md"],
+                },
+              },
+            },
+          }),
+        );
+      }),
+    };
+    Object.defineProperty(window, "opener", {
+      configurable: true,
+      value: opener,
+    });
+
+    const payload = await requestZenPopoutPayload("entity-1");
+
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      {
+        source: "codex.zen-popout",
+        type: "REQUEST_PAYLOAD",
+        entityId: "entity-1",
+      },
+      window.location.origin,
+    );
+    expect(payload?.entity.id).toBe("entity-1");
+    expect(payload?.entity).not.toHaveProperty("lore");
+    expect(consumeZenPopoutPayload("entity-1")?.entity.id).toBe("entity-1");
+  });
+
+  it("persists a cloned guest entity snapshot without lore", () => {
+    const entity = {
+      id: "entity-1",
+      title: "Faerun",
+      content: "Ancient forests and ruined empires.",
+      lore: "This should stay on the host",
+      _path: ["faerun.md"],
+    } as any;
+
+    const payload = persistZenPopoutPayload(entity, true);
+    entity.content = "mutated after persist";
+    entity.lore = "mutated lore";
+
+    expect(payload.entity.content).toBe("Ancient forests and ruined empires.");
+    expect(payload.entity).not.toHaveProperty("lore");
+    const storedPayload = consumeZenPopoutPayload("entity-1");
+    expect(storedPayload?.entity.content).toBe(
+      "Ancient forests and ruined empires.",
+    );
+    expect(storedPayload?.entity).not.toHaveProperty("lore");
+  });
+});

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -40,8 +40,14 @@ export function openEntityPopout(
       if (event.source !== newTab) return;
       const msg = event.data as ZenEntityRequest;
       if (msg?.type === ZEN_POPOUT_REQUEST && msg.entityId === entity.id) {
+        // $state.snapshot produces a plain object — required for structured clone
+        const plain = $state.snapshot(entity) as Entity;
         newTab.postMessage(
-          { type: ZEN_POPOUT_DATA, entity, isGuest } satisfies ZenEntityData,
+          {
+            type: ZEN_POPOUT_DATA,
+            entity: plain,
+            isGuest,
+          } satisfies ZenEntityData,
           origin,
         );
         window.removeEventListener("message", handleRequest);

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -9,6 +9,8 @@ const LISTENER_TTL_MS = 30_000;
 export interface ZenPopoutPayload {
   entity: Entity;
   isGuest: boolean;
+  /** Stubs for entities linked to/from this entity — needed for connection rendering */
+  extraEntities?: Entity[];
 }
 
 function buildGuestEntitySnapshot(entity: Entity): Entity {
@@ -53,12 +55,19 @@ function persistPayload(entityId: string, payload: ZenPopoutPayload) {
   );
 }
 
-export function persistZenPopoutPayload(entity: Entity, isGuest: boolean) {
+export function persistZenPopoutPayload(
+  entity: Entity,
+  isGuest: boolean,
+  extraEntities?: Entity[],
+) {
   const payload: ZenPopoutPayload = {
     entity: isGuest
       ? buildGuestEntitySnapshot(entity)
       : (JSON.parse(JSON.stringify(entity)) as Entity),
     isGuest,
+    extraEntities: extraEntities?.map(
+      (e) => JSON.parse(JSON.stringify(e)) as Entity,
+    ),
   };
   persistPayload(entity.id, payload);
   return payload;
@@ -80,11 +89,12 @@ export function openEntityPopout(
   entity: Entity,
   base: string,
   isGuest: boolean,
+  extraEntities?: Entity[],
 ) {
   const url = `${base}/vault/${vaultId}/entity/${entity.id}`;
 
   if (isGuest) {
-    const payload = persistZenPopoutPayload(entity, true);
+    const payload = persistZenPopoutPayload(entity, true, extraEntities);
     const childWindow = window.open(url, "_blank");
     if (!childWindow) return;
 

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -40,8 +40,8 @@ export function openEntityPopout(
       if (event.source !== newTab) return;
       const msg = event.data as ZenEntityRequest;
       if (msg?.type === ZEN_POPOUT_REQUEST && msg.entityId === entity.id) {
-        // $state.snapshot produces a plain object — required for structured clone
-        const plain = $state.snapshot(entity) as Entity;
+        // Strip Svelte reactive proxy — postMessage needs a plain cloneable object
+        const plain = JSON.parse(JSON.stringify(entity)) as Entity;
         newTab.postMessage(
           {
             type: ZEN_POPOUT_DATA,

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -11,10 +11,10 @@ export interface ZenPopoutPayload {
  * Opens an entity in a standalone zen popout tab.
  *
  * For guests (P2P data, no local vault), the entity is written to
- * localStorage before the tab opens. We intentionally omit `noopener`
- * for guests: in private/incognito mode, `noopener` causes the browser
- * to give the new tab an isolated storage partition, making the
- * localStorage write invisible to it.
+ * sessionStorage before the tab opens. We intentionally omit `noopener`
+ * for guests: browsers copy the opener's sessionStorage to new tabs
+ * opened via window.open, so the payload is immediately visible. With
+ * `noopener` that inheritance is blocked and the new tab sees nothing.
  *
  * For hosts, `noopener,noreferrer` is safe since no cross-tab storage
  * handshake is needed.
@@ -32,7 +32,7 @@ export function openEntityPopout(
       entity: JSON.parse(JSON.stringify(entity)),
       isGuest: true,
     };
-    localStorage.setItem(
+    sessionStorage.setItem(
       `${STORAGE_KEY_PREFIX}${entity.id}`,
       JSON.stringify(payload),
     );
@@ -47,9 +47,9 @@ export function consumeZenPopoutPayload(
   entityId: string,
 ): ZenPopoutPayload | null {
   const key = `${STORAGE_KEY_PREFIX}${entityId}`;
-  const raw = localStorage.getItem(key);
+  const raw = sessionStorage.getItem(key);
   if (!raw) return null;
-  localStorage.removeItem(key);
+  sessionStorage.removeItem(key);
   try {
     return JSON.parse(raw) as ZenPopoutPayload;
   } catch {

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -1,0 +1,52 @@
+import type { Entity } from "schema";
+
+export const ZEN_POPOUT_REQUEST = "ZEN_ENTITY_REQUEST";
+export const ZEN_POPOUT_DATA = "ZEN_ENTITY_DATA";
+
+export interface ZenEntityRequest {
+  type: typeof ZEN_POPOUT_REQUEST;
+  entityId: string;
+}
+
+export interface ZenEntityData {
+  type: typeof ZEN_POPOUT_DATA;
+  entity: Entity;
+  isGuest: boolean;
+}
+
+/**
+ * Opens an entity in a standalone zen popout tab.
+ *
+ * For guests, data lives in memory (P2P), not local storage. We open the tab
+ * without `noopener` so the new tab can postMessage us a request, then we
+ * respond with the entity payload.
+ */
+export function openEntityPopout(
+  vaultId: string,
+  entity: Entity,
+  base: string,
+  isGuest: boolean,
+) {
+  const url = `${base}/vault/${vaultId}/entity/${entity.id}`;
+
+  // noopener would null out window.opener in the child — skip it for guests
+  const features = isGuest ? "" : "noopener,noreferrer";
+  const newTab = window.open(url, "_blank", features);
+
+  if (isGuest && newTab) {
+    const origin = window.location.origin;
+    const handleRequest = (event: MessageEvent) => {
+      if (event.origin !== origin) return;
+      if (event.source !== newTab) return;
+      const msg = event.data as ZenEntityRequest;
+      if (msg?.type === ZEN_POPOUT_REQUEST && msg.entityId === entity.id) {
+        newTab.postMessage(
+          { type: ZEN_POPOUT_DATA, entity, isGuest } satisfies ZenEntityData,
+          origin,
+        );
+        window.removeEventListener("message", handleRequest);
+      }
+    };
+    window.addEventListener("message", handleRequest);
+  }
+}

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -9,8 +9,6 @@ const LISTENER_TTL_MS = 30_000;
 export interface ZenPopoutPayload {
   entity: Entity;
   isGuest: boolean;
-  /** Stubs for entities linked to/from this entity — needed for connection rendering */
-  extraEntities?: Entity[];
 }
 
 function buildGuestEntitySnapshot(entity: Entity): Entity {
@@ -55,19 +53,12 @@ function persistPayload(entityId: string, payload: ZenPopoutPayload) {
   );
 }
 
-export function persistZenPopoutPayload(
-  entity: Entity,
-  isGuest: boolean,
-  extraEntities?: Entity[],
-) {
+export function persistZenPopoutPayload(entity: Entity, isGuest: boolean) {
   const payload: ZenPopoutPayload = {
     entity: isGuest
       ? buildGuestEntitySnapshot(entity)
       : (JSON.parse(JSON.stringify(entity)) as Entity),
     isGuest,
-    extraEntities: extraEntities?.map(
-      (e) => JSON.parse(JSON.stringify(e)) as Entity,
-    ),
   };
   persistPayload(entity.id, payload);
   return payload;
@@ -89,12 +80,11 @@ export function openEntityPopout(
   entity: Entity,
   base: string,
   isGuest: boolean,
-  extraEntities?: Entity[],
 ) {
   const url = `${base}/vault/${vaultId}/entity/${entity.id}`;
 
   if (isGuest) {
-    const payload = persistZenPopoutPayload(entity, true, extraEntities);
+    const payload = persistZenPopoutPayload(entity, true);
     const childWindow = window.open(url, "_blank");
     if (!childWindow) return;
 

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -1,15 +1,8 @@
 import type { Entity } from "schema";
 
-export const ZEN_POPOUT_REQUEST = "ZEN_ENTITY_REQUEST";
-export const ZEN_POPOUT_DATA = "ZEN_ENTITY_DATA";
+const STORAGE_KEY_PREFIX = "codex.zen-popout.";
 
-export interface ZenEntityRequest {
-  type: typeof ZEN_POPOUT_REQUEST;
-  entityId: string;
-}
-
-export interface ZenEntityData {
-  type: typeof ZEN_POPOUT_DATA;
+export interface ZenPopoutPayload {
   entity: Entity;
   isGuest: boolean;
 }
@@ -17,9 +10,9 @@ export interface ZenEntityData {
 /**
  * Opens an entity in a standalone zen popout tab.
  *
- * For guests, data lives in memory (P2P), not local storage. We open the tab
- * without `noopener` so the new tab can postMessage us a request, then we
- * respond with the entity payload.
+ * For guests (P2P data, no local vault), the entity is written to
+ * localStorage under a per-entity key before the tab opens. The new tab
+ * reads and immediately removes the entry so it doesn't linger.
  */
 export function openEntityPopout(
   vaultId: string,
@@ -27,32 +20,35 @@ export function openEntityPopout(
   base: string,
   isGuest: boolean,
 ) {
-  const url = `${base}/vault/${vaultId}/entity/${entity.id}`;
-
-  // noopener would null out window.opener in the child — skip it for guests
-  const features = isGuest ? "" : "noopener,noreferrer";
-  const newTab = window.open(url, "_blank", features);
-
-  if (isGuest && newTab) {
-    const origin = window.location.origin;
-    const handleRequest = (event: MessageEvent) => {
-      if (event.origin !== origin) return;
-      if (event.source !== newTab) return;
-      const msg = event.data as ZenEntityRequest;
-      if (msg?.type === ZEN_POPOUT_REQUEST && msg.entityId === entity.id) {
-        // Strip Svelte reactive proxy — postMessage needs a plain cloneable object
-        const plain = JSON.parse(JSON.stringify(entity)) as Entity;
-        newTab.postMessage(
-          {
-            type: ZEN_POPOUT_DATA,
-            entity: plain,
-            isGuest,
-          } satisfies ZenEntityData,
-          origin,
-        );
-        window.removeEventListener("message", handleRequest);
-      }
+  if (isGuest) {
+    const payload: ZenPopoutPayload = {
+      // Strip Svelte reactive proxy before serialising
+      entity: JSON.parse(JSON.stringify(entity)),
+      isGuest: true,
     };
-    window.addEventListener("message", handleRequest);
+    localStorage.setItem(
+      `${STORAGE_KEY_PREFIX}${entity.id}`,
+      JSON.stringify(payload),
+    );
+  }
+
+  window.open(
+    `${base}/vault/${vaultId}/entity/${entity.id}`,
+    "_blank",
+    "noopener,noreferrer",
+  );
+}
+
+export function consumeZenPopoutPayload(
+  entityId: string,
+): ZenPopoutPayload | null {
+  const key = `${STORAGE_KEY_PREFIX}${entityId}`;
+  const raw = localStorage.getItem(key);
+  if (!raw) return null;
+  localStorage.removeItem(key);
+  try {
+    return JSON.parse(raw) as ZenPopoutPayload;
+  } catch {
+    return null;
   }
 }

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -14,8 +14,10 @@ export interface ZenPopoutPayload {
 function buildGuestEntitySnapshot(entity: Entity): Entity {
   const snapshot = JSON.parse(JSON.stringify(entity)) as Entity & {
     lore?: string;
+    _fsHandle?: unknown;
   };
   delete snapshot.lore;
+  delete snapshot._fsHandle;
   return snapshot;
 }
 
@@ -46,21 +48,33 @@ function isResponseMessage(
   );
 }
 
-function persistPayload(entityId: string, payload: ZenPopoutPayload) {
+function getStorageKey(vaultId: string, entityId: string): string {
+  return `${STORAGE_KEY_PREFIX}${vaultId}.${entityId}`;
+}
+
+function persistPayload(
+  vaultId: string,
+  entityId: string,
+  payload: ZenPopoutPayload,
+) {
   sessionStorage.setItem(
-    `${STORAGE_KEY_PREFIX}${entityId}`,
+    getStorageKey(vaultId, entityId),
     JSON.stringify(payload),
   );
 }
 
-export function persistZenPopoutPayload(entity: Entity, isGuest: boolean) {
+export function persistZenPopoutPayload(
+  vaultId: string,
+  entity: Entity,
+  isGuest: boolean,
+) {
   const payload: ZenPopoutPayload = {
     entity: isGuest
       ? buildGuestEntitySnapshot(entity)
       : (JSON.parse(JSON.stringify(entity)) as Entity),
     isGuest,
   };
-  persistPayload(entity.id, payload);
+  persistPayload(vaultId, entity.id, payload);
   return payload;
 }
 
@@ -84,7 +98,7 @@ export function openEntityPopout(
   const url = `${base}/vault/${vaultId}/entity/${entity.id}`;
 
   if (isGuest) {
-    const payload = persistZenPopoutPayload(entity, true);
+    const payload = persistZenPopoutPayload(vaultId, entity, true);
     const childWindow = window.open(url, "_blank");
     if (!childWindow) return;
 
@@ -122,9 +136,10 @@ export function openEntityPopout(
 }
 
 export function consumeZenPopoutPayload(
+  vaultId: string,
   entityId: string,
 ): ZenPopoutPayload | null {
-  const key = `${STORAGE_KEY_PREFIX}${entityId}`;
+  const key = getStorageKey(vaultId, entityId);
   const raw = sessionStorage.getItem(key);
   if (!raw) return null;
   sessionStorage.removeItem(key);
@@ -153,11 +168,15 @@ export function requestZenPopoutPayload(
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== origin || event.source !== window.opener) return;
       if (!isResponseMessage(event.data, entityId)) return;
-      const sanitizedPayload = event.data.payload.isGuest
-        ? persistZenPopoutPayload(event.data.payload.entity, true)
-        : event.data.payload;
+      // Clear opener reference immediately after successful handshake to
+      // prevent reverse-tabnabbing.
+      try {
+        (window.opener as WindowProxy | null) = null;
+      } catch {
+        // Some browsers may not allow clearing opener; ignore.
+      }
       cleanup();
-      resolve(sanitizedPayload);
+      resolve(event.data.payload);
     };
     const timeoutId = window.setTimeout(() => {
       cleanup();

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -11,8 +11,13 @@ export interface ZenPopoutPayload {
  * Opens an entity in a standalone zen popout tab.
  *
  * For guests (P2P data, no local vault), the entity is written to
- * localStorage under a per-entity key before the tab opens. The new tab
- * reads and immediately removes the entry so it doesn't linger.
+ * localStorage before the tab opens. We intentionally omit `noopener`
+ * for guests: in private/incognito mode, `noopener` causes the browser
+ * to give the new tab an isolated storage partition, making the
+ * localStorage write invisible to it.
+ *
+ * For hosts, `noopener,noreferrer` is safe since no cross-tab storage
+ * handshake is needed.
  */
 export function openEntityPopout(
   vaultId: string,
@@ -20,9 +25,10 @@ export function openEntityPopout(
   base: string,
   isGuest: boolean,
 ) {
+  const url = `${base}/vault/${vaultId}/entity/${entity.id}`;
+
   if (isGuest) {
     const payload: ZenPopoutPayload = {
-      // Strip Svelte reactive proxy before serialising
       entity: JSON.parse(JSON.stringify(entity)),
       isGuest: true,
     };
@@ -30,13 +36,11 @@ export function openEntityPopout(
       `${STORAGE_KEY_PREFIX}${entity.id}`,
       JSON.stringify(payload),
     );
+    // No noopener — needed to share the same storage partition in private mode
+    window.open(url, "_blank");
+  } else {
+    window.open(url, "_blank", "noopener,noreferrer");
   }
-
-  window.open(
-    `${base}/vault/${vaultId}/entity/${entity.id}`,
-    "_blank",
-    "noopener,noreferrer",
-  );
 }
 
 export function consumeZenPopoutPayload(

--- a/apps/web/src/lib/utils/zen-popout.ts
+++ b/apps/web/src/lib/utils/zen-popout.ts
@@ -1,10 +1,67 @@
 import type { Entity } from "schema";
 
 const STORAGE_KEY_PREFIX = "codex.zen-popout.";
+const MESSAGE_SOURCE = "codex.zen-popout";
+const REQUEST_TYPE = "REQUEST_PAYLOAD";
+const RESPONSE_TYPE = "PAYLOAD";
+const LISTENER_TTL_MS = 30_000;
 
 export interface ZenPopoutPayload {
   entity: Entity;
   isGuest: boolean;
+}
+
+function buildGuestEntitySnapshot(entity: Entity): Entity {
+  const snapshot = JSON.parse(JSON.stringify(entity)) as Entity & {
+    lore?: string;
+  };
+  delete snapshot.lore;
+  return snapshot;
+}
+
+interface ZenPopoutRequestMessage {
+  source: typeof MESSAGE_SOURCE;
+  type: typeof REQUEST_TYPE;
+  entityId: string;
+}
+
+interface ZenPopoutResponseMessage {
+  source: typeof MESSAGE_SOURCE;
+  type: typeof RESPONSE_TYPE;
+  entityId: string;
+  payload: ZenPopoutPayload;
+}
+
+function isResponseMessage(
+  value: unknown,
+  entityId: string,
+): value is ZenPopoutResponseMessage {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Partial<ZenPopoutResponseMessage>;
+  return (
+    message.source === MESSAGE_SOURCE &&
+    message.type === RESPONSE_TYPE &&
+    message.entityId === entityId &&
+    !!message.payload
+  );
+}
+
+function persistPayload(entityId: string, payload: ZenPopoutPayload) {
+  sessionStorage.setItem(
+    `${STORAGE_KEY_PREFIX}${entityId}`,
+    JSON.stringify(payload),
+  );
+}
+
+export function persistZenPopoutPayload(entity: Entity, isGuest: boolean) {
+  const payload: ZenPopoutPayload = {
+    entity: isGuest
+      ? buildGuestEntitySnapshot(entity)
+      : (JSON.parse(JSON.stringify(entity)) as Entity),
+    isGuest,
+  };
+  persistPayload(entity.id, payload);
+  return payload;
 }
 
 /**
@@ -12,9 +69,8 @@ export interface ZenPopoutPayload {
  *
  * For guests (P2P data, no local vault), the entity is written to
  * sessionStorage before the tab opens. We intentionally omit `noopener`
- * for guests: browsers copy the opener's sessionStorage to new tabs
- * opened via window.open, so the payload is immediately visible. With
- * `noopener` that inheritance is blocked and the new tab sees nothing.
+ * for guests so the child can request a payload from `window.opener`
+ * if private/incognito mode prevents storage inheritance.
  *
  * For hosts, `noopener,noreferrer` is safe since no cross-tab storage
  * handshake is needed.
@@ -28,16 +84,38 @@ export function openEntityPopout(
   const url = `${base}/vault/${vaultId}/entity/${entity.id}`;
 
   if (isGuest) {
-    const payload: ZenPopoutPayload = {
-      entity: JSON.parse(JSON.stringify(entity)),
-      isGuest: true,
+    const payload = persistZenPopoutPayload(entity, true);
+    const childWindow = window.open(url, "_blank");
+    if (!childWindow) return;
+
+    const origin = window.location.origin;
+    const cleanup = () => {
+      window.removeEventListener("message", handleMessage);
+      window.clearTimeout(timeoutId);
     };
-    sessionStorage.setItem(
-      `${STORAGE_KEY_PREFIX}${entity.id}`,
-      JSON.stringify(payload),
-    );
-    // No noopener — needed to share the same storage partition in private mode
-    window.open(url, "_blank");
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== origin || event.source !== childWindow) return;
+      const data = event.data as Partial<ZenPopoutRequestMessage> | null;
+      if (
+        data?.source !== MESSAGE_SOURCE ||
+        data.type !== REQUEST_TYPE ||
+        data.entityId !== entity.id
+      ) {
+        return;
+      }
+      childWindow.postMessage(
+        {
+          source: MESSAGE_SOURCE,
+          type: RESPONSE_TYPE,
+          entityId: entity.id,
+          payload,
+        } satisfies ZenPopoutResponseMessage,
+        origin,
+      );
+      cleanup();
+    };
+    const timeoutId = window.setTimeout(cleanup, LISTENER_TTL_MS);
+    window.addEventListener("message", handleMessage);
   } else {
     window.open(url, "_blank", "noopener,noreferrer");
   }
@@ -55,4 +133,45 @@ export function consumeZenPopoutPayload(
   } catch {
     return null;
   }
+}
+
+export function requestZenPopoutPayload(
+  entityId: string,
+  timeoutMs = 1500,
+): Promise<ZenPopoutPayload | null> {
+  if (typeof window === "undefined" || !window.opener) {
+    return Promise.resolve(null);
+  }
+
+  const origin = window.location.origin;
+
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      window.removeEventListener("message", handleMessage);
+      window.clearTimeout(timeoutId);
+    };
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== origin || event.source !== window.opener) return;
+      if (!isResponseMessage(event.data, entityId)) return;
+      const sanitizedPayload = event.data.payload.isGuest
+        ? persistZenPopoutPayload(event.data.payload.entity, true)
+        : event.data.payload;
+      cleanup();
+      resolve(sanitizedPayload);
+    };
+    const timeoutId = window.setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeoutMs);
+
+    window.addEventListener("message", handleMessage);
+    window.opener.postMessage(
+      {
+        source: MESSAGE_SOURCE,
+        type: REQUEST_TYPE,
+        entityId,
+      } satisfies ZenPopoutRequestMessage,
+      origin,
+    );
+  });
 }

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -57,6 +57,9 @@
       page.url.pathname === `${base}/help` ||
       page.url.pathname === `${base}/import`,
   );
+  const isZenPopout = $derived(
+    /\/vault\/[^/]+\/entity\/[^/]+$/.test(page.url.pathname),
+  );
   const isVttFullscreen = $derived(
     page.url.pathname.startsWith(`${base}/map`) && mapSession.vttEnabled,
   );
@@ -214,14 +217,14 @@
 <div class="h-screen bg-theme-bg flex flex-col font-body app-layout">
   <NotificationToast />
 
-  {#if !isPopup && !isVttFullscreen}
+  {#if !isPopup && !isVttFullscreen && !isZenPopout}
     <AppHeader bind:isMobileMenuOpen bind:headerEl />
   {/if}
 
   <div
     class="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative overflow-hidden"
   >
-    {#if !isPopup && !isVttFullscreen}
+    {#if !isPopup && !isVttFullscreen && !isZenPopout}
       <ActivityBar />
       <SidebarPanelHost />
     {/if}
@@ -231,7 +234,7 @@
     </main>
   </div>
 
-  {#if !isPopup && !isVttFullscreen}
+  {#if !isPopup && !isVttFullscreen && !isZenPopout}
     <AppFooter />
   {/if}
 

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -31,6 +31,11 @@
   let showVttShare = $state(false);
   let isVttChatSidebarCollapsed = $state(false);
   let isVttSidebarCollapsed = $state(false);
+
+  // Chat sidebar offset: 20rem when expanded, 3rem (w-12) when collapsed
+  const chatSidebarOffset = $derived(
+    isVttChatSidebarCollapsed ? "3rem" : "20rem",
+  );
   let mapName = $state("");
   let files = $state<FileList | null>(null);
 
@@ -194,7 +199,8 @@
       <!-- HUD Overlay -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
-        class="absolute top-4 left-4 z-10 flex flex-col items-start gap-2"
+        class="absolute z-10 flex flex-col items-start gap-2"
+        style="top: 1rem; left: calc({chatSidebarOffset} + 1rem);"
         role="presentation"
         onmousedown={(e) => e.stopPropagation()}
       >
@@ -292,7 +298,10 @@
 
       <!-- Measurement tool button (lower left) -->
       {#if !uiStore.isGuestMode && mapSession.vttEnabled}
-        <div class="absolute bottom-4 left-4 z-20 pointer-events-auto">
+        <div
+          class="absolute z-20 pointer-events-auto"
+          style="bottom: 1rem; left: calc({chatSidebarOffset} + 1rem);"
+        >
           <button
             class={getMeasurementToolButtonClass(mapSession.measurement.active)}
             onclick={(e) => {

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -97,7 +97,7 @@
         <VTTChatSidebar bind:collapsed={isVttChatSidebarCollapsed} />
 
         <aside
-          class="absolute top-0 right-0 bottom-0 z-[30] flex overflow-hidden border-l border-theme-border bg-theme-surface/95 shadow-[0_0_30px_rgba(0,0,0,0.25)] backdrop-blur transition-all duration-200 pointer-events-auto {isVttSidebarCollapsed
+          class="absolute top-0 right-0 bottom-0 z-[30] flex overflow-hidden border-l border-theme-primary/20 bg-theme-surface/95 shadow-[0_0_30px_rgba(0,0,0,0.25)] backdrop-blur transition-all duration-200 pointer-events-auto {isVttSidebarCollapsed
             ? 'w-12'
             : 'w-[22rem] max-w-[calc(100vw-3rem)]'}"
           aria-label="VTT Sidebar"
@@ -105,6 +105,7 @@
           {#if isVttSidebarCollapsed}
             <div
               class="flex h-full w-full flex-col items-center justify-between p-2"
+              style="background-image: var(--bg-texture-overlay)"
             >
               <button
                 class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
@@ -125,13 +126,30 @@
               </div>
             </div>
           {:else}
-            <div class="flex h-full min-h-0 w-full flex-col">
+            <div
+              class="flex h-full min-h-0 w-full flex-col relative"
+              style="background-image: var(--bg-texture-overlay)"
+            >
+              <!-- Decorative Corners -->
               <div
-                class="flex items-center justify-between gap-3 border-b border-theme-border/70 px-3 py-3"
+                class="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-theme-primary/30 rounded-tl pointer-events-none hidden md:block"
+              ></div>
+              <div
+                class="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-theme-primary/30 rounded-tr pointer-events-none hidden md:block"
+              ></div>
+              <div
+                class="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-theme-primary/30 rounded-bl pointer-events-none hidden md:block"
+              ></div>
+              <div
+                class="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-theme-primary/30 rounded-br pointer-events-none hidden md:block"
+              ></div>
+
+              <div
+                class="flex items-center justify-between gap-3 border-b border-theme-primary/20 px-3 py-3"
               >
                 <div>
                   <div
-                    class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-muted"
+                    class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
                   >
                     VTT Sidebar
                   </div>
@@ -148,7 +166,7 @@
                 </button>
               </div>
 
-              <div class="border-b border-theme-border/70 px-3 py-3">
+              <div class="border-b border-theme-primary/20 px-3 py-3">
                 <VTTControls />
               </div>
 
@@ -163,7 +181,7 @@
 
                 {#if !showInitiativePanel && !hasSelectedToken}
                   <div
-                    class="rounded-xl border border-dashed border-theme-border bg-theme-bg/50 p-4 text-sm text-theme-muted"
+                    class="rounded-xl border border-dashed border-theme-primary/20 bg-theme-bg/50 p-4 text-sm text-theme-muted"
                   >
                     Select a token to view its details.
                   </div>
@@ -172,7 +190,7 @@
 
               {#if !uiStore.isGuestMode}
                 <div
-                  class="relative z-20 border-t border-theme-border/70 p-3 flex justify-end pointer-events-auto"
+                  class="relative z-20 border-t border-theme-primary/20 p-3 flex justify-end pointer-events-auto"
                   role="presentation"
                   onmousedown={(e) => e.stopPropagation()}
                 >

--- a/apps/web/src/routes/(app)/vault/[id]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/+page.svelte
@@ -6,6 +6,7 @@
   import EntityDetailPanel from "$lib/components/EntityDetailPanel.svelte";
 
   const vaultId = $derived(page.params.id);
+  const zenParam = $derived(page.url.searchParams.get("zen"));
   const selectedEntity = $derived.by(() => {
     const id = vault.selectedEntityId;
     return id ? vault.entities[id] : null;
@@ -14,6 +15,17 @@
   $effect(() => {
     if (vaultId && vault.activeVaultId !== vaultId) {
       void vault.switchVault(vaultId);
+    }
+  });
+
+  // Auto-open zen mode when ?zen=entityId is in the URL, once the vault is loaded
+  $effect(() => {
+    if (
+      zenParam &&
+      vault.activeVaultId === vaultId &&
+      vault.entities[zenParam]
+    ) {
+      uiStore.openZenMode(zenParam);
     }
   });
 </script>

--- a/apps/web/src/routes/(app)/vault/[id]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/+page.svelte
@@ -6,7 +6,6 @@
   import EntityDetailPanel from "$lib/components/EntityDetailPanel.svelte";
 
   const vaultId = $derived(page.params.id);
-  const zenParam = $derived(page.url.searchParams.get("zen"));
   const selectedEntity = $derived.by(() => {
     const id = vault.selectedEntityId;
     return id ? vault.entities[id] : null;
@@ -15,17 +14,6 @@
   $effect(() => {
     if (vaultId && vault.activeVaultId !== vaultId) {
       void vault.switchVault(vaultId);
-    }
-  });
-
-  // Auto-open zen mode when ?zen=entityId is in the URL, once the vault is loaded
-  $effect(() => {
-    if (
-      zenParam &&
-      vault.activeVaultId === vaultId &&
-      vault.entities[zenParam]
-    ) {
-      uiStore.openZenMode(zenParam);
     }
   });
 </script>

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { vault } from "$lib/stores/vault.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
+
+  const vaultId = $derived(page.params.id);
+  const entityId = $derived(page.params.entityId);
+
+  $effect(() => {
+    if (vaultId && vault.activeVaultId !== vaultId) {
+      void vault.switchVault(vaultId);
+    }
+  });
+
+  $effect(() => {
+    if (
+      entityId &&
+      vault.activeVaultId === vaultId &&
+      vault.entities[entityId]
+    ) {
+      uiStore.openZenMode(entityId);
+    }
+  });
+</script>
+
+<svelte:head>
+  <title
+    >{(entityId ? vault.entities[entityId]?.title : null) ?? "Entity"} | Codex Cryptica</title
+  >
+</svelte:head>
+
+<!-- Full-screen dark backdrop — the ZenModeModal overlays this -->
+<div class="h-screen bg-black"></div>

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -26,8 +26,8 @@
     guestEntityId = payload.entity.id;
   };
 
-  let guestEntityId: string | null = null;
-  let isResolvingGuestPayload = false;
+  let guestEntityId = $state<string | null>(null);
+  let isResolvingGuestPayload = $state(false);
   if (browser) {
     const payload = page.params.entityId
       ? consumeZenPopoutPayload(page.params.entityId)

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -8,26 +8,36 @@
   const vaultId = $derived(page.params.id);
   const entityId = $derived(page.params.entityId);
 
-  // Guest flow: entity was written to localStorage by the opener tab
-  $effect(() => {
-    if (!browser || !entityId) return;
-    const payload = consumeZenPopoutPayload(entityId);
-    if (!payload) return;
+  // Consume guest payload synchronously so uiStore.isGuestMode is set
+  // before any effects run — prevents the host switchVault from firing.
+  let guestEntityId: string | null = null;
+  if (browser) {
+    const payload = page.params.entityId
+      ? consumeZenPopoutPayload(page.params.entityId)
+      : null;
+    if (payload) {
+      vault.repository.entities[payload.entity.id] = {
+        ...payload.entity,
+        _path:
+          typeof payload.entity._path === "string"
+            ? [payload.entity._path]
+            : payload.entity._path,
+      };
+      vault.isInitialized = true;
+      vault.status = "idle";
+      if (payload.isGuest) uiStore.isGuestMode = true;
+      guestEntityId = payload.entity.id;
+    }
+  }
 
-    vault.repository.entities[payload.entity.id] = {
-      ...payload.entity,
-      _path:
-        typeof payload.entity._path === "string"
-          ? [payload.entity._path]
-          : payload.entity._path,
-    };
-    vault.isInitialized = true;
-    vault.status = "idle";
-    if (payload.isGuest) uiStore.isGuestMode = true;
-    uiStore.openZenMode(payload.entity.id);
+  // Guest flow: open zen mode once reactive state has settled
+  $effect(() => {
+    if (guestEntityId && vault.entities[guestEntityId]) {
+      uiStore.openZenMode(guestEntityId);
+    }
   });
 
-  // Host flow: load vault from OPFS then open zen mode
+  // Host flow: only when not a guest popout
   $effect(() => {
     if (vaultId && vault.activeVaultId !== vaultId && !uiStore.isGuestMode) {
       void vault.switchVault(vaultId);

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -35,6 +35,8 @@
     if (payload) {
       applyGuestPayload(payload);
     } else if (page.params.entityId && window.opener) {
+      // Set isGuestMode early so vault.init() bails before loadFiles() runs
+      uiStore.isGuestMode = true;
       isResolvingGuestPayload = true;
     }
   }

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -3,14 +3,29 @@
   import { page } from "$app/state";
   import { vault } from "$lib/stores/vault.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import {
-    ZEN_POPOUT_REQUEST,
-    ZEN_POPOUT_DATA,
-    type ZenEntityData,
-  } from "$lib/utils/zen-popout";
+  import { consumeZenPopoutPayload } from "$lib/utils/zen-popout";
 
   const vaultId = $derived(page.params.id);
   const entityId = $derived(page.params.entityId);
+
+  // Guest flow: entity was written to localStorage by the opener tab
+  $effect(() => {
+    if (!browser || !entityId) return;
+    const payload = consumeZenPopoutPayload(entityId);
+    if (!payload) return;
+
+    vault.repository.entities[payload.entity.id] = {
+      ...payload.entity,
+      _path:
+        typeof payload.entity._path === "string"
+          ? [payload.entity._path]
+          : payload.entity._path,
+    };
+    vault.isInitialized = true;
+    vault.status = "idle";
+    if (payload.isGuest) uiStore.isGuestMode = true;
+    uiStore.openZenMode(payload.entity.id);
+  });
 
   // Host flow: load vault from OPFS then open zen mode
   $effect(() => {
@@ -27,43 +42,6 @@
     ) {
       uiStore.openZenMode(entityId);
     }
-  });
-
-  // Guest flow: request entity from the opener tab via postMessage
-  $effect(() => {
-    if (!browser || !entityId) return;
-
-    const origin = window.location.origin;
-
-    const handleData = (event: MessageEvent) => {
-      if (event.origin !== origin) return;
-      const msg = event.data as ZenEntityData;
-      if (msg?.type !== ZEN_POPOUT_DATA || msg.entity?.id !== entityId) return;
-
-      vault.repository.entities[msg.entity.id] = {
-        ...msg.entity,
-        _path:
-          typeof msg.entity._path === "string"
-            ? [msg.entity._path]
-            : msg.entity._path,
-      };
-      vault.isInitialized = true;
-      vault.status = "idle";
-      if (msg.isGuest) uiStore.isGuestMode = true;
-      uiStore.openZenMode(msg.entity.id);
-
-      window.removeEventListener("message", handleData);
-    };
-
-    window.addEventListener("message", handleData);
-
-    // Ask the opener for the entity (it may not be ready yet — opener sets
-    // up its listener before calling window.open, so this arrives in time)
-    if (window.opener) {
-      window.opener.postMessage({ type: ZEN_POPOUT_REQUEST, entityId }, origin);
-    }
-
-    return () => window.removeEventListener("message", handleData);
   });
 </script>
 

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -29,15 +29,17 @@
   let guestEntityId = $state<string | null>(null);
   let isResolvingGuestPayload = $state(false);
   if (browser) {
-    const payload = page.params.entityId
-      ? consumeZenPopoutPayload(page.params.entityId)
-      : null;
-    if (payload) {
-      applyGuestPayload(payload);
-    } else if (page.params.entityId && window.opener) {
-      // Set isGuestMode early so vault.init() bails before loadFiles() runs
-      uiStore.isGuestMode = true;
-      isResolvingGuestPayload = true;
+    const vid = page.params.id;
+    const eid = page.params.entityId;
+    if (vid && eid) {
+      const payload = consumeZenPopoutPayload(vid, eid);
+      if (payload) {
+        applyGuestPayload(payload);
+      } else if (window.opener) {
+        // Set isGuestMode early so vault.init() bails before loadFiles() runs
+        uiStore.isGuestMode = true;
+        isResolvingGuestPayload = true;
+      }
     }
   }
 

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -3,32 +3,57 @@
   import { page } from "$app/state";
   import { vault } from "$lib/stores/vault.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import { consumeZenPopoutPayload } from "$lib/utils/zen-popout";
+  import {
+    consumeZenPopoutPayload,
+    requestZenPopoutPayload,
+    type ZenPopoutPayload,
+  } from "$lib/utils/zen-popout";
 
   const vaultId = $derived(page.params.id);
   const entityId = $derived(page.params.entityId);
 
-  // Consume guest payload synchronously so uiStore.isGuestMode is set
-  // before any effects run — prevents the host switchVault from firing.
+  const applyGuestPayload = (payload: ZenPopoutPayload) => {
+    vault.repository.entities[payload.entity.id] = {
+      ...payload.entity,
+      _path:
+        typeof payload.entity._path === "string"
+          ? [payload.entity._path]
+          : payload.entity._path,
+    };
+    vault.isInitialized = true;
+    vault.status = "idle";
+    if (payload.isGuest) uiStore.isGuestMode = true;
+    guestEntityId = payload.entity.id;
+  };
+
   let guestEntityId: string | null = null;
+  let isResolvingGuestPayload = false;
   if (browser) {
     const payload = page.params.entityId
       ? consumeZenPopoutPayload(page.params.entityId)
       : null;
     if (payload) {
-      vault.repository.entities[payload.entity.id] = {
-        ...payload.entity,
-        _path:
-          typeof payload.entity._path === "string"
-            ? [payload.entity._path]
-            : payload.entity._path,
-      };
-      vault.isInitialized = true;
-      vault.status = "idle";
-      if (payload.isGuest) uiStore.isGuestMode = true;
-      guestEntityId = payload.entity.id;
+      applyGuestPayload(payload);
+    } else if (page.params.entityId && window.opener) {
+      isResolvingGuestPayload = true;
     }
   }
+
+  $effect(() => {
+    if (!browser || !isResolvingGuestPayload || !entityId) return;
+
+    let isCancelled = false;
+
+    void requestZenPopoutPayload(entityId).then((payload) => {
+      if (isCancelled) return;
+      if (payload) applyGuestPayload(payload);
+      isResolvingGuestPayload = false;
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  });
 
   // Guest flow: open zen mode once reactive state has settled
   $effect(() => {
@@ -39,7 +64,12 @@
 
   // Host flow: only when not a guest popout
   $effect(() => {
-    if (vaultId && vault.activeVaultId !== vaultId && !uiStore.isGuestMode) {
+    if (
+      vaultId &&
+      vault.activeVaultId !== vaultId &&
+      !uiStore.isGuestMode &&
+      !isResolvingGuestPayload
+    ) {
       void vault.switchVault(vaultId);
     }
   });

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -12,14 +12,26 @@
   const vaultId = $derived(page.params.id);
   const entityId = $derived(page.params.entityId);
 
+  const normalizeEntity = (e: {
+    _path?: string | string[] | null;
+    [k: string]: unknown;
+  }) => ({
+    ...e,
+    _path: typeof e._path === "string" ? [e._path] : (e._path ?? []),
+  });
+
   const applyGuestPayload = (payload: ZenPopoutPayload) => {
-    vault.repository.entities[payload.entity.id] = {
-      ...payload.entity,
-      _path:
-        typeof payload.entity._path === "string"
-          ? [payload.entity._path]
-          : payload.entity._path,
-    };
+    vault.repository.entities[payload.entity.id] = normalizeEntity(
+      payload.entity,
+    ) as any;
+
+    // Hydrate stubs for connected entities so connection rendering works
+    for (const extra of payload.extraEntities ?? []) {
+      if (!vault.repository.entities[extra.id]) {
+        vault.repository.entities[extra.id] = normalizeEntity(extra) as any;
+      }
+    }
+
     vault.isInitialized = true;
     vault.status = "idle";
     if (payload.isGuest) uiStore.isGuestMode = true;

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
+  import { browser } from "$app/environment";
   import { page } from "$app/state";
   import { vault } from "$lib/stores/vault.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
+  import {
+    ZEN_POPOUT_REQUEST,
+    ZEN_POPOUT_DATA,
+    type ZenEntityData,
+  } from "$lib/utils/zen-popout";
 
   const vaultId = $derived(page.params.id);
   const entityId = $derived(page.params.entityId);
 
+  // Host flow: load vault from OPFS then open zen mode
   $effect(() => {
-    if (vaultId && vault.activeVaultId !== vaultId) {
+    if (vaultId && vault.activeVaultId !== vaultId && !uiStore.isGuestMode) {
       void vault.switchVault(vaultId);
     }
   });
@@ -21,6 +28,43 @@
       uiStore.openZenMode(entityId);
     }
   });
+
+  // Guest flow: request entity from the opener tab via postMessage
+  $effect(() => {
+    if (!browser || !entityId) return;
+
+    const origin = window.location.origin;
+
+    const handleData = (event: MessageEvent) => {
+      if (event.origin !== origin) return;
+      const msg = event.data as ZenEntityData;
+      if (msg?.type !== ZEN_POPOUT_DATA || msg.entity?.id !== entityId) return;
+
+      vault.repository.entities[msg.entity.id] = {
+        ...msg.entity,
+        _path:
+          typeof msg.entity._path === "string"
+            ? [msg.entity._path]
+            : msg.entity._path,
+      };
+      vault.isInitialized = true;
+      vault.status = "idle";
+      if (msg.isGuest) uiStore.isGuestMode = true;
+      uiStore.openZenMode(msg.entity.id);
+
+      window.removeEventListener("message", handleData);
+    };
+
+    window.addEventListener("message", handleData);
+
+    // Ask the opener for the entity (it may not be ready yet — opener sets
+    // up its listener before calling window.open, so this arrives in time)
+    if (window.opener) {
+      window.opener.postMessage({ type: ZEN_POPOUT_REQUEST, entityId }, origin);
+    }
+
+    return () => window.removeEventListener("message", handleData);
+  });
 </script>
 
 <svelte:head>
@@ -29,5 +73,5 @@
   >
 </svelte:head>
 
-<!-- Full-screen dark backdrop — the ZenModeModal overlays this -->
+<!-- Full-screen dark backdrop — ZenModeModal overlays this -->
 <div class="h-screen bg-black"></div>

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -12,26 +12,14 @@
   const vaultId = $derived(page.params.id);
   const entityId = $derived(page.params.entityId);
 
-  const normalizeEntity = (e: {
-    _path?: string | string[] | null;
-    [k: string]: unknown;
-  }) => ({
-    ...e,
-    _path: typeof e._path === "string" ? [e._path] : (e._path ?? []),
-  });
-
   const applyGuestPayload = (payload: ZenPopoutPayload) => {
-    vault.repository.entities[payload.entity.id] = normalizeEntity(
-      payload.entity,
-    ) as any;
-
-    // Hydrate stubs for connected entities so connection rendering works
-    for (const extra of payload.extraEntities ?? []) {
-      if (!vault.repository.entities[extra.id]) {
-        vault.repository.entities[extra.id] = normalizeEntity(extra) as any;
-      }
-    }
-
+    vault.repository.entities[payload.entity.id] = {
+      ...payload.entity,
+      _path:
+        typeof payload.entity._path === "string"
+          ? [payload.entity._path]
+          : payload.entity._path,
+    };
     vault.isInitialized = true;
     vault.status = "idle";
     if (payload.isGuest) uiStore.isGuestMode = true;

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/page.route.test.ts
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/page.route.test.ts
@@ -1,0 +1,94 @@
+import { render, waitFor } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RoutePage from "./+page.svelte";
+import { uiStore } from "$lib/stores/ui.svelte";
+import { vault } from "$lib/stores/vault.svelte";
+import { requestZenPopoutPayload } from "$lib/utils/zen-popout";
+
+type MutableVaultMock = {
+  activeVaultId: string | null;
+  isInitialized: boolean;
+  status: string;
+  repository: { entities: Record<string, { id: string; title?: string }> };
+  entities: Record<string, { id: string; title?: string }>;
+  switchVault: ReturnType<typeof vi.fn>;
+};
+
+vi.mock("svelte", async () => {
+  // @ts-expect-error - force the client Svelte runtime so testing-library can mount
+  return await import("../../../../../../../../../node_modules/svelte/src/index-client.js");
+});
+
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
+
+vi.mock("$app/state", () => ({
+  page: {
+    params: {
+      id: "vault-123",
+      entityId: "entity-1",
+    },
+  },
+}));
+
+vi.mock("$lib/stores/ui.svelte", () => ({
+  uiStore: {
+    isGuestMode: false,
+    openZenMode: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    activeVaultId: null as string | null,
+    isInitialized: false,
+    status: "idle",
+    repository: {
+      entities: {} as Record<string, { id: string; title?: string }>,
+    },
+    entities: {} as Record<string, { id: string; title?: string }>,
+    switchVault: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/utils/zen-popout", () => ({
+  consumeZenPopoutPayload: vi.fn(() => null),
+  requestZenPopoutPayload: vi.fn(),
+}));
+
+describe("/vault/[id]/entity/[entityId] page", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "opener", {
+      configurable: true,
+      value: {},
+    });
+
+    const mutableVault = vault as unknown as MutableVaultMock;
+    const entities: Record<string, { id: string; title?: string }> = {};
+    mutableVault.activeVaultId = null;
+    mutableVault.isInitialized = false;
+    mutableVault.status = "idle";
+    mutableVault.repository.entities = entities;
+    mutableVault.entities = entities;
+    uiStore.isGuestMode = false;
+    vi.clearAllMocks();
+  });
+
+  it("waits for guest popout hydration before taking the host switchVault path", async () => {
+    vi.mocked(requestZenPopoutPayload).mockResolvedValue({
+      isGuest: true,
+      entity: { id: "entity-1", title: "Faerun", _path: ["faerun.md"] } as any,
+    });
+
+    render(RoutePage);
+
+    expect(vault.switchVault).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(uiStore.isGuestMode).toBe(true);
+    });
+
+    expect(vault.switchVault).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #609

- **"Look at \<name\>"** right-click option on VTT tokens and initiative list rows opens the linked entity in zen mode (host and guest, respects `canViewToken` visibility)
- **Zen popout** — new button in zen header opens the entity in a standalone browser tab with no app chrome (header/sidebar/footer suppressed)
- **Guest popout** works across all modes including incognito: sessionStorage for the fast path, postMessage via `window.opener` as a fallback when storage is isolated
- **Image** is converted to a data URL before opening the tab so it renders without a P2P connection
- **Connections** are hidden in the guest popout (no vault context); host popout keeps them
- Escape / click-outside suppressed in popped-out tabs; X button confirms before closing the tab
- `vault.init()` bails early when `isGuestMode` is already set, preventing `loadFiles()` from overwriting guest-injected entity data

## Test plan

- [ ] Host: right-click token on map → "Look at \<name\>" opens zen mode overlay
- [ ] Host: click pop-out button → opens entity in new tab with full connections visible
- [ ] Guest: same right-click flow opens zen overlay; pop-out opens new tab with image + content, no connections panel
- [ ] Guest incognito: pop-out still works (postMessage fallback)
- [ ] Popped-out tab: Escape and backdrop click do nothing; X button shows confirm dialog
- [ ] Pop-out button hidden when already in a popped-out tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)