### PR TITLE
⚡ Bolt: [performance improvement] Optimize vttTokens derivation in MapView

### DIFF
--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -158,17 +158,25 @@
     const isHost = mapStore.isGMMode;
     const peerId = mapSession.myPeerId;
     const selected = mapSession.selectedTokens;
+    const tokens = Object.values(mapSession.tokens);
+    const result = [];
 
-    return Object.values(mapSession.tokens)
-      .filter((token) => mapSession.canViewToken(token.id, peerId, isHost))
-      .map((token) => ({
-        ...token,
-        label: token.name,
-        image: tokenImageCache[token.id] ?? null,
-        selected: mapSession.selection === token.id || selected.has(token.id),
-        active: mapSession.activeTokenId === token.id,
-        visible: true,
-      }));
+    // ⚡ Bolt Optimization: Replace chained .filter().map() with an imperative loop
+    // to avoid intermediate array allocations and reduce GC pressure.
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (mapSession.canViewToken(token.id, peerId, isHost)) {
+        result.push({
+          ...token,
+          label: token.name,
+          image: tokenImageCache[token.id] ?? null,
+          selected: mapSession.selection === token.id || selected.has(token.id),
+          active: mapSession.activeTokenId === token.id,
+          visible: true,
+        });
+      }
+    }
+    return result;
   });
 
   $effect(() => {


### PR DESCRIPTION
💡 What:
Replaced the chained `.filter().map()` operations with a single imperative loop in the `vttTokens` `$derived.by` block within `apps/web/src/lib/components/map/MapView.svelte`.

🎯 Why:
To eliminate intermediate array allocations generated by chained array methods. `Object.values(mapSession.tokens)` combined with chained mapping and filtering created unnecessary garbage collection overhead in a highly reactive block that gets evaluated frequently during gameplay (e.g., when tokens move).

📊 Impact:
Reduces array allocations in the `vttTokens` reactive recalculation by preventing the creation of the intermediate filtered array before mapping. This slightly reduces memory allocations and limits GC pressure during high-frequency reactivity loops.

🔬 Measurement:
This can be verified by observing the memory snapshot during token drags, which will show fewer short-lived array allocations. The test suite fully covers the core functionality to ensure nothing broke.

---
*PR created automatically by Jules for task [9525076198743195004](https://jules.google.com/task/9525076198743195004) started by @eserlan*