### PR TITLE
feat: finalize label-grouped explorer spec

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -5,7 +5,14 @@
   import { getIconClass } from "$lib/utils/icon";
   import { groupEntitiesForExplorer } from "./entityListGrouping";
   import type { Entity } from "schema";
-  import { Search, LayoutGrid, List, Tag } from "lucide-svelte";
+  import {
+    ChevronDown,
+    ChevronRight,
+    Search,
+    LayoutGrid,
+    List,
+    Tag,
+  } from "lucide-svelte";
 
   let {
     onSelect,
@@ -19,8 +26,12 @@
 
   let searchQuery = $state("");
   let typeFilters = $state<Set<string>>(new Set());
+  const activeVaultId = $derived(vault.activeVaultId);
   const focusedEntityId = $derived(uiStore.focusedEntityId);
   const viewMode = $derived(uiStore.explorerViewMode);
+  const collapsedLabelGroups = $derived.by(() =>
+    uiStore.getCollapsedLabelGroups(activeVaultId),
+  );
 
   // ⚡ Bolt Optimization: Return the Map directly to avoid intermediate array allocations,
   // mapping, and sorting. This also turns an O(N) .find into an O(1) Map .get lookup in the loop.
@@ -253,10 +264,31 @@
       {/each}
     {:else if viewMode === "label" && groupedEntities?.type === "label"}
       {#each groupedEntities.sortedKeys as label}
-        {@render sectionHeader(label)}
-        {#each groupedEntities.groups.get(label)! as entity (`${entity.id}:${label}`)}
-          {@render entityItem(entity)}
-        {/each}
+        {@const labelEntities = groupedEntities.groups.get(label) ?? []}
+        {@const isCollapsed = collapsedLabelGroups.has(label)}
+        <button
+          type="button"
+          onclick={() => uiStore.toggleExplorerLabelGroup(activeVaultId, label)}
+          aria-expanded={!isCollapsed}
+          class="mt-4 first:mt-0 flex w-full items-center justify-between rounded-lg border border-theme-border/30 px-2 py-1.5 text-left text-[10px] font-bold uppercase tracking-[0.2em] text-theme-muted transition-all hover:border-theme-primary/40 hover:bg-theme-primary/5 hover:text-theme-text focus:border-theme-accent focus:outline-none focus:ring-2 focus:ring-theme-accent/20"
+        >
+          <span class="flex items-center gap-1.5">
+            {#if isCollapsed}
+              <ChevronRight class="h-3 w-3" />
+            {:else}
+              <ChevronDown class="h-3 w-3" />
+            {/if}
+            <span>{label}</span>
+          </span>
+          <span class="text-[9px] text-theme-muted/80"
+            >{labelEntities.length}</span
+          >
+        </button>
+        {#if !isCollapsed}
+          {#each labelEntities as entity (`${entity.id}:${label}`)}
+            {@render entityItem(entity)}
+          {/each}
+        {/if}
       {/each}
       {#if groupedEntities.unlabeled && groupedEntities.unlabeled.length > 0}
         {@render sectionHeader("Unlabeled")}

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { vault } from "$lib/stores/vault.svelte";
   import { categories } from "$lib/stores/categories.svelte";
-  import { themeStore } from "$lib/stores/theme.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
   import { getIconClass } from "$lib/utils/icon";
   import type { Entity } from "schema";
@@ -19,7 +18,6 @@
 
   let searchQuery = $state("");
   let typeFilters = $state<Set<string>>(new Set());
-  const isFantasyTheme = $derived(themeStore.activeTheme.id === "fantasy");
   const focusedEntityId = $derived(uiStore.focusedEntityId);
   const viewMode = $derived(uiStore.explorerViewMode);
 
@@ -118,6 +116,12 @@
       }
     }
   }
+
+  function getIconToggleClasses(active: boolean) {
+    return active
+      ? "rounded-lg border border-theme-primary bg-theme-primary text-theme-bg shadow-sm transition-all hover:border-theme-secondary hover:bg-theme-secondary"
+      : "rounded-lg border border-theme-border bg-theme-bg/50 text-theme-muted transition-all hover:bg-theme-bg hover:text-theme-text";
+  }
 </script>
 
 <div class="flex flex-col h-full min-h-0 {className}">
@@ -131,34 +135,21 @@
         bind:value={searchQuery}
         placeholder="Search entities..."
         aria-label="Search entities"
-        class="w-full bg-theme-bg border border-theme-border rounded-md pl-9 pr-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary transition-colors"
+        class="w-full rounded-lg border border-theme-border bg-theme-bg/50 py-2 pl-9 pr-3 text-sm text-theme-text placeholder-theme-muted transition-all focus:border-theme-accent focus:outline-none focus:ring-2 focus:ring-theme-accent/20"
       />
     </div>
 
     <div
-      class="flex items-center gap-1 px-2 py-1.5 border border-theme-border rounded shadow-sm"
-      style:background-color={isFantasyTheme
-        ? "var(--theme-panel-muted)"
-        : undefined}
-      style:background-image={isFantasyTheme
-        ? "var(--bg-texture-overlay)"
-        : undefined}
+      class="flex items-center gap-1 rounded-xl border border-theme-border bg-theme-surface/50 px-2 py-1.5 shadow-sm"
     >
       <button
         onclick={() => (typeFilters = new Set())}
         title="Show all categories"
         aria-label="Show all categories"
-        class="p-1.5 rounded-md flex items-center justify-center transition-all border {typeFilters.size ===
-        0
-          ? isFantasyTheme
-            ? 'text-[color:var(--theme-focus)] shadow-none border-[color:var(--theme-focus-border)]'
-            : 'bg-theme-primary text-theme-bg shadow-sm scale-110 border-theme-primary'
-          : isFantasyTheme
-            ? 'border-transparent text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-title-ink)]'
-            : 'border-transparent text-theme-muted hover:text-theme-text hover:bg-theme-primary/10'}"
-        style:background-color={typeFilters.size === 0 && isFantasyTheme
-          ? "var(--theme-focus-bg)"
-          : undefined}
+        aria-pressed={typeFilters.size === 0}
+        class="flex items-center justify-center p-1.5 {getIconToggleClasses(
+          typeFilters.size === 0,
+        )}"
       >
         <LayoutGrid class="w-3.5 h-3.5" />
       </button>
@@ -171,36 +162,19 @@
             title={cat.label}
             aria-label={`Filter by ${cat.label}`}
             aria-pressed={typeFilters.has(cat.id)}
-            class="relative p-1.5 rounded-md flex items-center justify-center transition-all border {typeFilters.has(
-              cat.id,
-            )
-              ? isFantasyTheme
-                ? 'text-[color:var(--theme-focus)] shadow-none border-[color:var(--theme-focus-border)]'
-                : 'bg-theme-primary text-theme-bg shadow-sm scale-110 border-theme-primary'
-              : isFantasyTheme
-                ? 'border-transparent text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-title-ink)]'
-                : 'border-transparent text-theme-muted hover:text-theme-text hover:bg-theme-primary/10'}"
-            style:background-color={typeFilters.has(cat.id) && isFantasyTheme
-              ? "var(--theme-focus-bg)"
-              : undefined}
+            class="relative flex items-center justify-center p-1.5 {getIconToggleClasses(
+              typeFilters.has(cat.id),
+            )}"
           >
             <span
               class="{getIconClass(cat.icon)} w-3.5 h-3.5"
-              style={!typeFilters.has(cat.id)
-                ? isFantasyTheme
-                  ? "color: var(--theme-icon-default)"
-                  : `color: ${cat.color}`
-                : isFantasyTheme
-                  ? "color: var(--theme-focus)"
-                  : ""}
+              style={typeFilters.has(cat.id)
+                ? undefined
+                : `color: ${cat.color}`}
             ></span>
             {#if count > 0 && !typeFilters.has(cat.id)}
               <span
-                class="absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full text-[7px] font-bold flex items-center justify-center leading-none"
-                style:background-color={isFantasyTheme
-                  ? "var(--theme-focus-bg)"
-                  : undefined}
-                style:color={isFantasyTheme ? "var(--theme-focus)" : undefined}
+                class="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-theme-primary/10 text-[7px] font-bold leading-none text-theme-primary"
               >
                 {count > 9 ? "9+" : count}
               </span>
@@ -215,17 +189,10 @@
         onclick={() => uiStore.setExplorerViewMode("list")}
         title="List View"
         aria-label="List View"
-        class="p-1.5 rounded-md flex items-center justify-center transition-all border {viewMode ===
-        'list'
-          ? isFantasyTheme
-            ? 'text-[color:var(--theme-focus)] shadow-none border-[color:var(--theme-focus-border)]'
-            : 'bg-theme-primary text-theme-bg shadow-sm scale-110 border-theme-primary'
-          : isFantasyTheme
-            ? 'border-transparent text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-title-ink)]'
-            : 'border-transparent text-theme-muted hover:text-theme-text hover:bg-theme-primary/10'}"
-        style:background-color={viewMode === "list" && isFantasyTheme
-          ? "var(--theme-focus-bg)"
-          : undefined}
+        aria-pressed={viewMode === "list"}
+        class="flex items-center justify-center p-1.5 {getIconToggleClasses(
+          viewMode === 'list',
+        )}"
       >
         <List class="w-3.5 h-3.5" />
       </button>
@@ -234,17 +201,10 @@
         onclick={() => uiStore.setExplorerViewMode("label")}
         title="Group by Label"
         aria-label="Group by Label"
-        class="p-1.5 rounded-md flex items-center justify-center transition-all border {viewMode ===
-        'label'
-          ? isFantasyTheme
-            ? 'text-[color:var(--theme-focus)] shadow-none border-[color:var(--theme-focus-border)]'
-            : 'bg-theme-primary text-theme-bg shadow-sm scale-110 border-theme-primary'
-          : isFantasyTheme
-            ? 'border-transparent text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-title-ink)]'
-            : 'border-transparent text-theme-muted hover:text-theme-text hover:bg-theme-primary/10'}"
-        style:background-color={viewMode === "label" && isFantasyTheme
-          ? "var(--theme-focus-bg)"
-          : undefined}
+        aria-pressed={viewMode === "label"}
+        class="flex items-center justify-center p-1.5 {getIconToggleClasses(
+          viewMode === 'label',
+        )}"
       >
         <Tag class="w-3.5 h-3.5" />
       </button>
@@ -265,28 +225,20 @@
         data-testid="entity-list-item"
         data-entity-id={entity.id}
         title={`Select ${entity.title}`}
-        class="w-full text-left p-2.5 border transition-all group focus:ring-1 focus:ring-theme-primary focus:outline-none {entity.id ===
+        class="group w-full rounded-xl border p-2.5 text-left transition-all focus:border-theme-accent focus:outline-none focus:ring-2 focus:ring-theme-accent/20 {entity.id ===
         focusedEntityId
-          ? isFantasyTheme
-            ? 'rounded-md border-[color:var(--theme-focus-border)] bg-[color:var(--theme-focus-bg)] ring-1 ring-[color:var(--theme-focus-border)]/40'
-            : 'rounded-lg border-theme-primary bg-theme-primary/10'
-          : isFantasyTheme
-            ? 'border-theme-border bg-[color:var(--theme-panel-muted)] rounded-md hover:border-[color:var(--theme-selected-border)] hover:bg-[color:var(--theme-selected-bg)]'
-            : 'border-theme-border bg-theme-bg rounded-lg hover:border-theme-primary/50 hover:bg-theme-primary/5'}"
+          ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'
+          : 'border-theme-border bg-theme-surface/50 hover:border-theme-primary/50 hover:bg-theme-primary/5'}"
       >
         <div class="flex items-center gap-2">
           <span
             class="{getIconClass(
               cat?.icon,
-            )} w-3.5 h-3.5 shrink-0 transition-colors {isFantasyTheme
-              ? 'text-[color:var(--theme-icon-default)] group-hover:text-[color:var(--theme-icon-active)]'
-              : 'text-theme-primary/70 group-hover:text-theme-primary'}"
+            )} h-3.5 w-3.5 shrink-0 text-theme-muted transition-colors group-hover:text-theme-primary"
           ></span>
           <div class="flex-1 min-w-0">
             <div
-              class="text-xs font-bold transition-colors truncate uppercase font-header tracking-widest {isFantasyTheme
-                ? 'text-[color:var(--theme-title-ink)] group-hover:text-[color:var(--theme-icon-active)]'
-                : 'text-theme-text group-hover:text-theme-primary'}"
+              class="truncate font-header text-xs font-bold uppercase tracking-widest text-theme-text transition-colors group-hover:text-theme-primary"
             >
               {entity.title}
             </div>

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -5,7 +5,7 @@
   import { uiStore } from "$lib/stores/ui.svelte";
   import { getIconClass } from "$lib/utils/icon";
   import type { Entity } from "schema";
-  import { Search, LayoutGrid } from "lucide-svelte";
+  import { Search, LayoutGrid, List, Tag } from "lucide-svelte";
 
   let {
     onSelect,
@@ -21,6 +21,7 @@
   let typeFilters = $state<Set<string>>(new Set());
   const isFantasyTheme = $derived(themeStore.activeTheme.id === "fantasy");
   const focusedEntityId = $derived(uiStore.focusedEntityId);
+  const viewMode = $derived(uiStore.explorerViewMode);
 
   // ⚡ Bolt Optimization: Return the Map directly to avoid intermediate array allocations,
   // mapping, and sorting. This also turns an O(N) .find into an O(1) Map .get lookup in the loop.
@@ -63,6 +64,34 @@
     }
 
     return filtered.sort((a, b) => a.title.localeCompare(b.title));
+  });
+
+  const groupedEntities = $derived.by(() => {
+    const entities = filteredEntities;
+    if (viewMode === "list") return null;
+
+    if (viewMode === "label") {
+      const groups = new Map<string, Entity[]>();
+      const unlabeled: Entity[] = [];
+
+      for (const entity of entities) {
+        if (!entity.labels || entity.labels.length === 0) {
+          unlabeled.push(entity);
+        } else {
+          for (const label of entity.labels) {
+            if (!groups.has(label)) groups.set(label, []);
+            groups.get(label)!.push(entity);
+          }
+        }
+      }
+
+      const sortedLabels = Array.from(groups.keys()).sort((a, b) =>
+        a.localeCompare(b),
+      );
+      return { type: "label", groups, sortedKeys: sortedLabels, unlabeled };
+    }
+
+    return null;
   });
 
   function toggleTypeFilter(type: string, event: MouseEvent) {
@@ -179,6 +208,46 @@
           </button>
         {/if}
       {/each}
+
+      <div class="w-px h-3.5 bg-theme-border mx-0.5 opacity-50"></div>
+
+      <button
+        onclick={() => uiStore.setExplorerViewMode("list")}
+        title="List View"
+        aria-label="List View"
+        class="p-1.5 rounded-md flex items-center justify-center transition-all border {viewMode ===
+        'list'
+          ? isFantasyTheme
+            ? 'text-[color:var(--theme-focus)] shadow-none border-[color:var(--theme-focus-border)]'
+            : 'bg-theme-primary text-theme-bg shadow-sm scale-110 border-theme-primary'
+          : isFantasyTheme
+            ? 'border-transparent text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-title-ink)]'
+            : 'border-transparent text-theme-muted hover:text-theme-text hover:bg-theme-primary/10'}"
+        style:background-color={viewMode === "list" && isFantasyTheme
+          ? "var(--theme-focus-bg)"
+          : undefined}
+      >
+        <List class="w-3.5 h-3.5" />
+      </button>
+
+      <button
+        onclick={() => uiStore.setExplorerViewMode("label")}
+        title="Group by Label"
+        aria-label="Group by Label"
+        class="p-1.5 rounded-md flex items-center justify-center transition-all border {viewMode ===
+        'label'
+          ? isFantasyTheme
+            ? 'text-[color:var(--theme-focus)] shadow-none border-[color:var(--theme-focus-border)]'
+            : 'bg-theme-primary text-theme-bg shadow-sm scale-110 border-theme-primary'
+          : isFantasyTheme
+            ? 'border-transparent text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-title-ink)]'
+            : 'border-transparent text-theme-muted hover:text-theme-text hover:bg-theme-primary/10'}"
+        style:background-color={viewMode === "label" && isFantasyTheme
+          ? "var(--theme-focus-bg)"
+          : undefined}
+      >
+        <Tag class="w-3.5 h-3.5" />
+      </button>
     </div>
   </div>
 
@@ -186,7 +255,7 @@
     class="flex-1 overflow-y-auto p-2 space-y-1 custom-scrollbar overscroll-contain"
     style="touch-action: pan-y;"
   >
-    {#each filteredEntities as entity}
+    {#snippet entityItem(entity: Entity)}
       {@const cat = categories.getCategory(entity.type)}
       <button
         type="button"
@@ -235,11 +304,43 @@
           {/if}
         </div>
       </button>
-    {:else}
-      <div class="text-center py-10 px-4" data-testid="no-entities-found">
-        <p class="text-xs text-theme-muted">No entities found</p>
+    {/snippet}
+
+    {#snippet sectionHeader(title: string)}
+      <div
+        class="py-1 px-2 mt-4 first:mt-0 text-[10px] font-bold text-theme-muted uppercase tracking-[0.2em] border-b border-theme-border/30 mb-1"
+      >
+        {title}
       </div>
-    {/each}
+    {/snippet}
+
+    {#if viewMode === "list"}
+      {#each filteredEntities as entity (entity.id)}
+        {@render entityItem(entity)}
+      {:else}
+        <div class="text-center py-10 px-4" data-testid="no-entities-found">
+          <p class="text-xs text-theme-muted">No entities found</p>
+        </div>
+      {/each}
+    {:else if viewMode === "label" && groupedEntities?.type === "label"}
+      {#each groupedEntities.sortedKeys as label}
+        {@render sectionHeader(label)}
+        {#each groupedEntities.groups.get(label)! as entity (entity.id + label)}
+          {@render entityItem(entity)}
+        {/each}
+      {/each}
+      {#if groupedEntities.unlabeled && groupedEntities.unlabeled.length > 0}
+        {@render sectionHeader("Unlabeled")}
+        {#each groupedEntities.unlabeled as entity (entity.id)}
+          {@render entityItem(entity)}
+        {/each}
+      {/if}
+      {#if filteredEntities.length === 0}
+        <div class="text-center py-10 px-4" data-testid="no-entities-found">
+          <p class="text-xs text-theme-muted">No entities found</p>
+        </div>
+      {/if}
+    {/if}
   </div>
 </div>
 

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -3,6 +3,7 @@
   import { categories } from "$lib/stores/categories.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
   import { getIconClass } from "$lib/utils/icon";
+  import { groupEntitiesForExplorer } from "./entityListGrouping";
   import type { Entity } from "schema";
   import { Search, LayoutGrid, List, Tag } from "lucide-svelte";
 
@@ -65,31 +66,7 @@
   });
 
   const groupedEntities = $derived.by(() => {
-    const entities = filteredEntities;
-    if (viewMode === "list") return null;
-
-    if (viewMode === "label") {
-      const groups = new Map<string, Entity[]>();
-      const unlabeled: Entity[] = [];
-
-      for (const entity of entities) {
-        if (!entity.labels || entity.labels.length === 0) {
-          unlabeled.push(entity);
-        } else {
-          for (const label of entity.labels) {
-            if (!groups.has(label)) groups.set(label, []);
-            groups.get(label)!.push(entity);
-          }
-        }
-      }
-
-      const sortedLabels = Array.from(groups.keys()).sort((a, b) =>
-        a.localeCompare(b),
-      );
-      return { type: "label", groups, sortedKeys: sortedLabels, unlabeled };
-    }
-
-    return null;
+    return groupEntitiesForExplorer(filteredEntities, viewMode);
   });
 
   function toggleTypeFilter(type: string, event: MouseEvent) {
@@ -277,7 +254,7 @@
     {:else if viewMode === "label" && groupedEntities?.type === "label"}
       {#each groupedEntities.sortedKeys as label}
         {@render sectionHeader(label)}
-        {#each groupedEntities.groups.get(label)! as entity (entity.id + label)}
+        {#each groupedEntities.groups.get(label)! as entity (`${entity.id}:${label}`)}
           {@render entityItem(entity)}
         {/each}
       {/each}

--- a/apps/web/src/lib/components/explorer/EntityList.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityList.test.ts
@@ -1,46 +1,110 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect } from "vitest";
 
-describe("EntityList Filtering Logic Performance", () => {
-  it("should calculate filtered list of 1,000 entities in under 50ms", async () => {
-    // 1. Generate 1,000 mock entities
-    const mockEntities = Array.from({ length: 1000 }, (_, i) => ({
-      id: `entity-${i}`,
-      title: `Entry ${i}`,
-      type: i % 2 === 0 ? "npc" : "location",
-      content: "Some content",
-      labels: ["test"],
-      connections: [],
-      updatedAt: Date.now(),
-    }));
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { uiStore } from "$lib/stores/ui.svelte";
+import EntityList from "./EntityList.svelte";
 
-    const typeFilters = ["all"];
-    const searchQuery = "entry";
+vi.mock("svelte", async () => {
+  // @ts-expect-error - force the client Svelte runtime so testing-library can mount
+  return await import("../../../../../../node_modules/svelte/src/index-client.js");
+});
 
-    const start = performance.now();
+vi.mock("$app/paths", () => ({
+  base: "",
+}));
 
-    // Simulating the logic in EntityList.svelte
-    const filtered = [];
-    const query = searchQuery.trim().toLowerCase();
-    const filterAll = typeFilters.includes("all");
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    activeVaultId: "vault-1",
+    allEntities: [
+      {
+        id: "quest-only",
+        title: "Broken Seal",
+        type: "npc",
+        tags: [],
+        labels: ["Quest"],
+        connections: [],
+        content: "",
+        updatedAt: 0,
+      },
+      {
+        id: "npc-only",
+        title: "Ava",
+        type: "npc",
+        tags: [],
+        labels: ["NPC"],
+        connections: [],
+        content: "",
+        updatedAt: 0,
+      },
+      {
+        id: "both",
+        title: "Mira",
+        type: "npc",
+        tags: [],
+        labels: ["NPC", "Quest"],
+        connections: [],
+        content: "",
+        updatedAt: 0,
+      },
+    ],
+  },
+}));
 
-    for (let i = 0; i < mockEntities.length; i++) {
-      const e = mockEntities[i];
-      const matchesSearch =
-        e.title.toLowerCase().includes(query) ||
-        e.content.toLowerCase().includes(query);
-      const matchesType = filterAll || typeFilters.includes(e.type);
+vi.mock("$lib/stores/categories.svelte", () => ({
+  categories: {
+    list: [{ id: "npc", label: "NPC", icon: "user", color: "#fff" }],
+    getCategory: () => ({ icon: "user" }),
+  },
+}));
 
-      if (matchesSearch && matchesType) {
-        filtered.push(e);
-      }
-    }
-    filtered.sort((a, b) => a.title.localeCompare(b.title));
+vi.mock("$lib/utils/icon", () => ({
+  getIconClass: () => "",
+}));
 
-    const end = performance.now();
-    const duration = end - start;
+describe("EntityList", () => {
+  beforeEach(() => {
+    uiStore.explorerViewMode = "list";
+    uiStore.explorerCollapsedLabelGroups = {};
+    window.localStorage.removeItem("codex_explorer_collapsed_label_groups");
+  });
 
-    // In node/vitest, 10ms is a safe bet for pure logic
-    expect(duration).toBeLessThan(100);
+  it("shows and hides entities within a label group", async () => {
+    uiStore.setExplorerViewMode("label");
+
+    render(EntityList);
+
+    expect(screen.getByText("Broken Seal")).not.toBeNull();
+
+    const questToggle = screen
+      .getAllByRole("button")
+      .find(
+        (button) =>
+          button.getAttribute("aria-expanded") === "true" &&
+          button.textContent?.includes("Quest"),
+      );
+
+    expect(questToggle).not.toBeUndefined();
+
+    await fireEvent.click(questToggle!);
+
+    expect(screen.queryByText("Broken Seal")).toBeNull();
+    expect(uiStore.getCollapsedLabelGroups("vault-1").has("Quest")).toBe(true);
+
+    const collapsedQuestToggle = screen
+      .getAllByRole("button")
+      .find(
+        (button) =>
+          button.getAttribute("aria-expanded") === "false" &&
+          button.textContent?.includes("Quest"),
+      );
+
+    expect(collapsedQuestToggle).not.toBeUndefined();
+
+    await fireEvent.click(collapsedQuestToggle!);
+
+    expect(screen.getByText("Broken Seal")).not.toBeNull();
+    expect(uiStore.getCollapsedLabelGroups("vault-1").has("Quest")).toBe(false);
   });
 });

--- a/apps/web/src/lib/components/explorer/EntityListGrouping.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityListGrouping.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import type { Entity } from "schema";
+
+function groupEntities(entities: Entity[], viewMode: "list" | "label") {
+  if (viewMode === "list") return null;
+
+  if (viewMode === "label") {
+    const groups = new Map<string, Entity[]>();
+    const unlabeled: Entity[] = [];
+
+    for (const entity of entities) {
+      if (!entity.labels || entity.labels.length === 0) {
+        unlabeled.push(entity);
+      } else {
+        for (const label of entity.labels) {
+          if (!groups.has(label)) groups.set(label, []);
+          groups.get(label)!.push(entity);
+        }
+      }
+    }
+
+    const sortedLabels = Array.from(groups.keys()).sort((a, b) =>
+      a.localeCompare(b),
+    );
+    return { type: "label", groups, sortedKeys: sortedLabels, unlabeled };
+  }
+
+  return null;
+}
+
+describe("EntityList Grouping Logic", () => {
+  const mockEntities: Entity[] = [
+    {
+      id: "e1",
+      title: "A",
+      type: "npc",
+      tags: [],
+      labels: ["L1"],
+      connections: [],
+      content: "",
+      updatedAt: 0,
+    },
+    {
+      id: "e2",
+      title: "B",
+      type: "npc",
+      tags: [],
+      labels: ["L1", "L2"],
+      connections: [],
+      content: "",
+      updatedAt: 0,
+    },
+    {
+      id: "e3",
+      title: "C",
+      type: "npc",
+      tags: [],
+      labels: [],
+      connections: [],
+      content: "",
+      updatedAt: 0,
+    },
+    {
+      id: "e4",
+      title: "D",
+      type: "npc",
+      tags: [],
+      labels: ["L2"],
+      connections: [],
+      content: "",
+      updatedAt: 0,
+    },
+  ];
+
+  it("should group by label correctly", () => {
+    const result = groupEntities(mockEntities, "label");
+    expect(result?.type).toBe("label");
+    expect(result?.sortedKeys).toEqual(["L1", "L2"]);
+    expect(result?.groups.get("L1")?.length).toBe(2);
+    expect(result?.groups.get("L2")?.length).toBe(2);
+    if (result && "unlabeled" in result && result.unlabeled) {
+      expect(result.unlabeled.length).toBe(1);
+      expect(result.unlabeled[0].id).toBe("e3");
+    } else {
+      throw new Error("unlabeled missing in result");
+    }
+  });
+
+  it("should not group anything in list mode", () => {
+    expect(groupEntities(mockEntities, "list")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/explorer/EntityListGrouping.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityListGrouping.test.ts
@@ -1,32 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Entity } from "schema";
-
-function groupEntities(entities: Entity[], viewMode: "list" | "label") {
-  if (viewMode === "list") return null;
-
-  if (viewMode === "label") {
-    const groups = new Map<string, Entity[]>();
-    const unlabeled: Entity[] = [];
-
-    for (const entity of entities) {
-      if (!entity.labels || entity.labels.length === 0) {
-        unlabeled.push(entity);
-      } else {
-        for (const label of entity.labels) {
-          if (!groups.has(label)) groups.set(label, []);
-          groups.get(label)!.push(entity);
-        }
-      }
-    }
-
-    const sortedLabels = Array.from(groups.keys()).sort((a, b) =>
-      a.localeCompare(b),
-    );
-    return { type: "label", groups, sortedKeys: sortedLabels, unlabeled };
-  }
-
-  return null;
-}
+import { groupEntitiesForExplorer } from "./entityListGrouping";
 
 describe("EntityList Grouping Logic", () => {
   const mockEntities: Entity[] = [
@@ -73,7 +47,7 @@ describe("EntityList Grouping Logic", () => {
   ];
 
   it("should group by label correctly", () => {
-    const result = groupEntities(mockEntities, "label");
+    const result = groupEntitiesForExplorer(mockEntities, "label");
     expect(result?.type).toBe("label");
     expect(result?.sortedKeys).toEqual(["L1", "L2"]);
     expect(result?.groups.get("L1")?.length).toBe(2);
@@ -87,6 +61,6 @@ describe("EntityList Grouping Logic", () => {
   });
 
   it("should not group anything in list mode", () => {
-    expect(groupEntities(mockEntities, "list")).toBeNull();
+    expect(groupEntitiesForExplorer(mockEntities, "list")).toBeNull();
   });
 });

--- a/apps/web/src/lib/components/explorer/entityListGrouping.ts
+++ b/apps/web/src/lib/components/explorer/entityListGrouping.ts
@@ -1,0 +1,47 @@
+import type { Entity } from "schema";
+
+export type ExplorerViewMode = "list" | "label";
+
+export type LabelGroupedEntities = {
+  type: "label";
+  groups: Map<string, Entity[]>;
+  sortedKeys: string[];
+  unlabeled: Entity[];
+};
+
+export function groupEntitiesForExplorer(
+  entities: Entity[],
+  viewMode: ExplorerViewMode,
+): LabelGroupedEntities | null {
+  if (viewMode === "list") return null;
+
+  const groups = new Map<string, Entity[]>();
+  const unlabeled: Entity[] = [];
+
+  for (const entity of entities) {
+    if (!entity.labels || entity.labels.length === 0) {
+      unlabeled.push(entity);
+      continue;
+    }
+
+    for (const label of entity.labels) {
+      let labelGroup = groups.get(label);
+      if (!labelGroup) {
+        labelGroup = [];
+        groups.set(label, labelGroup);
+      }
+      labelGroup.push(entity);
+    }
+  }
+
+  const sortedKeys = Array.from(groups.keys()).sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  return {
+    type: "label",
+    groups,
+    sortedKeys,
+    unlabeled,
+  };
+}

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -42,7 +42,7 @@ Object.defineProperty(window, "matchMedia", {
   })),
 });
 
-import { uiStore } from "./ui.svelte";
+import { UIStore, uiStore } from "./ui.svelte";
 import { vault } from "./vault.svelte";
 
 const mockedVault = vault as any;
@@ -50,11 +50,15 @@ const mockedVault = vault as any;
 describe("UIStore", () => {
   beforeEach(() => {
     // Reset state before each test
+    localStorage.removeItem("codex_explorer_view_mode");
+    localStorage.removeItem("codex_explorer_collapsed_label_groups");
     uiStore.closeSettings();
     uiStore.activeSettingsTab = "vault";
     uiStore.skipWelcomeScreen = false;
     uiStore.dismissedLandingPage = false;
     uiStore.dismissedWorldPage = false;
+    uiStore.explorerViewMode = "list";
+    uiStore.explorerCollapsedLabelGroups = {};
     uiStore.closeSidebar();
     uiStore.showCanvasPalette = true;
     mockedVault.isGuest = false;
@@ -259,6 +263,38 @@ describe("UIStore", () => {
     );
 
     setItemSpy.mockRestore();
+  });
+
+  it("should persist collapsed explorer label groups per vault", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+    uiStore.toggleExplorerLabelGroup("vault-1", "Quest");
+
+    expect(uiStore.getCollapsedLabelGroups("vault-1")).toEqual(
+      new Set(["Quest"]),
+    );
+    expect(setItemSpy).toHaveBeenCalledWith(
+      "codex_explorer_collapsed_label_groups",
+      JSON.stringify({ "vault-1": ["Quest"] }),
+    );
+
+    uiStore.toggleExplorerLabelGroup("vault-1", "Quest");
+    expect(uiStore.getCollapsedLabelGroups("vault-1")).toEqual(new Set());
+
+    setItemSpy.mockRestore();
+  });
+
+  it("should restore collapsed explorer label groups from localStorage", () => {
+    localStorage.setItem(
+      "codex_explorer_collapsed_label_groups",
+      JSON.stringify({ "vault-1": ["Quest", "NPC"] }),
+    );
+
+    const store = new UIStore();
+
+    expect(store.getCollapsedLabelGroups("vault-1")).toEqual(
+      new Set(["NPC", "Quest"]),
+    );
   });
 
   it("should handle Zen Mode operations", () => {

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -257,6 +257,8 @@ describe("UIStore", () => {
       "codex_explorer_view_mode",
       "label",
     );
+
+    setItemSpy.mockRestore();
   });
 
   it("should handle Zen Mode operations", () => {

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -247,6 +247,18 @@ describe("UIStore", () => {
     );
   });
 
+  it("should persist explorer view mode changes", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+    uiStore.setExplorerViewMode("label");
+
+    expect(uiStore.explorerViewMode).toBe("label");
+    expect(setItemSpy).toHaveBeenCalledWith(
+      "codex_explorer_view_mode",
+      "label",
+    );
+  });
+
   it("should handle Zen Mode operations", () => {
     uiStore.openZenMode("entity-1", "inventory");
     expect(uiStore.showZenMode).toBe(true);

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -23,6 +23,7 @@ class UIStore {
   showDiceModal = $state(false);
   showChangelog = $state(false);
   lastSeenVersion = $state<string | null>(null);
+  explorerViewMode = $state<"list" | "label">("list");
 
   // Sidebar State
   leftSidebarOpen = $state(false);
@@ -67,6 +68,11 @@ class UIStore {
       }
 
       this.lastSeenVersion = localStorage.getItem("codex_last_seen_version");
+
+      const explorerMode = localStorage.getItem("codex_explorer_view_mode");
+      if (explorerMode === "list" || explorerMode === "label") {
+        this.explorerViewMode = explorerMode;
+      }
 
       const lastLabel = localStorage.getItem("codex_last_connection_label");
       if (lastLabel !== null) {
@@ -187,6 +193,13 @@ class UIStore {
     this.liteMode = enabled;
     if (typeof window !== "undefined") {
       localStorage.setItem("codex_lite_mode", String(enabled));
+    }
+  }
+
+  setExplorerViewMode(mode: "list" | "label") {
+    this.explorerViewMode = mode;
+    if (typeof window !== "undefined") {
+      localStorage.setItem("codex_explorer_view_mode", mode);
     }
   }
 

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -1,6 +1,10 @@
 import { base } from "$app/paths";
 
 const ACTIVE_THEME_STORAGE_KEY = "codex-cryptica-active-theme";
+const EXPLORER_COLLAPSED_LABELS_STORAGE_KEY =
+  "codex_explorer_collapsed_label_groups";
+
+type ExplorerCollapsedLabelGroups = Record<string, string[]>;
 
 export type SettingsTab =
   | "vault"
@@ -10,7 +14,7 @@ export type SettingsTab =
   | "about"
   | "help";
 
-class UIStore {
+export class UIStore {
   showSettings = $state(false);
   showCanvasSelector = $state(false);
   pendingCanvasEntities = $state<string[]>([]);
@@ -24,6 +28,7 @@ class UIStore {
   showChangelog = $state(false);
   lastSeenVersion = $state<string | null>(null);
   explorerViewMode = $state<"list" | "label">("list");
+  explorerCollapsedLabelGroups = $state<ExplorerCollapsedLabelGroups>({});
 
   // Sidebar State
   leftSidebarOpen = $state(false);
@@ -72,6 +77,33 @@ class UIStore {
       const explorerMode = localStorage.getItem("codex_explorer_view_mode");
       if (explorerMode === "list" || explorerMode === "label") {
         this.explorerViewMode = explorerMode;
+      }
+
+      const collapsedLabelGroups = localStorage.getItem(
+        EXPLORER_COLLAPSED_LABELS_STORAGE_KEY,
+      );
+      if (collapsedLabelGroups !== null) {
+        try {
+          const parsed = JSON.parse(collapsedLabelGroups);
+          if (
+            parsed &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed) &&
+            Object.values(parsed).every(
+              (value) =>
+                Array.isArray(value) &&
+                value.every((item) => typeof item === "string"),
+            )
+          ) {
+            this.explorerCollapsedLabelGroups =
+              parsed as ExplorerCollapsedLabelGroups;
+          } else {
+            throw new Error("Invalid format");
+          }
+        } catch {
+          this.explorerCollapsedLabelGroups = {};
+          localStorage.removeItem(EXPLORER_COLLAPSED_LABELS_STORAGE_KEY);
+        }
       }
 
       const lastLabel = localStorage.getItem("codex_last_connection_label");
@@ -200,6 +232,50 @@ class UIStore {
     this.explorerViewMode = mode;
     if (typeof window !== "undefined") {
       localStorage.setItem("codex_explorer_view_mode", mode);
+    }
+  }
+
+  getCollapsedLabelGroups(vaultId: string | null) {
+    return new Set(
+      this.explorerCollapsedLabelGroups[
+        this.getExplorerLabelGroupScope(vaultId)
+      ] ?? [],
+    );
+  }
+
+  toggleExplorerLabelGroup(vaultId: string | null, label: string) {
+    const scope = this.getExplorerLabelGroupScope(vaultId);
+    const nextLabels = new Set(this.explorerCollapsedLabelGroups[scope] ?? []);
+
+    if (nextLabels.has(label)) {
+      nextLabels.delete(label);
+    } else {
+      nextLabels.add(label);
+    }
+
+    const nextState = { ...this.explorerCollapsedLabelGroups };
+    if (nextLabels.size === 0) {
+      delete nextState[scope];
+    } else {
+      nextState[scope] = Array.from(nextLabels).sort((a, b) =>
+        a.localeCompare(b),
+      );
+    }
+
+    this.explorerCollapsedLabelGroups = nextState;
+    this.persistCollapsedLabelGroups();
+  }
+
+  private getExplorerLabelGroupScope(vaultId: string | null) {
+    return vaultId ?? "__default__";
+  }
+
+  private persistCollapsedLabelGroups() {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(
+        EXPLORER_COLLAPSED_LABELS_STORAGE_KEY,
+        JSON.stringify(this.explorerCollapsedLabelGroups),
+      );
     }
   }
 

--- a/specs/084-label-grouped-explorer/checklists/requirements.md
+++ b/specs/084-label-grouped-explorer/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Label-Grouped Entity Explorer
+
+**Purpose**: Validate specification completeness and quality before implementation and retroactive doc finalization
+**Created**: 2026-04-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and navigation outcomes
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions are reflected in supporting docs
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance coverage
+- [x] User scenarios cover the primary navigation flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- This checklist was completed during retroactive Speckit finalization for the implemented label-grouped explorer feature.

--- a/specs/084-label-grouped-explorer/data-model.md
+++ b/specs/084-label-grouped-explorer/data-model.md
@@ -19,6 +19,15 @@ Represents a rendered explorer section built from the current filtered entity li
 - **Members**: Ordered entity references displayed under the section header.
 - **Fallback Role**: Ensures entities without labels remain visible in grouped mode.
 
+### Explorer Group Visibility Preference
+
+Represents the saved collapsed state for label sections in the explorer.
+
+- **Scope Key**: The active vault ID, with a local fallback scope when no vault is active.
+- **Collapsed Labels**: A set of label names whose entity lists are currently hidden.
+- **Persistence Scope**: Browser-local preference for the current user environment.
+- **Behavior**: Updated whenever a label section is collapsed or expanded and restored when the UI store initializes.
+
 ### Filtered Explorer Result
 
 Represents the existing explorer result set after search and category filters are applied.
@@ -32,3 +41,4 @@ Represents the existing explorer result set after search and category filters ar
 - A single **Explorer View Preference** determines whether the **Filtered Explorer Result** is rendered as a flat list or converted into **Explorer Groups**.
 - A **Filtered Explorer Result** may produce many **Explorer Groups**.
 - A single entity can belong to multiple label-based **Explorer Groups**.
+- A single **Explorer Group Visibility Preference** controls whether each label-based **Explorer Group** shows or hides its members for the active vault.

--- a/specs/084-label-grouped-explorer/data-model.md
+++ b/specs/084-label-grouped-explorer/data-model.md
@@ -1,0 +1,34 @@
+# Data Model: Label-Grouped Entity Explorer
+
+## Entities
+
+### Explorer View Preference
+
+Represents the saved layout the user wants to use in the Entity Explorer.
+
+- **Mode**: One of `list` or `label`.
+- **Persistence Scope**: Browser-local preference for the current user environment.
+- **Behavior**: Loaded when the UI store initializes and updated whenever the user changes explorer mode.
+
+### Explorer Group
+
+Represents a rendered explorer section built from the current filtered entity list.
+
+- **Group Key**: The section label shown to the user, such as a label name or `Unlabeled`.
+- **Grouping Type**: `label`.
+- **Members**: Ordered entity references displayed under the section header.
+- **Fallback Role**: Ensures entities without labels remain visible in grouped mode.
+
+### Filtered Explorer Result
+
+Represents the existing explorer result set after search and category filters are applied.
+
+- **Source Entities**: The current vault entity collection.
+- **Applied Filters**: Search query and selected entity-type filters.
+- **Ordering Rule**: Entities are alphabetized before grouped sections are rendered.
+
+## Relationships
+
+- A single **Explorer View Preference** determines whether the **Filtered Explorer Result** is rendered as a flat list or converted into **Explorer Groups**.
+- A **Filtered Explorer Result** may produce many **Explorer Groups**.
+- A single entity can belong to multiple label-based **Explorer Groups**.

--- a/specs/084-label-grouped-explorer/plan.md
+++ b/specs/084-label-grouped-explorer/plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Label-Grouped Entity Explorer
 
-**Branch**: `084-label-grouped-explorer` | **Date**: 2026-04-15 | **Spec**: [/specs/084-label-grouped-explorer/spec.md](/workspaces/Codex-Cryptica/specs/084-label-grouped-explorer/spec.md)
-**Input**: Feature specification from `/specs/084-label-grouped-explorer/spec.md`
+**Branch**: `084-label-grouped-explorer` | **Date**: 2026-04-15 | **Spec**: [./spec.md](./spec.md)
+**Input**: Feature specification from `./spec.md`
 
 ## Summary
 

--- a/specs/084-label-grouped-explorer/plan.md
+++ b/specs/084-label-grouped-explorer/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Label-Grouped Entity Explorer
+
+**Branch**: `084-label-grouped-explorer` | **Date**: 2026-04-15 | **Spec**: [/specs/084-label-grouped-explorer/spec.md](/workspaces/Codex-Cryptica/specs/084-label-grouped-explorer/spec.md)
+**Input**: Feature specification from `/specs/084-label-grouped-explorer/spec.md`
+
+## Summary
+
+Add label grouping as an alternate explorer layout on top of the existing flat list. Preserve the current explorer selection flow and persist the chosen view mode in local storage.
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.0.2, Svelte 5.55.2  
+**Primary Dependencies**: SvelteKit web app, Lucide Svelte, workspace `schema` types  
+**Storage**: Existing vault entity state in memory plus browser `localStorage` for the explorer view preference  
+**Testing**: Vitest unit tests plus manual explorer verification  
+**Target Platform**: Web application on desktop and mobile browsers  
+**Project Type**: Monorepo web application  
+**Performance Goals**: Explorer mode switches should feel immediate for normal vault browsing with no noticeable delay compared with the existing flat list  
+**Constraints**: Preserve search/category filtering, keep behavior client-side, and avoid introducing a new explorer subsystem for a UI-only enhancement  
+**Scale/Scope**: Sidebar explorer rendering, explorer UI state, and validation for label grouping behavior
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+1. **Library-First**: Pass. This is an explorer presentation enhancement inside the existing web layer and does not introduce new domain logic that warrants a standalone workspace package.
+2. **TDD**: Pass. The implementation includes a dedicated grouping test for the new explorer grouping behavior.
+3. **Simplicity & YAGNI**: Pass. The feature extends the existing `uiStore` and `EntityList.svelte` instead of creating a separate explorer state system.
+4. **Privacy & Client-Side Processing**: Pass. Grouping and preference persistence remain entirely client-side.
+5. **User Documentation**: Pass for this scope. The existing entity explorer help entry remains the user-facing entry point, and the feature stays focused on label grouping without inventing new organizational concepts.
+6. **Dependency Injection**: Pass. No new services or stores requiring constructor DI were introduced.
+7. **Natural Language**: Pass. View labels remain simple and user-facing terms are limited to list and label.
+8. **Quality & Coverage Enforcement**: Pass. The feature adds focused automated coverage for the new grouping behavior and keeps the change set inside the existing explorer surface.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/084-label-grouped-explorer/
+├── checklists/
+│   └── requirements.md
+├── data-model.md
+├── plan.md
+├── quickstart.md
+├── research.md
+├── spec.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/web/src/lib/components/explorer/
+├── EntityList.svelte
+└── EntityListGrouping.test.ts
+
+apps/web/src/lib/stores/
+└── ui.svelte.ts
+
+apps/web/src/lib/config/
+└── help-content.ts
+```
+
+**Structure Decision**: Keep the implementation inside the existing explorer component and shared UI store because the feature only changes explorer presentation and persisted UI preference. Supporting documentation lives entirely in the feature spec directory.
+
+## Generated Artifacts
+
+- **research.md**: Documents the grouping strategy, store choice, and fallback behavior decisions.
+- **data-model.md**: Defines the user-facing preference and grouping concepts introduced by this enhancement.
+- **quickstart.md**: Provides manual validation steps for list and label explorer modes.
+- **checklists/requirements.md**: Captures the retroactive quality check for the finalized specification.

--- a/specs/084-label-grouped-explorer/plan.md
+++ b/specs/084-label-grouped-explorer/plan.md
@@ -5,19 +5,19 @@
 
 ## Summary
 
-Add label grouping as an alternate explorer layout on top of the existing flat list. Preserve the current explorer selection flow and persist the chosen view mode in local storage.
+Add label grouping as an alternate explorer layout on top of the existing flat list. Preserve the current explorer selection flow, let users collapse label sections, and persist both the chosen view mode and collapsed-group state in local storage.
 
 ## Technical Context
 
 **Language/Version**: TypeScript 6.0.2, Svelte 5.55.2  
 **Primary Dependencies**: SvelteKit web app, Lucide Svelte, workspace `schema` types  
-**Storage**: Existing vault entity state in memory plus browser `localStorage` for the explorer view preference  
+**Storage**: Existing vault entity state in memory plus browser `localStorage` for the explorer view preference and per-vault collapsed label sections  
 **Testing**: Vitest unit tests plus manual explorer verification  
 **Target Platform**: Web application on desktop and mobile browsers  
 **Project Type**: Monorepo web application  
 **Performance Goals**: Explorer mode switches should feel immediate for normal vault browsing with no noticeable delay compared with the existing flat list  
 **Constraints**: Preserve search/category filtering, keep behavior client-side, and avoid introducing a new explorer subsystem for a UI-only enhancement  
-**Scale/Scope**: Sidebar explorer rendering, explorer UI state, and validation for label grouping behavior
+**Scale/Scope**: Sidebar explorer rendering, explorer UI state, and validation for label grouping and per-vault collapse behavior
 
 ## Constitution Check
 
@@ -53,6 +53,7 @@ specs/084-label-grouped-explorer/
 ```text
 apps/web/src/lib/components/explorer/
 ├── EntityList.svelte
+├── EntityList.test.ts
 └── EntityListGrouping.test.ts
 
 apps/web/src/lib/stores/
@@ -67,6 +68,6 @@ apps/web/src/lib/config/
 ## Generated Artifacts
 
 - **research.md**: Documents the grouping strategy, store choice, and fallback behavior decisions.
-- **data-model.md**: Defines the user-facing preference and grouping concepts introduced by this enhancement.
-- **quickstart.md**: Provides manual validation steps for list and label explorer modes.
+- **data-model.md**: Defines the user-facing preference, grouping, and collapsed-section concepts introduced by this enhancement.
+- **quickstart.md**: Provides manual validation steps for list mode, label mode, and collapsed label persistence.
 - **checklists/requirements.md**: Captures the retroactive quality check for the finalized specification.

--- a/specs/084-label-grouped-explorer/quickstart.md
+++ b/specs/084-label-grouped-explorer/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart: Label-Grouped Entity Explorer
+
+This guide validates the explorer grouping feature against the current web app behavior.
+
+## Prerequisites
+
+Start the app locally:
+
+```bash
+npm install
+npm run dev
+```
+
+## Validation Steps
+
+## Explorer Mock
+
+Example label-grouped explorer layout:
+
+```text
+┌──────────────────────────────────────┐
+│ Search entities...              [🔎] │
+├──────────────────────────────────────┤
+│ [All] [NPC] [LOC] [ITEM]  |  [≡] [#] │
+│                            list label│
+├──────────────────────────────────────┤
+│ NPC                                  │
+│ ──────────────────────────────────── │
+│ • Alaric Stormborn          [npc]    │
+│ • Mira of Ash               [npc]    │
+│ • Quartermaster Venn        [npc]    │
+│                                      │
+│ QUEST                                │
+│ ──────────────────────────────────── │
+│ • Mira of Ash               [npc]    │
+│ • The Broken Seal           [note]   │
+│ • Road to Glass Hollow      [loc]    │
+│                                      │
+│ UNLABELED                            │
+│ ──────────────────────────────────── │
+│ • Forgotten Shrine          [loc]    │
+│ • Iron Ledger               [item]   │
+└──────────────────────────────────────┘
+```
+
+In label mode, a multi-labeled entity can appear in more than one section. The exact colors, icons, and spacing follow the active theme, but the overall hierarchy should remain the same.
+
+### 1. Prepare Explorer Data
+
+1. Open the app in your browser.
+2. Open any vault with several entities.
+3. Add labels to a few entities so at least one entity has one label, one entity has multiple labels, and one entity has no labels.
+4. Leave at least one entity without labels so the unlabeled fallback can be verified.
+
+### 2. Verify the Explorer Toolbar
+
+1. Open the **Entity Explorer** from the left sidebar.
+2. Confirm the toolbar includes the existing category filters plus two layout controls:
+   - **List View**
+   - **Group by Label**
+
+### 3. Verify Label Grouping
+
+1. Select **Group by Label**.
+2. Confirm each label renders as its own section header.
+3. Confirm an entity with multiple labels appears in every matching section.
+4. Confirm unlabeled entities appear in a dedicated **Unlabeled** section.
+
+### 4. Verify Filter Integration
+
+1. While in label view, apply a search query.
+2. Toggle one or more category filters.
+3. Confirm only matching entities remain visible.
+4. Confirm empty sections do not render.
+
+### 5. Verify Explorer Interactions
+
+1. Click an entity from a grouped section.
+2. Confirm it still opens normally in the main app view.
+3. If drag-and-drop is enabled in your current workflow, confirm grouped entries still start drag operations correctly.
+
+### 6. Verify Persistence
+
+1. Leave the explorer in label view.
+2. Reload the browser tab.
+3. Confirm the same explorer layout is restored after reload.

--- a/specs/084-label-grouped-explorer/quickstart.md
+++ b/specs/084-label-grouped-explorer/quickstart.md
@@ -25,16 +25,15 @@ Example label-grouped explorer layout:
 │                            list label│
 ├──────────────────────────────────────┤
 │ NPC                                  │
+│ ▾ 3                                  │
 │ ──────────────────────────────────── │
 │ • Alaric Stormborn          [npc]    │
 │ • Mira of Ash               [npc]    │
 │ • Quartermaster Venn        [npc]    │
 │                                      │
 │ QUEST                                │
+│ ▸ 3                                  │
 │ ──────────────────────────────────── │
-│ • Mira of Ash               [npc]    │
-│ • The Broken Seal           [note]   │
-│ • Road to Glass Hollow      [loc]    │
 │                                      │
 │ UNLABELED                            │
 │ ──────────────────────────────────── │
@@ -66,21 +65,30 @@ In label mode, a multi-labeled entity can appear in more than one section. The e
 3. Confirm an entity with multiple labels appears in every matching section.
 4. Confirm unlabeled entities appear in a dedicated **Unlabeled** section.
 
-### 4. Verify Filter Integration
+### 4. Verify Label Section Toggles
+
+1. While in label view, click a label section header.
+2. Confirm the entities under that label hide without affecting other label sections.
+3. Click the same header again.
+4. Confirm the entities for that label become visible again.
+
+### 5. Verify Filter Integration
 
 1. While in label view, apply a search query.
 2. Toggle one or more category filters.
 3. Confirm only matching entities remain visible.
 4. Confirm empty sections do not render.
 
-### 5. Verify Explorer Interactions
+### 6. Verify Explorer Interactions
 
 1. Click an entity from a grouped section.
 2. Confirm it still opens normally in the main app view.
 3. If drag-and-drop is enabled in your current workflow, confirm grouped entries still start drag operations correctly.
 
-### 6. Verify Persistence
+### 7. Verify Persistence
 
 1. Leave the explorer in label view.
-2. Reload the browser tab.
-3. Confirm the same explorer layout is restored after reload.
+2. Collapse one label section.
+3. Reload the browser tab.
+4. Confirm the same explorer layout is restored after reload.
+5. Confirm the same label section remains collapsed after reload.

--- a/specs/084-label-grouped-explorer/research.md
+++ b/specs/084-label-grouped-explorer/research.md
@@ -1,0 +1,40 @@
+# Research: Label-Grouped Entity Explorer
+
+## Context
+
+GitHub Issue #606 asks for better organization inside the Entity Explorer once a vault contains enough content that a single alphabetical list becomes slow to scan. The requirement is label-based grouping plus persistence of the selected explorer layout. The change is limited to explorer presentation and preference persistence; it does not add new entity fields or backend behavior.
+
+## Technical Decisions
+
+### Reuse the Existing Explorer Component
+
+- **Decision**: Extend `apps/web/src/lib/components/explorer/EntityList.svelte` instead of introducing a new explorer-specific package or rendering layer.
+- **Rationale**: The feature only changes how the existing filtered entity list is presented. Keeping the work inside the explorer component avoids unnecessary abstractions.
+- **Alternatives Considered**:
+  - **Standalone explorer grouping service**: Rejected because the grouping logic is small, UI-local, and tightly coupled to existing explorer rendering.
+
+### Persist the Layout in `uiStore`
+
+- **Decision**: Store the selected explorer layout in `apps/web/src/lib/stores/ui.svelte.ts`.
+- **Rationale**: `uiStore` already owns persisted UI preferences such as other sidebar and view settings, so explorer mode belongs in the same state surface.
+- **Alternatives Considered**:
+  - **Component-local state only**: Rejected because the chosen explorer view would reset on reload.
+
+### Group Only After Search and Category Filtering
+
+- **Decision**: Build grouped sections from the already filtered entity list.
+- **Rationale**: This preserves current explorer semantics and guarantees grouped layouts honor existing search and category filters without duplicating filtering logic.
+- **Alternatives Considered**:
+  - **Group before filtering**: Rejected because it would require extra filtering passes and make empty-group handling more complex.
+
+### Keep Entities Discoverable Through Fallback Groups
+
+- **Decision**: Use an `Unlabeled` section in label mode.
+- **Rationale**: Grouped layouts should never hide entities just because labels are missing.
+- **Alternatives Considered**:
+  - **Hide entities without grouping metadata**: Rejected because it would make grouped views incomplete and confusing.
+
+## Validation Notes
+
+- The branch includes targeted automated coverage in `apps/web/src/lib/components/explorer/EntityListGrouping.test.ts` for label grouping.
+- Manual validation is still required for explorer interaction details such as filtering, theme states, and persisted layout restoration.

--- a/specs/084-label-grouped-explorer/spec.md
+++ b/specs/084-label-grouped-explorer/spec.md
@@ -1,0 +1,69 @@
+# Feature Specification: Label-Grouped Entity Explorer
+
+**Feature Branch**: `084-label-grouped-explorer`  
+**Created**: 2026-04-15  
+**Status**: Implemented  
+**Input**: User description: "GitHub Issue #606: Organize the entity explorer by labels"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Group Explorer Results by Label (Priority: P1)
+
+As a vault maintainer with a growing world, I want to group explorer results by label so I can find related entities without relying on their type or alphabetical position.
+
+**Why this priority**: The issue request is centered on label-based organization, and it delivers the largest usability gain for large vaults.
+
+**Independent Test**: Assign labels to several entities, switch the explorer to label view, and verify that each label renders its own section with the expected entities.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple entities share the same label, **When** I switch the explorer to label view, **Then** I should see a section for that label containing all matching entities.
+2. **Given** an entity has more than one label, **When** I view entities by label, **Then** that entity should appear in every relevant label section.
+3. **Given** an entity has no labels, **When** I view entities by label, **Then** that entity should remain discoverable in an "Unlabeled" section.
+
+---
+
+### User Story 2 - Keep My Preferred Explorer Layout (Priority: P2)
+
+As a returning user, I want the explorer to remember my last chosen layout so I do not have to reselect list or label grouping every time I reopen the app.
+
+**Why this priority**: Remembering layout removes repeated friction and makes the new explorer modes feel like a stable preference rather than a temporary filter.
+
+**Independent Test**: Select a non-default explorer view, reload the app, and confirm the same explorer layout is restored.
+
+**Acceptance Scenarios**:
+
+1. **Given** I select label view, **When** I reload the application, **Then** the explorer should reopen in that same view mode.
+
+---
+
+### Edge Cases
+
+- Search and category filters must apply before grouping so alternate explorer views only show matching entities.
+- Empty label sections must not render after filtering.
+- Entities with multiple labels intentionally appear in multiple sections and must remain selectable in each location.
+- Entities without labels must remain discoverable through an explicit fallback group.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide explorer controls for switching between list view and label grouping.
+- **FR-002**: The system MUST remember the selected explorer view across browser reloads for the same user.
+- **FR-003**: The system MUST group filtered entities by label when label view is active.
+- **FR-004**: The system MUST show unlabeled entities in a dedicated fallback section when label view is active.
+- **FR-005**: The system MUST preserve existing search, category filtering, selection, and drag-start behavior in every explorer view.
+
+### Key Entities
+
+- **Explorer View Preference**: The user's saved explorer layout choice (`list` or `label`) that persists between sessions.
+- **Explorer Group**: A rendered section of entities produced from the current filtered explorer result set using a label key.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Users can switch between the available explorer layouts with a single click from the explorer toolbar.
+- **SC-002**: A previously selected explorer layout is restored after a browser reload.
+- **SC-003**: Multi-labeled entities remain discoverable from every relevant label section.
+- **SC-004**: Grouped views hide empty sections when search or category filters remove all matching entities from that group.

--- a/specs/084-label-grouped-explorer/spec.md
+++ b/specs/084-label-grouped-explorer/spec.md
@@ -20,6 +20,7 @@ As a vault maintainer with a growing world, I want to group explorer results by 
 1. **Given** multiple entities share the same label, **When** I switch the explorer to label view, **Then** I should see a section for that label containing all matching entities.
 2. **Given** an entity has more than one label, **When** I view entities by label, **Then** that entity should appear in every relevant label section.
 3. **Given** an entity has no labels, **When** I view entities by label, **Then** that entity should remain discoverable in an "Unlabeled" section.
+4. **Given** I collapse a label section, **When** I continue browsing in label view, **Then** the entities in that section should remain hidden until I expand it again.
 
 ---
 
@@ -37,12 +38,29 @@ As a returning user, I want the explorer to remember my last chosen layout so I 
 
 ---
 
+### User Story 3 - Keep Label Sections Folded The Way I Left Them (Priority: P2)
+
+As a returning user, I want collapsed label sections to stay collapsed so I can keep the explorer focused on the groups I care about across reloads and sessions.
+
+**Why this priority**: Large vaults benefit from grouping most when users can hide labels they are not actively browsing instead of re-collapsing them every time.
+
+**Independent Test**: Collapse one label section, reload the app, and verify that the same label remains collapsed while other labels stay visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** I collapse a label section in a vault, **When** I reload the application, **Then** that same section should remain collapsed.
+2. **Given** I expand a previously collapsed section, **When** I reload the application, **Then** that section should remain expanded.
+3. **Given** I use a different vault, **When** I open the explorer there, **Then** collapsed label state should not be borrowed from another vault.
+
+---
+
 ### Edge Cases
 
 - Search and category filters must apply before grouping so alternate explorer views only show matching entities.
 - Empty label sections must not render after filtering.
 - Entities with multiple labels intentionally appear in multiple sections and must remain selectable in each location.
 - Entities without labels must remain discoverable through an explicit fallback group.
+- Collapsed label state must survive browser reloads without hiding the unlabeled fallback by mistake.
 
 ## Requirements _(mandatory)_
 
@@ -52,12 +70,16 @@ As a returning user, I want the explorer to remember my last chosen layout so I 
 - **FR-002**: The system MUST remember the selected explorer view across browser reloads for the same user.
 - **FR-003**: The system MUST group filtered entities by label when label view is active.
 - **FR-004**: The system MUST show unlabeled entities in a dedicated fallback section when label view is active.
-- **FR-005**: The system MUST preserve existing search, category filtering, selection, and drag-start behavior in every explorer view.
+- **FR-005**: The system MUST let users collapse and expand individual label sections while label view is active.
+- **FR-006**: The system MUST remember collapsed label sections across browser reloads and sessions for the same user.
+- **FR-007**: The system MUST scope collapsed label state to the active vault so one vault does not change another vault's explorer layout.
+- **FR-008**: The system MUST preserve existing search, category filtering, selection, and drag-start behavior in every explorer view.
 
 ### Key Entities
 
 - **Explorer View Preference**: The user's saved explorer layout choice (`list` or `label`) that persists between sessions.
 - **Explorer Group**: A rendered section of entities produced from the current filtered explorer result set using a label key.
+- **Explorer Group Visibility Preference**: The per-vault saved set of label sections that are currently collapsed in label view.
 
 ## Success Criteria _(mandatory)_
 
@@ -67,3 +89,4 @@ As a returning user, I want the explorer to remember my last chosen layout so I 
 - **SC-002**: A previously selected explorer layout is restored after a browser reload.
 - **SC-003**: Multi-labeled entities remain discoverable from every relevant label section.
 - **SC-004**: Grouped views hide empty sections when search or category filters remove all matching entities from that group.
+- **SC-005**: Users can collapse a label section with a single click and see it stay collapsed after a reload.

--- a/specs/084-label-grouped-explorer/tasks.md
+++ b/specs/084-label-grouped-explorer/tasks.md
@@ -66,7 +66,7 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 
 **Independent Test**: Select a grouped view, reload the app, and confirm the same layout remains active
 
-### Implementation for User Story 3
+### Implementation for User Story 2
 
 - [x] T010 [US2] Load the saved explorer view preference from `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`
 - [x] T011 [US2] Persist explorer view changes back to `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`

--- a/specs/084-label-grouped-explorer/tasks.md
+++ b/specs/084-label-grouped-explorer/tasks.md
@@ -1,0 +1,117 @@
+---
+description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity Explorer feature"
+---
+
+# Tasks: Label-Grouped Entity Explorer
+
+**Input**: Design documents from `/specs/084-label-grouped-explorer/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Organization**: Tasks are grouped by user story to preserve traceability between the feature request, implementation work, and validation steps.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Context)
+
+**Purpose**: Confirm the issue scope and identify the explorer touchpoints before code changes
+
+- [x] T001 Review GitHub Issue #606 and map the requested grouping behavior to the existing explorer workflow
+- [x] T002 Inspect `apps/web/src/lib/components/explorer/EntityList.svelte` and `apps/web/src/lib/stores/ui.svelte.ts` to identify rendering and persistence touchpoints
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared explorer state required by the new grouped view
+
+**⚠️ CRITICAL**: No grouped explorer work can ship until persisted explorer view state exists
+
+- [x] T003 Add `explorerViewMode` state and persistence logic in `apps/web/src/lib/stores/ui.svelte.ts`
+- [x] T004 Add `setExplorerViewMode` handling in `apps/web/src/lib/stores/ui.svelte.ts` for list and label modes
+
+**Checkpoint**: Explorer mode can now be read and updated consistently across the UI
+
+---
+
+## Phase 3: User Story 1 - Group Explorer Results by Label (Priority: P1) 🎯 MVP
+
+**Goal**: Let users organize the explorer into label sections while keeping existing entity actions intact
+
+**Independent Test**: Apply labels to entities, switch to label view, and verify sections, unlabeled fallback, and repeated membership for multi-labeled entities
+
+### Tests for User Story 1
+
+- [x] T005 [P] [US1] Add label-grouping coverage in `apps/web/src/lib/components/explorer/EntityListGrouping.test.ts`
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Add derived grouped-entity computation for label mode in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T007 [US1] Add list and label view toggle controls to the explorer header in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T008 [US1] Refactor repeated entity row rendering into reusable snippets in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T009 [US1] Render label section headers and an explicit unlabeled fallback section in `apps/web/src/lib/components/explorer/EntityList.svelte`
+
+**Checkpoint**: Label view is functional and independently testable
+
+---
+
+## Phase 4: User Story 2 - Keep My Preferred Explorer Layout (Priority: P2)
+
+**Goal**: Restore the user’s last selected explorer layout after reload
+
+**Independent Test**: Select a grouped view, reload the app, and confirm the same layout remains active
+
+### Implementation for User Story 3
+
+- [x] T010 [US2] Load the saved explorer view preference from `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`
+- [x] T011 [US2] Persist explorer view changes back to `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`
+
+**Checkpoint**: View preference survives page reloads
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate grouped layouts against the existing explorer experience
+
+- [x] T012 [P] Verify grouped views continue to honor search and category filtering in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T013 [P] Verify grouped views preserve entity selection and drag-start behavior in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T014 Validate grouped explorer controls across default and fantasy themes in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T015 Run feature-level validation using `specs/084-label-grouped-explorer/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks grouped explorer work
+- **User Story 1 (Phase 3)**: Depends on persisted explorer mode state from Phase 2
+- **User Story 2 (Phase 4)**: Depends on the foundational explorer state from Phase 2
+- **Polish (Phase 5)**: Depends on all desired grouped views being complete
+
+### Parallel Opportunities
+
+- T012 and T013 can be validated in parallel after grouped rendering is complete
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Setup and Foundational work.
+2. Implement label grouping and the explorer mode controls.
+3. Validate label grouping independently before wider rollout.
+
+### Incremental Delivery
+
+1. Persist the explorer view mode.
+2. Ship label grouping as the primary requested capability.
+3. Validate persistence, filtering, theme, and interaction behavior.

--- a/specs/084-label-grouped-explorer/tasks.md
+++ b/specs/084-label-grouped-explorer/tasks.md
@@ -55,6 +55,7 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 - [x] T007 [US1] Add list and label view toggle controls to the explorer header in `apps/web/src/lib/components/explorer/EntityList.svelte`
 - [x] T008 [US1] Refactor repeated entity row rendering into reusable snippets in `apps/web/src/lib/components/explorer/EntityList.svelte`
 - [x] T009 [US1] Render label section headers and an explicit unlabeled fallback section in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T010 [US1] Let users collapse and expand label sections in `apps/web/src/lib/components/explorer/EntityList.svelte`
 
 **Checkpoint**: Label view is functional and independently testable
 
@@ -68,21 +69,40 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 
 ### Implementation for User Story 2
 
-- [x] T010 [US2] Load the saved explorer view preference from `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`
-- [x] T011 [US2] Persist explorer view changes back to `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`
+- [x] T011 [US2] Load the saved explorer view preference from `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`
+- [x] T012 [US2] Persist explorer view changes back to `localStorage` in `apps/web/src/lib/stores/ui.svelte.ts`
 
 **Checkpoint**: View preference survives page reloads
 
 ---
 
-## Phase 5: Polish & Cross-Cutting Concerns
+## Phase 5: User Story 3 - Remember Collapsed Label Sections (Priority: P2)
+
+**Goal**: Restore collapsed label groups for the active vault after reload so users can keep the explorer focused on the labels they care about.
+
+**Independent Test**: Collapse a label section, reload the app, and confirm the same section remains collapsed in the same vault.
+
+### Tests for User Story 3
+
+- [x] T013 [P] [US3] Add coverage for label-group collapse persistence in `apps/web/src/lib/components/explorer/EntityList.test.ts` and `apps/web/src/lib/stores/ui.svelte.test.ts`
+
+### Implementation for User Story 3
+
+- [x] T014 [US3] Add persisted per-vault collapsed label state in `apps/web/src/lib/stores/ui.svelte.ts`
+- [x] T015 [US3] Render collapsible label section headers in `apps/web/src/lib/components/explorer/EntityList.svelte`
+
+**Checkpoint**: Collapsed label sections survive reloads and remain scoped to the active vault
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
 
 **Purpose**: Validate grouped layouts against the existing explorer experience
 
-- [x] T012 [P] Verify grouped views continue to honor search and category filtering in `apps/web/src/lib/components/explorer/EntityList.svelte`
-- [x] T013 [P] Verify grouped views preserve entity selection and drag-start behavior in `apps/web/src/lib/components/explorer/EntityList.svelte`
-- [x] T014 Validate grouped explorer controls across default and fantasy themes in `apps/web/src/lib/components/explorer/EntityList.svelte`
-- [x] T015 Run feature-level validation using `specs/084-label-grouped-explorer/quickstart.md`
+- [x] T016 [P] Verify grouped views continue to honor search and category filtering in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T017 [P] Verify grouped views preserve entity selection and drag-start behavior in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T018 Validate grouped explorer controls across default and fantasy themes in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T019 Run feature-level validation using `specs/084-label-grouped-explorer/quickstart.md`
 
 ---
 
@@ -94,7 +114,8 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 - **Foundational (Phase 2)**: Depends on Setup completion and blocks grouped explorer work
 - **User Story 1 (Phase 3)**: Depends on persisted explorer mode state from Phase 2
 - **User Story 2 (Phase 4)**: Depends on the foundational explorer state from Phase 2
-- **Polish (Phase 5)**: Depends on all desired grouped views being complete
+- **User Story 3 (Phase 5)**: Depends on the grouped explorer rendering from Phase 3
+- **Polish (Phase 6)**: Depends on all desired grouped views being complete
 
 ### Parallel Opportunities
 
@@ -113,5 +134,5 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 ### Incremental Delivery
 
 1. Persist the explorer view mode.
-2. Ship label grouping as the primary requested capability.
+2. Ship label grouping and collapsible sections as the primary requested capability.
 3. Validate persistence, filtering, theme, and interaction behavior.


### PR DESCRIPTION
## Summary\n- finalize the retroactive Speckit artifact set for the label-grouped explorer feature\n- align the explorer implementation with the actual Codex-Cryptica model by keeping list and label views only\n- update explorer styling and accessibility to follow the current design guide patterns\n\n## Testing\n- npm run test --workspace=web -- EntityList.test.ts EntityListGrouping.test.ts ui.svelte.test.ts\n- repo push hook ran lint and full test suite