### PR TITLE
Add VTT entity list with drag-to-map token placement

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -145,7 +145,7 @@ TypeScript: Follow standard conventions
 
 ## Recent Changes
 
-- 085-vtt-entity-list: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
+- 085-vtt-entity-list: Added VTT sidebar "Vault Entities" section with collapsible entity list, drag-to-map token placement (host add / guest request), canvas ghost-token drag preview, and persisted sidebar collapse state. Also added label-grouped explorer view mode with collapsible label groups and persisted view state.
 
 - 083-style-guide-doc: Added TypeScript 5.9.3, Svelte 5 (Runes) + Tailwind CSS 4, Lucide Svelte, Marked (for Markdown rendering if integrated into the web app)
 

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -83,11 +83,7 @@
 
     event.dataTransfer.setData("application/codex-entity", entityId);
     event.dataTransfer.effectAllowed = "copy";
-    mapSession.setDragPreview({
-      entityId,
-      x: 0,
-      y: 0,
-    });
+    mapSession.clearDragPreview();
   }
 
   function handleEntityDragEnd() {
@@ -115,6 +111,7 @@
 
       if (
         entity &&
+        VTT_ENTITY_TYPES.includes(entity.type) &&
         activeMap &&
         mapCoords.x >= 0 &&
         mapCoords.y >= 0 &&


### PR DESCRIPTION
## Summary
- add a persistent Vault Entities section to the VTT sidebar
- support dragging allowed entities onto the map with host/guest-safe token creation
- render drag previews, add help content, and cover the store/UI behavior with tests
- add label-grouped explorer view mode with collapsible label groups and persisted view state (explorer persistence piggybacked onto this branch)

Closes #621.

## Verification
- npm run check --workspace=web
- npm run test --workspace=web -- src/lib/stores/map-session.test.ts src/lib/stores/ui.svelte.test.ts
- pre-push hooks: turbo run lint, turbo run test