### PR TITLE
:bug: fix(vtt): entity list scrolling and zen popout 500 error

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -231,7 +231,7 @@
 
   <div
     role="list"
-    class="flex-1 overflow-y-auto p-2 space-y-1 custom-scrollbar overscroll-contain"
+    class="flex-1 overflow-y-auto p-2 space-y-1 custom-scrollbar"
     style="touch-action: pan-y;"
   >
     {#snippet entityItem(entity: Entity)}
@@ -242,14 +242,14 @@
         focusedEntityId
           ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'
           : 'border-theme-border bg-theme-surface/50 hover:border-theme-primary/50 hover:bg-theme-primary/5'}"
-        draggable={!!onDragStart}
-        ondragstart={(e) => onDragStart?.(e, entity.id)}
-        ondragend={() => onDragEnd?.()}
         data-testid="entity-list-item"
         data-entity-id={entity.id}
       >
         <button
           type="button"
+          draggable={!!onDragStart}
+          ondragstart={(e) => onDragStart?.(e, entity.id)}
+          ondragend={() => onDragEnd?.()}
           onclick={() => onSelect?.(entity)}
           title={`Select ${entity.title}`}
           class="flex flex-1 min-w-0 items-center gap-2 p-2.5 text-left focus:outline-none focus:ring-2 focus:ring-theme-accent/20 rounded-xl"

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -230,14 +230,12 @@
   </div>
 
   <div
-    role="list"
     class="flex-1 overflow-y-auto p-2 space-y-1 custom-scrollbar"
     style="touch-action: pan-y;"
   >
     {#snippet entityItem(entity: Entity)}
       {@const cat = categories.getCategory(entity.type)}
       <div
-        role="listitem"
         class="group relative flex items-stretch rounded-xl border transition-all {entity.id ===
         focusedEntityId
           ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -18,12 +18,14 @@
     onSelect,
     onDragStart,
     onDragEnd,
+    onOpenZen,
     allowedTypes = null,
     class: className = "",
   }: {
     onSelect?: (entity: Entity) => void;
     onDragStart?: (event: DragEvent, entityId: string) => void;
     onDragEnd?: () => void;
+    onOpenZen?: (entity: Entity) => void;
     allowedTypes?: string[] | null;
     class?: string;
   } = $props();
@@ -228,26 +230,30 @@
   </div>
 
   <div
+    role="list"
     class="flex-1 overflow-y-auto p-2 space-y-1 custom-scrollbar overscroll-contain"
     style="touch-action: pan-y;"
   >
     {#snippet entityItem(entity: Entity)}
       {@const cat = categories.getCategory(entity.type)}
-      <button
-        type="button"
-        draggable={!!onDragStart}
-        ondragstart={(e) => onDragStart?.(e, entity.id)}
-        ondragend={() => onDragEnd?.()}
-        onclick={() => onSelect?.(entity)}
-        data-testid="entity-list-item"
-        data-entity-id={entity.id}
-        title={`Select ${entity.title}`}
-        class="group w-full rounded-xl border p-2.5 text-left transition-all focus:border-theme-accent focus:outline-none focus:ring-2 focus:ring-theme-accent/20 {entity.id ===
+      <div
+        role="listitem"
+        class="group relative flex items-stretch rounded-xl border transition-all {entity.id ===
         focusedEntityId
           ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'
           : 'border-theme-border bg-theme-surface/50 hover:border-theme-primary/50 hover:bg-theme-primary/5'}"
+        draggable={!!onDragStart}
+        ondragstart={(e) => onDragStart?.(e, entity.id)}
+        ondragend={() => onDragEnd?.()}
+        data-testid="entity-list-item"
+        data-entity-id={entity.id}
       >
-        <div class="flex items-center gap-2">
+        <button
+          type="button"
+          onclick={() => onSelect?.(entity)}
+          title={`Select ${entity.title}`}
+          class="flex flex-1 min-w-0 items-center gap-2 p-2.5 text-left focus:outline-none focus:ring-2 focus:ring-theme-accent/20 rounded-xl"
+        >
           <span
             class="{getIconClass(
               cat?.icon,
@@ -271,8 +277,19 @@
               {/each}
             </div>
           {/if}
-        </div>
-      </button>
+        </button>
+        {#if onOpenZen}
+          <button
+            type="button"
+            onclick={() => onOpenZen(entity)}
+            title="Open in Zen Mode"
+            aria-label="Open {entity.title} in Zen Mode"
+            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100"
+          >
+            <span class="icon-[lucide--book-open] h-3.5 w-3.5"></span>
+          </button>
+        {/if}
+      </div>
     {/snippet}
 
     {#snippet sectionHeader(title: string)}

--- a/apps/web/src/lib/components/vtt/InitiativePanel.svelte
+++ b/apps/web/src/lib/components/vtt/InitiativePanel.svelte
@@ -155,13 +155,12 @@
 
   <div
     class="mt-3 flex-1 min-h-0 space-y-2 overflow-y-auto custom-scrollbar pr-1"
-    role="list"
   >
     {#each entries as entry, index (entry.tokenId)}
       {@const token = mapSession.tokens[entry.tokenId]}
-      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions a11y_no_static_element_interactions -->
       <div
-        role="listitem"
+        data-testid="initiative-row"
         draggable="true"
         onmousedown={(e) => e.stopPropagation()}
         ondragstart={() => (draggedIndex = index)}

--- a/apps/web/src/lib/components/vtt/InitiativePanel.test.ts
+++ b/apps/web/src/lib/components/vtt/InitiativePanel.test.ts
@@ -100,7 +100,7 @@ describe("InitiativePanel", () => {
   it("pings a combatant on double click", async () => {
     render(InitiativePanel);
 
-    await fireEvent.dblClick(screen.getByRole("listitem"));
+    await fireEvent.dblClick(screen.getByTestId("initiative-row"));
 
     expect(mapSessionMock.pingToken).toHaveBeenCalledWith("token-abc123");
   });

--- a/apps/web/src/lib/services/search.ts
+++ b/apps/web/src/lib/services/search.ts
@@ -8,6 +8,8 @@ import { entityDb } from "../utils/entity-db";
 import { vaultEventBus } from "../stores/vault/events";
 
 const INDEX_BATCH_SIZE = 50;
+const SEARCH_INIT_TIMEOUT_MS = 2000;
+const SEARCH_INIT_POLL_MS = 100;
 
 export class SearchService {
   private worker: Worker | null = null;
@@ -285,9 +287,17 @@ export class SearchService {
 
     // Wait for worker to be ready
     let retries = 0;
-    while (!this.isInitialized && retries < 20) {
-      await new Promise((r) => setTimeout(r, 100));
+    const maxRetries = SEARCH_INIT_TIMEOUT_MS / SEARCH_INIT_POLL_MS;
+    while (!this.isInitialized && retries < maxRetries) {
+      await new Promise((r) => setTimeout(r, SEARCH_INIT_POLL_MS));
       retries++;
+    }
+
+    if (!this.isInitialized) {
+      debugStore.warn(
+        `[SearchService] Search worker initialization timed out after ${SEARCH_INIT_TIMEOUT_MS}ms.`,
+      );
+      return false;
     }
 
     this.activeVaultId = vaultId;

--- a/apps/web/src/lib/stores/map-session.svelte.ts
+++ b/apps/web/src/lib/stores/map-session.svelte.ts
@@ -22,7 +22,7 @@ import type {
   VTTMessage,
 } from "../../types/vtt";
 import type { Point } from "schema";
-import { snapToGrid } from "$lib/utils/vtt-helpers";
+import { snapToGrid, clampPointToBounds } from "$lib/utils/vtt-helpers";
 import { uiStore } from "./ui.svelte";
 import { diceEngine, type RollResult } from "dice-engine";
 
@@ -950,6 +950,11 @@ export class MapSessionStore {
         height: tokenSize.height,
       };
 
+    let targetX = point.x;
+    let targetY = point.y;
+    let targetWidth = tokenSize.width;
+    let targetHeight = tokenSize.height;
+
     if (this.deps.mapStore.showGrid) {
       const gridSize = this.deps.mapStore.gridSize;
       const offsetX = this.deps.mapStore.gridOffsetX;
@@ -957,28 +962,30 @@ export class MapSessionStore {
 
       // Snap position to grid lines
       const snapped = snapToGrid(point, gridSize, offsetX, offsetY);
+      targetX = snapped.x;
+      targetY = snapped.y;
 
       // Snap size to nearest grid cell multiple
-      const snappedWidth = gridSize
+      targetWidth = gridSize
         ? Math.max(gridSize, Math.round(tokenSize.width / gridSize) * gridSize)
         : tokenSize.width;
-      const snappedHeight = gridSize
+      targetHeight = gridSize
         ? Math.max(gridSize, Math.round(tokenSize.height / gridSize) * gridSize)
         : tokenSize.height;
-
-      return {
-        x: snapped.x,
-        y: snapped.y,
-        width: snappedWidth,
-        height: snappedHeight,
-      };
     }
 
+    // Always clamp to map bounds to prevent invisible placements
+    const clamped = clampPointToBounds(
+      { x: targetX, y: targetY },
+      activeMap.dimensions,
+      { width: targetWidth, height: targetHeight },
+    );
+
     return {
-      x: point.x,
-      y: point.y,
-      width: tokenSize.width,
-      height: tokenSize.height,
+      x: clamped.x,
+      y: clamped.y,
+      width: targetWidth,
+      height: targetHeight,
     };
   }
 

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -334,6 +334,7 @@
                         onSelect={handleEntitySelect}
                         onDragStart={handleEntityDragStart}
                         onDragEnd={handleEntityDragEnd}
+                        onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
                       />
                     </div>
                   {/if}

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -109,15 +109,7 @@
       const entity = vault.entities[entityId];
       const activeMap = mapStore.activeMap;
 
-      if (
-        entity &&
-        VTT_ENTITY_TYPES.includes(entity.type) &&
-        activeMap &&
-        mapCoords.x >= 0 &&
-        mapCoords.y >= 0 &&
-        mapCoords.x <= activeMap.dimensions.width &&
-        mapCoords.y <= activeMap.dimensions.height
-      ) {
+      if (entity && VTT_ENTITY_TYPES.includes(entity.type) && activeMap) {
         const tokenInput = {
           name: entity.title,
           entityId: entity.id,
@@ -207,6 +199,7 @@
             ? 'w-12'
             : 'w-[22rem] max-w-[calc(100vw-3rem)]'}"
           aria-label="VTT Sidebar"
+          onwheel={(e) => e.stopPropagation()}
         >
           {#if uiStore.vttSidebarCollapsed}
             <div
@@ -283,62 +276,63 @@
                   <InitiativePanel />
                 {/if}
 
-                <section
-                  class="rounded-xl border border-theme-primary/20 bg-theme-bg/50"
-                  data-testid="vtt-entity-list-section"
-                >
-                  <button
-                    type="button"
-                    class="flex w-full items-center justify-between gap-3 px-3 py-3 text-left"
-                    onclick={() =>
-                      uiStore.toggleVttEntityList(
-                        !uiStore.vttEntityListCollapsed,
-                      )}
-                    aria-expanded={!uiStore.vttEntityListCollapsed}
-                    aria-controls="vtt-entity-list"
+                {#if !uiStore.isGuestMode}
+                  <section
+                    class="rounded-xl border border-theme-primary/20 bg-theme-bg/50"
+                    data-testid="vtt-entity-list-section"
                   >
-                    <div>
-                      <div
-                        class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
-                      >
-                        Vault Entities
-                      </div>
-                      <div class="text-xs text-theme-muted">
-                        Drag characters, creatures, and items onto the map.
-                      </div>
-                    </div>
-                    <div class="flex items-center gap-2">
-                      <span
-                        class="rounded-full border border-theme-border px-2 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-muted"
-                      >
-                        {vttEntityCount}
-                      </span>
-                      <span
-                        class="icon-[lucide--chevron-down] h-4 w-4 text-theme-muted transition-transform {uiStore.vttEntityListCollapsed
-                          ? '-rotate-90'
-                          : ''}"
-                      ></span>
-                    </div>
-                  </button>
-
-                  {#if !uiStore.vttEntityListCollapsed}
-                    <div
-                      id="vtt-entity-list"
-                      class="border-t border-theme-primary/20"
-                      role="presentation"
-                      onmousedown={(event) => event.stopPropagation()}
+                    <button
+                      type="button"
+                      class="flex w-full items-center justify-between gap-3 px-3 py-3 text-left"
+                      onclick={() =>
+                        uiStore.toggleVttEntityList(
+                          !uiStore.vttEntityListCollapsed,
+                        )}
+                      aria-expanded={!uiStore.vttEntityListCollapsed}
+                      aria-controls="vtt-entity-list"
                     >
-                      <EntityList
-                        class="h-[22rem]"
-                        allowedTypes={VTT_ENTITY_TYPES}
-                        onSelect={handleEntitySelect}
-                        onDragStart={handleEntityDragStart}
-                        onDragEnd={handleEntityDragEnd}
-                        onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
-                      />
-                    </div>
-                  {/if}
-                </section>
+                      <div>
+                        <div
+                          class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
+                        >
+                          Vault Entities
+                        </div>
+                        <div class="text-xs text-theme-muted">
+                          Drag characters, creatures, and items onto the map.
+                        </div>
+                      </div>
+                      <div class="flex items-center gap-2">
+                        <span
+                          class="rounded-full border border-theme-border px-2 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-muted"
+                        >
+                          {vttEntityCount}
+                        </span>
+                        <span
+                          class="icon-[lucide--chevron-down] h-4 w-4 text-theme-muted transition-transform {uiStore.vttEntityListCollapsed
+                            ? '-rotate-90'
+                            : ''}"
+                        ></span>
+                      </div>
+                    </button>
+
+                    {#if !uiStore.vttEntityListCollapsed}
+                      <div
+                        id="vtt-entity-list"
+                        class="border-t border-theme-primary/20 flex flex-col max-h-[50vh]"
+                        role="presentation"
+                        onmousedown={(event) => event.stopPropagation()}
+                      >
+                        <EntityList
+                          allowedTypes={VTT_ENTITY_TYPES}
+                          onSelect={handleEntitySelect}
+                          onDragStart={handleEntityDragStart}
+                          onDragEnd={handleEntityDragEnd}
+                          onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
+                        />
+                      </div>
+                    {/if}
+                  </section>
+                {/if}
 
                 <TokenDetail />
 

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -9,12 +9,18 @@
     type ZenPopoutPayload,
   } from "$lib/utils/zen-popout";
 
+  const VAULT_INIT_TIMEOUT_MS = 5000;
+  const VAULT_INIT_POLL_MS = 50;
+  const MAX_VAULT_INIT_RETRIES = VAULT_INIT_TIMEOUT_MS / VAULT_INIT_POLL_MS;
+
   const vaultId = $derived(
     (page.params as { id: string; entityId: string }).id,
   );
   const entityId = $derived(
     (page.params as { id: string; entityId: string }).entityId,
   );
+
+  let error = $state<string | null>(null);
 
   const applyGuestPayload = (payload: ZenPopoutPayload) => {
     vault.repository.entities[payload.entity.id] = {
@@ -32,52 +38,75 @@
 
   onMount(() => {
     const initEntityView = async () => {
-      const vid = vaultId;
-      const eid = entityId;
+      try {
+        const vid = vaultId;
+        const eid = entityId;
 
-      if (!vid || !eid) return;
-
-      // 1. Try to get guest payload synchronously (from sessionStorage)
-      let payload = consumeZenPopoutPayload(vid, eid);
-
-      // 2. If not found but we have an opener, request it via postMessage
-      if (!payload && window.opener) {
-        uiStore.isGuestMode = true; // Set early to prevent default vault load
-        payload = await requestZenPopoutPayload(eid);
-      }
-
-      if (payload) {
-        // Guest Flow
-        const loadedEntityId = applyGuestPayload(payload);
-        if (vault.entities[loadedEntityId]) {
-          uiStore.openZenMode(loadedEntityId);
+        if (!vid || !eid) {
+          error = "Vault ID or Entity ID is missing.";
+          return;
         }
-      } else {
-        // Host Flow
-        uiStore.isGuestMode = false;
-        if (vault.activeVaultId !== vid) {
-          await vault.switchVault(vid);
-        } else {
-          // If this vault was already active from LocalStorage restoration,
-          // we must wait for its background initialization (OPFS read) to finish.
-          let retries = 0;
-          while (!vault.isInitialized && retries < 100) {
-            await new Promise((r) => setTimeout(r, 50));
-            retries++;
+
+        // 1. Try to get guest payload synchronously (from sessionStorage)
+        let payload = consumeZenPopoutPayload(vid, eid);
+
+        // 2. If not found but we have an opener, request it via postMessage
+        if (!payload && window.opener) {
+          uiStore.isGuestMode = true; // Set early to prevent default vault load
+          payload = await requestZenPopoutPayload(eid);
+
+          if (!payload) {
+            error =
+              "Guest handshake failed. The host window may have been closed or the session timed out.";
+            return;
           }
         }
 
-        if (vault.entities[eid]) {
-          uiStore.openZenMode(eid);
+        if (payload) {
+          // Guest Flow (or Handover Flow)
+          const loadedEntityId = applyGuestPayload(payload);
+          if (vault.entities[loadedEntityId]) {
+            uiStore.openZenMode(loadedEntityId);
+          } else {
+            error = `Failed to load entity ${loadedEntityId} into memory.`;
+          }
         } else {
-          console.warn(
-            `[Entity Popout] Entity ${eid} not found in vault ${vid}`,
-          );
+          // Host Flow
+          uiStore.isGuestMode = false;
+          if (vault.activeVaultId !== vid) {
+            await vault.switchVault(vid);
+          } else {
+            // If this vault was already active from LocalStorage restoration,
+            // we must wait for its background initialization (OPFS read) to finish.
+            let retries = 0;
+            while (!vault.isInitialized && retries < MAX_VAULT_INIT_RETRIES) {
+              await new Promise((r) => setTimeout(r, VAULT_INIT_POLL_MS));
+              retries++;
+            }
+
+            if (!vault.isInitialized) {
+              error =
+                "Vault initialization timed out. Please refresh the page.";
+              return;
+            }
+          }
+
+          if (vault.entities[eid]) {
+            uiStore.openZenMode(eid);
+          } else {
+            error = `Entity "${eid}" not found in vault "${vid}".`;
+            console.warn(
+              `[Entity Popout] Entity ${eid} not found in vault ${vid}`,
+            );
+          }
         }
+      } catch (err) {
+        console.error("[Entity Popout] Unexpected initialization error:", err);
+        error = "An unexpected error occurred while preparing the entity view.";
       }
     };
 
-    initEntityView();
+    void initEntityView();
   });
 </script>
 
@@ -87,5 +116,27 @@
   >
 </svelte:head>
 
-<!-- Full-screen dark backdrop — ZenModeModal overlays this -->
-<div class="h-screen bg-black"></div>
+<!-- Full-screen dark backdrop — ZenModeModal overlays this if successful -->
+<div class="h-screen bg-black flex items-center justify-center p-6">
+  {#if error}
+    <div class="max-w-md text-center">
+      <div
+        class="icon-[lucide--alert-triangle] w-12 h-12 text-theme-primary/50 mx-auto mb-4"
+      ></div>
+      <h1
+        class="text-theme-primary font-header text-xl font-bold uppercase tracking-widest mb-4"
+      >
+        View Error
+      </h1>
+      <p class="text-theme-text/80 text-sm mb-8 leading-relaxed">
+        {error}
+      </p>
+      <button
+        onclick={() => window.close()}
+        class="px-8 py-2.5 bg-theme-primary text-theme-bg rounded-lg text-xs font-bold uppercase tracking-widest hover:bg-theme-secondary transition-all active:scale-95 shadow-lg"
+      >
+        Close Tab
+      </button>
+    </div>
+  {/if}
+</div>

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { browser } from "$app/environment";
+  import { onMount } from "svelte";
   import { page } from "$app/state";
   import { vault } from "$lib/stores/vault.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
@@ -27,69 +27,57 @@
     vault.isInitialized = true;
     vault.status = "idle";
     if (payload.isGuest) uiStore.isGuestMode = true;
-    guestEntityId = payload.entity.id;
+    return payload.entity.id;
   };
 
-  let guestEntityId = $state<string | null>(null);
-  let isResolvingGuestPayload = $state(false);
-  if (browser) {
-    const vid = (page.params as { id: string; entityId: string }).id;
-    const eid = (page.params as { id: string; entityId: string }).entityId;
-    if (vid && eid) {
-      const payload = consumeZenPopoutPayload(vid, eid);
-      if (payload) {
-        applyGuestPayload(payload);
-      } else if (window.opener) {
-        // Set isGuestMode early so vault.init() bails before loadFiles() runs
-        uiStore.isGuestMode = true;
-        isResolvingGuestPayload = true;
+  onMount(() => {
+    const initEntityView = async () => {
+      const vid = vaultId;
+      const eid = entityId;
+
+      if (!vid || !eid) return;
+
+      // 1. Try to get guest payload synchronously (from sessionStorage)
+      let payload = consumeZenPopoutPayload(vid, eid);
+
+      // 2. If not found but we have an opener, request it via postMessage
+      if (!payload && window.opener) {
+        uiStore.isGuestMode = true; // Set early to prevent default vault load
+        payload = await requestZenPopoutPayload(eid);
       }
-    }
-  }
 
-  $effect(() => {
-    if (!browser || !isResolvingGuestPayload || !entityId) return;
+      if (payload) {
+        // Guest Flow
+        const loadedEntityId = applyGuestPayload(payload);
+        if (vault.entities[loadedEntityId]) {
+          uiStore.openZenMode(loadedEntityId);
+        }
+      } else {
+        // Host Flow
+        uiStore.isGuestMode = false;
+        if (vault.activeVaultId !== vid) {
+          await vault.switchVault(vid);
+        } else {
+          // If this vault was already active from LocalStorage restoration,
+          // we must wait for its background initialization (OPFS read) to finish.
+          let retries = 0;
+          while (!vault.isInitialized && retries < 100) {
+            await new Promise((r) => setTimeout(r, 50));
+            retries++;
+          }
+        }
 
-    let isCancelled = false;
-
-    void requestZenPopoutPayload(entityId).then((payload) => {
-      if (isCancelled) return;
-      if (payload) applyGuestPayload(payload);
-      isResolvingGuestPayload = false;
-    });
-
-    return () => {
-      isCancelled = true;
+        if (vault.entities[eid]) {
+          uiStore.openZenMode(eid);
+        } else {
+          console.warn(
+            `[Entity Popout] Entity ${eid} not found in vault ${vid}`,
+          );
+        }
+      }
     };
-  });
 
-  // Guest flow: open zen mode once reactive state has settled
-  $effect(() => {
-    if (guestEntityId && vault.entities[guestEntityId]) {
-      uiStore.openZenMode(guestEntityId);
-    }
-  });
-
-  // Host flow: only when not a guest popout
-  $effect(() => {
-    if (
-      vaultId &&
-      vault.activeVaultId !== vaultId &&
-      !uiStore.isGuestMode &&
-      !isResolvingGuestPayload
-    ) {
-      void vault.switchVault(vaultId);
-    }
-  });
-
-  $effect(() => {
-    if (
-      entityId &&
-      vault.activeVaultId === vaultId &&
-      vault.entities[entityId]
-    ) {
-      uiStore.openZenMode(entityId);
-    }
+    initEntityView();
   });
 </script>
 


### PR DESCRIPTION
### What changed?
1. **VTT Entity List Scrolling:** The `EntityList` component requires an explicit height boundary to trigger its internal scrolling. In the Map view sidebar, it was expanding infinitely, preventing mousewheel events from bubbling or scrolling. Fixed by adding `flex-col max-h-[50vh]` to its wrapper.
2. **Zen Popout 500 Error:** When opening a Zen Mode entity in a new tab, synchronous browser checks and uncoordinated `$effect` hooks competed to initialize the vault. If the vault was cached locally as 'active', the code attempted to access `vault.entities` before the background file-loading task finished, throwing an unhandled exception that tripped the Vite dev server's HMR client. Fixed by consolidating the initialization into a single sequential `onMount` block that explicitly waits for `vault.isInitialized`.

### Testing
- [x] Mousewheel scrolling works on the VTT Entity list without getting trapped.
- [x] Opening a Zen Mode entity in a new tab reliably waits for the vault and successfully displays the entity.