### PR TITLE
:sparkles: release: 0.18.0 - The Tactical Explorer Update

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -145,6 +145,8 @@ TypeScript: Follow standard conventions
 
 ## Recent Changes
 
+- 0.18.0 - The Tactical Explorer Update: Added Label-Grouped Entity Explorer with persistence, VTT sidebar Entity List, and token drag-and-drop. Improved Zen Popout error handling and map coordinate bounds safety.
+
 - 085-vtt-entity-list: Added VTT sidebar "Vault Entities" section with collapsible entity list, drag-to-map token placement (host add / guest request), canvas ghost-token drag preview, and persisted sidebar collapse state. Also added label-grouped explorer view mode with collapsible label groups and persisted view state.
 
 - 083-style-guide-doc: Added TypeScript 5.9.3, Svelte 5 (Runes) + Tailwind CSS 4, Lucide Svelte, Marked (for Markdown rendering if integrated into the web app)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.17.37",
+  "version": "0.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/src/lib/components/modals/ChangelogModal.test.ts
+++ b/apps/web/src/lib/components/modals/ChangelogModal.test.ts
@@ -10,6 +10,7 @@ vi.mock("svelte", async () => {
 
 import ChangelogModal from "./ChangelogModal.svelte";
 import { uiStore } from "$lib/stores/ui.svelte";
+import { VERSION } from "$lib/config";
 
 describe("ChangelogModal", () => {
   beforeEach(() => {
@@ -54,7 +55,7 @@ describe("ChangelogModal", () => {
     await fireEvent.click(closeButton);
     expect(uiStore.showChangelog).toBe(false);
     expect(window.localStorage.getItem("codex_last_seen_version")).toBe(
-      "0.17.37",
+      VERSION,
     );
 
     unmount();

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -8,7 +8,7 @@ const versionFromBuild =
     : undefined;
 
 export const VERSION =
-  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.17.37";
+  import.meta.env.VITE_APP_VERSION ?? versionFromBuild ?? "0.18.0";
 export const CODENAME = import.meta.env.VITE_APP_CODENAME ?? "Cryptica";
 
 export const APP_NAME = "Codex Cryptica";

--- a/apps/web/src/lib/content/changelog/releases.json
+++ b/apps/web/src/lib/content/changelog/releases.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.18.0",
+    "title": "The Tactical Explorer Update",
+    "date": "2026-04-16",
+    "type": "minor",
+    "highlights": [
+      "Label-Grouped Explorer: Organize your vault by labels with collapsible sections and persisted view preferences.",
+      "VTT Entity List: Access your entire vault directly from the VTT sidebar to streamline encounter management.",
+      "Token Drag-and-Drop: Seamlessly place tokens on tactical maps by dragging entities from the sidebar.",
+      "Zen Popout Refinements: Enhanced reliability and error handling for detached entity view windows."
+    ]
+  },
+  {
     "version": "0.17.0",
     "title": "The Playable Tabletop Update",
     "date": "2026-04-14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     "apps/web": {
-      "version": "0.17.37",
+      "version": "0.18.0",
       "dependencies": {
         "@codex/canvas-engine": "^0.0.0",
         "@codex/importer": "*",


### PR DESCRIPTION
## Summary
This minor release introduces the Label-Grouped Entity Explorer, VTT sidebar Entity List, and token drag-and-drop functionality, along with significant reliability improvements for Zen Popouts and map coordinate safety.

## Highlights
- **Label-Grouped Explorer**: Organize your vault by labels with collapsible sections and persisted view preferences.
- **VTT Entity List**: Access your entire vault directly from the VTT sidebar to streamline encounter management.
- **Token Drag-and-Drop**: Seamlessly place tokens on tactical maps by dragging entities from the sidebar.
- **Zen Popout Refinements**: Enhanced reliability and error handling for detached entity view windows.