### PR TITLE
Improve front page loading and briefing polish

### DIFF
--- a/apps/web/src/lib/components/modals/ChangelogModal.svelte
+++ b/apps/web/src/lib/components/modals/ChangelogModal.svelte
@@ -24,7 +24,7 @@
   });
 
   const close = () => {
-    uiStore.markVersionAsSeen(VERSION);
+    uiStore.markVersionAsSeen(releases[0]?.version ?? VERSION);
     uiStore.showChangelog = false;
   };
 

--- a/apps/web/src/lib/components/world/FrontPage.svelte
+++ b/apps/web/src/lib/components/world/FrontPage.svelte
@@ -314,46 +314,49 @@
     <div
       class="relative z-10 flex min-h-[inherit] flex-col gap-6 md:gap-8 xl:gap-10"
     >
-      <header
-        class="relative flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between"
+      <div
+        class="flex flex-wrap items-start justify-between gap-x-4 gap-y-3 sm:flex-nowrap sm:items-center"
       >
-        <div class="w-full space-y-4 xl:pr-56">
-          <div
-            class="inline-flex items-center gap-2 rounded-full border border-theme-primary/45 bg-theme-surface/80 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.24em] text-theme-primary shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-theme-primary)_12%,transparent)] backdrop-blur-sm"
-          >
-            <span class="w-2 h-2 rounded-full bg-theme-primary animate-pulse"
-            ></span>
-            Front Page
-          </div>
+        <div
+          class="inline-flex w-fit items-center gap-2 rounded-full border border-theme-primary/45 bg-theme-surface/55 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.24em] text-theme-primary shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--color-theme-primary)_10%,transparent)] backdrop-blur-sm"
+        >
+          <span class="h-2 w-2 rounded-full bg-theme-primary animate-pulse"
+          ></span>
+          Front Page
         </div>
 
-        {#if coverImage}
-          <FrontPageHero
-            {coverImageUrl}
-            {coverImage}
-            {showCoverEditor}
-            showPanel={false}
-            isSaving={worldStore.isSaving}
-            {onClose}
-            onOpenCoverEditor={openCoverEditor}
-            onCloseCoverEditor={closeCoverEditor}
-            onOpenLightbox={openCoverLightbox}
-            onUploadCover={handleUploadCover}
-            onGenerateCover={handleGenerateCover}
-          />
-        {:else if onClose}
-          <div class="flex justify-end xl:absolute xl:right-0 xl:top-0">
+        <div class="flex items-center gap-2 self-start sm:self-center">
+          {#if coverImage}
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-theme-border bg-theme-bg/70 text-theme-muted backdrop-blur-sm transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
+              class="inline-flex h-8 items-center rounded-full border border-theme-primary/30 bg-theme-surface/45 px-3 text-[9px] font-bold uppercase tracking-[0.18em] text-theme-primary transition-colors hover:bg-theme-primary/10 hover:border-theme-primary/50 disabled:opacity-50"
+              onclick={openCoverEditor}
+              disabled={worldStore.isSaving}
+            >
+              Change Image
+            </button>
+          {/if}
+          {#if coverImageUrl}
+            <button
+              class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-border/70 bg-theme-bg/45 text-theme-muted/85 backdrop-blur-sm transition-colors hover:border-theme-primary/35 hover:text-theme-primary"
+              onclick={openCoverLightbox}
+              aria-label="Open cover image lightbox"
+              title="Open cover image"
+            >
+              <span class="icon-[lucide--maximize-2] h-3.5 w-3.5"></span>
+            </button>
+          {/if}
+          {#if onClose}
+            <button
+              class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-border/70 bg-theme-bg/45 text-theme-muted/85 backdrop-blur-sm transition-colors hover:border-theme-primary/35 hover:text-theme-primary"
               onclick={onClose}
               aria-label="Close front page"
               title="Close front page"
             >
-              <span class="icon-[lucide--x] h-4 w-4"></span>
+              <span class="icon-[lucide--x] h-3.5 w-3.5"></span>
             </button>
-          </div>
-        {/if}
-      </header>
+          {/if}
+        </div>
+      </div>
 
       <ZenImageLightbox
         bind:show={showCoverLightbox}

--- a/apps/web/src/lib/components/world/FrontPage.test.ts
+++ b/apps/web/src/lib/components/world/FrontPage.test.ts
@@ -746,10 +746,12 @@ describe("FrontPage", () => {
       ),
     );
     expect(mocks.generateBriefing).toHaveBeenCalledWith(
-      expect.stringContaining('Write a high-level briefing for "Moonfall".'),
+      expect.stringContaining(
+        'Write a high-level world briefing for "Moonfall".',
+      ),
     );
     expect(mocks.generateBriefing).toHaveBeenCalledWith(
-      expect.stringContaining("Current Conflict"),
+      expect.stringContaining("Write exactly 3 prose paragraphs"),
     );
     expect(mocks.generateBriefing).toHaveBeenCalledWith(
       expect.stringContaining("Sky-market politics and drone wars."),

--- a/apps/web/src/lib/components/world/FrontPageBriefing.svelte
+++ b/apps/web/src/lib/components/world/FrontPageBriefing.svelte
@@ -111,7 +111,7 @@
           {/if}
         </div>
         <div
-          class="absolute right-3 top-3 z-20 flex flex-wrap justify-end gap-1"
+          class="absolute right-3 top-3 z-20 flex flex-wrap items-center justify-end gap-1.5"
         >
           <button
             class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-border/80 bg-theme-bg/75 text-theme-muted backdrop-blur-sm transition-colors hover:border-theme-primary/50 hover:text-theme-primary"
@@ -123,13 +123,23 @@
             <span class="icon-[lucide--pencil] h-4 w-4"></span>
           </button>
           <button
-            class="group inline-flex h-8 w-8 items-center justify-center rounded-full border border-theme-primary/30 bg-theme-bg/75 text-theme-primary backdrop-blur-sm transition-colors hover:bg-theme-primary/15 disabled:opacity-50"
+            class={`group inline-flex h-8 items-center justify-center rounded-full border border-theme-primary/30 bg-theme-bg/75 text-theme-primary backdrop-blur-sm transition-colors disabled:opacity-60 ${isGenerating ? "gap-1.5 px-3 hover:bg-theme-bg/75" : "w-8 hover:bg-theme-primary/15"}`}
             onclick={onGenerate}
             disabled={isSaving || isGenerating}
-            title="Generate briefing"
-            aria-label="Generate briefing"
+            title={isGenerating ? "Generating briefing" : "Generate briefing"}
+            aria-label={isGenerating
+              ? "Generating briefing"
+              : "Generate briefing"}
           >
-            <span class="icon-[lucide--sparkles] h-4 w-4"></span>
+            {#if isGenerating}
+              <span class="icon-[lucide--loader-2] h-3.5 w-3.5 animate-spin"
+              ></span>
+              <span class="text-[9px] font-bold uppercase tracking-[0.18em]"
+                >Generating</span
+              >
+            {:else}
+              <span class="icon-[lucide--sparkles] h-4 w-4"></span>
+            {/if}
           </button>
         </div>
       </div>

--- a/apps/web/src/lib/components/world/front-page/front-page-prompts.test.ts
+++ b/apps/web/src/lib/components/world/front-page/front-page-prompts.test.ts
@@ -138,9 +138,11 @@ describe("front-page-prompts", () => {
         "Desc",
         "Context",
       );
-      expect(result).toContain("atmospheric intro paragraph");
-      expect(result).toContain("3 to 5 markdown bullet points");
-      expect(result).toContain("Do not mention that you are an AI");
+      expect(result).toContain("Write exactly 3 prose paragraphs");
+      expect(result).toContain("Do not use bullet points");
+      expect(result).toContain(
+        "opening page of a campaign guide or prestige sourcebook",
+      );
     });
   });
 });

--- a/apps/web/src/lib/components/world/front-page/front-page-prompts.ts
+++ b/apps/web/src/lib/components/world/front-page/front-page-prompts.ts
@@ -46,24 +46,30 @@ export function createWorldBriefingPrompt(
   const safeContext =
     retrievedWorldContext.trim() || "No additional context was retrieved.";
 
-  return `Write a high-level briefing for "${safeName}".
+  return `Write a high-level world briefing for "${safeName}".
 
 Theme:
 - Name: ${themeName}
 - Description: ${themeDescription}
 
-Requirements:
-- Start with 1 short atmospheric intro paragraph.
-- Follow with 3 to 5 markdown bullet points using bold labels such as **The Setting:**, **Current Conflict:**, **Key Players:**, or **Immediate Hook:** when they fit the world.
-- Clearly explain the setting, mood, and immediate premise.
-- Use specific details from the world instead of generic language.
-- Keep it readable, welcoming, and easy to scan.
-- Keep each bullet to one compact sentence.
-- Avoid headings and meta commentary.
-- Do not mention that you are an AI.
-
-Retrieved context:
+Retrieved world context:
 ${safeContext}
 
-Match the briefing to the theme atmosphere and visual identity, and focus on what a player or GM needs to know at a glance.`;
+Requirements:
+- Write exactly 3 prose paragraphs.
+- Do not use bullet points.
+- Do not use headings or markdown labels.
+- Each paragraph should be 3 to 5 sentences.
+- Paragraph 1 should establish the setting, atmosphere, physical world, and daily texture of life.
+- Paragraph 2 should explain the power structure, political order, factions, and social hierarchy.
+- Paragraph 3 should explain the current disruption, major conflict, or immediate pressure shaping the world right now.
+- Use specific details from the context, not generic genre language.
+- Make it vivid, compressed, and readable at a glance.
+- Match the tone and visual identity of the theme.
+- Avoid meta commentary, AI self-reference, and "here is the summary"-style framing.
+
+Style target:
+- Write like the opening page of a campaign guide or prestige sourcebook.
+- Favor strong nouns, concrete imagery, and confident world-specific phrasing.
+- Keep the prose cohesive and cinematic rather than list-like.`;
 }

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -22,6 +22,7 @@
   import { demoService } from "$lib/services/demo";
   import { HELP_ARTICLES } from "$lib/config/help-content";
   import releases from "$lib/content/changelog/releases.json";
+  import { VERSION } from "$lib/config";
   import { THEMES, isEntityVisible } from "schema";
 
   // Components & Providers
@@ -196,7 +197,8 @@
         if (
           vault.allEntities.length === 0 &&
           !uiStore.isDemoMode &&
-          !isTesting
+          !isTesting &&
+          !uiStore.dismissedLandingPage
         ) {
           demoService.startDemo("fantasy");
         } else {
@@ -208,20 +210,25 @@
 
   // Automatic Release Note Trigger
   $effect(() => {
-    if (browser && !uiStore.showChangelog && !uiStore.isDemoMode) {
+    if (
+      browser &&
+      !uiStore.showChangelog &&
+      !uiStore.isDemoMode &&
+      !uiStore.isLandingPageVisible
+    ) {
       const lastSeenStr = uiStore.lastSeenVersion;
 
-      const hasUnseenMinorRelease = (() => {
-        if (!lastSeenStr) return true;
-        const currentStoredMinor = parseInt(
-          lastSeenStr.split(".")[1] || "0",
-          10,
-        );
-        return releases.some((r) => {
-          const releaseMinor = parseInt(r.version.split(".")[1] || "0", 10);
-          return releaseMinor > currentStoredMinor;
-        });
-      })();
+      // First-time user: no changelog popup, silently mark latest known release as seen
+      if (!lastSeenStr) {
+        uiStore.markVersionAsSeen(releases[0]?.version ?? VERSION);
+        return;
+      }
+
+      const currentStoredMinor = parseInt(lastSeenStr.split(".")[1] || "0", 10);
+      const hasUnseenMinorRelease = releases.some((r) => {
+        const releaseMinor = parseInt(r.version.split(".")[1] || "0", 10);
+        return releaseMinor > currentStoredMinor;
+      });
 
       if (hasUnseenMinorRelease) {
         // Delay to not conflict with tour/demo triggers

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -354,9 +354,7 @@
                   <button
                     class="w-8 h-8 flex flex-shrink-0 items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-muted transition hover:text-theme-primary"
                     onclick={() => {
-                      console.log("[MapPage] VTT share requested");
                       showVttShare = true;
-                      console.log("[MapPage] showVttShare set", showVttShare);
                     }}
                     type="button"
                     title="Share Campaign"


### PR DESCRIPTION
## Summary
- improve app/front-page loading flow and related page shell behavior
- refine the front-page header hierarchy and restore an explicit briefing generation state
- switch the front-page AI briefing prompt back to a prose-oriented three-paragraph format

## Verification
- `npm exec --workspace=apps/web vitest run src/lib/components/world/FrontPage.test.ts src/lib/components/world/front-page/front-page-prompts.test.ts`
- full pre-push lint and test suite passed during `git push`
