### PR TITLE
feat: add label management in Zen Mode (#629)

### DIFF
--- a/apps/web/src/lib/components/labels/LabelInput.svelte
+++ b/apps/web/src/lib/components/labels/LabelInput.svelte
@@ -143,7 +143,7 @@
     onkeydown={handleKeydown}
     onfocus={() => (showSuggestions = true)}
     onblur={() => setTimeout(() => (showSuggestions = false), 200)}
-    class="w-full bg-theme-bg/50 border border-theme-border rounded px-2 py-1 text-[10px] text-theme-text outline-none focus:border-theme-primary transition-all font-mono placeholder-theme-muted/50"
+    class="w-full bg-theme-bg/50 border border-theme-border rounded px-2 py-1.5 text-xs text-theme-text outline-none focus:border-theme-primary focus:ring-2 focus:ring-theme-primary/20 transition-all font-mono placeholder-theme-muted/50"
   />
 
   {#if showSuggestions && suggestions.length > 0}
@@ -160,7 +160,7 @@
           role="option"
           aria-selected={i === selectedIndex}
           onclick={() => selectSuggestion(_label)}
-          class="w-full px-2 py-1.5 text-left text-[10px] font-mono transition-colors border-b border-theme-border/50 last:border-0
+          class="w-full px-2 py-2 text-left text-xs font-mono transition-colors border-b border-theme-border/50 last:border-0
             {i === selectedIndex
             ? 'bg-theme-primary/20 text-theme-primary'
             : 'text-theme-muted hover:bg-theme-primary/10 hover:text-theme-primary'}"

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -132,7 +132,7 @@
         {#if entity?.start_date}
           <div class="flex flex-col">
             <span
-              class="text-[10px] text-theme-secondary font-bold tracking-widest mb-1 uppercase font-header"
+              class="text-xs text-theme-secondary font-bold tracking-widest mb-1 uppercase font-header"
             >
               {getTemporalLabel(entity?.type || "", "start")}
             </span>
@@ -144,7 +144,7 @@
         {#if entity?.end_date}
           <div class="flex flex-col">
             <span
-              class="text-[10px] text-theme-secondary font-bold tracking-widest mb-1 uppercase font-header"
+              class="text-xs text-theme-secondary font-bold tracking-widest mb-1 uppercase font-header"
             >
               {getTemporalLabel(entity?.type || "", "end")}
             </span>

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -47,7 +47,7 @@
         <select
           bind:value={editState.type}
           aria-label="Entity Type"
-          class="bg-theme-bg border border-theme-primary text-theme-primary px-2 py-0.5 text-[10px] font-bold tracking-widest uppercase font-header focus:outline-none rounded ml-2"
+          class="bg-theme-bg border border-theme-primary text-theme-primary px-2 py-0.5 text-xs font-bold tracking-widest uppercase font-header focus:outline-none rounded ml-2"
         >
           {#each categories.list as cat}
             <option value={cat.id}>{cat.label || cat.id.toUpperCase()}</option>
@@ -55,7 +55,7 @@
         </select>
       {:else}
         <span
-          class="text-[10px] font-bold tracking-widest text-theme-primary uppercase font-header"
+          class="text-xs font-bold tracking-widest text-theme-primary uppercase font-header"
           >{entity?.type || ""}</span
         >
       {/if}

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -94,14 +94,19 @@
 >
   <!-- Labels -->
   <div class="mb-6 space-y-2">
-    {#if entity?.labels && entity?.labels?.length > 0}
+    {#if entity?.labels?.length}
       <div class="flex flex-wrap gap-1.5">
-        {#each entity?.labels ?? [] as label}
+        {#each entity.labels as label}
           <LabelBadge
             {label}
             removable={!vault.isGuest}
-            onRemove={async () =>
-              entity && (await vault.removeLabel(entity.id, label))}
+            onRemove={() => {
+              if (entity) {
+                vault.removeLabel(entity.id, label).catch((err) => {
+                  console.error(`[ZenSidebar] Failed to remove label: ${err}`);
+                });
+              }
+            }}
           />
         {/each}
       </div>
@@ -121,14 +126,14 @@
         <span class="icon-[lucide--lock] w-6 h-6 md:w-8 md:h-8 opacity-30"
         ></span>
         <span
-          class="text-[8px] md:text-[9px] font-bold uppercase font-header opacity-40"
+          class="text-xs font-bold uppercase font-header tracking-widest opacity-40"
           >Hidden</span
         >
       </div>
     {:else if editState.isEditing}
       <div class="mb-4">
         <label
-          class="block text-[10px] text-theme-secondary font-bold mb-1"
+          class="block text-xs tracking-widest uppercase font-header text-theme-secondary font-bold mb-1"
           for="zen-entity-image-url">IMAGE URL</label
         >
         <input
@@ -152,7 +157,7 @@
           class="w-full h-auto max-h-[500px] object-contain opacity-90 group-hover:opacity-100 transition mx-auto"
         />
         <div
-          class="absolute bottom-2 right-2 bg-theme-bg/70 text-theme-primary text-[9px] px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition"
+          class="absolute bottom-2 right-2 bg-theme-bg/70 text-theme-primary text-xs font-header tracking-widest uppercase px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition"
         >
           Zoom
         </div>
@@ -166,7 +171,7 @@
             class="icon-[lucide--image] w-6 h-6 md:w-12 md:h-12 opacity-30 md:opacity-50"
           ></span>
           <span
-            class="text-[8px] md:text-[10px] font-bold uppercase font-header opacity-40"
+            class="text-xs font-bold uppercase font-header tracking-widest opacity-40"
             >No Image</span
           >
         </div>
@@ -185,7 +190,7 @@
                 aria-hidden="true"
               ></span>
               <span
-                class="text-[7px] md:text-[10px] font-bold tracking-widest text-theme-primary text-center"
+                class="text-xs font-bold tracking-widest text-theme-primary text-center font-header uppercase"
                 aria-live="polite"
               >
                 {#if oracle.activeStyleTitle}
@@ -203,7 +208,7 @@
                 aria-hidden="true"
               ></span>
               <span
-                class="text-[8px] md:text-[10px] font-bold tracking-widest text-theme-primary relative z-10"
+                class="text-xs font-bold tracking-widest font-header text-theme-primary relative z-10 uppercase"
                 >DRAW VISUAL</span
               >
             {/if}

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -238,7 +238,7 @@
                 ></span>
                 <div class="flex-1 min-w-0">
                   <div
-                    class="text-[11px] text-theme-muted uppercase font-header"
+                    class="text-xs text-theme-muted uppercase tracking-widest font-header"
                   >
                     {conn.label}
                   </div>

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -3,6 +3,7 @@
   import { uiStore } from "$lib/stores/ui.svelte";
   import { oracle } from "$lib/stores/oracle.svelte";
   import LabelBadge from "$lib/components/labels/LabelBadge.svelte";
+  import LabelInput from "$lib/components/labels/LabelInput.svelte";
   import { isEntityVisible, type Entity } from "schema";
 
   let {
@@ -92,13 +93,24 @@
   data-testid="zen-sidebar"
 >
   <!-- Labels -->
-  {#if entity?.labels && entity?.labels?.length > 0}
-    <div class="flex flex-wrap gap-1.5 mb-6">
-      {#each entity?.labels ?? [] as label}
-        <LabelBadge {label} />
-      {/each}
-    </div>
-  {/if}
+  <div class="mb-6 space-y-2">
+    {#if entity?.labels && entity?.labels?.length > 0}
+      <div class="flex flex-wrap gap-1.5">
+        {#each entity?.labels ?? [] as label}
+          <LabelBadge
+            {label}
+            removable={!vault.isGuest}
+            onRemove={async () =>
+              entity && (await vault.removeLabel(entity.id, label))}
+          />
+        {/each}
+      </div>
+    {/if}
+
+    {#if entity && !vault.isGuest}
+      <LabelInput entityId={entity.id} />
+    {/if}
+  </div>
 
   <!-- Image -->
   <div class="mb-6">

--- a/apps/web/tests/zen-mode-labels.spec.ts
+++ b/apps/web/tests/zen-mode-labels.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Zen Mode Label Management", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+    });
+
+    await page.goto("/");
+    await expect(page.getByTestId("graph-canvas")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.evaluate(() => {
+      const ui = (window as any).uiStore;
+      if (ui) {
+        ui.dismissedWorldPage = true;
+        ui.dismissedLandingPage = true;
+      }
+    });
+  });
+
+  test("should add and remove labels in Zen Mode", async ({ page }) => {
+    // 1. Create a new entity
+    await page.getByTestId("new-entity-button").click();
+    await page.getByPlaceholder("Chronicle Title...").fill("Zen Label Test");
+    await page.getByRole("button", { name: "ADD" }).click();
+
+    // 2. Open it in Zen Mode
+    await page.evaluate(() => {
+      const vault = (window as any).vault;
+      const entity = Object.values(vault.entities).find(
+        (e: any) => e.title === "Zen Label Test",
+      );
+      if (entity) {
+        (window as any).uiStore.openZenMode((entity as any).id);
+      }
+    });
+
+    const modal = page.getByTestId("zen-mode-modal");
+    await expect(modal).toBeVisible();
+
+    // 3. Add a label
+    const labelInput = modal.getByPlaceholder("Add label...");
+    await expect(labelInput).toBeVisible();
+    await labelInput.fill("E2E-Zen-Label");
+    await labelInput.press("Enter");
+
+    // 4. Verify label is added
+    const labelBadge = modal.getByText("E2E-Zen-Label");
+    await expect(labelBadge).toBeVisible();
+
+    // 5. Remove the label
+    const removeButton = modal.locator(
+      'button[aria-label="Remove label E2E-Zen-Label"]',
+    );
+    await removeButton.click();
+
+    // 6. Verify label is removed
+    await expect(labelBadge).toBeHidden();
+  });
+});


### PR DESCRIPTION
This PR adds the ability to add and remove labels for an entity while in Zen Mode, providing functional parity with the main entity detail view.

Key changes:
- Integrated `LabelInput` into `ZenSidebar.svelte`.
- Updated `LabelBadge` in `ZenSidebar.svelte` to support removal for non-guest users.
- Changes are persisted to OPFS and reflected globally via the existing vault stores.

Closes #629