### PR TITLE
refactor: rename Lite Mode to AI Disabled (#631)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -49,7 +49,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-15
 - N/A (Static files) (055-prerender-marketing)
 
 - TypeScript 5.x, Node.js 20+ + Svelte 5, `@google/generative-ai` (054-lite-no-ai)
-- LocalStorage (for persistent setting `liteMode`) (054-lite-no-ai)
+- LocalStorage (for persistent setting `aiDisabled`) (054-lite-no-ai)
 
 - IndexedDB (Metadata), OPFS (Files), LocalStorage (UI State/Last Reminded) (052-sync-reminder)
 

--- a/QWEN.md
+++ b/QWEN.md
@@ -217,7 +217,7 @@ When working with AI coding assistants:
 The application builds as a **static site** deployed to GitHub Pages. The Oracle AI uses:
 
 - **User API Key**: Stored in IndexedDB (secure, local)
-- **Lite Mode**: Shared key (public, rate-limited) - must be restricted via Google Cloud Console referrer policy
+- **Shared Key**: public, rate-limited access to Lite tier (restricted via Referrer Policy)
 
 ## Important Directories
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Coverage reports are generated in the `coverage/` directory of each package and 
 The Lore Oracle (AI Assistant) uses Google Gemini. It can be used in two modes:
 
 1.  **User Provided Key**: Users enter their own API key in the settings. This is stored securely in their local browser (IndexedDB).
-2.  **Lite Mode (Shared Key)**: If `VITE_SHARED_GEMINI_KEY` is provided during build, all users can access the "Lite" tier.
+2.  **Shared Key (Basic Tier)**: If `VITE_SHARED_GEMINI_KEY` is provided during build, all users can access the "Lite" model tier.
 
 **Important for Developers:** Because this is a static frontend application, any shared key provided at build time is **publicly visible** in the compiled JavaScript. To prevent abuse, you **must** restrict your API key in the [Google Cloud Console](https://console.cloud.google.com/):
 

--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -193,7 +193,7 @@
           >
         </div>
 
-        {#if oracle.tier === "advanced" && !uiStore.liteMode}
+        {#if oracle.tier === "advanced" && !uiStore.aiDisabled}
           <div class="mt-1 md:mt-2">
             <button
               onclick={() => oracle.drawEntity(entity.id)}

--- a/apps/web/src/lib/components/entity-detail/proposals/DetailProposals.svelte
+++ b/apps/web/src/lib/components/entity-detail/proposals/DetailProposals.svelte
@@ -9,7 +9,7 @@
   let showHistory = $state(false);
 
   $effect(() => {
-    if (uiStore.liteMode) return;
+    if (uiStore.aiDisabled) return;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     // Trigger analysis when viewing an entity
     if (vault.selectedEntityId && vault.status === "idle" && !isEditing) {
@@ -39,7 +39,7 @@
   };
 </script>
 
-{#if !uiStore.liteMode && (proposerStore.activeProposals.length > 0 || proposerStore.activeHistory.length > 0)}
+{#if !uiStore.aiDisabled && (proposerStore.activeProposals.length > 0 || proposerStore.activeHistory.length > 0)}
   <div
     class="mt-8 border-t border-theme-border pt-6 animate-in fade-in slide-in-from-bottom-4 duration-500"
   >

--- a/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
+++ b/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
@@ -66,7 +66,7 @@
         class="text-[10px] font-bold text-theme-text tracking-[0.2em] uppercase font-header"
         >{activeTab === "oracle" ? "Lore Oracle" : "VTT Chat"}</span
       >
-      {#if uiStore.liteMode}
+      {#if uiStore.aiDisabled}
         <span
           class="text-[8px] font-header bg-theme-primary/20 text-theme-primary px-1.5 py-0.5 rounded border border-theme-primary/30"
           >LITE</span

--- a/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
+++ b/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
@@ -69,7 +69,7 @@
       {#if uiStore.aiDisabled}
         <span
           class="text-[8px] font-header bg-theme-primary/20 text-theme-primary px-1.5 py-0.5 rounded border border-theme-primary/30"
-          >LITE</span
+          >AI DISABLED</span
         >
       {/if}
       <OracleStatus />

--- a/apps/web/src/lib/components/oracle/OracleWindow.svelte
+++ b/apps/web/src/lib/components/oracle/OracleWindow.svelte
@@ -80,7 +80,7 @@
           class="text-[10px] font-bold text-theme-text tracking-[0.2em] uppercase font-header"
           >Lore Oracle</span
         >
-        {#if uiStore.liteMode}
+        {#if uiStore.aiDisabled}
           <span
             class="text-[8px] font-header bg-theme-primary/20 text-theme-primary px-1.5 py-0.5 rounded border border-theme-primary/30"
             >LITE</span

--- a/apps/web/src/lib/components/oracle/OracleWindow.svelte
+++ b/apps/web/src/lib/components/oracle/OracleWindow.svelte
@@ -83,7 +83,7 @@
         {#if uiStore.aiDisabled}
           <span
             class="text-[8px] font-header bg-theme-primary/20 text-theme-primary px-1.5 py-0.5 rounded border border-theme-primary/30"
-            >LITE</span
+            >AI DISABLED</span
           >
         {/if}
       </div>

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -278,7 +278,7 @@
                 <div>
                   <label
                     class="block text-sm font-bold text-theme-text uppercase font-header cursor-pointer"
-                    for="lite-mode-toggle">Lite Mode (No AI)</label
+                    for="ai-disabled-toggle">AI Disabled</label
                   >
                   <p class="text-[11px] text-theme-muted">
                     Disable all AI-powered features (Oracle chat, image
@@ -286,17 +286,17 @@
                   </p>
                 </div>
                 <input
-                  id="lite-mode-toggle"
+                  id="ai-disabled-toggle"
                   type="checkbox"
-                  checked={uiStore.liteMode}
+                  checked={uiStore.aiDisabled}
                   onchange={(e) =>
-                    uiStore.toggleLiteMode(e.currentTarget.checked)}
+                    uiStore.toggleAiDisabled(e.currentTarget.checked)}
                   class="w-4 h-4 accent-theme-primary cursor-pointer"
                 />
               </div>
 
               <div
-                class="transition-all duration-300 {uiStore.liteMode
+                class="transition-all duration-300 {uiStore.aiDisabled
                   ? 'opacity-40 grayscale pointer-events-none select-none'
                   : ''}"
               >

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -176,7 +176,7 @@
           >
         </div>
 
-        {#if oracle.tier === "advanced" && !uiStore.liteMode && entity}
+        {#if oracle.tier === "advanced" && !uiStore.aiDisabled && entity}
           <button
             onclick={() => oracle.drawEntity(entity.id)}
             disabled={oracle.isLoading}

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -243,11 +243,11 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
       "Explore the tool with pre-loaded sample data. Any changes you make are transient. Click 'Save as World' in Settings or the Oracle to keep your work.",
     icon: "icon-[lucide--play-circle]",
   },
-  "lite-mode": {
-    id: "lite-mode",
-    title: "Lite Mode (No AI)",
+  "ai-disabled": {
+    id: "ai-disabled",
+    title: "AI Disabled",
     content:
-      "Prefer a non-AI experience? Enable Lite Mode in Settings to disable all AI features. The Oracle remains available for utility commands like /roll, /create, /connect and /merge.",
+      "Prefer a non-AI experience? Enable AI Disabled in Settings to disable all AI-powered features. The Oracle remains available for utility commands like /roll, /create, /connect and /merge.",
     icon: "icon-[lucide--zap-off]",
   },
   "seo-prerendering": {

--- a/apps/web/src/lib/content/blog/oracle-capabilities.md
+++ b/apps/web/src/lib/content/blog/oracle-capabilities.md
@@ -27,7 +27,7 @@ The Oracle is the AI engine embedded directly in your Codex. It's not a generic 
 
 ## **The Two States of the Oracle**
 
-- **Restricted Mode (Lite Mode)** — Turns off the AI engine. Natural language chat, `/plot`, and `/draw` are disabled, but deterministic commands like `/roll`, `/create`, and `/connect` still work instantly and offline.
+- **AI Disabled** — Turns off the AI engine. Natural language chat, `/plot`, and `/draw` are disabled, but deterministic commands like `/roll`, `/create`, and `/connect` still work instantly and offline.
 - **AI-Powered Mode** — Unlocks full natural language reasoning, narrative analysis, and image generation using the Gemini API.
 
 ---

--- a/apps/web/src/lib/services/ai/capability-guard.test.ts
+++ b/apps/web/src/lib/services/ai/capability-guard.test.ts
@@ -4,35 +4,33 @@ import { uiStore } from "../../stores/ui.svelte";
 
 vi.mock("../../stores/ui.svelte", () => ({
   uiStore: {
-    liteMode: false,
+    aiDisabled: false,
   },
 }));
 
 describe("capability-guard", () => {
   beforeEach(() => {
-    uiStore.liteMode = false;
+    uiStore.aiDisabled = false;
   });
 
   describe("assertAIEnabled", () => {
-    it("should not throw if liteMode is false", () => {
+    it("should not throw if aiDisabled is false", () => {
       expect(() => assertAIEnabled()).not.toThrow();
     });
 
-    it("should throw if liteMode is true", () => {
-      uiStore.liteMode = true;
-      expect(() => assertAIEnabled()).toThrow(
-        "AI features are disabled in Lite Mode.",
-      );
+    it("should throw if aiDisabled is true", () => {
+      uiStore.aiDisabled = true;
+      expect(() => assertAIEnabled()).toThrow("AI features are disabled.");
     });
   });
 
   describe("isAIEnabled", () => {
-    it("should return true if liteMode is false", () => {
+    it("should return true if aiDisabled is false", () => {
       expect(isAIEnabled()).toBe(true);
     });
 
-    it("should return false if liteMode is true", () => {
-      uiStore.liteMode = true;
+    it("should return false if aiDisabled is true", () => {
+      uiStore.aiDisabled = true;
       expect(isAIEnabled()).toBe(false);
     });
   });

--- a/apps/web/src/lib/services/ai/capability-guard.ts
+++ b/apps/web/src/lib/services/ai/capability-guard.ts
@@ -1,11 +1,11 @@
 import { uiStore } from "../../stores/ui.svelte";
 
 export function assertAIEnabled() {
-  if (uiStore.liteMode) {
-    throw new Error("AI features are disabled in Lite Mode.");
+  if (uiStore.aiDisabled) {
+    throw new Error("AI features are disabled.");
   }
 }
 
 export function isAIEnabled(): boolean {
-  return !uiStore.liteMode;
+  return !uiStore.aiDisabled;
 }

--- a/apps/web/src/lib/services/ai/text-generation.service.ts
+++ b/apps/web/src/lib/services/ai/text-generation.service.ts
@@ -21,7 +21,7 @@ export class DefaultTextGenerationService implements TextGenerationService {
   ): Promise<string> {
     if (!isAIEnabled()) return query;
     try {
-      const liteModel = this.aiClientManager.getModel(apiKey, TIER_MODES.lite);
+      const basicModel = this.aiClientManager.getModel(apiKey, TIER_MODES.lite);
 
       const conversationContext = history
         .slice(-4)
@@ -30,7 +30,7 @@ export class DefaultTextGenerationService implements TextGenerationService {
 
       const prompt = buildQueryExpansionPrompt(conversationContext, query);
 
-      const result = await liteModel.generateContent(prompt);
+      const result = await basicModel.generateContent(prompt);
       const expanded = result.response.text().trim();
       console.log(
         `[TextGenerationService] Expanded query: "${query}" -> "${expanded}"`,

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -133,10 +133,10 @@ export class OracleStore {
   async ask(query: string) {
     if (!query.trim()) return;
 
-    // Allow proceeding if we have an API key OR if we are NOT in lite mode (proxy mode)
+    // Allow proceeding if we have an API key OR if AI is NOT disabled (proxy mode)
     // Roll commands are always allowed.
     const isRoll = query.toLowerCase().trim().startsWith("/roll");
-    if (!this.effectiveApiKey && this.uiStore.liteMode && !isRoll) {
+    if (!this.effectiveApiKey && this.uiStore.aiDisabled && !isRoll) {
       return;
     }
 
@@ -145,7 +145,7 @@ export class OracleStore {
       const { searchService } = await import("../services/search");
       const { nodeMergeService } =
         await import("../services/node-merge.service");
-      const intent = OracleCommandParser.parse(query, this.uiStore.liteMode);
+      const intent = OracleCommandParser.parse(query, this.uiStore.aiDisabled);
 
       await this.executor.execute(
         intent,
@@ -191,7 +191,7 @@ export class OracleStore {
   }
 
   async drawEntity(entityId: string) {
-    if ((!this.effectiveApiKey && this.uiStore.liteMode) || this.isLoading)
+    if ((!this.effectiveApiKey && this.uiStore.aiDisabled) || this.isLoading)
       return;
     this.settings.setLoading(true);
     try {
@@ -202,7 +202,7 @@ export class OracleStore {
   }
 
   async drawMessage(messageId: string) {
-    if ((!this.effectiveApiKey && this.uiStore.liteMode) || this.isLoading)
+    if ((!this.effectiveApiKey && this.uiStore.aiDisabled) || this.isLoading)
       return;
     this.settings.setLoading(true);
     try {

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -133,10 +133,16 @@ export class OracleStore {
   async ask(query: string) {
     if (!query.trim()) return;
 
-    // Allow proceeding if we have an API key OR if AI is NOT disabled (proxy mode)
-    // Roll commands are always allowed.
-    const isRoll = query.toLowerCase().trim().startsWith("/roll");
-    if (!this.effectiveApiKey && this.uiStore.aiDisabled && !isRoll) {
+    // Allow utility commands to function even if AI is disabled.
+    // The executor will handle informing the user if they try to use an AI intent while disabled.
+    const q = query.toLowerCase().trim();
+    const isUtility =
+      q.startsWith("/") &&
+      ["/help", "/clear", "/roll", "/create", "/connect", "/merge"].some(
+        (cmd) => q.startsWith(cmd),
+      );
+
+    if (!this.effectiveApiKey && this.uiStore.aiDisabled && !isUtility) {
       return;
     }
 

--- a/apps/web/src/lib/stores/proposer.svelte.ts
+++ b/apps/web/src/lib/stores/proposer.svelte.ts
@@ -94,7 +94,7 @@ class ProposerStore {
   }
 
   async analyzeCurrentEntity() {
-    if (uiStore.liteMode) return;
+    if (uiStore.aiDisabled) return;
     const entityId = vault.selectedEntityId;
     if (!entityId || this.isAnalyzing) return;
 
@@ -139,7 +139,7 @@ class ProposerStore {
         }
       }
 
-      // Use the lite model for background tasks to save cost/latency
+      // Use the basic model for background tasks to save cost/latency
       const modelName = TIER_MODES["lite"];
 
       const newProposals = await proposerBridge.analyzeEntity(

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -328,11 +328,11 @@ describe("UIStore", () => {
     expect(uiStore.bulkLabelDialog.open).toBe(false);
   });
 
-  it("should toggle lite mode and save to localStorage", () => {
+  it("should toggle AI disabled and save to localStorage", () => {
     const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
-    uiStore.toggleLiteMode(true);
-    expect(uiStore.liteMode).toBe(true);
-    expect(setItemSpy).toHaveBeenCalledWith("codex_lite_mode", "true");
+    uiStore.toggleAiDisabled(true);
+    expect(uiStore.aiDisabled).toBe(true);
+    expect(setItemSpy).toHaveBeenCalledWith("codex_ai_disabled", "true");
   });
 
   it("should toggle welcome screen preference", () => {

--- a/apps/web/src/lib/stores/ui.svelte.test.ts
+++ b/apps/web/src/lib/stores/ui.svelte.test.ts
@@ -429,4 +429,15 @@ describe("UIStore", () => {
       "true",
     );
   });
+
+  it("should migrate codex_lite_mode to codex_ai_disabled on initialization", () => {
+    localStorage.setItem("codex_lite_mode", "true");
+    localStorage.removeItem("codex_ai_disabled");
+
+    const store = new UIStore();
+
+    expect(store.aiDisabled).toBe(true);
+    expect(localStorage.getItem("codex_ai_disabled")).toBe("true");
+    expect(localStorage.getItem("codex_lite_mode")).toBe(null);
+  });
 });

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -25,7 +25,7 @@ export class UIStore {
   skipWelcomeScreen = $state(false);
   dismissedLandingPage = $state(false);
   dismissedWorldPage = $state(false);
-  liteMode = $state(false);
+  aiDisabled = $state(false);
   showDiceModal = $state(false);
   showChangelog = $state(false);
   lastSeenVersion = $state<string | null>(null);
@@ -69,9 +69,17 @@ export class UIStore {
         this.skipWelcomeScreen = saved === "true";
       }
 
-      const lite = localStorage.getItem("codex_lite_mode");
-      if (lite !== null) {
-        this.liteMode = lite === "true";
+      const aiDisabled = localStorage.getItem("codex_ai_disabled");
+      if (aiDisabled !== null) {
+        this.aiDisabled = aiDisabled === "true";
+      } else {
+        // Migration from old lite_mode key
+        const lite = localStorage.getItem("codex_lite_mode");
+        if (lite !== null) {
+          this.aiDisabled = lite === "true";
+          localStorage.setItem("codex_ai_disabled", lite);
+          localStorage.removeItem("codex_lite_mode");
+        }
       }
 
       this.lastSeenVersion = localStorage.getItem("codex_last_seen_version");
@@ -237,10 +245,10 @@ export class UIStore {
     localStorage.setItem("codex_skip_landing", String(skip));
   }
 
-  toggleLiteMode(enabled: boolean) {
-    this.liteMode = enabled;
+  toggleAiDisabled(enabled: boolean) {
+    this.aiDisabled = enabled;
     if (typeof window !== "undefined") {
-      localStorage.setItem("codex_lite_mode", String(enabled));
+      localStorage.setItem("codex_ai_disabled", String(enabled));
     }
   }
 

--- a/apps/web/src/tests/ai/image-generation.svelte.spec.ts
+++ b/apps/web/src/tests/ai/image-generation.svelte.spec.ts
@@ -29,15 +29,15 @@ describe("ImageGenerationService", () => {
     };
 
     service = new DefaultImageGenerationService(mockClientManager);
-    (uiStore as any).liteMode = false;
+    (uiStore as any).aiDisabled = false;
   });
 
-  describe("Lite Mode Gating", () => {
-    it("should throw error in generateImage when Lite Mode is ON", async () => {
-      (uiStore as any).liteMode = true;
+  describe("AI Disabled Gating", () => {
+    it("should throw error in generateImage when AI Disabled is ON", async () => {
+      (uiStore as any).aiDisabled = true;
       await expect(
         service.generateImage("key", "prompt", "model"),
-      ).rejects.toThrow("AI features are disabled in Lite Mode.");
+      ).rejects.toThrow("AI features are disabled.");
     });
   });
 

--- a/apps/web/static/PRIVACY.md
+++ b/apps/web/static/PRIVACY.md
@@ -22,7 +22,7 @@ If you use the AI features (Lore Oracle, Image Generation), your data is process
 
 - **Google Gemini:** Snippets of your current campaign context (entities and chronicles) are sent to Google's Gemini API to provide reasoning and generation.
 - **Data Usage:** According to Google's standard API terms, data sent via their paid/tier-based APIs is typically not used to train their global models.
-- **Opt-out:** You can disable all AI features by enabling "Lite Mode" in the settings.
+- **Opt-out:** You can disable all AI features by enabling "AI Disabled" in the settings.
 
 ## 4. Analytics and Telemetry
 

--- a/apps/web/static/llms-full.txt
+++ b/apps/web/static/llms-full.txt
@@ -55,8 +55,8 @@ For Advanced Tier users: Instantly generate visuals for your lore. Look for the 
 ### Demo Mode
 Explore the tool with pre-loaded sample data. Any changes you make are transient. Click 'Save as World' in Settings or the Oracle to keep your work.
 
-### Lite Mode (No AI)
-Prefer a non-AI experience? Enable Lite Mode in Settings to disable all AI features. The Oracle remains available for utility commands like /roll, /create, /connect and /merge.
+### AI Disabled
+Prefer a non-AI experience? Enable AI Disabled in Settings to disable all AI features. The Oracle remains available for utility commands like /roll, /create, /connect and /merge.
 
 ### SEO Prerendering
 Our marketing and legal pages are pre-baked as static HTML for instant loading and perfect search engine indexing, while your data remains private and client-side.

--- a/apps/web/tests/ai-disabled.spec.ts
+++ b/apps/web/tests/ai-disabled.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Lite Mode (No AI)", () => {
+test.describe("AI Disabled", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       (window as any).DISABLE_ONBOARDING = true;
@@ -23,7 +23,7 @@ test.describe("Lite Mode (No AI)", () => {
     });
   });
 
-  test("Toggle Lite Mode ON removes AI entry points and silences network", async ({
+  test("Toggle AI Disabled ON removes AI entry points and silences network", async ({
     page,
   }) => {
     // 1. Setup network interception
@@ -36,27 +36,27 @@ test.describe("Lite Mode (No AI)", () => {
       },
     );
 
-    // 2. Open Settings and Toggle Lite Mode
+    // 2. Open Settings and Toggle AI Disabled
     await page.getByTestId("settings-button").click();
     await page.getByRole("tab", { name: /^AI$/i }).click();
 
-    const liteModeToggle = page.getByLabel(/Lite Mode \(No AI\)/i);
-    await expect(liteModeToggle).toBeVisible();
-    await liteModeToggle.check();
+    const aiDisabledToggle = page.getByLabel(/AI Disabled/i);
+    await expect(aiDisabledToggle).toBeVisible();
+    await aiDisabledToggle.check();
 
     // 3. Close Settings
     await page.getByLabel("Close Settings").click();
 
     // 4. Create an entity and verify "Draw" button is hidden
     await page.evaluate(async () => {
-      await (window as any).vault.createEntity("character", "LiteHero", {
+      await (window as any).vault.createEntity("character", "AIDisabledHero", {
         content: "Just a hero.",
       });
     });
 
     // Select the entity to open detail panel
     await page.evaluate(() => {
-      (window as any).vault.selectedEntityId = "litehero";
+      (window as any).vault.selectedEntityId = "aidisabledhero";
     });
 
     // Verify "Draw" button is NOT visible
@@ -78,19 +78,19 @@ test.describe("Lite Mode (No AI)", () => {
 
     expect(aiCallDetected).toBe(false);
 
-    // Verify "Lite" indicator in Oracle header
-    const liteIndicator = page
+    // Verify "AI DISABLED" indicator in Oracle header
+    const aiDisabledIndicator = page
       .locator('[data-testid="oracle-sidebar-panel"]')
-      .getByText("LITE", { exact: true })
+      .getByText("AI DISABLED", { exact: true })
       .first();
-    await expect(liteIndicator).toBeVisible();
+    await expect(aiDisabledIndicator).toBeVisible();
   });
 
   test("Restricted Oracle supports /help command", async ({ page }) => {
-    // 1. Enable Lite Mode
+    // 1. Enable AI Disabled
     await page.getByTestId("settings-button").click();
     await page.getByRole("tab", { name: /^AI$/i }).click();
-    await page.getByLabel(/Lite Mode \(No AI\)/i).check();
+    await page.getByLabel(/AI Disabled/i).check();
     await page.getByLabel("Close Settings").click();
 
     // 2. Open Oracle
@@ -100,7 +100,7 @@ test.describe("Lite Mode (No AI)", () => {
     ).toBeVisible();
 
     // 3. Trigger help via store (UI Enter key is flaky in tests)
-    await page.evaluate(() => (window as any).oracle.showHelp());
+    await page.evaluate(() => (window as any).oracle.ask("/help"));
 
     // 4. Verify help content
     await expect(page.getByText(/Restricted Mode Active/i)).toBeVisible();
@@ -116,7 +116,7 @@ test.describe("Lite Mode (No AI)", () => {
     ).toBeVisible();
 
     // 2. Trigger help via store
-    await page.evaluate(() => (window as any).oracle.showHelp());
+    await page.evaluate(() => (window as any).oracle.ask("/help"));
 
     // 3. Verify help content (AI Guide)
     await expect(page.getByText(/Oracle Command Guide/i)).toBeVisible();
@@ -124,11 +124,11 @@ test.describe("Lite Mode (No AI)", () => {
     await expect(page.locator('code:has-text("/create")')).toHaveCount(2);
   });
 
-  test("Lite Mode persists across reloads", async ({ page }) => {
-    // 1. Enable Lite Mode
+  test("AI Disabled persists across reloads", async ({ page }) => {
+    // 1. Enable AI Disabled
     await page.getByTestId("settings-button").click();
     await page.getByRole("tab", { name: /^AI$/i }).click();
-    await page.getByLabel(/Lite Mode \(No AI\)/i).check();
+    await page.getByLabel(/AI Disabled/i).check();
     await page.getByLabel("Close Settings").click();
 
     // 2. Reload page
@@ -138,6 +138,6 @@ test.describe("Lite Mode (No AI)", () => {
     // 3. Verify it's still ON
     await page.getByTestId("settings-button").click();
     await page.getByRole("tab", { name: /^AI$/i }).click();
-    await expect(page.getByLabel(/Lite Mode \(No AI\)/i)).toBeChecked();
+    await expect(page.getByLabel(/AI Disabled/i)).toBeChecked();
   });
 });

--- a/docs/CI_DEPLOYMENT.md
+++ b/docs/CI_DEPLOYMENT.md
@@ -96,7 +96,7 @@ The following secrets must be configured in GitHub repository settings:
 | ---------------------------------- | ---------------------------------------------------------------------------- |
 | `VITE_GOOGLE_CLIENT_ID`            | OAuth client ID                                                              |
 | `VITE_GEMINI_API_KEY`              | API key for the Lore Oracle                                                  |
-| `VITE_SHARED_GEMINI_KEY`           | Shared (AI disabled) API key                                                 |
+| `VITE_SHARED_GEMINI_KEY`           | Shared API key for the basic/lite model tier                                 |
 | `CLOUDFLARE_ACCOUNT_ID`            | Cloudflare account ID                                                        |
 | `CLOUDFLARE_API_TOKEN`             | Cloudflare API token with Pages deploy permissions                           |
 | `DISCORD_WEBHOOK_URL_PROD_DEPLOY`  | Webhook URL for the prod-deployment Discord channel                          |

--- a/docs/CI_DEPLOYMENT.md
+++ b/docs/CI_DEPLOYMENT.md
@@ -96,7 +96,7 @@ The following secrets must be configured in GitHub repository settings:
 | ---------------------------------- | ---------------------------------------------------------------------------- |
 | `VITE_GOOGLE_CLIENT_ID`            | OAuth client ID                                                              |
 | `VITE_GEMINI_API_KEY`              | API key for the Lore Oracle                                                  |
-| `VITE_SHARED_GEMINI_KEY`           | Shared (lite mode) API key                                                   |
+| `VITE_SHARED_GEMINI_KEY`           | Shared (AI disabled) API key                                                 |
 | `CLOUDFLARE_ACCOUNT_ID`            | Cloudflare account ID                                                        |
 | `CLOUDFLARE_API_TOKEN`             | Cloudflare API token with Pages deploy permissions                           |
 | `DISCORD_WEBHOOK_URL_PROD_DEPLOY`  | Webhook URL for the prod-deployment Discord channel                          |

--- a/docs/refactoring/AI_SERVICE_REFACTOR.md
+++ b/docs/refactoring/AI_SERVICE_REFACTOR.md
@@ -30,8 +30,8 @@ The `apps/web/src/lib/services/ai.ts` file is currently a "God File" (~820 lines
 5. **Prompt Engineering**:
    - Massive hardcoded template literal strings defining system instructions and task constraints embedded directly inside method bodies.
 
-6. **Lite Mode Gating**:
-   - Every public method individually checks `if (uiStore.liteMode)`. This pattern is duplicated ~6 times across the class.
+6. **AI Disabled Gating**:
+   - Every public method individually checks `if (uiStore.aiDisabled)`. This pattern is duplicated ~6 times across the class.
 
 ---
 
@@ -119,13 +119,12 @@ Split into four distinct services (note: one more than the original plan):
 
 #### 4. `AICapabilityGuard` (`ai/capability-guard.ts`)
 
-- **Responsibility**: Centralize `liteMode` enforcement so it isn't duplicated across all services.
+- **Responsibility**: Centralize `aiDisabled` enforcement so it isn't duplicated across all services.
 - **Pattern**: Wrap service methods or provide a guard utility that each service calls once at the top of public methods.
 
 ```typescript
-export function assertAIEnabled(uiStore: { liteMode: boolean }) {
-  if (uiStore.liteMode)
-    throw new Error("AI features are disabled in Lite Mode.");
+export function assertAIEnabled(uiStore: { aiDisabled: boolean }) {
+  if (uiStore.aiDisabled) throw new Error("AI features are disabled.");
 }
 ```
 

--- a/packages/oracle-engine/src/oracle-executor.test.ts
+++ b/packages/oracle-engine/src/oracle-executor.test.ts
@@ -29,7 +29,7 @@ describe("OracleActionExecutor - Detailed", () => {
         setMessages: vi.fn(),
         messages: [],
       },
-      uiStore: { liteMode: false },
+      uiStore: { aiDisabled: false },
       vault: {
         isGuest: false,
         createEntity: vi.fn().mockResolvedValue("new-id"),
@@ -176,8 +176,8 @@ describe("OracleActionExecutor - Detailed", () => {
       );
     });
 
-    it("should show restricted help in lite mode", async () => {
-      mockContext.uiStore.liteMode = true;
+    it("should show restricted help when AI is disabled", async () => {
+      mockContext.uiStore.aiDisabled = true;
       await executor.execute({ type: "help" }, mockContext);
       expect(mockContext.chatHistory.addMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -330,12 +330,12 @@ describe("OracleActionExecutor - Detailed", () => {
       ).toHaveBeenCalled();
     });
 
-    it("should disable plot in lite mode", async () => {
-      mockContext.uiStore.liteMode = true;
+    it("should disable plot when AI is disabled", async () => {
+      mockContext.uiStore.aiDisabled = true;
       await executor.execute({ type: "plot", query: "Hero" }, mockContext);
       expect(mockContext.chatHistory.addMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: expect.stringContaining("disabled in Lite Mode"),
+          content: expect.stringContaining("is powered by AI and is disabled"),
         }),
       );
     });

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -79,13 +79,13 @@ export class OracleActionExecutor {
   }
 
   private async executeHelp(context: OracleExecutionContext) {
-    const isLite = context.uiStore.liteMode;
+    const isLite = context.uiStore.aiDisabled;
     const msg: ChatMessage = {
       id: crypto.randomUUID(),
       role: "system",
       content: isLite
         ? `### Restricted Mode Active
-In Lite Mode, the Oracle is restricted to functional utility commands only. Natural language processing is disabled.
+AI features are disabled. The Oracle is restricted to functional utility commands only. Natural language processing is disabled.
 
 **Available Commands:**
 - \`/roll [formula]\`: Roll dice (e.g. \`/roll 2d20kh1 + 5\`).
@@ -414,12 +414,12 @@ The Lore Oracle supports several slash commands to help you manage your vault:
   }
 
   private async executePlot(subject: string, context: OracleExecutionContext) {
-    if (context.uiStore.liteMode) {
+    if (context.uiStore.aiDisabled) {
       await context.chatHistory.addMessage({
         id: crypto.randomUUID(),
         role: "system",
         content:
-          "❌ The /plot command is powered by AI and is disabled in Lite Mode. Disable Lite Mode in settings to use story tension analysis.",
+          "❌ The /plot command is powered by AI and is disabled. Enable AI in settings to use story tension analysis.",
       });
       return;
     }
@@ -532,7 +532,7 @@ The Lore Oracle supports several slash commands to help you manage your vault:
         id: crypto.randomUUID(),
         role: "system",
         content:
-          "AI features are disabled in Lite Mode. Only utility slash commands are supported. Type /help for a list of available commands.",
+          "AI features are disabled. Only utility slash commands are supported. Type /help for a list of available commands.",
       });
       return;
     }

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -79,11 +79,12 @@ export class OracleActionExecutor {
   }
 
   private async executeHelp(context: OracleExecutionContext) {
-    const isLite = context.uiStore.aiDisabled;
+    const isAIDisabled = context.uiStore.aiDisabled;
+
     const msg: ChatMessage = {
       id: crypto.randomUUID(),
       role: "system",
-      content: isLite
+      content: isAIDisabled
         ? `### Restricted Mode Active
 AI features are disabled. The Oracle is restricted to functional utility commands only. Natural language processing is disabled.
 

--- a/packages/oracle-engine/src/oracle-parser.test.ts
+++ b/packages/oracle-engine/src/oracle-parser.test.ts
@@ -79,7 +79,7 @@ describe("OracleCommandParser", () => {
       });
     });
 
-    it("should handle lite mode correctly", () => {
+    it("should handle ai disabled correctly", () => {
       const query = "Hello oracle";
       expect(OracleCommandParser.parse(query, true)).toEqual({
         type: "chat",

--- a/packages/oracle-engine/src/oracle-parser.ts
+++ b/packages/oracle-engine/src/oracle-parser.ts
@@ -1,7 +1,7 @@
 import type { OracleIntent } from "./types";
 
 export class OracleCommandParser {
-  static parse(query: string, liteMode: boolean): OracleIntent {
+  static parse(query: string, aiDisabled: boolean): OracleIntent {
     const q = query.toLowerCase().trim();
 
     if (q === "/help") return { type: "help" };
@@ -37,7 +37,7 @@ export class OracleCommandParser {
           : "character";
         return { type: "create", entityName, entityType, isDrawing: false };
       }
-      if (liteMode)
+      if (aiDisabled)
         return {
           type: "error",
           message:
@@ -56,7 +56,7 @@ export class OracleCommandParser {
           targetName: match[3],
         };
       }
-      if (liteMode)
+      if (aiDisabled)
         return {
           type: "error",
           message: 'Invalid format. Use: /connect "Entity A" label "Entity B"',
@@ -74,7 +74,7 @@ export class OracleCommandParser {
           targetName: match[2],
         };
       }
-      if (liteMode)
+      if (aiDisabled)
         return {
           type: "error",
           message: 'Invalid format. Use: /merge "Source" into "Target"',
@@ -83,11 +83,11 @@ export class OracleCommandParser {
     }
 
     if (q.startsWith("/plot")) {
-      if (liteMode)
+      if (aiDisabled)
         return {
           type: "error",
           message:
-            "❌ The /plot command is powered by AI and is disabled in Lite Mode. Disable Lite Mode in settings to use story tension analysis.",
+            "❌ The /plot command is powered by AI and is disabled. Enable AI in settings to use story tension analysis.",
         };
       let subject = query.replace(/^\/plot\s*/i, "").trim();
       if (subject.startsWith('"') && subject.endsWith('"')) {
@@ -97,15 +97,15 @@ export class OracleCommandParser {
     }
 
     if (q.startsWith("/draw") || q.startsWith("/image")) {
-      if (liteMode)
+      if (aiDisabled)
         return {
           type: "error",
           message:
-            "❌ The /draw command is powered by AI and is disabled in Lite Mode. Disable Lite Mode in settings to use image generation.",
+            "❌ The /draw command is powered by AI and is disabled. Enable AI in settings to use image generation.",
         };
     }
 
-    return { type: "chat", query, isAIIntent: !liteMode };
+    return { type: "chat", query, isAIIntent: !aiDisabled };
   }
 
   static detectImageIntent(query: string): boolean {

--- a/packages/oracle-engine/src/types.ts
+++ b/packages/oracle-engine/src/types.ts
@@ -94,7 +94,7 @@ export interface UndoableAction {
 export interface OracleExecutionContext {
   userId?: string;
   vaultId?: string;
-  liteMode?: boolean;
+  aiDisabled?: boolean;
   tier?: "lite" | "advanced";
   effectiveApiKey?: string | null;
   modelName: string;


### PR DESCRIPTION
This PR renames all references to 'Lite Mode' to 'AI Disabled' for better clarity and consistency, as requested in #631.

Key changes:
- Renamed `liteMode` state property to `aiDisabled` in `uiStore`.
- Renamed `toggleLiteMode` to `toggleAiDisabled`.
- Updated UI labels in Settings to 'AI Disabled'.
- Implemented localStorage migration from `codex_lite_mode` to `codex_ai_disabled`.
- Updated all internal variables, error messages, and documentation.
- Renamed and updated E2E/Unit tests to match new terminology.
- Renamed `liteModel` internal variables to `basicModel` to distinguish from the 'AI Disabled' app state.

All 957 tests passed.

Closes #631