### PR TITLE
fix: mobile chat input accessibility and clarify terminology (#633)

### DIFF
--- a/apps/web/src/lib/components/oracle/OracleChat.svelte
+++ b/apps/web/src/lib/components/oracle/OracleChat.svelte
@@ -238,7 +238,7 @@
             <div class="flex flex-col items-center gap-1">
               <span
                 class="text-[9px] text-theme-muted uppercase tracking-widest font-bold font-header"
-                >Current Tier</span
+                >Model Tier</span
               >
               <span
                 class="text-xs px-2 py-0.5 rounded border font-bold uppercase font-header tracking-wider shadow-sm
@@ -260,7 +260,7 @@
                 <span
                   class="text-xs px-2 py-0.5 rounded border border-theme-primary/30 bg-theme-primary/10 text-theme-primary uppercase tracking-wider font-bold font-header"
                 >
-                  LITE
+                  SHARED
                 </span>
               </div>
             {/if}

--- a/apps/web/src/lib/components/oracle/OracleWindow.svelte
+++ b/apps/web/src/lib/components/oracle/OracleWindow.svelte
@@ -48,7 +48,7 @@
 {#if oracle.isOpen}
   <!-- Backdrop (always on mobile, only on modal mode for desktop) -->
   <div
-    class="fixed inset-0 bg-black/40 z-40 {oracle.isModal
+    class="fixed inset-0 bg-black/40 z-[89] {oracle.isModal
       ? 'block'
       : 'md:hidden'}"
     onclick={() => oracle.toggle()}
@@ -57,10 +57,10 @@
   ></div>
 
   <div
-    class="oracle-window-container fixed transition-all duration-500 ease-in-out z-50 flex flex-col bg-theme-surface border border-theme-border shadow-2xl
+    class="oracle-window-container fixed transition-all duration-500 ease-in-out z-[90] flex flex-col bg-theme-surface border border-theme-border shadow-2xl
     {oracle.isModal
       ? 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[90vw] h-full max-h-[85vh] md:w-[800px] md:max-h-[70vh] rounded-xl'
-      : 'bottom-0 left-0 w-full h-full rounded-t-xl'}"
+      : 'bottom-0 left-0 w-full h-[100dvh] rounded-t-xl'}"
     transition:fly={{ y: 50, duration: 300 }}
     role={oracle.isModal ? "dialog" : "region"}
     aria-modal={oracle.isModal ? "true" : undefined}


### PR DESCRIPTION
This PR fixes the issue where the chat input was inaccessible on mobile devices and addresses user confusion regarding the 'lite' label.

Key changes:
- **A11y**: Increased z-index of `OracleWindow` to sit above the ActivityBar on mobile.
- **Layout**: Switched to `h-[100dvh]` for the mobile view to correctly handle browser toolbars.
- **UX**: Renamed 'LITE' access to 'SHARED' and 'Current Tier' to 'Model Tier' for better clarity.

Closes #633