### PR TITLE
✨ feat: unify zen mode experience with shared ZenView component (#635)

### DIFF
--- a/apps/web/src/lib/components/canvas/EntityPalette.svelte
+++ b/apps/web/src/lib/components/canvas/EntityPalette.svelte
@@ -138,6 +138,10 @@
       </div>
     </div>
 
-    <EntityList onSelect={handleSelect} {onDragStart} />
+    <EntityList
+      onSelect={handleSelect}
+      {onDragStart}
+      onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
+    />
   {/if}
 </div>

--- a/apps/web/src/lib/components/entity/EmbeddedEntityView.svelte
+++ b/apps/web/src/lib/components/entity/EmbeddedEntityView.svelte
@@ -1,76 +1,12 @@
 <script lang="ts">
-  import { vault } from "$lib/stores/vault.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import ZenHeader from "../zen/ZenHeader.svelte";
-  import ZenSidebar from "../zen/ZenSidebar.svelte";
-  import ZenContent from "../zen/ZenContent.svelte";
-  import ZenImageLightbox from "../zen/ZenImageLightbox.svelte";
-  import { createEditState } from "$lib/hooks/useEditState.svelte";
-  import { createZenModeActions } from "$lib/hooks/useZenModeActions.svelte";
-  import { clipboardService } from "$lib/services/ClipboardService";
+  import ZenView from "../zen/ZenView.svelte";
   import { fade } from "svelte/transition";
-  import { untrack } from "svelte";
 
   let { entityId } = $props<{ entityId: string }>();
 
-  let entity = $derived(vault.entities[entityId] || null);
-  let resolvedImageUrl = $state("");
-  let showLightbox = $state(false);
-  let scrollContainer = $state<HTMLDivElement>();
-
-  // Pass initial entity state; start() will be used to sync on demand
-  const editState = createEditState(null);
-  const actions = createZenModeActions(editState);
-
-  // Sync edit state when entity changes while NOT editing
-  $effect(() => {
-    // We only want to react to 'entity' changes
-    const currentEntity = entity;
-
-    untrack(() => {
-      if (currentEntity && !editState.isEditing) {
-        // Only sync metadata fields to avoid triggering incomplete async hydration
-        editState.title = currentEntity.title;
-        editState.type = currentEntity.type;
-        editState.image = currentEntity.image || "";
-      }
-    });
-  });
-
-  // Load content from Dexie when entityId changes
-  $effect(() => {
-    if (entityId) {
-      void vault.loadEntityContent(entityId);
-    }
-  });
-
-  // Resolve image URL
-  $effect(() => {
-    let isStale = false;
-    if (entity?.image) {
-      void vault.resolveImageUrl(entity.image).then((url) => {
-        if (!isStale) {
-          resolvedImageUrl = url;
-        }
-      });
-    } else {
-      resolvedImageUrl = "";
-    }
-    return () => {
-      isStale = true;
-    };
-  });
-
-  function handleNavigate(id: string) {
-    actions.handleClose(() => uiStore.focusEntity(id));
-  }
-
-  function handleCopy() {
-    if (entity) {
-      void clipboardService.copyEntity(entity).then(() => {
-        uiStore.notify("Content copied to clipboard");
-      });
-    }
+  function handleClose() {
+    uiStore.focusEntity(null);
   }
 </script>
 
@@ -81,71 +17,5 @@
   transition:fade={{ duration: 200 }}
   data-testid="embedded-entity-view"
 >
-  {#if entity}
-    <ZenHeader
-      {entity}
-      {editState}
-      isSaving={actions.isSaving}
-      isCopied={false}
-      onCopy={() => handleCopy()}
-      onStartEdit={() => editState.start(entity!)}
-      onCancelEdit={() => actions.handleClose(() => {})}
-      onSave={() => actions.saveChanges(entityId)}
-      onClose={() => actions.handleClose(() => uiStore.focusEntity(null))}
-    />
-
-    <div class="flex-1 flex flex-col md:flex-row overflow-hidden">
-      <ZenSidebar
-        {entity}
-        {editState}
-        {resolvedImageUrl}
-        onShowLightbox={() => (showLightbox = true)}
-        onNavigate={handleNavigate}
-        onDelete={() =>
-          actions.handleDelete(entity!, () => uiStore.focusEntity(null))}
-      />
-
-      <div
-        data-testid="embedded-entity-scroll"
-        class="flex-1 flex flex-col md:flex-row min-h-0 overflow-y-auto md:overflow-hidden w-full h-full custom-scrollbar overscroll-contain"
-        style="touch-action: pan-y;"
-      >
-        <ZenContent
-          {entity}
-          {editState}
-          bind:scrollContainer
-          showConnections={true}
-        />
-      </div>
-    </div>
-
-    <ZenImageLightbox
-      bind:show={showLightbox}
-      imageUrl={resolvedImageUrl}
-      title={entity.title}
-    />
-  {:else}
-    <div class="flex-1 flex items-center justify-center p-12 text-center">
-      <div class="max-w-md space-y-4">
-        <span
-          class="icon-[lucide--alert-circle] w-12 h-12 text-theme-muted opacity-20"
-        ></span>
-        <h3
-          class="text-xl font-header font-bold text-theme-text uppercase tracking-widest"
-        >
-          Entry Not Found
-        </h3>
-        <p class="text-theme-muted font-body text-sm">
-          The requested record could not be localized within the current
-          archive.
-        </p>
-        <button
-          onclick={() => uiStore.focusEntity(null)}
-          class="btnSecondary px-6 py-2"
-        >
-          Return to Workspace
-        </button>
-      </div>
-    </div>
-  {/if}
+  <ZenView {entityId} onClose={handleClose} onPopOut={() => {}} />
 </div>

--- a/apps/web/src/lib/components/entity/EmbeddedEntityView.svelte
+++ b/apps/web/src/lib/components/entity/EmbeddedEntityView.svelte
@@ -17,5 +17,5 @@
   transition:fade={{ duration: 200 }}
   data-testid="embedded-entity-view"
 >
-  <ZenView {entityId} onClose={handleClose} onPopOut={() => {}} />
+  <ZenView {entityId} onClose={handleClose} />
 </div>

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -6,7 +6,7 @@
   import type { Entity } from "schema";
 
   function handleSelect(entity: Entity) {
-    uiStore.focusEntity(entity.id);
+    uiStore.openZenMode(entity.id);
   }
 </script>
 
@@ -55,6 +55,9 @@
 
   <!-- List -->
   <div class="flex-1 min-h-0 flex flex-col">
-    <EntityList onSelect={handleSelect} />
+    <EntityList
+      onSelect={handleSelect}
+      onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
+    />
   </div>
 </div>

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -4,19 +4,8 @@
   import { fly, fade } from "svelte/transition";
   import { base } from "$app/paths";
   import { page } from "$app/state";
-  import {
-    openEntityPopout,
-    persistZenPopoutPayload,
-  } from "$lib/utils/zen-popout";
-
-  import { clipboardService } from "$lib/services/ClipboardService";
-  import ZenImageLightbox from "../zen/ZenImageLightbox.svelte";
-  import { createEditState } from "$lib/hooks/useEditState.svelte";
-  import { createZenModeActions } from "$lib/hooks/useZenModeActions.svelte";
-  import ZenHeader from "../zen/ZenHeader.svelte";
-  import ZenSidebar from "../zen/ZenSidebar.svelte";
-  import ZenContent from "../zen/ZenContent.svelte";
-  import DetailMapTab from "$lib/components/entity-detail/DetailMapTab.svelte";
+  import { openEntityPopout } from "$lib/utils/zen-popout";
+  import ZenView from "../zen/ZenView.svelte";
 
   const isPopout = $derived(
     /\/vault\/[^/]+\/entity\/[^/]+$/.test(page.url.pathname),
@@ -25,87 +14,12 @@
   let entityId = $derived(uiStore.zenModeEntityId);
   let entity = $derived(entityId ? vault.entities[entityId] : null);
 
-  // Lazy-load content when Zen Mode is opened or navigated
-  $effect(() => {
-    if (entityId) {
-      vault.loadEntityContent(entityId);
-    }
-  });
-
-  // Logic & State Hooks
-  let editState = $state(createEditState(null));
-  const actions = createZenModeActions(() => editState);
-
-  let isEditing = $derived(editState.isEditing);
-  let isSaving = $derived(actions.isSaving);
-
   // Close Zen Mode if the entity being viewed is deleted
   $effect(() => {
     if (uiStore.showZenMode && entityId && !entity) {
       uiStore.closeZenMode();
     }
   });
-
-  // Keep the guest popout payload fresh after Zen Mode renders and after
-  // lazy-loaded entity content updates the active entity snapshot.
-  $effect(() => {
-    if (!uiStore.showZenMode || !entity || !vault.isGuest) return;
-    persistZenPopoutPayload(vault.activeVaultId ?? "guest", entity, true);
-  });
-
-  let activeTab = $derived(uiStore.zenModeActiveTab);
-  let showLightbox = $state(false);
-  let scrollContainer = $state<HTMLDivElement>();
-  let mobileScroller = $state<HTMLDivElement>();
-  let tabOverview = $state<HTMLButtonElement>();
-  let tabInventory = $state<HTMLButtonElement>();
-  let tabMap = $state<HTMLButtonElement>();
-
-  let resolvedImageUrl = $state("");
-  let isCopied = $state(false);
-
-  $effect(() => {
-    let isStale = false;
-    if (entity?.image) {
-      vault.resolveImageUrl(entity.image).then((url) => {
-        if (!isStale) resolvedImageUrl = url;
-      });
-    } else {
-      resolvedImageUrl = "";
-    }
-    return () => {
-      isStale = true;
-    };
-  });
-
-  const handleCopy = async () => {
-    if (!entity) return;
-    const success = await clipboardService.copyEntity(entity, resolvedImageUrl);
-    if (success) {
-      isCopied = true;
-      setTimeout(() => (isCopied = false), 2000);
-    }
-  };
-
-  const startEditing = () => {
-    if (entity) editState.start(entity);
-  };
-
-  const cancelEditing = () => {
-    editState.cancel();
-  };
-
-  const saveChanges = async () => {
-    if (entity) await actions.saveChanges(entity.id);
-  };
-
-  const handleDelete = async () => {
-    if (entity) {
-      await actions.handleDelete(entity, () => {
-        handleClose();
-      });
-    }
-  };
 
   const handleClose = async () => {
     if (isPopout) {
@@ -117,24 +31,25 @@
       if (confirmed) window.close();
       return;
     }
-    actions.handleClose(() => {
-      uiStore.closeZenMode();
-    });
+    uiStore.closeZenMode();
   };
 
   const handlePopOut = () => {
     if (!entity) return;
     const popOutEntity = async () => {
-      let entityForPopout = entity;
+      let entityForPopout = entity!;
 
-      if (vault.isGuest && entityId && !entity.content) {
+      if (vault.isGuest && entityId && !entity!.content) {
         await vault.loadEntityContent(entityId);
         entityForPopout = vault.entities[entityId] ?? entityForPopout;
       }
 
-      // Convert blob URL → data URL so the image survives cross-tab (no P2P in popout)
-      if (resolvedImageUrl) {
+      // Convert blob URL → data URL so the image survives cross-tab
+      if (entityForPopout.image) {
         try {
+          const resolvedImageUrl = await vault.resolveImageUrl(
+            entityForPopout.image,
+          );
           const resp = await fetch(resolvedImageUrl);
           const blob = await resp.blob();
           const dataUrl = await new Promise<string>((resolve, reject) => {
@@ -145,7 +60,7 @@
           });
           entityForPopout = { ...entityForPopout, image: dataUrl };
         } catch {
-          // silently skip — image just won't appear in the popout
+          // silently skip
         }
       }
 
@@ -160,85 +75,9 @@
 
     void popOutEntity();
   };
-
-  const navigateTo = async (id: string) => {
-    if (editState.isEditing) {
-      if (
-        !(await uiStore.confirm({
-          title: "Unsaved Changes",
-          message: "Discard unsaved changes to navigate?",
-          confirmLabel: "Discard",
-          isDangerous: true,
-        }))
-      )
-        return;
-      editState.cancel();
-    }
-    uiStore.zenModeEntityId = id;
-  };
-
-  const handleTabKeydown = (e: KeyboardEvent) => {
-    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
-      e.preventDefault();
-      const tabs: ("overview" | "inventory" | "map")[] = [
-        "overview",
-        "inventory",
-        "map",
-      ];
-      const currentIndex = tabs.indexOf(activeTab);
-      const nextIndex =
-        e.key === "ArrowRight"
-          ? (currentIndex + 1) % tabs.length
-          : (currentIndex - 1 + tabs.length) % tabs.length;
-
-      uiStore.zenModeActiveTab = tabs[nextIndex];
-      const nextTab = uiStore.zenModeActiveTab;
-      if (nextTab === "overview") tabOverview?.focus();
-      else if (nextTab === "inventory") tabInventory?.focus();
-      else if (nextTab === "map") tabMap?.focus();
-    }
-  };
 </script>
 
-<svelte:window
-  onkeydown={(e) => {
-    if (!uiStore.showZenMode) return;
-
-    if (showLightbox) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        e.stopPropagation();
-        showLightbox = false;
-      }
-      return;
-    }
-
-    if (
-      document.activeElement?.tagName === "INPUT" ||
-      document.activeElement?.tagName === "TEXTAREA" ||
-      document.activeElement?.closest('[role="combobox"]')
-    )
-      return;
-
-    if (e.key === "Escape") {
-      if (!isPopout) handleClose();
-    } else if (!isEditing) {
-      const scroller =
-        window.innerWidth < 768 ? mobileScroller : scrollContainer;
-      if (!scroller) return;
-
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        scroller.scrollBy({ top: 150, behavior: "auto" });
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        scroller.scrollBy({ top: -150, behavior: "auto" });
-      }
-    }
-  }}
-/>
-
-{#if uiStore.showZenMode && entity}
+{#if uiStore.showZenMode && entityId}
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
@@ -248,199 +87,17 @@
     data-testid="zen-mode-modal"
   >
     <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="entity-modal-title"
-      tabindex="-1"
-      class="zen-dialog w-full md:max-w-6xl h-full md:h-[90vh] bg-theme-bg md:border border-theme-border shadow-2xl flex flex-col overflow-hidden relative"
-      style:--local-radius="var(--theme-border-radius)"
-      style:--local-width="var(--theme-border-width)"
+      class="w-full md:max-w-6xl h-full md:h-[90vh] shadow-2xl overflow-hidden"
       style:box-shadow="var(--theme-glow)"
-      style="background-image: var(--bg-texture-overlay)"
       transition:fly={{ y: 20, duration: 300 }}
       onclick={(e) => e.stopPropagation()}
     >
-      <!-- Decorative Corners -->
-      <div
-        class="absolute top-0 left-0 w-8 h-8 border-t-2 border-l-2 border-theme-primary/30 rounded-tl-lg pointer-events-none hidden md:block"
-      ></div>
-      <div
-        class="absolute top-0 right-0 w-8 h-8 border-t-2 border-r-2 border-theme-primary/30 rounded-tr-lg pointer-events-none hidden md:block"
-      ></div>
-      <div
-        class="absolute bottom-0 left-0 w-8 h-8 border-b-2 border-l-2 border-theme-primary/30 rounded-bl-lg pointer-events-none hidden md:block"
-      ></div>
-      <div
-        class="absolute bottom-0 right-0 w-8 h-8 border-b-2 border-r-2 border-theme-primary/30 rounded-br-lg pointer-events-none hidden md:block"
-      ></div>
-
-      <!-- Header -->
-      <ZenHeader
-        {entity}
-        bind:editState
-        {isSaving}
-        {isCopied}
-        onCopy={handleCopy}
-        onStartEdit={startEditing}
-        onCancelEdit={cancelEditing}
-        onSave={saveChanges}
+      <ZenView
+        {entityId}
+        {isPopout}
         onClose={handleClose}
         onPopOut={isPopout ? undefined : handlePopOut}
       />
-
-      <!-- Navigation Tabs -->
-      <div
-        role="tablist"
-        aria-label="Entity Sections"
-        style="background-image: var(--bg-texture-overlay)"
-        class="flex gap-4 md:gap-8 px-4 md:px-8 border-b border-theme-border bg-theme-surface shrink-0 overflow-x-auto no-scrollbar"
-      >
-        <button
-          bind:this={tabOverview}
-          role="tab"
-          id="tab-overview"
-          aria-selected={activeTab === "overview"}
-          aria-controls="panel-overview"
-          tabindex={activeTab === "overview" ? 0 : -1}
-          class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
-          'overview'
-            ? 'text-theme-primary border-theme-primary'
-            : 'text-theme-muted border-transparent hover:text-theme-text'}"
-          onclick={() => (uiStore.zenModeActiveTab = "overview")}
-          onkeydown={handleTabKeydown}
-        >
-          OVERVIEW
-        </button>
-        {#if !vault.isGuest}
-          <button
-            bind:this={tabInventory}
-            role="tab"
-            id="tab-inventory"
-            aria-selected={activeTab === "inventory"}
-            aria-controls="panel-inventory"
-            tabindex={activeTab === "inventory" ? 0 : -1}
-            class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
-            'inventory'
-              ? 'text-theme-primary border-theme-primary'
-              : 'text-theme-muted border-transparent hover:text-theme-text'}"
-            onclick={() => (uiStore.zenModeActiveTab = "inventory")}
-            onkeydown={handleTabKeydown}
-          >
-            INVENTORY
-          </button>
-          <button
-            bind:this={tabMap}
-            role="tab"
-            id="tab-map"
-            aria-selected={activeTab === "map"}
-            aria-controls="panel-map"
-            tabindex={activeTab === "map" ? 0 : -1}
-            class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
-            'map'
-              ? 'text-theme-primary border-theme-primary'
-              : 'text-theme-muted border-transparent hover:text-theme-text'}"
-            onclick={() => (uiStore.zenModeActiveTab = "map")}
-            onkeydown={handleTabKeydown}
-          >
-            MAP
-          </button>
-        {/if}
-      </div>
-
-      <!-- Main Body -->
-      <div class="flex-1 overflow-hidden flex flex-col md:flex-row">
-        {#if activeTab === "overview"}
-          <div
-            role="tabpanel"
-            id="panel-overview"
-            aria-labelledby="tab-overview"
-            bind:this={mobileScroller}
-            class="flex-1 flex flex-col md:flex-row overflow-y-auto md:overflow-hidden w-full h-full custom-scrollbar"
-          >
-            <ZenSidebar
-              {entity}
-              bind:editState
-              {resolvedImageUrl}
-              {isPopout}
-              onShowLightbox={() => (showLightbox = true)}
-              onNavigate={navigateTo}
-              onDelete={handleDelete}
-            />
-
-            <ZenContent {entity} bind:editState bind:scrollContainer />
-          </div>
-        {:else if activeTab === "map"}
-          <div
-            role="tabpanel"
-            id="panel-map"
-            aria-labelledby="tab-map"
-            class="flex-1 w-full h-full p-8 overflow-y-auto custom-scrollbar bg-theme-bg"
-            style="background-image: var(--bg-texture-overlay)"
-          >
-            <div
-              class="max-w-4xl mx-auto h-full min-h-[500px] border border-theme-border rounded bg-theme-surface/50"
-            >
-              <DetailMapTab {entity} />
-            </div>
-          </div>
-        {:else if activeTab === "inventory"}
-          <div
-            role="tabpanel"
-            id="panel-inventory"
-            aria-labelledby="tab-inventory"
-            class="flex-1 p-8 flex items-center justify-center text-theme-muted font-header text-sm italic"
-          >
-            Inventory system initialization pending...
-          </div>
-        {/if}
-      </div>
     </div>
   </div>
-
-  <ZenImageLightbox
-    bind:show={showLightbox}
-    imageUrl={resolvedImageUrl}
-    title={entity.title}
-  />
 {/if}
-
-<style>
-  .custom-scrollbar::-webkit-scrollbar {
-    width: 6px;
-  }
-  .custom-scrollbar::-webkit-scrollbar-track {
-    background: #000;
-  }
-  .custom-scrollbar::-webkit-scrollbar-thumb {
-    background: #15803d33;
-    border-radius: 10px;
-  }
-  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-    background: #15803d66;
-  }
-
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-  .no-scrollbar {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-
-  /* Add affordance for horizontal scrolling */
-  div[role="tablist"].overflow-x-auto {
-    mask-image: linear-gradient(to right, black 90%, transparent);
-  }
-
-  .zen-dialog {
-    border-radius: var(--local-radius);
-    border-width: var(--local-width);
-  }
-
-  @media (max-width: 767px) {
-    .zen-dialog {
-      --local-radius: 0;
-      --local-width: 0;
-    }
-  }
-</style>

--- a/apps/web/src/lib/components/zen/ZenContent.connections.test.ts
+++ b/apps/web/src/lib/components/zen/ZenContent.connections.test.ts
@@ -10,7 +10,7 @@ describe("ZenContent connections wiring", () => {
 
     expect(source).toContain("showConnections = false");
     expect(source).toContain("themeStore.jargon.connections_header");
-    expect(source).toContain("uiStore.focusEntity(conn.targetId)");
+    expect(source).toContain("onNavigate(conn.targetId)");
   });
 
   it("enables connections in the embedded entity view", () => {
@@ -19,6 +19,6 @@ describe("ZenContent connections wiring", () => {
       "utf8",
     );
 
-    expect(source).toContain("showConnections={true}");
+    expect(source).toContain("<ZenView");
   });
 });

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { vault } from "$lib/stores/vault.svelte";
-  import { uiStore } from "$lib/stores/ui.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
   import TemporalEditor from "$lib/components/timeline/TemporalEditor.svelte";
@@ -10,11 +9,13 @@
     entity,
     editState = $bindable(),
     scrollContainer = $bindable(),
+    onNavigate,
     showConnections = false,
   } = $props<{
     entity: Entity | null;
     editState: any;
     scrollContainer: HTMLDivElement | undefined;
+    onNavigate: (id: string) => void;
     showConnections?: boolean;
   }>();
 
@@ -234,7 +235,7 @@
               <button
                 type="button"
                 class="flex-1 min-w-0 text-left hover:text-theme-primary transition flex items-center flex-wrap gap-y-1"
-                onclick={() => uiStore.focusEntity(conn.targetId)}
+                onclick={() => onNavigate(conn.targetId)}
               >
                 {#if conn.isOutbound}
                   <span class="text-theme-secondary">{entity?.title}</span>

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -1,0 +1,403 @@
+<script lang="ts">
+  import { uiStore } from "$lib/stores/ui.svelte";
+  import { vault } from "$lib/stores/vault.svelte";
+  import { clipboardService } from "$lib/services/ClipboardService";
+  import ZenImageLightbox from "./ZenImageLightbox.svelte";
+  import { createEditState } from "$lib/hooks/useEditState.svelte";
+  import { createZenModeActions } from "$lib/hooks/useZenModeActions.svelte";
+  import ZenHeader from "./ZenHeader.svelte";
+  import ZenSidebar from "./ZenSidebar.svelte";
+  import ZenContent from "./ZenContent.svelte";
+  import DetailMapTab from "$lib/components/entity-detail/DetailMapTab.svelte";
+  import { persistZenPopoutPayload } from "$lib/utils/zen-popout";
+
+  let {
+    entityId,
+    onClose,
+    onPopOut,
+    isPopout = false,
+    class: className = "",
+  } = $props<{
+    entityId: string;
+    onClose: () => void;
+    onPopOut?: () => void;
+    isPopout?: boolean;
+    class?: string;
+  }>();
+
+  let entity = $derived(vault.entities[entityId] || null);
+
+  // Lazy-load content when Zen Mode is opened or navigated
+  $effect(() => {
+    if (entityId) {
+      vault.loadEntityContent(entityId);
+    }
+  });
+
+  // Logic & State Hooks
+  let editState = $state(createEditState(null));
+  const actions = createZenModeActions(() => editState);
+
+  let isEditing = $derived(editState.isEditing);
+  let isSaving = $derived(actions.isSaving);
+
+  // Keep the guest popout payload fresh
+  $effect(() => {
+    if (!entity || !vault.isGuest) return;
+    persistZenPopoutPayload(vault.activeVaultId ?? "guest", entity, true);
+  });
+
+  let activeTab = $derived(uiStore.zenModeActiveTab);
+  let showLightbox = $state(false);
+  let scrollContainer = $state<HTMLDivElement>();
+  let mobileScroller = $state<HTMLDivElement>();
+  let tabOverview = $state<HTMLButtonElement>();
+  let tabInventory = $state<HTMLButtonElement>();
+  let tabMap = $state<HTMLButtonElement>();
+
+  let resolvedImageUrl = $state("");
+  let isCopied = $state(false);
+
+  $effect(() => {
+    let isStale = false;
+    if (entity?.image) {
+      vault.resolveImageUrl(entity.image).then((url) => {
+        if (!isStale) resolvedImageUrl = url;
+      });
+    } else {
+      resolvedImageUrl = "";
+    }
+    return () => {
+      isStale = true;
+    };
+  });
+
+  const handleCopy = async () => {
+    if (!entity) return;
+    const success = await clipboardService.copyEntity(entity, resolvedImageUrl);
+    if (success) {
+      isCopied = true;
+      setTimeout(() => (isCopied = false), 2000);
+    }
+  };
+
+  const startEditing = () => {
+    if (entity) editState.start(entity);
+  };
+
+  const cancelEditing = () => {
+    editState.cancel();
+  };
+
+  const saveChanges = async () => {
+    if (entity) await actions.saveChanges(entity.id);
+  };
+
+  const handlePopOutClick = async () => {
+    await actions.handlePopOut(entityId);
+  };
+
+  const handleDelete = async () => {
+    if (entity) {
+      await actions.handleDelete(entity, () => {
+        onClose();
+      });
+    }
+  };
+
+  const navigateTo = async (id: string) => {
+    if (editState.isEditing) {
+      if (
+        !(await uiStore.confirm({
+          title: "Unsaved Changes",
+          message: "Discard unsaved changes to navigate?",
+          confirmLabel: "Discard",
+          isDangerous: true,
+        }))
+      )
+        return;
+      editState.cancel();
+    }
+
+    // Check if we are in modal mode or embedded mode
+    if (uiStore.showZenMode) {
+      uiStore.zenModeEntityId = id;
+    } else {
+      uiStore.focusEntity(id);
+    }
+  };
+
+  const handleTabKeydown = (e: KeyboardEvent) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      const tabs: ("overview" | "inventory" | "map")[] = [
+        "overview",
+        "inventory",
+        "map",
+      ];
+      const currentIndex = tabs.indexOf(activeTab);
+      const nextIndex =
+        e.key === "ArrowRight"
+          ? (currentIndex + 1) % tabs.length
+          : (currentIndex - 1 + tabs.length) % tabs.length;
+
+      uiStore.zenModeActiveTab = tabs[nextIndex];
+      const nextTab = uiStore.zenModeActiveTab;
+      if (nextTab === "overview") tabOverview?.focus();
+      else if (nextTab === "inventory") tabInventory?.focus();
+      else if (nextTab === "map") tabMap?.focus();
+    }
+  };
+
+  // Handle keyboard shortcuts locally within the view
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (showLightbox) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        showLightbox = false;
+      }
+      return;
+    }
+
+    if (
+      document.activeElement?.tagName === "INPUT" ||
+      document.activeElement?.tagName === "TEXTAREA" ||
+      document.activeElement?.closest('[role="combobox"]')
+    )
+      return;
+
+    if (!isEditing) {
+      const scroller =
+        window.innerWidth < 768 ? mobileScroller : scrollContainer;
+      if (!scroller) return;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        scroller.scrollBy({ top: 150, behavior: "auto" });
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        scroller.scrollBy({ top: -150, behavior: "auto" });
+      }
+    }
+  };
+</script>
+
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="entity-modal-title"
+  tabindex="-1"
+  class="zen-view w-full h-full bg-theme-bg flex flex-col overflow-hidden relative border-theme-border border-solid {className}"
+  style:border-radius="var(--local-radius)"
+  style:border-width="var(--local-width)"
+  style:--local-radius="var(--theme-border-radius)"
+  style:--local-width="var(--theme-border-width)"
+  style="background-image: var(--bg-texture-overlay)"
+  onkeydown={handleKeydown}
+>
+  {#if entity}
+    <!-- Decorative Corners (Visible in desktop/modal mode via CSS) -->
+    <div
+      class="decorative-corner absolute top-0 left-0 w-8 h-8 border-t-2 border-l-2 border-theme-primary/30 rounded-tl-lg pointer-events-none hidden md:block"
+    ></div>
+    <div
+      class="decorative-corner absolute top-0 right-0 w-8 h-8 border-t-2 border-r-2 border-theme-primary/30 rounded-tr-lg pointer-events-none hidden md:block"
+    ></div>
+    <div
+      class="decorative-corner absolute bottom-0 left-0 w-8 h-8 border-b-2 border-l-2 border-theme-primary/30 rounded-bl-lg pointer-events-none hidden md:block"
+    ></div>
+    <div
+      class="decorative-corner absolute bottom-0 right-0 w-8 h-8 border-b-2 border-r-2 border-theme-primary/30 rounded-br-lg pointer-events-none hidden md:block"
+    ></div>
+
+    <!-- Header -->
+    <ZenHeader
+      {entity}
+      bind:editState
+      {isSaving}
+      {isCopied}
+      onCopy={handleCopy}
+      onStartEdit={startEditing}
+      onCancelEdit={cancelEditing}
+      onSave={saveChanges}
+      {onClose}
+      onPopOut={onPopOut ? handlePopOutClick : undefined}
+    />
+
+    <!-- Navigation Tabs -->
+    <div
+      role="tablist"
+      aria-label="Entity Sections"
+      style="background-image: var(--bg-texture-overlay)"
+      class="flex gap-4 md:gap-8 px-4 md:px-8 border-b border-theme-border bg-theme-surface shrink-0 overflow-x-auto no-scrollbar"
+    >
+      <button
+        bind:this={tabOverview}
+        role="tab"
+        id="tab-overview"
+        aria-selected={activeTab === "overview"}
+        aria-controls="panel-overview"
+        tabindex={activeTab === "overview" ? 0 : -1}
+        class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
+        'overview'
+          ? 'text-theme-primary border-theme-primary'
+          : 'text-theme-muted border-transparent hover:text-theme-text'}"
+        onclick={() => (uiStore.zenModeActiveTab = "overview")}
+        onkeydown={handleTabKeydown}
+      >
+        OVERVIEW
+      </button>
+      {#if !vault.isGuest}
+        <button
+          bind:this={tabInventory}
+          role="tab"
+          id="tab-inventory"
+          aria-selected={activeTab === "inventory"}
+          aria-controls="panel-inventory"
+          tabindex={activeTab === "inventory" ? 0 : -1}
+          class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
+          'inventory'
+            ? 'text-theme-primary border-theme-primary'
+            : 'text-theme-muted border-transparent hover:text-theme-text'}"
+          onclick={() => (uiStore.zenModeActiveTab = "inventory")}
+          onkeydown={handleTabKeydown}
+        >
+          INVENTORY
+        </button>
+        <button
+          bind:this={tabMap}
+          role="tab"
+          id="tab-map"
+          aria-selected={activeTab === "map"}
+          aria-controls="panel-map"
+          tabindex={activeTab === "map" ? 0 : -1}
+          class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
+          'map'
+            ? 'text-theme-primary border-theme-primary'
+            : 'text-theme-muted border-transparent hover:text-theme-text'}"
+          onclick={() => (uiStore.zenModeActiveTab = "map")}
+          onkeydown={handleTabKeydown}
+        >
+          MAP
+        </button>
+      {/if}
+    </div>
+
+    <!-- Main Body -->
+    <div class="flex-1 overflow-hidden flex flex-col md:flex-row">
+      {#if activeTab === "overview"}
+        <div
+          role="tabpanel"
+          id="panel-overview"
+          aria-labelledby="tab-overview"
+          bind:this={mobileScroller}
+          class="flex-1 flex flex-col md:flex-row overflow-y-auto md:overflow-hidden w-full h-full custom-scrollbar"
+        >
+          <ZenSidebar
+            {entity}
+            bind:editState
+            {resolvedImageUrl}
+            {isPopout}
+            onShowLightbox={() => (showLightbox = true)}
+            onNavigate={navigateTo}
+            onDelete={handleDelete}
+          />
+
+          <ZenContent
+            {entity}
+            bind:editState
+            bind:scrollContainer
+            onNavigate={navigateTo}
+            showConnections={true}
+          />
+        </div>
+      {:else if activeTab === "map"}
+        <div
+          role="tabpanel"
+          id="panel-map"
+          aria-labelledby="tab-map"
+          class="flex-1 w-full h-full p-8 overflow-y-auto custom-scrollbar bg-theme-bg"
+          style="background-image: var(--bg-texture-overlay)"
+        >
+          <div
+            class="max-w-4xl mx-auto h-full min-h-[500px] border border-theme-border rounded bg-theme-surface/50"
+          >
+            <DetailMapTab {entity} />
+          </div>
+        </div>
+      {:else if activeTab === "inventory"}
+        <div
+          role="tabpanel"
+          id="panel-inventory"
+          aria-labelledby="tab-inventory"
+          class="flex-1 p-8 flex items-center justify-center text-theme-muted font-header text-sm italic"
+        >
+          Inventory system initialization pending...
+        </div>
+      {/if}
+    </div>
+
+    <ZenImageLightbox
+      bind:show={showLightbox}
+      imageUrl={resolvedImageUrl}
+      title={entity.title}
+    />
+  {:else}
+    <div class="flex-1 flex items-center justify-center p-12 text-center">
+      <div class="max-w-md space-y-4">
+        <span
+          class="icon-[lucide--alert-circle] w-12 h-12 text-theme-muted opacity-20"
+        ></span>
+        <h3
+          class="text-xl font-header font-bold text-theme-text uppercase tracking-widest"
+        >
+          Entry Not Found
+        </h3>
+        <p class="text-theme-muted font-body text-sm">
+          The requested record could not be localized within the current
+          archive.
+        </p>
+        <button onclick={onClose} class="btnSecondary px-6 py-2">
+          Return to Workspace
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 6px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: #000;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background: #15803d33;
+    border-radius: 10px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: #15803d66;
+  }
+
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  /* Add affordance for horizontal scrolling */
+  div[role="tablist"].overflow-x-auto {
+    mask-image: linear-gradient(to right, black 90%, transparent);
+  }
+
+  @media (max-width: 767px) {
+    .zen-view {
+      --local-radius: 0;
+      --local-width: 0;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -149,8 +149,8 @@
     }
   };
 
-  // Handle keyboard shortcuts locally within the view
-  const handleKeydown = (e: KeyboardEvent) => {
+  // Handle keyboard shortcuts
+  const handleKeydown = async (e: KeyboardEvent) => {
     if (showLightbox) {
       if (e.key === "Escape") {
         e.preventDefault();
@@ -167,6 +167,13 @@
     )
       return;
 
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      await actions.handleClose(onClose);
+      return;
+    }
+
     if (!isEditing) {
       const scroller =
         window.innerWidth < 768 ? mobileScroller : scrollContainer;
@@ -181,11 +188,17 @@
       }
     }
   };
+
+  const ariaRole = $derived(uiStore.showZenMode ? "dialog" : "region");
+  const ariaModal = $derived(uiStore.showZenMode ? "true" : undefined);
 </script>
 
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
-  role="dialog"
-  aria-modal="true"
+  role={ariaRole}
+  aria-modal={ariaModal}
   aria-labelledby="entity-modal-title"
   tabindex="-1"
   class="zen-view w-full h-full bg-theme-bg flex flex-col overflow-hidden relative border-theme-border border-solid {className}"
@@ -194,7 +207,6 @@
   style:--local-radius="var(--theme-border-radius)"
   style:--local-width="var(--theme-border-width)"
   style="background-image: var(--bg-texture-overlay)"
-  onkeydown={handleKeydown}
 >
   {#if entity}
     <!-- Decorative Corners (Visible in desktop/modal mode via CSS) -->

--- a/apps/web/src/lib/hooks/useZenModeActions.svelte.test.ts
+++ b/apps/web/src/lib/hooks/useZenModeActions.svelte.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createZenModeActions } from "./useZenModeActions.svelte";
 
+vi.mock("$lib/utils/zen-popout", () => ({
+  openEntityPopout: vi.fn(),
+}));
+
+import { openEntityPopout } from "$lib/utils/zen-popout";
+
 describe("useZenModeActions", () => {
   let mockUiStore: any;
   let mockVault: any;
@@ -197,6 +203,45 @@ describe("useZenModeActions", () => {
       await actions.handleClose(onClose);
       expect(onClose).toHaveBeenCalled();
       expect(mockEditState.isEditing).toBe(false);
+    });
+  });
+
+  describe("handlePopOut", () => {
+    const mockEntity = { id: "e1", title: "Pop" } as any;
+
+    beforeEach(() => {
+      mockVault.entities = { e1: mockEntity };
+      mockUiStore.showZenMode = false;
+      mockUiStore.mainViewMode = "visualization";
+      mockUiStore.closeZenMode = vi.fn();
+      mockUiStore.focusEntity = vi.fn();
+    });
+
+    it("should call openEntityPopout and close views", async () => {
+      mockUiStore.showZenMode = true;
+      const actions = createZenModeActions(mockEditState, {
+        uiStore: mockUiStore,
+        vault: mockVault,
+      });
+
+      await actions.handlePopOut("e1");
+
+      expect(openEntityPopout).toHaveBeenCalled();
+      expect(mockUiStore.closeZenMode).toHaveBeenCalled();
+    });
+
+    it("should close focus mode if active", async () => {
+      mockUiStore.showZenMode = false;
+      mockUiStore.mainViewMode = "focus";
+      const actions = createZenModeActions(mockEditState, {
+        uiStore: mockUiStore,
+        vault: mockVault,
+      });
+
+      await actions.handlePopOut("e1");
+
+      expect(openEntityPopout).toHaveBeenCalled();
+      expect(mockUiStore.focusEntity).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/apps/web/src/lib/hooks/useZenModeActions.svelte.ts
+++ b/apps/web/src/lib/hooks/useZenModeActions.svelte.ts
@@ -1,5 +1,7 @@
 import { uiStore as defaultUiStore } from "$lib/stores/ui.svelte";
 import { vault as defaultVault } from "$lib/stores/vault.svelte";
+import { base } from "$app/paths";
+import { openEntityPopout } from "$lib/utils/zen-popout";
 import type { Entity } from "schema";
 
 export interface ZenModeActionsDependencies {
@@ -80,6 +82,52 @@ export function createZenModeActions(
     editState.isEditing = false;
   };
 
+  const handlePopOut = async (entityId: string) => {
+    const entity = vault.entities[entityId];
+    if (!entity) return;
+
+    let entityForPopout = entity;
+
+    if (vault.isGuest && !entity.content) {
+      await vault.loadEntityContent(entityId);
+      entityForPopout = vault.entities[entityId] ?? entityForPopout;
+    }
+
+    // Convert blob URL → data URL so the image survives cross-tab
+    if (entityForPopout.image) {
+      try {
+        const resolvedImageUrl = await vault.resolveImageUrl(
+          entityForPopout.image,
+        );
+        const resp = await fetch(resolvedImageUrl);
+        const blob = await resp.blob();
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
+        entityForPopout = { ...entityForPopout, image: dataUrl };
+      } catch {
+        // silently skip
+      }
+    }
+
+    openEntityPopout(
+      vault.activeVaultId ?? "guest",
+      entityForPopout,
+      base,
+      vault.isGuest,
+    );
+
+    // Close whatever view we're in
+    if (uiStore.showZenMode) {
+      uiStore.closeZenMode();
+    } else if (uiStore.mainViewMode === "focus") {
+      uiStore.focusEntity(null);
+    }
+  };
+
   return {
     get isSaving() {
       return isSaving;
@@ -87,5 +135,6 @@ export function createZenModeActions(
     saveChanges,
     handleDelete,
     handleClose,
+    handlePopOut,
   };
 }

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -180,7 +180,7 @@
   }
 
   function handleEntitySelect(entity: Entity) {
-    uiStore.focusEntity(entity.id);
+    uiStore.openZenMode(entity.id);
   }
 </script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -351,6 +352,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -1164,6 +1166,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1210,6 +1213,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1230,6 +1234,7 @@
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -1241,6 +1246,7 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1534,7 +1540,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1837,6 +1842,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -2603,7 +2609,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2612,7 +2617,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2621,7 +2625,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2633,7 +2636,6 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3535,7 +3537,6 @@
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -3547,6 +3548,7 @@
       "integrity": "sha512-TMiqCTy9ZW4KBHvmTgeWU/hF6jcFpeMgR+9ekE06uhhGnbUZ7wpIY6l1Uk4ThRzlWYJnCVfzmtVNaHaDjaSiSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -3988,6 +3990,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
       "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4027,6 +4030,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.3.tgz",
       "integrity": "sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -4110,6 +4114,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.3.tgz",
       "integrity": "sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4208,6 +4213,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
       "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4287,6 +4293,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.22.3.tgz",
       "integrity": "sha512-inbQSusJad7H0T++L1APg/anfL5d15cNGp2YG3vwo6TQr71nn2c9pepvmz3xuAIt8eygZDRba+4GT/COP1f9QA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4366,6 +4373,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
       "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4380,6 +4388,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
       "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4825,7 +4834,6 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/gapi": {
@@ -4922,15 +4930,15 @@
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
@@ -4984,6 +4992,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -5089,7 +5098,6 @@
       "version": "8.58.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
       "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5204,6 +5212,7 @@
       "resolved": "https://registry.npmjs.org/@xyflow/svelte/-/svelte-1.5.2.tgz",
       "integrity": "sha512-jPLc2cwRmrkXSv/jvsNDQqTGCsNyTWURKtBl28UCH3BdOAA3CIc0/oQ0EvIcjPdzr0NwvWMgq9TmLdjOIccCEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@svelte-put/shortcut": "^4.1.0",
         "@xyflow/system": "0.0.76"
@@ -5232,6 +5241,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5468,7 +5478,6 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -5772,6 +5781,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -6226,6 +6236,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6382,6 +6393,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6777,6 +6789,7 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7013,7 +7026,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -7265,7 +7277,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -7310,7 +7322,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7327,7 +7338,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7344,7 +7354,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7361,7 +7370,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7378,7 +7386,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7395,7 +7402,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7412,7 +7418,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7429,7 +7434,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7446,7 +7450,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7463,7 +7466,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7480,7 +7482,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7497,7 +7498,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7514,7 +7514,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7531,7 +7530,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7548,7 +7546,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7565,7 +7562,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7582,7 +7578,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7599,7 +7594,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7616,7 +7610,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7633,7 +7626,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7650,7 +7642,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7667,7 +7658,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7684,7 +7674,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7701,7 +7690,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7718,7 +7706,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7783,6 +7770,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7956,7 +7944,6 @@
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -8013,7 +8000,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
       "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -9141,7 +9127,6 @@
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -9226,7 +9211,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9802,7 +9787,6 @@
     },
     "node_modules/locate-character": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -11482,6 +11466,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11580,6 +11565,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11701,6 +11687,7 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11816,6 +11803,7 @@
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11850,6 +11838,7 @@
     "node_modules/prosemirror-state": {
       "version": "1.4.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11890,6 +11879,7 @@
     "node_modules/prosemirror-view": {
       "version": "1.41.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -12767,8 +12757,8 @@
       "version": "5.55.2",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.2.tgz",
       "integrity": "sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -12901,7 +12891,6 @@
     },
     "node_modules/svelte/node_modules/aria-query": {
       "version": "5.3.1",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -12942,7 +12931,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -13148,6 +13138,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13215,7 +13206,7 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -13224,6 +13215,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -13388,6 +13380,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13723,6 +13716,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -13936,7 +13930,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14062,7 +14056,6 @@
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {
@@ -14108,6 +14101,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14252,6 +14246,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14351,6 +14346,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14495,6 +14491,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14593,6 +14590,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14737,6 +14735,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14842,6 +14841,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14986,6 +14986,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15091,6 +15092,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15235,6 +15237,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15345,6 +15348,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15489,6 +15493,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15590,6 +15595,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15734,6 +15740,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15842,6 +15849,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15986,6 +15994,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16090,6 +16099,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16234,6 +16244,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16335,6 +16346,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16479,6 +16491,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16583,6 +16596,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16727,6 +16741,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16831,6 +16846,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16975,6 +16991,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -17082,6 +17099,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -17226,6 +17244,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -352,7 +351,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -1166,7 +1164,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1213,7 +1210,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1234,7 +1230,6 @@
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -1246,7 +1241,6 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1540,6 +1534,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1842,7 +1837,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -2609,6 +2603,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2617,6 +2612,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2625,6 +2621,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2636,6 +2633,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3537,6 +3535,7 @@
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -3548,7 +3547,6 @@
       "integrity": "sha512-TMiqCTy9ZW4KBHvmTgeWU/hF6jcFpeMgR+9ekE06uhhGnbUZ7wpIY6l1Uk4ThRzlWYJnCVfzmtVNaHaDjaSiSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -3990,7 +3988,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
       "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4030,7 +4027,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.3.tgz",
       "integrity": "sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -4114,7 +4110,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.3.tgz",
       "integrity": "sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4213,7 +4208,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
       "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4293,7 +4287,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.22.3.tgz",
       "integrity": "sha512-inbQSusJad7H0T++L1APg/anfL5d15cNGp2YG3vwo6TQr71nn2c9pepvmz3xuAIt8eygZDRba+4GT/COP1f9QA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4373,7 +4366,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
       "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4388,7 +4380,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
       "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4834,6 +4825,7 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/gapi": {
@@ -4930,15 +4922,15 @@
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
@@ -4992,7 +4984,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -5098,6 +5089,7 @@
       "version": "8.58.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
       "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5212,7 +5204,6 @@
       "resolved": "https://registry.npmjs.org/@xyflow/svelte/-/svelte-1.5.2.tgz",
       "integrity": "sha512-jPLc2cwRmrkXSv/jvsNDQqTGCsNyTWURKtBl28UCH3BdOAA3CIc0/oQ0EvIcjPdzr0NwvWMgq9TmLdjOIccCEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@svelte-put/shortcut": "^4.1.0",
         "@xyflow/system": "0.0.76"
@@ -5241,7 +5232,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5478,6 +5468,7 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -5781,7 +5772,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -6236,7 +6226,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6393,7 +6382,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6789,7 +6777,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7026,6 +7013,7 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -7277,7 +7265,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -7322,6 +7310,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7338,6 +7327,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7354,6 +7344,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7370,6 +7361,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7386,6 +7378,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7402,6 +7395,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7418,6 +7412,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7434,6 +7429,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7450,6 +7446,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7466,6 +7463,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7482,6 +7480,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7498,6 +7497,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7514,6 +7514,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7530,6 +7531,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7546,6 +7548,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7562,6 +7565,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7578,6 +7582,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7594,6 +7599,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7610,6 +7616,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7626,6 +7633,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7642,6 +7650,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7658,6 +7667,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7674,6 +7684,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7690,6 +7701,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7706,6 +7718,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7770,7 +7783,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7944,6 +7956,7 @@
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -8000,6 +8013,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
       "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -9127,6 +9141,7 @@
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -9211,7 +9226,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9787,6 +9802,7 @@
     },
     "node_modules/locate-character": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -11466,7 +11482,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11565,7 +11580,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11687,7 +11701,6 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11803,7 +11816,6 @@
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11838,7 +11850,6 @@
     "node_modules/prosemirror-state": {
       "version": "1.4.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11879,7 +11890,6 @@
     "node_modules/prosemirror-view": {
       "version": "1.41.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -12757,8 +12767,8 @@
       "version": "5.55.2",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.2.tgz",
       "integrity": "sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -12891,6 +12901,7 @@
     },
     "node_modules/svelte/node_modules/aria-query": {
       "version": "5.3.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -12931,8 +12942,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -13138,7 +13148,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13206,7 +13215,7 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -13215,7 +13224,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -13380,7 +13388,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -13716,7 +13723,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -13930,7 +13936,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14056,6 +14062,7 @@
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {
@@ -14101,7 +14108,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14246,7 +14252,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14346,7 +14351,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14491,7 +14495,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14590,7 +14593,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14735,7 +14737,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14841,7 +14842,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14986,7 +14986,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15092,7 +15091,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15237,7 +15235,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15348,7 +15345,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15493,7 +15489,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15595,7 +15590,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15740,7 +15734,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15849,7 +15842,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15994,7 +15986,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16099,7 +16090,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16244,7 +16234,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16346,7 +16335,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16491,7 +16479,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16596,7 +16583,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16741,7 +16727,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16846,7 +16831,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16991,7 +16975,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -17099,7 +17082,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -17244,7 +17226,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",


### PR DESCRIPTION
Unified the Zen Mode experience by creating a shared `ZenView.svelte` component and using it in both the `ZenModeModal` and `EmbeddedEntityView`.

Key changes:
- Created `ZenView.svelte` as a reusable component for entity details.
- Refactored `ZenModeModal.svelte` and `EmbeddedEntityView.svelte` to use the new `ZenView`.
- Moved shared entity "Popout" logic to `useZenModeActions.svelte.ts`.
- Updated all entity lists (`EntityExplorer`, `EntityPalette`, VTT sidebar) to consistently open entities in the Zen Mode modal.
- Fixed navigation inconsistencies when clicking connection links within Zen Mode.
- Ensured strict compliance with the project's Style Guide and Svelte 5 patterns.