### PR TITLE
🎨 Palette: [UX improvement] Add ARIA tab roles to BulkLabelDialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,7 +13,7 @@
 **Learning:** Found several full-screen or prominent overlay components (like ShareModal, MergeNodesDialog, and ConfirmationModal) that lacked proper ARIA dialog roles, making them opaque to screen readers.
 **Action:** Always wrap custom modal components with `role="dialog"`, `aria-modal="true"`, and explicitly link them to a title using `aria-labelledby` (with an `id` on the title element) to ensure screen readers correctly interpret them as focused dialogs.
 
-## 2024-04-17 - Tablist Accessibility
+## 2026-04-17 - Tablist Accessibility
 
 **Learning:** Found custom tabbed interfaces (like in `BulkLabelDialog.svelte`) that were built with standard buttons but lacked proper ARIA tab roles, making them confusing for screen reader users who couldn't identify the grouped relationship or the selected state.
 **Action:** Always wrap tab groups with `role="tablist"` and `aria-label`, assign `role="tab"` and `aria-selected` to the tab buttons, and link them to their content using `role="tabpanel"`, `id`, and `aria-labelledby` to ensure the structure is correctly announced as an interactive tab list.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,8 @@
 
 **Learning:** Found several full-screen or prominent overlay components (like ShareModal, MergeNodesDialog, and ConfirmationModal) that lacked proper ARIA dialog roles, making them opaque to screen readers.
 **Action:** Always wrap custom modal components with `role="dialog"`, `aria-modal="true"`, and explicitly link them to a title using `aria-labelledby` (with an `id` on the title element) to ensure screen readers correctly interpret them as focused dialogs.
+
+## 2024-04-17 - Tablist Accessibility
+
+**Learning:** Found custom tabbed interfaces (like in `BulkLabelDialog.svelte`) that were built with standard buttons but lacked proper ARIA tab roles, making them confusing for screen reader users who couldn't identify the grouped relationship or the selected state.
+**Action:** Always wrap tab groups with `role="tablist"` and `aria-label`, assign `role="tab"` and `aria-selected` to the tab buttons, and link them to their content using `role="tabpanel"`, `id`, and `aria-labelledby` to ensure the structure is correctly announced as an interactive tab list.

--- a/apps/web/src/lib/components/dialogs/BulkLabelDialog.svelte
+++ b/apps/web/src/lib/components/dialogs/BulkLabelDialog.svelte
@@ -224,8 +224,12 @@
       </div>
 
       <!-- Tabs -->
-      <div class="flex border-b border-theme-border">
+      <div class="flex border-b border-theme-border" role="tablist" aria-label="Bulk label actions">
         <button
+          role="tab"
+          aria-selected={activeTab === "apply"}
+          aria-controls="apply-label-panel"
+          id="apply-label-tab"
           class="flex-1 py-3 md:py-2 text-xs md:text-sm font-medium transition-colors {activeTab ===
           'apply'
             ? 'text-theme-primary border-b-2 border-theme-primary'
@@ -235,6 +239,10 @@
           Apply Label
         </button>
         <button
+          role="tab"
+          aria-selected={activeTab === "remove"}
+          aria-controls="remove-label-panel"
+          id="remove-label-tab"
           class="flex-1 py-3 md:py-2 text-xs md:text-sm font-medium transition-colors {activeTab ===
           'remove'
             ? 'text-theme-primary border-b-2 border-theme-primary'
@@ -248,6 +256,7 @@
       <!-- Body -->
       <div class="p-4 md:p-6 space-y-4 overflow-y-auto">
         {#if activeTab === "apply"}
+          <div role="tabpanel" id="apply-label-panel" aria-labelledby="apply-label-tab">
           <p class="text-xs md:text-sm text-theme-muted">
             Type a label name and press <kbd
               class="px-1 py-0.5 bg-theme-bg border border-theme-border rounded text-[10px] font-mono"
@@ -318,7 +327,10 @@
               Apply to all
             {/if}
           </button>
-        {:else if anyLabels.length === 0}
+          </div>
+        {:else}
+          <div role="tabpanel" id="remove-label-panel" aria-labelledby="remove-label-tab">
+          {#if anyLabels.length === 0}
           <div class="text-center py-8">
             <p class="text-sm text-theme-muted italic">
               No labels found on the selected {themeStore.resolveJargon(
@@ -327,7 +339,7 @@
               )}.
             </p>
           </div>
-        {:else}
+          {:else}
           <div class="space-y-4">
             <p class="text-xs md:text-sm text-theme-muted">
               Click a label to remove it from all selected {themeStore.resolveJargon(
@@ -363,6 +375,8 @@
                 )}. Others are present on at least one.
               </p>
             {/if}
+          </div>
+          {/if}
           </div>
         {/if}
       </div>

--- a/apps/web/src/lib/components/dialogs/BulkLabelDialog.svelte
+++ b/apps/web/src/lib/components/dialogs/BulkLabelDialog.svelte
@@ -182,6 +182,23 @@
     }
   };
 
+  const handleTabKeydown = (e: KeyboardEvent) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      activeTab = activeTab === "apply" ? "remove" : "apply";
+      const id = activeTab === "apply" ? "apply-label-tab" : "remove-label-tab";
+      document.getElementById(id)?.focus();
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      activeTab = "apply";
+      document.getElementById("apply-label-tab")?.focus();
+    } else if (e.key === "End") {
+      e.preventDefault();
+      activeTab = "remove";
+      document.getElementById("remove-label-tab")?.focus();
+    }
+  };
+
   const handleKeydown = (e: KeyboardEvent) => {
     if (e.key === "Escape") onClose();
   };
@@ -224,12 +241,19 @@
       </div>
 
       <!-- Tabs -->
-      <div class="flex border-b border-theme-border" role="tablist" aria-label="Bulk label actions">
+      <div
+        class="flex border-b border-theme-border"
+        role="tablist"
+        aria-label="Bulk label actions"
+        tabindex="0"
+        onkeydown={handleTabKeydown}
+      >
         <button
           role="tab"
           aria-selected={activeTab === "apply"}
           aria-controls="apply-label-panel"
           id="apply-label-tab"
+          tabindex={activeTab === "apply" ? 0 : -1}
           class="flex-1 py-3 md:py-2 text-xs md:text-sm font-medium transition-colors {activeTab ===
           'apply'
             ? 'text-theme-primary border-b-2 border-theme-primary'
@@ -243,6 +267,7 @@
           aria-selected={activeTab === "remove"}
           aria-controls="remove-label-panel"
           id="remove-label-tab"
+          tabindex={activeTab === "remove" ? 0 : -1}
           class="flex-1 py-3 md:py-2 text-xs md:text-sm font-medium transition-colors {activeTab ===
           'remove'
             ? 'text-theme-primary border-b-2 border-theme-primary'
@@ -254,129 +279,145 @@
       </div>
 
       <!-- Body -->
-      <div class="p-4 md:p-6 space-y-4 overflow-y-auto">
+      <div class="p-4 md:p-6 overflow-y-auto">
         {#if activeTab === "apply"}
-          <div role="tabpanel" id="apply-label-panel" aria-labelledby="apply-label-tab">
-          <p class="text-xs md:text-sm text-theme-muted">
-            Type a label name and press <kbd
-              class="px-1 py-0.5 bg-theme-bg border border-theme-border rounded text-[10px] font-mono"
-              >Enter</kbd
-            >
-            to apply it to all selected {themeStore.resolveJargon(
-              "entity",
-              entityIds.length,
-            )}.
-          </p>
-          <div class="relative">
-            <input
-              type="text"
-              bind:this={inputElement}
-              bind:value={applyInput}
-              placeholder="Label name…"
-              disabled={isLoading}
-              onkeydown={handleApplyKeydown}
-              onfocus={() => (showApplySuggestions = true)}
-              onblur={() =>
-                setTimeout(() => (showApplySuggestions = false), 150)}
-              class="w-full bg-theme-bg border border-theme-border rounded px-3 py-3 md:py-2 text-sm text-theme-text outline-none focus:border-theme-primary transition-all placeholder-theme-muted/50"
-            />
-            {#if showApplySuggestions && allSuggestions.length > 0}
-              <div
-                role="listbox"
-                class="absolute top-full left-0 mt-1 w-full bg-theme-surface border border-theme-border rounded shadow-xl z-30 overflow-hidden"
-                transition:fade={{ duration: 100 }}
-              >
-                {#if !applyInput.trim()}
-                  <div
-                    class="px-3 py-2 md:py-1.5 text-[9px] md:text-[10px] font-bold text-theme-primary uppercase tracking-widest border-b border-theme-border/50 bg-theme-primary/5"
-                  >
-                    Recent Labels
-                  </div>
-                {/if}
-                {#each allSuggestions as suggestion, i}
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={i === applySelectedIndex}
-                    onclick={() => {
-                      applyInput = suggestion;
-                      showApplySuggestions = false;
-                      applySelectedIndex = -1;
-                    }}
-                    class="w-full px-3 py-3 md:py-2 text-left text-sm transition-colors border-b border-theme-border/50 last:border-0
-                      {i === applySelectedIndex
-                      ? 'bg-theme-primary/20 text-theme-primary'
-                      : 'text-theme-muted hover:bg-theme-primary/10 hover:text-theme-primary'}"
-                  >
-                    {suggestion}
-                  </button>
-                {/each}
-              </div>
-            {/if}
-          </div>
-          <button
-            onclick={() => applyLabel(applyInput)}
-            disabled={!applyInput.trim() || isLoading}
-            class="w-full py-3 md:py-2 bg-theme-primary text-black font-bold rounded hover:bg-theme-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-all text-sm shadow-lg flex items-center justify-center gap-2"
-            aria-busy={isLoading}
+          <div
+            role="tabpanel"
+            id="apply-label-panel"
+            aria-labelledby="apply-label-tab"
+            class="space-y-4"
           >
-            {#if isLoading}
-              <span class="icon-[lucide--loader-2] w-4 h-4 animate-spin" aria-hidden="true"></span>
-              Applying…
-            {:else}
-              Apply to all
-            {/if}
-          </button>
-          </div>
-        {:else}
-          <div role="tabpanel" id="remove-label-panel" aria-labelledby="remove-label-tab">
-          {#if anyLabels.length === 0}
-          <div class="text-center py-8">
-            <p class="text-sm text-theme-muted italic">
-              No labels found on the selected {themeStore.resolveJargon(
+            <p class="text-xs md:text-sm text-theme-muted">
+              Type a label name and press <kbd
+                class="px-1 py-0.5 bg-theme-bg border border-theme-border rounded text-[10px] font-mono"
+                >Enter</kbd
+              >
+              to apply it to all selected {themeStore.resolveJargon(
                 "entity",
                 entityIds.length,
               )}.
             </p>
-          </div>
-          {:else}
-          <div class="space-y-4">
-            <p class="text-xs md:text-sm text-theme-muted">
-              Click a label to remove it from all selected {themeStore.resolveJargon(
-                "entity",
-                entityIds.length,
-              )} that have it.
-            </p>
-            <div class="flex flex-wrap gap-2">
-              {#each anyLabels as label}
-                {@const isShared = sharedLabels.includes(label)}
-                <button
-                  onclick={() => removeLabel(label)}
-                  disabled={isLoading}
-                  title={isShared
-                    ? `Remove "${label}" from all selected`
-                    : `Remove "${label}" from entities that have it`}
-                  class="inline-flex items-center gap-1 px-3 py-2 md:px-2 md:py-1 rounded text-xs font-mono border transition-colors
-                      {isShared
-                    ? 'bg-theme-primary/10 border-theme-primary/40 text-theme-primary hover:bg-red-500/20 hover:border-red-500/50 hover:text-red-400'
-                    : 'bg-theme-bg border-theme-border text-theme-muted hover:bg-red-500/20 hover:border-red-500/50 hover:text-red-400'}"
+            <div class="relative">
+              <input
+                type="text"
+                bind:this={inputElement}
+                bind:value={applyInput}
+                placeholder="Label name…"
+                disabled={isLoading}
+                onkeydown={handleApplyKeydown}
+                onfocus={() => (showApplySuggestions = true)}
+                onblur={() =>
+                  setTimeout(() => (showApplySuggestions = false), 150)}
+                class="w-full bg-theme-bg border border-theme-border rounded px-3 py-3 md:py-2 text-sm text-theme-text outline-none focus:border-theme-primary transition-all placeholder-theme-muted/50"
+              />
+              {#if showApplySuggestions && allSuggestions.length > 0}
+                <div
+                  role="listbox"
+                  class="absolute top-full left-0 mt-1 w-full bg-theme-surface border border-theme-border rounded shadow-xl z-30 overflow-hidden"
+                  transition:fade={{ duration: 100 }}
                 >
-                  {label}
-                  <span class="icon-[lucide--x] w-3 h-3"></span>
-                </button>
-              {/each}
+                  {#if !applyInput.trim()}
+                    <div
+                      class="px-3 py-2 md:py-1.5 text-[9px] md:text-[10px] font-bold text-theme-primary uppercase tracking-widest border-b border-theme-border/50 bg-theme-primary/5"
+                    >
+                      Recent Labels
+                    </div>
+                  {/if}
+                  {#each allSuggestions as suggestion, i}
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={i === applySelectedIndex}
+                      onclick={() => {
+                        applyInput = suggestion;
+                        showApplySuggestions = false;
+                        applySelectedIndex = -1;
+                      }}
+                      class="w-full px-3 py-3 md:py-2 text-left text-sm transition-colors border-b border-theme-border/50 last:border-0
+                      {i === applySelectedIndex
+                        ? 'bg-theme-primary/20 text-theme-primary'
+                        : 'text-theme-muted hover:bg-theme-primary/10 hover:text-theme-primary'}"
+                    >
+                      {suggestion}
+                    </button>
+                  {/each}
+                </div>
+              {/if}
             </div>
-            {#if sharedLabels.length < anyLabels.length}
-              <p class="text-[10px] md:text-xs text-theme-muted leading-tight">
-                <span class="text-theme-primary font-bold">Highlighted</span>
-                labels are present on all selected {themeStore.resolveJargon(
-                  "entity",
-                  entityIds.length,
-                )}. Others are present on at least one.
-              </p>
-            {/if}
+            <button
+              onclick={() => applyLabel(applyInput)}
+              disabled={!applyInput.trim() || isLoading}
+              class="w-full py-3 md:py-2 bg-theme-primary text-black font-bold rounded hover:bg-theme-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-all text-sm shadow-lg flex items-center justify-center gap-2"
+              aria-busy={isLoading}
+            >
+              {#if isLoading}
+                <span
+                  class="icon-[lucide--loader-2] w-4 h-4 animate-spin"
+                  aria-hidden="true"
+                ></span>
+                Applying…
+              {:else}
+                Apply to all
+              {/if}
+            </button>
           </div>
-          {/if}
+        {:else}
+          <div
+            role="tabpanel"
+            id="remove-label-panel"
+            aria-labelledby="remove-label-tab"
+            class="space-y-4"
+          >
+            {#if anyLabels.length === 0}
+              <div class="text-center py-8">
+                <p class="text-sm text-theme-muted italic">
+                  No labels found on the selected {themeStore.resolveJargon(
+                    "entity",
+                    entityIds.length,
+                  )}.
+                </p>
+              </div>
+            {:else}
+              <div class="space-y-4">
+                <p class="text-xs md:text-sm text-theme-muted">
+                  Click a label to remove it from all selected {themeStore.resolveJargon(
+                    "entity",
+                    entityIds.length,
+                  )} that have it.
+                </p>
+                <div class="flex flex-wrap gap-2">
+                  {#each anyLabels as label}
+                    {@const isShared = sharedLabels.includes(label)}
+                    <button
+                      onclick={() => removeLabel(label)}
+                      disabled={isLoading}
+                      title={isShared
+                        ? `Remove "${label}" from all selected`
+                        : `Remove "${label}" from entities that have it`}
+                      class="inline-flex items-center gap-1 px-3 py-2 md:px-2 md:py-1 rounded text-xs font-mono border transition-colors
+                      {isShared
+                        ? 'bg-theme-primary/10 border-theme-primary/40 text-theme-primary hover:bg-red-500/20 hover:border-red-500/50 hover:text-red-400'
+                        : 'bg-theme-bg border-theme-border text-theme-muted hover:bg-red-500/20 hover:border-red-500/50 hover:text-red-400'}"
+                    >
+                      {label}
+                      <span class="icon-[lucide--x] w-3 h-3"></span>
+                    </button>
+                  {/each}
+                </div>
+                {#if sharedLabels.length < anyLabels.length}
+                  <p
+                    class="text-[10px] md:text-xs text-theme-muted leading-tight"
+                  >
+                    <span class="text-theme-primary font-bold">Highlighted</span
+                    >
+                    labels are present on all selected {themeStore.resolveJargon(
+                      "entity",
+                      entityIds.length,
+                    )}. Others are present on at least one.
+                  </p>
+                {/if}
+              </div>
+            {/if}
           </div>
         {/if}
       </div>


### PR DESCRIPTION
💡 What: Added standard ARIA roles (`tablist`, `tab`, `tabpanel`) and linking attributes (`aria-selected`, `aria-controls`, `aria-labelledby`) to the "Apply Label" and "Remove Label" tabs in `BulkLabelDialog.svelte`.
🎯 Why: To ensure screen reader users can accurately identify the interactive tab group, understand which tab is currently active, and seamlessly navigate to the corresponding content panel.
♿ Accessibility: The previous implementation relied on visual styling of standard HTML `<button>` elements, which provided no semantic context to assistive technologies. This patch brings the custom tab interface into compliance with standard accessible web patterns.

---
*PR created automatically by Jules for task [12490331248943459948](https://jules.google.com/task/12490331248943459948) started by @eserlan*