### PR TITLE
⚡ Bolt: [performance improvement] cache map session token array

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 
 **Learning:** Returning an array from a `$derived.by` block just to be used in a template's nested `.find()` loop results in `O(N)` lookups inside an `O(M)` loop (e.g. iterating over `categories` and calling `.find()` on `typeCounts`). Additionally, converting a `Map` to an `Array` using `.map()` and `.sort()` on every reactivity update generates GC pressure for arrays whose sort order isn't actually used.
 **Action:** In Svelte 5 `$derived.by` blocks computing keyed data for `#each` loops, return the `Map` directly. Then use `.get(id)` inside the `#each` loop to turn the `O(N)` array lookup into an `O(1)` Map lookup and eliminate intermediate array allocations.
+## 2026-04-19 - [Performance Insight: Array allocation in Svelte 5 nested deriveds]
+
+**Learning:** Caching `Object.values(state)` on a class as a `$derived` property (e.g., `allTokens = $derived.by(() => Object.values(this.tokens));`) and then accessing it inside another `$derived` block (e.g., `MapView`'s `$derived.by` using `mapSession.allTokens`) avoids recursive array allocation issues and minimizes garbage collection overhead, compared to calling `Object.values(mapSession.tokens)` repeatedly within each dependent block.
+**Action:** Expose an `allX = $derived.by(() => Object.values(this.X))` property on store classes whenever `Object.values` is needed by multiple external reactive derivations, and use this cached property instead of calling `Object.values` inline.

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -168,7 +168,7 @@
     const isHost = mapStore.isGMMode;
     const peerId = mapSession.myPeerId;
     const selected = mapSession.selectedTokens;
-    const tokens = Object.values(mapSession.tokens);
+    const tokens = mapSession.allTokens;
     const result = [];
 
     // ⚡ Bolt Optimization: Replace chained .filter().map() with an imperative loop
@@ -210,7 +210,7 @@
   });
 
   $effect(() => {
-    const currentTokens = Object.values(mapSession.tokens);
+    const currentTokens = mapSession.allTokens;
     for (const token of currentTokens) {
       const source =
         token.imageUrl ||
@@ -666,7 +666,7 @@
 
     if (mapSession.vttEnabled && cachedRect) {
       const hitToken = hitTestToken(
-        Object.values(mapSession.tokens),
+        mapSession.allTokens,
         (point) => mapStore.project(point),
         lastMousePos.x,
         lastMousePos.y,
@@ -815,7 +815,7 @@
 
     if (boxSelectStart && boxSelectEnd && cachedRect) {
       // Find all tokens within the selection rectangle
-      const allTokens = Object.values(mapSession.tokens);
+      const allTokens = mapSession.allTokens;
       const x1 = Math.min(boxSelectStart.x, boxSelectEnd.x);
       const y1 = Math.min(boxSelectStart.y, boxSelectEnd.y);
       const x2 = Math.max(boxSelectStart.x, boxSelectEnd.x);
@@ -907,7 +907,7 @@
 
     if (mapSession.vttEnabled) {
       const hitToken = hitTestToken(
-        Object.values(mapSession.tokens),
+        mapSession.allTokens,
         (point) => mapStore.project(point),
         x,
         y,
@@ -985,7 +985,7 @@
     const y = e.clientY - rect.top;
 
     const hitToken = hitTestToken(
-      Object.values(mapSession.tokens),
+      mapSession.allTokens,
       (point) => mapStore.project(point),
       x,
       y,
@@ -1014,7 +1014,7 @@
       const mouseY = e.clientY - rect.top;
 
       const hitToken = hitTestToken(
-        Object.values(mapSession.tokens),
+        mapSession.allTokens,
         (point) => mapStore.project(point),
         mouseX,
         mouseY,

--- a/apps/web/src/lib/stores/map-session.svelte.ts
+++ b/apps/web/src/lib/stores/map-session.svelte.ts
@@ -134,6 +134,7 @@ export class MapSessionStore {
     { previous: Token; timeoutId: number }
   >();
 
+    allTokens = $derived.by(() => Object.values(this.tokens));
   activeTokenId = $derived(this.initiativeOrder[this.turnIndex] ?? null);
   selectedToken = $derived.by(() => {
     if (!this.selection) return null;
@@ -1217,7 +1218,7 @@ export class MapSessionStore {
     );
     let highest = 1;
 
-    for (const token of Object.values(this.tokens)) {
+    for (const token of this.allTokens) {
       const match = token.name.trim().match(pattern);
       if (!match) continue;
       const suffix = match[1] ? Number(match[1]) : 1;
@@ -1242,7 +1243,7 @@ export class MapSessionStore {
       y: source.y + offset,
       zIndex:
         Math.max(
-          ...Object.values(this.tokens).map((token) => token.zIndex),
+          ...this.allTokens.map((token) => token.zIndex),
           source.zIndex,
         ) + 1,
     };

--- a/apps/web/src/lib/stores/map-session.svelte.ts
+++ b/apps/web/src/lib/stores/map-session.svelte.ts
@@ -134,7 +134,7 @@ export class MapSessionStore {
     { previous: Token; timeoutId: number }
   >();
 
-    allTokens = $derived.by(() => Object.values(this.tokens));
+  allTokens = $derived.by(() => Object.values(this.tokens));
   activeTokenId = $derived(this.initiativeOrder[this.turnIndex] ?? null);
   selectedToken = $derived.by(() => {
     if (!this.selection) return null;


### PR DESCRIPTION
💡 What: Added a derived `allTokens` property to `MapSessionStore` to cache the result of `Object.values(this.tokens)`. Updated `MapView.svelte` to use this cached array instead of calling `Object.values(mapSession.tokens)` repeatedly in derived blocks and event handlers.
🎯 Why: `mapSession.tokens` is highly reactive. Calling `Object.values()` multiple times on this object generates numerous intermediate arrays, putting pressure on the garbage collector. This is particularly noticeable when tokens are moved or pings are triggered.
📊 Impact: Reduces GC pressure and redundant array allocations during map interactions, yielding a smoother VTT experience by optimizing the hot path during UI re-renders and hit-testing loops.
🔬 Measurement: Verify by checking memory allocation profiling during intense token movement; you should see significantly fewer array allocation spikes. Tests confirm all map functionalities and VTT hit-tests remain functionally identical.

---
*PR created automatically by Jules for task [8397375854643400314](https://jules.google.com/task/8397375854643400314) started by @eserlan*