### PR TITLE
:iphone: fix: improve mobile friendliness and reachability for Oracle chat

### DIFF
--- a/apps/web/src/lib/services/ai/client-manager.ts
+++ b/apps/web/src/lib/services/ai/client-manager.ts
@@ -220,7 +220,9 @@ export class DefaultAIClientManager {
           }
 
           const data = await response.json();
-          console.log("[OracleProxy] Received raw data:", data);
+          if (import.meta.env.DEV) {
+            console.log("[OracleProxy] Received raw data:", data);
+          }
 
           // Support for both text and image modalities by providing a safe text() helper
           // but always passing the full rawResponse for modality-specific services.
@@ -234,10 +236,12 @@ export class DefaultAIClientManager {
             .filter(Boolean)
             .join("");
 
-          console.log(
-            `[OracleProxy] Extracted text (${extractedText.length} chars):`,
-            extractedText.substring(0, 50) + "...",
-          );
+          if (import.meta.env.DEV) {
+            console.log(
+              `[OracleProxy] Extracted text (${extractedText.length} chars):`,
+              extractedText.substring(0, 50) + "...",
+            );
+          }
 
           return {
             response: {

--- a/apps/web/src/lib/services/ai/client-manager.ts
+++ b/apps/web/src/lib/services/ai/client-manager.ts
@@ -220,16 +220,29 @@ export class DefaultAIClientManager {
           }
 
           const data = await response.json();
-          console.log("[OracleProxy] Received data:", data);
+          console.log("[OracleProxy] Received raw data:", data);
 
           // Support for both text and image modalities by providing a safe text() helper
           // but always passing the full rawResponse for modality-specific services.
-          const firstPart = data.candidates?.[0]?.content?.parts?.[0];
+          const candidates = data.candidates || [];
+          const firstCandidate = candidates[0];
+          const parts = firstCandidate?.content?.parts || [];
+
+          // Join all text parts (some models might return thoughts or multiple text parts)
+          const extractedText = parts
+            .map((p: any) => p.text || "")
+            .filter(Boolean)
+            .join("");
+
+          console.log(
+            `[OracleProxy] Extracted text (${extractedText.length} chars):`,
+            extractedText.substring(0, 50) + "...",
+          );
 
           return {
             response: {
-              text: () => firstPart?.text || "",
-              candidates: data.candidates || [],
+              text: () => extractedText,
+              candidates,
             },
             rawResponse: data,
           };

--- a/packages/oracle-engine/src/chat-history.svelte.ts
+++ b/packages/oracle-engine/src/chat-history.svelte.ts
@@ -88,13 +88,19 @@ export class ChatHistoryService {
     return this.clearMessages();
   }
 
-  async updateMessage(id: string, updates: Partial<ChatMessage>) {
+  async updateMessage(
+    id: string,
+    updates: Partial<ChatMessage>,
+    persist = true,
+  ) {
     const msgIndex = this.messages.findIndex((m) => m.id === id);
     if (msgIndex !== -1) {
       this.messages[msgIndex] = { ...this.messages[msgIndex], ...updates };
       this.messages = [...this.messages];
       this.lastUpdated = Date.now();
-      await this.saveToDB();
+      if (persist) {
+        await this.saveToDB();
+      }
     }
   }
 

--- a/packages/oracle-engine/src/oracle-executor.test.ts
+++ b/packages/oracle-engine/src/oracle-executor.test.ts
@@ -441,6 +441,7 @@ describe("OracleActionExecutor - Detailed", () => {
       expect(mockContext.chatHistory.updateMessage).toHaveBeenCalledWith(
         expect.any(String),
         { content: "partial response" },
+        false,
       );
       expect(mockContext.chatHistory.messages.at(-1)?.content).toBe(
         "partial response",

--- a/packages/oracle-engine/src/oracle-executor.test.ts
+++ b/packages/oracle-engine/src/oracle-executor.test.ts
@@ -25,6 +25,17 @@ describe("OracleActionExecutor - Detailed", () => {
         addMessage: vi.fn().mockImplementation(async (msg) => {
           mockContext.chatHistory.messages.push(msg);
         }),
+        updateMessage: vi.fn().mockImplementation(async (id, updates) => {
+          const index = mockContext.chatHistory.messages.findIndex(
+            (msg: { id: string }) => msg.id === id,
+          );
+          if (index !== -1) {
+            mockContext.chatHistory.messages[index] = {
+              ...mockContext.chatHistory.messages[index],
+              ...updates,
+            };
+          }
+        }),
         clearMessages: vi.fn().mockResolvedValue(undefined),
         setMessages: vi.fn(),
         messages: [],
@@ -411,11 +422,29 @@ describe("OracleActionExecutor - Detailed", () => {
     });
 
     it("should handle text response", async () => {
+      mockGenerator.generateChatResponse.mockImplementation(
+        async (
+          _query: string,
+          _context: any,
+          onPartial: (partial: string) => void,
+        ) => {
+          onPartial("partial response");
+          return { primaryEntityId: "e1", sourceIds: ["e1"] };
+        },
+      );
+
       await executor.execute(
         { type: "chat", query: "tell me a story", isAIIntent: true },
         mockContext,
       );
 
+      expect(mockContext.chatHistory.updateMessage).toHaveBeenCalledWith(
+        expect.any(String),
+        { content: "partial response" },
+      );
+      expect(mockContext.chatHistory.messages.at(-1)?.content).toBe(
+        "partial response",
+      );
       expect(mockContext.chatHistory.setMessages).toHaveBeenCalled();
     });
   });

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -551,6 +551,14 @@ The Lore Oracle supports several slash commands to help you manage your vault:
     };
     await context.chatHistory.addMessage(assistantMsg);
 
+    const handlePartialResponse = (partial: string) => {
+      assistantMsg.content = partial;
+      void context.chatHistory.updateMessage?.(assistantMsg.id, {
+        content: partial,
+      });
+      onPartialResponse?.(partial);
+    };
+
     try {
       if (isImageRequest) {
         // Identify the primary entity to attach the image to, without triggering
@@ -593,7 +601,7 @@ The Lore Oracle supports several slash commands to help you manage your vault:
           await this.generator.generateChatResponse(
             query,
             context,
-            onPartialResponse || (() => {}),
+            handlePartialResponse,
           );
 
         // Final update with entity context

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -553,9 +553,11 @@ The Lore Oracle supports several slash commands to help you manage your vault:
 
     const handlePartialResponse = (partial: string) => {
       assistantMsg.content = partial;
-      void context.chatHistory.updateMessage?.(assistantMsg.id, {
-        content: partial,
-      });
+      void context.chatHistory.updateMessage?.(
+        assistantMsg.id,
+        { content: partial },
+        false, // skip persistence during streaming
+      );
       onPartialResponse?.(partial);
     };
 


### PR DESCRIPTION
This PR addresses mobile usability and response handling issues for the Oracle chat window and Front Page.

### Key Changes
- **Mobile Layout Fix**: Updated `SidebarPanelHost.svelte` to use `md:h-full`, allowing the panel to correctly use `top` and `bottom` constraints on mobile without overflowing the viewport.
- **Improved Reachability**: Refactored the Front Page and Oracle Chat headers/footers to better handle mobile viewports and safe-area insets (`pb-safe`, `100dvh`).
- **Robust Response Handling**: Updated `client-manager.ts` to join all AI response parts, ensuring compatibility with models that return thought blocks or multiple text segments.
- **Reactive UI Updates**: Implemented `handlePartialResponse` in the oracle engine to ensure the UI updates reactively as AI responses arrive.
- **A11y & Tests**: Visually hid the Front Page header text using `sr-only` to declutter the UI while maintaining compatibility with unit tests and screen readers.

### Verification
- Manual verification using Chrome DevTools mobile emulation (390x844).
- Verified unit tests in `FrontPage.test.ts` and `oracle-executor.test.ts` pass locally.