### PR TITLE
🎨 Palette: [UX improvement] Replace map link div with semantic button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,8 @@
 
 **Learning:** Found several full-screen or prominent overlay components (like ShareModal, MergeNodesDialog, and ConfirmationModal) that lacked proper ARIA dialog roles, making them opaque to screen readers.
 **Action:** Always wrap custom modal components with `role="dialog"`, `aria-modal="true"`, and explicitly link them to a title using `aria-labelledby` (with an `id` on the title element) to ensure screen readers correctly interpret them as focused dialogs.
+
+## 2026-04-14 - Semantic Buttons for Image Overlays
+
+**Learning:** Found instances where `<div>` elements with `onclick` handlers were used as interactive overlays on top of images (requiring `svelte-ignore` comments to bypass accessibility warnings). This practice breaks keyboard navigation and screen reader support.
+**Action:** Always replace interactive `<div>` elements with semantic `<button type="button">` elements. When using these as full-cover overlays (e.g., `absolute inset-0`), include `w-full h-full`, keyboard focus ring classes (e.g., `focus:ring-2`, `focus:outline-none`, `focus:opacity-100`), and descriptive `aria-label`s to ensure full accessibility and usability.

--- a/apps/web/src/lib/components/entity-detail/DetailMapTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailMapTab.svelte
@@ -129,10 +129,10 @@
             class="w-full h-full object-cover opacity-60 group-hover:opacity-100 transition-opacity"
           />
         {/await}
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-          class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/40 cursor-pointer"
+        <button
+          type="button"
+          class="absolute inset-0 w-full h-full flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100 focus:ring-2 focus:ring-theme-primary focus:outline-none transition-opacity bg-black/40 cursor-pointer"
+          aria-label={`Enter location: ${linkedMap.name}`}
           onclick={() => {
             mapStore.selectMap(linkedMap!.id, true);
             uiStore.closeZenMode();
@@ -144,7 +144,7 @@
           >
             Enter Location
           </span>
-        </div>
+        </button>
       </div>
     </div>
   {:else}


### PR DESCRIPTION
💡 **What:** Replaced an interactive `<div>` serving as an image overlay link with a semantic `<button>` in `DetailMapTab.svelte`, complete with proper ARIA labels and focus states.

🎯 **Why:** The previous implementation used an `onclick` handler on a `<div>` and bypassed compiler warnings with `svelte-ignore` comments. This created an accessibility trap because the element could not receive keyboard focus natively, making it impossible for keyboard-only users to navigate to the linked map. Using a semantic button restores standard web behavior.

📸 **Before/After:**
*Before:* `<div>` with `onclick`, no focus styles, invisible to screen readers, ignored by compiler.
*After:* `<button>` with `focus:ring-2`, explicit `aria-label`, visible keyboard outline, native behavior.

♿ **Accessibility:**
- Restored keyboard navigation by using a semantic `<button>`.
- Added `focus:opacity-100`, `focus:ring-2`, and `focus:outline-none` so keyboard users receive visual feedback when the element is focused.
- Added `aria-label="Enter location: {linkedMap.name}"` to provide clear context for screen reader users.

---
*PR created automatically by Jules for task [8326779769402459311](https://jules.google.com/task/8326779769402459311) started by @eserlan*