### PR TITLE
⚡ Bolt: [performance improvement] map session initiative entries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 
 **Learning:** Returning an array from a `$derived.by` block just to be used in a template's nested `.find()` loop results in `O(N)` lookups inside an `O(M)` loop (e.g. iterating over `categories` and calling `.find()` on `typeCounts`). Additionally, converting a `Map` to an `Array` using `.map()` and `.sort()` on every reactivity update generates GC pressure for arrays whose sort order isn't actually used.
 **Action:** In Svelte 5 `$derived.by` blocks computing keyed data for `#each` loops, return the `Map` directly. Then use `.get(id)` inside the `#each` loop to turn the `O(N)` array lookup into an `O(1)` Map lookup and eliminate intermediate array allocations.
+## 2026-04-20 - [Performance Insight: O(N²) scaling in chained array methods]
+
+**Learning:** When using `.map()` to transform an array and simultaneously referencing the current element's index via an external `indexOf` lookup (e.g., `this.initiativeOrder.indexOf(tokenId)`), the overall operation silently scales to O(N²). This happens because `indexOf` is O(N) and executes once per element in the O(N) map.
+**Action:** Replace the chained `.map().filter()` containing the `indexOf` lookup with a single imperative `for` loop, utilizing the loop index directly (e.g., `for (let i = 0; i < len; i++)`) to achieve an O(N) transformation and eliminate unnecessary intermediate array allocation.

--- a/apps/web/src/lib/stores/map-session.svelte.ts
+++ b/apps/web/src/lib/stores/map-session.svelte.ts
@@ -140,21 +140,26 @@ export class MapSessionStore {
     return this.tokens[this.selection] ?? null;
   });
   initiativeEntries = $derived.by(() => {
-    return this.initiativeOrder
-      .map((tokenId): InitiativeEntry | null => {
-        const token = this.tokens[tokenId];
-        if (!token) return null;
-        return {
+    const entries: InitiativeEntry[] = [];
+    const orderLength = this.initiativeOrder.length;
+    // ⚡ Bolt Optimization: Replace chained .map().filter() with an imperative loop
+    // to prevent intermediate array allocations and reduce GC pressure during highly reactive VTT updates.
+    for (let i = 0; i < orderLength; i++) {
+      const tokenId = this.initiativeOrder[i];
+      const token = this.tokens[tokenId];
+      if (token) {
+        entries.push({
           tokenId,
           initiativeValue: this.initiativeValues[tokenId] ?? 0,
           hasActed:
             this.mode === "combat" &&
             this.activeTokenId !== null &&
             this.activeTokenId !== tokenId &&
-            this.turnIndex > this.initiativeOrder.indexOf(tokenId),
-        };
-      })
-      .filter((entry): entry is InitiativeEntry => entry !== null);
+            this.turnIndex > i,
+        });
+      }
+    }
+    return entries;
   });
 
   constructor(private deps: MapSessionDependencies) {


### PR DESCRIPTION
💡 What: Optimized the computation of `initiativeEntries` in `MapSessionStore`. The chained array `.map().filter()` operations inside a `$derived.by` block were replaced with a single imperative loop.
🎯 Why: The original `.map()` operation implicitly used an `indexOf()` lookup on the original array (`this.initiativeOrder.indexOf(tokenId)`), making the computation O(N²). Additionally, the `.map().filter()` chain created unnecessary intermediate array allocations, increasing garbage collection (GC) pressure inside a highly reactive path. This optimization drops the time complexity to O(N) by utilizing the iterative loop index variable and limits GC overhead.
📊 Impact: Eliminates O(N²) scaling issue in the reactive initialization order updates, preventing performance degradation in heavy map scenes. Prevents continuous intermediate array allocations on every store update.
🔬 Measurement: Validated existing `map-session.test.ts` test suites.

---
*PR created automatically by Jules for task [9904327233725763663](https://jules.google.com/task/9904327233725763663) started by @eserlan*