### PR TITLE
💄 feat: more compact zen mode (#657)

### DIFF
--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -100,12 +100,12 @@
   style="background-image: var(--bg-texture-overlay)"
   data-testid="zen-content"
 >
-  <div class="max-w-3xl mx-auto space-y-8">
+  <div class="max-w-3xl mx-auto space-y-6">
     <!-- Temporal Data -->
     {#if editState.isEditing}
       <div class="bg-theme-surface p-4 rounded border border-theme-border">
         <h3
-          class="text-xs font-bold text-theme-secondary uppercase font-header tracking-widest mb-4"
+          class="text-xs font-bold text-theme-secondary uppercase font-header tracking-widest mb-3"
         >
           Timeline Configuration
         </h3>
@@ -161,7 +161,7 @@
     {#if editState.isEditing || isVisible}
       <div>
         <h2
-          class="text-xl font-header font-bold text-theme-primary mb-4 flex items-center gap-2 border-b border-theme-border pb-2"
+          class="text-xl font-header font-bold text-theme-primary mb-2 flex items-center gap-2 border-b border-theme-border pb-2"
         >
           <span class="icon-[lucide--book-open] w-5 h-5"></span>
           {themeStore.jargon.chronicle_header}
@@ -193,7 +193,7 @@
     {#if !vault.isGuest && (editState.isEditing || entity?.lore)}
       <div>
         <h2
-          class="text-xl font-header font-bold text-theme-primary mb-4 flex items-center gap-2 border-b border-theme-border pb-2"
+          class="text-xl font-header font-bold text-theme-primary mb-2 flex items-center gap-2 border-b border-theme-border pb-2"
         >
           <span class="icon-[lucide--scroll-text] w-5 h-5"></span>
           {themeStore.jargon.lore_header}
@@ -218,7 +218,7 @@
     {#if showConnections}
       <div>
         <h2
-          class="text-xl font-header font-bold text-theme-primary mb-4 flex items-center gap-2 border-b border-theme-border pb-2"
+          class="text-xl font-header font-bold text-theme-primary mb-3 flex items-center gap-2 border-b border-theme-border pb-2"
         >
           <span class="icon-[lucide--link-2] w-5 h-5"></span>
           {themeStore.jargon.connections_header}

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -96,11 +96,11 @@
 
 <div
   bind:this={scrollContainer}
-  class="flex-1 p-6 md:p-8 md:overflow-y-auto custom-scrollbar bg-theme-bg"
+  class="flex-1 p-4 md:p-6 md:overflow-y-auto custom-scrollbar bg-theme-bg"
   style="background-image: var(--bg-texture-overlay)"
   data-testid="zen-content"
 >
-  <div class="max-w-3xl mx-auto space-y-12">
+  <div class="max-w-3xl mx-auto space-y-8">
     <!-- Temporal Data -->
     {#if editState.isEditing}
       <div class="bg-theme-surface p-4 rounded border border-theme-border">

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -31,7 +31,7 @@
 
 <header
   style="background-image: var(--bg-texture-overlay)"
-  class="px-4 md:px-6 py-4 border-b border-theme-border bg-theme-surface flex justify-between items-start shrink-0"
+  class="px-4 md:px-6 py-2 md:py-3 border-b border-theme-border bg-theme-surface flex justify-between items-start shrink-0"
   data-testid="zen-header"
 >
   <div class="flex-1 mr-4 md:mr-8">

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -89,11 +89,11 @@
 
 <div
   style="background-image: var(--bg-texture-overlay)"
-  class="w-full md:w-80 lg:w-96 md:border-r border-theme-border p-6 md:overflow-y-auto custom-scrollbar bg-theme-surface shrink-0"
+  class="w-full md:w-80 lg:w-96 md:border-r border-theme-border p-4 md:p-5 md:overflow-y-auto custom-scrollbar bg-theme-surface shrink-0"
   data-testid="zen-sidebar"
 >
   <!-- Labels -->
-  <div class="mb-6 space-y-2">
+  <div class="mb-4 space-y-2">
     {#if entity?.labels?.length}
       <div class="flex flex-wrap gap-1.5">
         {#each entity.labels as label}
@@ -118,7 +118,7 @@
   </div>
 
   <!-- Image -->
-  <div class="mb-6">
+  <div class="mb-4">
     {#if !isVisible && vault.isGuest}
       <div
         class="w-full py-2 md:py-4 md:aspect-square rounded-lg border border-dashed border-theme-border flex flex-col items-center justify-center gap-2 md:gap-4 text-theme-muted bg-theme-primary/5 relative overflow-hidden"
@@ -219,10 +219,10 @@
   </div>
 
   <!-- Sidebar Content (Desktop) -->
-  <div class="hidden md:block space-y-6">
+  <div class="hidden md:block space-y-4">
     {#if !(isPopout && vault.isGuest)}
       <div
-        class="space-y-4 pt-8 border-t border-theme-border md:border-t-0 md:pt-0"
+        class="space-y-4 pt-6 border-t border-theme-border md:border-t-0 md:pt-0"
       >
         <h3
           class="text-xs font-bold text-theme-secondary uppercase font-header tracking-widest border-b border-theme-border pb-2"
@@ -266,7 +266,7 @@
     {/if}
 
     {#if editState.isEditing && !vault.isGuest}
-      <div class="mt-8 pt-8 border-t border-theme-border">
+      <div class="mt-6 pt-6 border-t border-theme-border">
         <button
           onclick={onDelete}
           class="w-full border border-red-900/30 text-red-800 hover:text-red-500 hover:border-red-600 hover:bg-red-950/30 text-xs font-bold px-4 py-2 rounded tracking-widest transition flex items-center justify-center gap-2"

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -253,7 +253,7 @@
       role="tablist"
       aria-label="Entity Sections"
       style="background-image: var(--bg-texture-overlay)"
-      class="flex gap-4 md:gap-8 px-4 md:px-8 border-b border-theme-border bg-theme-surface shrink-0 overflow-x-auto no-scrollbar"
+      class="flex gap-4 md:gap-6 px-4 md:px-6 border-b border-theme-border bg-theme-surface shrink-0 overflow-x-auto no-scrollbar"
     >
       <button
         bind:this={tabOverview}
@@ -262,7 +262,7 @@
         aria-selected={activeTab === "overview"}
         aria-controls="panel-overview"
         tabindex={activeTab === "overview" ? 0 : -1}
-        class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
+        class="py-2 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
         'overview'
           ? 'text-theme-primary border-theme-primary'
           : 'text-theme-muted border-transparent hover:text-theme-text'}"
@@ -279,7 +279,7 @@
           aria-selected={activeTab === "inventory"}
           aria-controls="panel-inventory"
           tabindex={activeTab === "inventory" ? 0 : -1}
-          class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
+          class="py-2 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
           'inventory'
             ? 'text-theme-primary border-theme-primary'
             : 'text-theme-muted border-transparent hover:text-theme-text'}"
@@ -295,7 +295,7 @@
           aria-selected={activeTab === "map"}
           aria-controls="panel-map"
           tabindex={activeTab === "map" ? 0 : -1}
-          class="py-3 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
+          class="py-2 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
           'map'
             ? 'text-theme-primary border-theme-primary'
             : 'text-theme-muted border-transparent hover:text-theme-text'}"


### PR DESCRIPTION
This PR implements a more compact Zen mode by reducing vertical and horizontal spacing across core components:

- **ZenHeader**: Vertical padding reduced (py-4 → py-2 md:py-3).
- **ZenSidebar**: Outer padding (p-6 → p-4 md:p-5) and vertical spacing (space-y-6 → space-y-4) reduced.
- **ZenContent**: Section spacing (space-y-12 → space-y-8) and outer padding (p-8 → p-6) reduced.
- **ZenView**: Navigation tabs condensed (gap-8 → gap-6, py-3 → py-2).

Fixes #657