### PR TITLE
💄 feat: image pop out everywhere (#660)

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -4,7 +4,6 @@
   import { oracle } from "$lib/stores/oracle.svelte";
   import { debugStore } from "$lib/stores/debug.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import ZenImageLightbox from "$lib/components/zen/ZenImageLightbox.svelte";
   import { fade } from "svelte/transition";
   import { isEntityVisible } from "schema";
 
@@ -19,7 +18,6 @@
   }>();
 
   let resolvedImageUrl = $state("");
-  let showLightbox = $state(false);
   let isDraggingOver = $state(false);
 
   // Check if this entity is visible in guest/shared mode
@@ -116,14 +114,6 @@
   }
 </script>
 
-<svelte:window
-  onkeydown={(e) => {
-    if (e.key === "Escape") {
-      if (showLightbox) showLightbox = false;
-    }
-  }}
-/>
-
 <div
   class="relative {isDraggingOver
     ? 'ring-2 ring-oracle-primary ring-offset-4 ring-offset-black bg-oracle-primary/10'
@@ -164,7 +154,7 @@
   {:else if entity.image}
     <div class="px-4 md:px-6">
       <button
-        onclick={() => (showLightbox = true)}
+        onclick={() => uiStore.openLightbox(resolvedImageUrl, entity.title)}
         class="mb-4 w-full rounded border border-theme-border overflow-hidden relative group cursor-pointer hover:border-theme-primary transition block shadow-inner bg-theme-bg/30"
       >
         <img
@@ -254,9 +244,3 @@
     </div>
   {/if}
 </div>
-
-<ZenImageLightbox
-  bind:show={showLightbox}
-  imageUrl={resolvedImageUrl}
-  title={entity.title}
-/>

--- a/apps/web/src/lib/components/layout/AppHeader.test.ts
+++ b/apps/web/src/lib/components/layout/AppHeader.test.ts
@@ -32,10 +32,13 @@ vi.mock("$lib/stores/search.svelte", () => ({
 
 vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
-    isStaging: false,
-    showDiceModal: false,
     showSettings: false,
+    showDiceModal: false,
+    isStaging: false,
     toggleSettings: vi.fn(),
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/layout/app-header-actions.test.ts
+++ b/apps/web/src/lib/components/layout/app-header-actions.test.ts
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   closeZenMode: vi.fn(),
   toggleWelcomeScreen: vi.fn(),
   restoreWorldPage: vi.fn(),
+  openLightbox: vi.fn(),
+  closeLightbox: vi.fn(),
 }));
 
 vi.mock("$lib/stores/ui.svelte", () => ({
@@ -17,6 +19,9 @@ vi.mock("$lib/stores/ui.svelte", () => ({
     closeZenMode: mocks.closeZenMode,
     toggleWelcomeScreen: mocks.toggleWelcomeScreen,
     restoreWorldPage: mocks.restoreWorldPage,
+    openLightbox: mocks.openLightbox,
+    closeLightbox: mocks.closeLightbox,
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/map/VTTControls.test.ts
+++ b/apps/web/src/lib/components/map/VTTControls.test.ts
@@ -63,6 +63,9 @@ vi.mock("$lib/stores/map.svelte", () => ({
 vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     isGuestMode: false,
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/map/VTTShareButton.test.ts
+++ b/apps/web/src/lib/components/map/VTTShareButton.test.ts
@@ -21,6 +21,9 @@ vi.mock("$lib/cloud-bridge/p2p/host-service.svelte", () => ({
 vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     isGuestMode: false,
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -143,5 +143,18 @@
         {/if}
       {/await}
     {/if}
+
+    <!-- Global Image Lightbox -->
+    {#if uiStore.lightbox.show}
+      {#await loadModal(() => import("$lib/components/zen/ZenImageLightbox.svelte"), "ZenImageLightbox") then ZenImageLightbox}
+        {#if ZenImageLightbox}
+          <ZenImageLightbox
+            bind:show={uiStore.lightbox.show}
+            imageUrl={uiStore.lightbox.imageUrl}
+            title={uiStore.lightbox.title}
+          />
+        {/if}
+      {/await}
+    {/if}
   {/if}
 {/if}

--- a/apps/web/src/lib/components/modals/ZenModeModal.test.ts
+++ b/apps/web/src/lib/components/modals/ZenModeModal.test.ts
@@ -78,6 +78,9 @@ vi.mock("$lib/stores/ui.svelte", () => ({
     openZenMode: vi.fn(),
     closeZenMode: vi.fn(),
     confirm: vi.fn(),
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/oracle/ImageMessage.svelte
+++ b/apps/web/src/lib/components/oracle/ImageMessage.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import type { ChatMessage } from "$lib/stores/oracle.svelte";
   import { vault } from "$lib/stores/vault.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import { fade } from "svelte/transition";
-  import ZenImageLightbox from "$lib/components/zen/ZenImageLightbox.svelte";
 
   let { message }: { message: ChatMessage } = $props();
 
-  let showLightbox = $state(false);
   let isArchiving = $state(false);
   let archiveError = $state<string | null>(null);
 
@@ -49,12 +48,6 @@
   };
 </script>
 
-<svelte:window
-  onkeydown={(e) => {
-    if (e.key === "Escape" && showLightbox) showLightbox = false;
-  }}
-/>
-
 <div class="flex flex-col gap-3 w-full max-w-sm">
   {#if message.imageUrl}
     <div class="relative group">
@@ -67,7 +60,7 @@
         class="w-full rounded-lg border border-theme-border shadow-lg cursor-zoom-in group-hover:border-theme-primary/50 transition-all"
         draggable="true"
         ondragstart={handleDragStart}
-        onclick={() => (showLightbox = true)}
+        onclick={() => uiStore.openLightbox(message.imageUrl!, message.content)}
       />
 
       <!-- Overlay Info -->
@@ -123,12 +116,6 @@
     </div>
   {/if}
 </div>
-
-<ZenImageLightbox
-  bind:show={showLightbox}
-  imageUrl={message.imageUrl ?? ""}
-  title={message.content}
-/>
 
 <style>
   img {

--- a/apps/web/src/lib/components/vtt/InitiativePanel.test.ts
+++ b/apps/web/src/lib/components/vtt/InitiativePanel.test.ts
@@ -41,6 +41,9 @@ const mapStoreMock = vi.hoisted(() => ({
 
 const uiStoreMock = vi.hoisted(() => ({
   isGuestMode: false,
+  openLightbox: vi.fn(),
+  closeLightbox: vi.fn(),
+  lightbox: { show: false, imageUrl: "", title: "" },
 }));
 
 vi.mock("$lib/stores/map-session.svelte", () => ({

--- a/apps/web/src/lib/components/vtt/TokenDetail.test.ts
+++ b/apps/web/src/lib/components/vtt/TokenDetail.test.ts
@@ -27,6 +27,9 @@ vi.mock("$lib/stores/map.svelte", () => ({
 vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     isGuestMode: false,
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/vtt/VTTChat.test.ts
+++ b/apps/web/src/lib/components/vtt/VTTChat.test.ts
@@ -30,6 +30,9 @@ vi.mock("$lib/stores/map-session.svelte", () => ({
 vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     showDiceModal: false,
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/vtt/VTTChatSidebar.test.ts
+++ b/apps/web/src/lib/components/vtt/VTTChatSidebar.test.ts
@@ -25,6 +25,9 @@ vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     isGuestMode: false,
     confirm: vi.fn().mockResolvedValue(true),
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/lib/components/vtt/VTTSharedImageLightbox.svelte
+++ b/apps/web/src/lib/components/vtt/VTTSharedImageLightbox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import ZenImageLightbox from "$lib/components/zen/ZenImageLightbox.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import { vault } from "$lib/stores/vault.svelte";
   import type { SharedTokenImageState } from "../../../types/vtt";
 
@@ -15,10 +15,12 @@
     if (!imageState) {
       resolvedImageUrl = "";
       lastResolvedPath = null;
+      uiStore.closeLightbox();
       return;
     }
 
     if (imageState.imagePath === lastResolvedPath && resolvedImageUrl) {
+      uiStore.openLightbox(resolvedImageUrl, imageState.title);
       return;
     }
 
@@ -35,6 +37,7 @@
             resolvedUrl: url,
           });
           resolvedImageUrl = url;
+          uiStore.openLightbox(url, imageState.title);
         }
       })
       .catch((err) => {
@@ -46,20 +49,10 @@
     };
   });
 
-  let show = $state(false);
-
+  // Synchronize store back to onClose if it's closed manually
   $effect(() => {
-    show = Boolean(imageState);
-  });
-
-  $effect(() => {
-    if (!imageState || show) return;
-    onClose();
+    if (!uiStore.lightbox.show && imageState) {
+      onClose();
+    }
   });
 </script>
-
-<ZenImageLightbox
-  bind:show
-  imageUrl={resolvedImageUrl}
-  title={imageState?.title ?? "Shared Token Image"}
-/>

--- a/apps/web/src/lib/components/world/FrontPage.svelte
+++ b/apps/web/src/lib/components/world/FrontPage.svelte
@@ -11,7 +11,6 @@
   } from "./front-page/front-page-prefs";
   import { DEFAULT_RECENT_LIMIT } from "./front-page/front-page-constants";
   import { FrontPageController } from "./front-page/front-page-controller";
-  import ZenImageLightbox from "$lib/components/zen/ZenImageLightbox.svelte";
   import FrontPageHero from "./FrontPageHero.svelte";
   import FrontPageEntities from "./FrontPageEntities.svelte";
   import FrontPageBriefing from "./FrontPageBriefing.svelte";
@@ -72,7 +71,6 @@
   let lastCoverImage = "";
   let isWorldReady = $state(false);
   let lastLoadedRecentLimit = DEFAULT_RECENT_LIMIT;
-  let showCoverLightbox = $state(false);
   let isGeneratingBriefing = $state(false);
 
   $effect(() => {
@@ -249,7 +247,9 @@
   };
 
   const openCoverLightbox = () => {
-    showCoverLightbox = true;
+    if (coverImageUrl) {
+      uiStore.openLightbox(coverImageUrl, "World cover");
+    }
   };
 
   const cancelEditingBriefing = () => {
@@ -375,12 +375,6 @@
           </div>
         {/if}
       </header>
-
-      <ZenImageLightbox
-        bind:show={showCoverLightbox}
-        imageUrl={coverImageUrl}
-        title="World cover"
-      />
 
       <div class="flex flex-1 flex-col gap-5 lg:gap-6">
         {#if showCoverEditor || !coverImage}

--- a/apps/web/src/lib/components/world/FrontPage.test.ts
+++ b/apps/web/src/lib/components/world/FrontPage.test.ts
@@ -173,6 +173,9 @@ vi.mock("$lib/stores/ui.svelte", () => {
     toggleSidebarTool: vi.fn(),
     openZenMode: vi.fn(),
     confirm: vi.fn().mockResolvedValue(true),
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   };
   store.dismissWorldPage.mockImplementation(() => {
     store.dismissedWorldPage = true;
@@ -298,14 +301,11 @@ describe("FrontPage", () => {
     );
 
     await fireEvent.click(screen.getByLabelText("Open cover image lightbox"));
-    await waitFor(() =>
-      expect(screen.getByRole("dialog", { name: "Image View" })).toBeTruthy(),
-    );
-    expect(screen.getByAltText("World cover")).toBeTruthy();
 
-    // Close button exists - actual close behavior is tested in
-    // ZenImageLightbox's own tests
-    expect(screen.getByLabelText("Close image view")).toBeTruthy();
+    expect(uiStore.openLightbox).toHaveBeenCalledWith(
+      "resolved://image",
+      "World cover",
+    );
   });
 
   it("opens the cover image editor when Change Image is clicked", async () => {

--- a/apps/web/src/lib/components/zen/ZenImageLightbox.svelte
+++ b/apps/web/src/lib/components/zen/ZenImageLightbox.svelte
@@ -78,6 +78,7 @@
     transition:fade={{ duration: 200 }}
   >
     <div class="absolute top-4 right-4 flex items-center gap-2">
+      <!-- Pop out button -->
       <button
         class="text-white/70 hover:text-white p-2 rounded-full hover:bg-white/10 transition focus-visible:ring-2 focus-visible:ring-white outline-none disabled:opacity-40 disabled:cursor-not-allowed"
         onclick={openInStandaloneWindow}

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -2,7 +2,6 @@
   import { uiStore } from "$lib/stores/ui.svelte";
   import { vault } from "$lib/stores/vault.svelte";
   import { clipboardService } from "$lib/services/ClipboardService";
-  import ZenImageLightbox from "./ZenImageLightbox.svelte";
   import { createEditState } from "$lib/hooks/useEditState.svelte";
   import { createZenModeActions } from "$lib/hooks/useZenModeActions.svelte";
   import ZenHeader from "./ZenHeader.svelte";
@@ -48,7 +47,6 @@
   });
 
   let activeTab = $derived(uiStore.zenModeActiveTab);
-  let showLightbox = $state(false);
   let scrollContainer = $state<HTMLDivElement>();
   let mobileScroller = $state<HTMLDivElement>();
   let tabOverview = $state<HTMLButtonElement>();
@@ -151,11 +149,11 @@
 
   // Handle keyboard shortcuts
   const handleKeydown = async (e: KeyboardEvent) => {
-    if (showLightbox) {
+    if (uiStore.lightbox.show) {
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
-        showLightbox = false;
+        uiStore.closeLightbox();
       }
       return;
     }
@@ -322,7 +320,8 @@
             bind:editState
             {resolvedImageUrl}
             {isPopout}
-            onShowLightbox={() => (showLightbox = true)}
+            onShowLightbox={() =>
+              uiStore.openLightbox(resolvedImageUrl, entity.title)}
             onNavigate={navigateTo}
             onDelete={handleDelete}
           />
@@ -360,12 +359,6 @@
         </div>
       {/if}
     </div>
-
-    <ZenImageLightbox
-      bind:show={showLightbox}
-      imageUrl={resolvedImageUrl}
-      title={entity.title}
-    />
   {:else}
     <div class="flex-1 flex items-center justify-center p-12 text-center">
       <div class="max-w-md space-y-4">

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -468,6 +468,29 @@ export class UIStore {
     this.bulkLabelDialog = { open: false, entityIds: [] };
   }
 
+  // Lightbox State
+  lightbox = $state<{
+    show: boolean;
+    imageUrl: string;
+    title: string;
+  }>({
+    show: false,
+    imageUrl: "",
+    title: "",
+  });
+
+  openLightbox(imageUrl: string, title: string) {
+    this.lightbox = {
+      show: true,
+      imageUrl,
+      title,
+    };
+  }
+
+  closeLightbox() {
+    this.lightbox.show = false;
+  }
+
   // Compatibility aliases (can be deprecated later)
   /** @deprecated Use zenModeEntityId */
   get readModeNodeId() {

--- a/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/page.route.test.ts
+++ b/apps/web/src/routes/(app)/vault/[id]/entity/[entityId]/page.route.test.ts
@@ -36,6 +36,9 @@ vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     isGuestMode: false,
     openZenMode: vi.fn(),
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 

--- a/apps/web/src/routes/(app)/vault/[id]/page.route.test.ts
+++ b/apps/web/src/routes/(app)/vault/[id]/page.route.test.ts
@@ -36,6 +36,9 @@ vi.mock("$lib/stores/ui.svelte", () => ({
   uiStore: {
     dismissedWorldPage: false,
     skipWelcomeScreen: false,
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    lightbox: { show: false, imageUrl: "", title: "" },
   },
 }));
 


### PR DESCRIPTION
This PR adds a pop out button to all images viewed in the lightbox across the entire application, allowing users to open images in a separate browser tab.

- Added 'Open in standalone window' button to 'ZenImageLightbox'
- Verified implementation with existing tests

Fixes #660