### PR TITLE
✨ feat: graph layout improvements — circles, clustering, filled nodes (#655)

### DIFF
--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -15,6 +15,7 @@
       isInitial?: boolean,
       isForced?: boolean,
       caller?: string,
+      randomizeForced?: boolean,
     ) => Promise<void>;
     selectedCount: number;
   }>();

--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -197,7 +197,7 @@
         {/if}
         <button
           class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
-          onclick={() => onApplyLayout(false, true, "UI Redraw Button")}
+          onclick={() => onApplyLayout(false, true, "UI Redraw Button", true)}
           title="Redraw Layout"
           aria-label="Redraw Layout"
           ><span

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -161,6 +161,46 @@ describe("LayoutManager", () => {
     expect(layoutCall.gravity).toBeGreaterThan(0.1);
   });
 
+  it("should not randomize when stableLayout is on, even with randomizeForced", async () => {
+    await layoutManager.apply(
+      {
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: true,
+        isGuest: false,
+      },
+      false,
+      true,
+      "UI Redraw Button",
+      true,
+    );
+    const layoutCall = mockCy.layout.mock.calls[0][0];
+    expect(layoutCall.randomize).toBe(false);
+  });
+
+  it("should randomize when stableLayout is off and randomizeForced is true", async () => {
+    await layoutManager.apply(
+      {
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: false,
+        isGuest: false,
+      },
+      false,
+      true,
+      "UI Redraw Button",
+      true,
+    );
+    const layoutCall = mockCy.layout.mock.calls[0][0];
+    expect(layoutCall.randomize).toBe(true);
+  });
+
   it("should call resize on apply", async () => {
     await layoutManager.apply({
       timelineMode: false,

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -121,7 +121,7 @@ describe("LayoutManager", () => {
     });
 
     const layoutCall = mockCy.layout.mock.calls[0][0];
-    expect(layoutCall.gravity).toBeLessThanOrEqual(0.1);
+    expect(layoutCall.gravity).toBeLessThanOrEqual(0.35);
   });
 
   it("should use higher gravity in portrait view", async () => {

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -202,12 +202,12 @@ export class LayoutManager {
 
     const baseOptions = getDynamicLayoutOptions(cyNodes.length);
 
-    // Cap gravity based on aspect ratio to avoid excessive clumping
-    // Landscape: use a lower max gravity to allow horizontal spread
-    // Portrait: allow a slightly higher max to reduce extreme vertical drift
+    // Cap gravity based on aspect ratio
+    // Landscape: allow stronger gravity for the circular pull but cap extreme values
+    // Portrait: allow a bit more to counteract vertical drift
     const gravity = isLandscape
-      ? Math.min(baseOptions.gravity, 0.1)
-      : Math.min(baseOptions.gravity, 0.4);
+      ? Math.min(baseOptions.gravity, 0.35)
+      : Math.min(baseOptions.gravity, 0.5);
 
     const shouldRandomize = randomize || (isForced && randomizeForced);
 

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -209,7 +209,9 @@ export class LayoutManager {
       ? Math.min(baseOptions.gravity, 0.35)
       : Math.min(baseOptions.gravity, 0.5);
 
-    const shouldRandomize = randomize || (isForced && randomizeForced);
+    // Don't randomize if the user has explicitly locked positions via stableLayout
+    const shouldRandomize =
+      randomize || (isForced && randomizeForced && !options.stableLayout);
 
     this.currentLayout = this.cy.layout({
       ...baseOptions,

--- a/packages/graph-engine/src/defaults.test.ts
+++ b/packages/graph-engine/src/defaults.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { getDynamicLayoutOptions } from "./defaults";
+
+describe("getDynamicLayoutOptions", () => {
+  it("returns higher gravity for smaller graphs", () => {
+    const small = getDynamicLayoutOptions(50);
+    const large = getDynamicLayoutOptions(300);
+    expect(small.gravity).toBeGreaterThan(large.gravity);
+  });
+
+  it("gravity never falls below minimum floor", () => {
+    expect(getDynamicLayoutOptions(1000).gravity).toBeGreaterThanOrEqual(0.08);
+  });
+
+  it("gravity never exceeds base cap", () => {
+    expect(getDynamicLayoutOptions(1).gravity).toBeLessThanOrEqual(0.4);
+  });
+
+  it("repulsion scales with node count", () => {
+    const small = getDynamicLayoutOptions(50);
+    const large = getDynamicLayoutOptions(300);
+    expect(large.nodeRepulsion).toBeGreaterThan(small.nodeRepulsion);
+  });
+
+  it("repulsion is capped at 130000", () => {
+    expect(getDynamicLayoutOptions(10000).nodeRepulsion).toBe(130000);
+  });
+
+  it("uses draft quality for graphs over 500 nodes", () => {
+    expect(getDynamicLayoutOptions(501).quality).toBe("draft");
+    expect(getDynamicLayoutOptions(499).quality).toBe("default");
+  });
+
+  it("separation and edgeLength scale with node count", () => {
+    const small = getDynamicLayoutOptions(50);
+    const large = getDynamicLayoutOptions(300);
+    expect(large.nodeSeparation).toBeGreaterThan(small.nodeSeparation);
+    expect(large.idealEdgeLength).toBeGreaterThan(small.idealEdgeLength);
+  });
+});

--- a/packages/graph-engine/src/defaults.ts
+++ b/packages/graph-engine/src/defaults.ts
@@ -6,34 +6,35 @@ export const DEFAULT_LAYOUT_OPTIONS = {
   randomize: true,
   packComponents: true,
   tile: true,
-  tilingPaddingVertical: 100,
-  tilingPaddingHorizontal: 100,
-  gravity: 0.1,
-  nodeRepulsion: 35000, // Increased baseline repulsion to reduce overlap in dense areas
-  idealEdgeLength: 80, // Tighter from 120
-  nodeSeparation: 80, // Tighter from 120
-  numIter: 3500, // Balanced iterations for speed/quality
-  nodeDimensionsIncludeLabels: true, // Essential for large entity cards to prevent overlap
-  nestingReprGrpFactor: 1.2, // Default value is more stable
+  tilingPaddingVertical: 60,
+  tilingPaddingHorizontal: 60,
+  gravity: 0.25,
+  nodeRepulsion: 18000,
+  idealEdgeLength: 55,
+  nodeSeparation: 55,
+  numIter: 3500,
+  nodeDimensionsIncludeLabels: true,
+  nestingReprGrpFactor: 1.2,
   initialEnergyOnIncremental: 0.3,
 };
 
 /**
  * Generates layout options tuned for the specific size of the graph.
+ * Targets an Obsidian-like layout: stronger gravity pulls the graph into a
+ * cohesive circular shape while moderate repulsion still lets clusters form.
  */
 export const getDynamicLayoutOptions = (nodeCount: number) => {
-  // Always use 'default' quality unless it's a massive graph (> 500 nodes)
   const quality = nodeCount > 500 ? "draft" : "default";
 
-  // Scale repulsion significantly to prevent clumping in dense areas
-  const repulsion = Math.min(200000, 35000 + nodeCount * 400);
+  // Moderate repulsion — enough to prevent overlap without blowing clusters apart
+  const repulsion = Math.min(130000, 18000 + nodeCount * 250);
 
-  // Increase separation and edge length to give large cards room
-  const separation = Math.min(300, 80 + Math.sqrt(nodeCount) * 10);
-  const edgeLength = Math.min(250, 80 + Math.sqrt(nodeCount) * 8);
+  // Tighter separation and edge length so connected nodes cluster visibly
+  const separation = Math.min(220, 55 + Math.sqrt(nodeCount) * 8);
+  const edgeLength = Math.min(180, 55 + Math.sqrt(nodeCount) * 6);
 
-  // Very light gravity to prevent the "hairball" effect
-  const gravity = Math.max(0.01, 0.15 - nodeCount * 0.0003);
+  // Stronger gravity creates the characteristic circular pull toward the center
+  const gravity = Math.max(0.08, 0.4 - nodeCount * 0.001);
 
   return {
     ...DEFAULT_LAYOUT_OPTIONS,

--- a/packages/graph-engine/src/defaults.ts
+++ b/packages/graph-engine/src/defaults.ts
@@ -8,6 +8,7 @@ export const DEFAULT_LAYOUT_OPTIONS = {
   tile: true,
   tilingPaddingVertical: 60,
   tilingPaddingHorizontal: 60,
+  // gravity/repulsion/separation/edgeLength are always overridden by getDynamicLayoutOptions
   gravity: 0.25,
   nodeRepulsion: 18000,
   idealEdgeLength: 55,

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -306,6 +306,7 @@ export const getGraphStyle = (
         "background-clip": "node",
         "background-image": "data(resolvedImage)",
         "background-image-crossorigin": "null",
+        "background-opacity": 1,
         "border-width": graph.nodeBorderWidth + 1,
         "border-color": tokens.primary,
       },

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -399,6 +399,8 @@ export const getGraphStyle = (
     style: {
       "border-color": cat.color,
       "border-width": graph.nodeBorderWidth + 2,
+      "background-color": cat.color,
+      "background-opacity": 0.4,
     },
   }));
 

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -407,6 +407,15 @@ export const getGraphStyle = (
 
   // Revealed styles come after category borders
   const revealedStyles: any[] = [
+    // Reset opacity for image nodes — categoryStyles sets 0.4 which would bleed through portraits
+    ...(showImages
+      ? [
+          {
+            selector: "node[resolvedImage][resolvedImage != 'none']",
+            style: { "background-opacity": 1 },
+          },
+        ]
+      : []),
     {
       selector: "node[isRevealed]",
       style: {
@@ -437,6 +446,7 @@ export const getGraphStyle = (
       selector: "node:selected",
       style: {
         "background-color": tokens.surface,
+        "background-opacity": 1,
         "border-color": tokens.primary,
         "border-width": graph.nodeBorderWidth + 1,
         color: "#fff",

--- a/packages/graph-engine/tests/themes.test.ts
+++ b/packages/graph-engine/tests/themes.test.ts
@@ -19,9 +19,9 @@ describe("Graph Theme Generation", () => {
       (s) => s.selector === "node",
     )?.style;
 
-    expect(scifiNode.shape).toBe("round-rectangle");
-    expect(fantasyNode.shape).toBe("round-rectangle");
-    expect(cyberpunkNode.shape).toBe("round-rectangle");
+    expect(scifiNode.shape).toBe("ellipse");
+    expect(fantasyNode.shape).toBe("ellipse");
+    expect(cyberpunkNode.shape).toBe("ellipse");
   });
 
   it("should generate different edge styles", () => {

--- a/packages/schema/src/theme.ts
+++ b/packages/schema/src/theme.ts
@@ -114,7 +114,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       fontBody: "'Inter', sans-serif",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "solid",
       nodeBorderWidth: 1,
       edgeWidth: 1,
@@ -175,7 +175,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       borderRadius: "3px",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "solid",
       nodeBorderWidth: 2,
       edgeWidth: 3, // Bolder — connections need to win against parchment bg
@@ -219,7 +219,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       fontBody: "'Inter', sans-serif",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "solid",
       nodeBorderWidth: 1,
       edgeWidth: 1,
@@ -248,7 +248,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       fontBody: "'Fira Code', monospace",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "dashed",
       nodeBorderWidth: 2,
       edgeWidth: 1,
@@ -293,7 +293,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       texture: "rust.svg",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "dotted",
       nodeBorderWidth: 1,
       edgeWidth: 1,
@@ -338,7 +338,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       texture: "blood.svg",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "solid",
       nodeBorderWidth: 2,
       edgeWidth: 1,
@@ -384,7 +384,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       texture: "crt.svg",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "solid",
       nodeBorderWidth: 1,
       edgeWidth: 1,
@@ -428,7 +428,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       fontBody: "'Inter', sans-serif",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "solid",
       nodeBorderWidth: 1,
       edgeWidth: 1,
@@ -472,7 +472,7 @@ export const THEMES: Record<string, StylingTemplate> = {
       fontBody: "'Inter', sans-serif",
     },
     graph: {
-      nodeShape: "round-rectangle",
+      nodeShape: "ellipse",
       edgeStyle: "solid",
       nodeBorderWidth: 1,
       edgeWidth: 1,


### PR DESCRIPTION
## Summary

- **Obsidian-like clustering**: Tuned fcose physics (gravity 2×, repulsion ~40% lower, tighter edge lengths) so the graph forms a cohesive oval with visible hub-and-spoke clusters instead of uniform spread
- **Circular nodes**: All themes switched from `round-rectangle` to `ellipse` — portrait images read as natural medallions, edges connect cleanly from any angle
- **Randomize on Redraw**: The Redraw Layout button now always produces a fresh layout (was running from saved positions, barely moving). Respects the stable layout lock — pinned layouts are not shuffled
- **Category fill tint**: Nodes filled at 40% opacity of their category color so clusters are immediately readable. Image nodes and selected nodes explicitly restore `background-opacity: 1` in the cascade after category styles

## Test plan

- [x] All 72 graph-engine tests pass (7 new: `defaults.test.ts` covering gravity/repulsion/separation scaling and caps, `LayoutManager` tests for stableLayout + randomize interaction)
- [x] Pre-push hook passes (lint + full test suite)
- [x] Visually verified in browser — circular layout, portrait medallions, colored cluster fills

🤖 Generated with [Claude Code](https://claude.com/claude-code)