### PR TITLE
💄 fix(web): hide llms.txt link from footer #672

### DIFF
--- a/apps/web/src/lib/components/layout/AppFooter.svelte
+++ b/apps/web/src/lib/components/layout/AppFooter.svelte
@@ -42,11 +42,6 @@
       class="text-[10px] font-header text-theme-secondary hover:text-theme-primary transition-colors uppercase tracking-widest"
       >Blog</a
     >
-    <a
-      href="{base}/llms.txt"
-      class="text-[10px] font-header text-theme-secondary hover:text-theme-primary transition-colors uppercase tracking-widest"
-      >LLMS.TXT</a
-    >
     <button
       onclick={() => uiStore.openSettings("help")}
       class="text-[10px] font-header text-theme-secondary hover:text-theme-primary transition-colors uppercase tracking-widest cursor-pointer"

--- a/apps/web/tests/footer.spec.ts
+++ b/apps/web/tests/footer.spec.ts
@@ -98,11 +98,10 @@ test.describe("Footer", () => {
     await context.setOffline(false);
   });
 
-  test("should display LLMS.TXT link in the footer", async ({ page }) => {
+  test("should NOT display LLMS.TXT link in the footer", async ({ page }) => {
     const footer = page.locator("footer");
     const llmsLink = footer.locator('a:has-text("LLMS.TXT")');
 
-    await expect(llmsLink).toBeVisible();
-    await expect(llmsLink).toHaveAttribute("href", /\/llms\.txt$/);
+    await expect(llmsLink).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Description
This PR hides the `LLMS.TXT` link from the application footer as requested in #672. The link was taking up space and is not necessary for human users, while AI agents can still discover the file via other standards-compliant methods already implemented.

### Key Changes
- **UI**: Removed the `LLMS.TXT` link from `AppFooter.svelte`.
- **Tests**: Updated `footer.spec.ts` to verify the link is no longer visible in the UI.
- **Maintenance**: Kept the `<link rel="llms">` tag in `app.html` and the entries in `robots.txt`/`sitemap.xml` so that AI agents (Cursor, Windsurf, etc.) can still automatically discover the project context.

### Validation
- [x] `npx playwright test apps/web/tests/footer.spec.ts` passes (verifies link is hidden).
- [x] `npx playwright test apps/web/tests/seo.spec.ts` passes (verifies `llms.txt` is still discoverable via crawler standards).
- [x] `npm test` passes across the workspace.

Closes #672