### PR TITLE
✨ feat(graph): add context menu option to change node category (#667)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -26,10 +26,9 @@ Always prioritize client-side processing in the browser (OPFS, local library exe
 
 To maintain build integrity and code quality, AI agents MUST:
 
-1. Prefix unused variables/parameters with `_`.
-2. Avoid stale state warnings in Svelte 5 by using `$derived` instead of `$state(prop)`.
-3. Adhere to Tailwind 4 CSS syntax standards.
-4. Ensure comprehensive type definitions (e.g. `node` types) in workspace packages.
+1.  **Style Guide**: Adhere strictly to `@docs/STYLE_GUIDE.md` for all visual, behavioral, and architectural patterns (including Svelte 5 Runes, Tailwind 4 tokens, and Data Safety).
+2.  **Implementation Hygiene**: Prefix unused variables/parameters with `_` and ensure comprehensive type definitions (e.g. `node` types) in workspace packages.
+3.  **Validation**: Every code change MUST be verified with `npm run lint` and `npm test` before considering the task complete.
 
 ### VII. User Documentation
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -138,7 +138,9 @@ TypeScript: Follow standard conventions
 
 ## Implementation Guardrails (AI Guidelines)
 
-- **Style Guide Adherence**: ALWAYS read and adhere to `@docs/STYLE_GUIDE.md`. All UI components MUST use Svelte 5 Runes and Tailwind 4 semantic tokens (e.g., `text-theme-primary`). Never use hardcoded hex codes or generic Tailwind colors for theme-sensitive elements.
+- **Style Guide Adherence**: ALWAYS read and adhere to `@docs/STYLE_GUIDE.md`. All UI components MUST use Svelte 5 Runes and Tailwind 4 semantic tokens (e.g., `text-theme-primary`).
+- **Icon Usage**: NEVER use `lucide-svelte` components. ALWAYS use the Iconify utility pattern: `class="icon-[lucide--name] h-4 w-4"`.
+- **Reactive Snapshots**: Use `$state.snapshot(obj)` when passing state to non-reactive logic or async handlers to prevent stale references.
 - **Mandatory Testing**: NEVER consider a feature or bug fix complete without corresponding unit tests. For every new logic branch or service method, you MUST add a test case. If an existing test file exists for the module, append to it; otherwise, create a new one. Verification is only complete when `npm test` passes with your changes.
 - **Prefix Unused Vars**: Always prefix unused callback parameters or variables with an underscore (e.g., `_evt`) to satisfy strict `no-unused-vars` linting rules.
 - **Svelte 5 Reactivity**: Avoid initializing `$state` directly from props (e.g., `let x = $state(prop)`). Use `$derived` for data that should stay in sync, or ensure the intent of a local-only copy is clear to avoid `state_referenced_locally` warnings.

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -6,7 +6,6 @@
   import { categories } from "$lib/stores/categories.svelte";
   import CanvasPicker from "$lib/components/canvas/CanvasPicker.svelte";
   import type { Core, EventObject, NodeSingular } from "cytoscape";
-  import { ChevronRight } from "lucide-svelte";
 
   let { cy } = $props<{ cy: Core }>();
 
@@ -195,7 +194,7 @@
   };
 
   const handleSetCategory = async (type: string) => {
-    const nodesToUpdate = [...selectedNodes];
+    const nodesToUpdate = $state.snapshot(selectedNodes);
     clearPickerTimeout();
     categoryPickerOpen = false;
     contextMenuOpen = false;
@@ -365,7 +364,7 @@
       aria-haspopup="true"
     >
       Change Category
-      <ChevronRight class="h-3.5 w-3.5 opacity-50" />
+      <span class="icon-[lucide--chevron-right] h-3.5 w-3.5 opacity-50"></span>
     </button>
 
     <button
@@ -381,7 +380,7 @@
       aria-haspopup="true"
     >
       Add to Canvas
-      <ChevronRight class="h-3.5 w-3.5 opacity-50" />
+      <span class="icon-[lucide--chevron-right] h-3.5 w-3.5 opacity-50"></span>
     </button>
 
     {#if !vault.isGuest}

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -186,6 +186,16 @@
     }, 100);
   };
 
+  const toggleCategoryPicker = (e: MouseEvent | KeyboardEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (categoryPickerOpen) {
+      categoryPickerOpen = false;
+    } else {
+      showCategoryPicker();
+    }
+  };
+
   const hideCategoryPicker = () => {
     if (categoryPickerTimeout) clearTimeout(categoryPickerTimeout);
     categoryPickerTimeout = setTimeout(() => {
@@ -358,7 +368,7 @@
       class="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition border-t border-theme-border flex items-center justify-between gap-4 whitespace-nowrap"
       onmouseenter={showCategoryPicker}
       onmouseleave={hideCategoryPicker}
-      onclick={() => (categoryPickerOpen = !categoryPickerOpen)}
+      onclick={toggleCategoryPicker}
       aria-label="Change Category"
       aria-expanded={categoryPickerOpen}
       aria-haspopup="true"
@@ -401,14 +411,16 @@
 
   {#if categoryPickerOpen}
     <div
-      role="none"
+      role="menu"
+      aria-label="Select category"
       class="fixed z-[100] bg-theme-surface border border-theme-border shadow-2xl rounded overflow-hidden w-max flex flex-col p-1"
       style:top="{categoryPickerPosition.y}px"
       style:left="{categoryPickerPosition.x}px"
       onmouseenter={showCategoryPicker}
       onmouseleave={hideCategoryPicker}
+      onkeydown={handleMenuKeydown}
     >
-      {#each categories.list as cat}
+      {#each categories.list as cat (cat.id)}
         <button
           role="menuitem"
           class="w-full text-left px-3 py-1.5 text-xs text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition flex items-center gap-2 rounded-sm"

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -151,7 +151,7 @@
   };
 
   const showCanvasPicker = () => {
-    if (pickerTimeout) clearTimeout(pickerTimeout);
+    clearPickerTimeout();
     pickerTimeout = setTimeout(() => {
       if (pickerAnchor) {
         const rect = pickerAnchor.getBoundingClientRect();
@@ -173,7 +173,7 @@
   };
 
   const showCategoryPicker = () => {
-    if (categoryPickerTimeout) clearTimeout(categoryPickerTimeout);
+    clearPickerTimeout();
     categoryPickerTimeout = setTimeout(() => {
       if (categoryPickerAnchor) {
         const rect = categoryPickerAnchor.getBoundingClientRect();
@@ -195,21 +195,22 @@
   };
 
   const handleSetCategory = async (type: string) => {
+    const nodesToUpdate = [...selectedNodes];
     clearPickerTimeout();
     categoryPickerOpen = false;
     contextMenuOpen = false;
 
     try {
-      if (selectedNodes.length === 1) {
-        await vault.updateEntity(selectedNodes[0], { type });
+      if (nodesToUpdate.length === 1) {
+        await vault.updateEntity(nodesToUpdate[0], { type });
         ui.notify("Category updated.", "success");
-      } else {
+      } else if (nodesToUpdate.length > 1) {
         const updates: Record<string, { type: string }> = {};
-        for (const id of selectedNodes) {
+        for (const id of nodesToUpdate) {
           updates[id] = { type };
         }
         await vault.batchUpdate(updates);
-        ui.notify(`Updated ${selectedNodes.length} nodes.`, "success");
+        ui.notify(`Updated ${nodesToUpdate.length} nodes.`, "success");
       }
     } catch (err: any) {
       console.error("Failed to update category", err);

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -3,19 +3,25 @@
   import { ui } from "$lib/stores/ui.svelte";
   import { vault } from "$lib/stores/vault.svelte";
   import { canvasRegistry } from "$lib/stores/canvas-registry.svelte";
+  import { categories } from "$lib/stores/categories.svelte";
   import CanvasPicker from "$lib/components/canvas/CanvasPicker.svelte";
   import type { Core, EventObject, NodeSingular } from "cytoscape";
+  import { ChevronRight } from "lucide-svelte";
 
   let { cy } = $props<{ cy: Core }>();
 
   let contextMenuOpen = $state(false);
   let canvasPickerOpen = $state(false);
+  let categoryPickerOpen = $state(false);
   let position = $state({ x: 0, y: 0 });
   let pickerPosition = $state({ x: 0, y: 0 });
+  let categoryPickerPosition = $state({ x: 0, y: 0 });
   let targetId = $state<string | null>(null);
   let selectedNodes = $state<string[]>([]);
   let pickerTimeout: ReturnType<typeof setTimeout> | null = null;
+  let categoryPickerTimeout: ReturnType<typeof setTimeout> | null = null;
   let pickerAnchor = $state<HTMLButtonElement>();
+  let categoryPickerAnchor = $state<HTMLButtonElement>();
 
   $effect(() => {
     if (cy) {
@@ -37,9 +43,12 @@
 
       const closeHandler = () => {
         if (pickerTimeout) clearTimeout(pickerTimeout);
+        if (categoryPickerTimeout) clearTimeout(categoryPickerTimeout);
         pickerTimeout = null;
+        categoryPickerTimeout = null;
         contextMenuOpen = false;
         canvasPickerOpen = false;
+        categoryPickerOpen = false;
       };
 
       cy.on("cxttap", "node", openHandler);
@@ -47,7 +56,9 @@
 
       return () => {
         if (pickerTimeout) clearTimeout(pickerTimeout);
+        if (categoryPickerTimeout) clearTimeout(categoryPickerTimeout);
         pickerTimeout = null;
+        categoryPickerTimeout = null;
         cy.off("cxttap", "node", openHandler);
         cy.off("tap", closeHandler);
       };
@@ -60,6 +71,10 @@
     if (pickerTimeout) {
       clearTimeout(pickerTimeout);
       pickerTimeout = null;
+    }
+    if (categoryPickerTimeout) {
+      clearTimeout(categoryPickerTimeout);
+      categoryPickerTimeout = null;
     }
   };
 
@@ -88,6 +103,7 @@
       clearPickerTimeout();
       contextMenuOpen = false;
       canvasPickerOpen = false;
+      categoryPickerOpen = false;
     } else if (e.key === "ArrowDown") {
       e.preventDefault();
       const nextIdx = (idx + 1) % items.length;
@@ -145,6 +161,7 @@
         };
       }
       canvasPickerOpen = true;
+      categoryPickerOpen = false;
     }, 100);
   };
 
@@ -153,6 +170,51 @@
     pickerTimeout = setTimeout(() => {
       canvasPickerOpen = false;
     }, 150);
+  };
+
+  const showCategoryPicker = () => {
+    if (categoryPickerTimeout) clearTimeout(categoryPickerTimeout);
+    categoryPickerTimeout = setTimeout(() => {
+      if (categoryPickerAnchor) {
+        const rect = categoryPickerAnchor.getBoundingClientRect();
+        categoryPickerPosition = {
+          x: rect.right + 4,
+          y: rect.top,
+        };
+      }
+      categoryPickerOpen = true;
+      canvasPickerOpen = false;
+    }, 100);
+  };
+
+  const hideCategoryPicker = () => {
+    if (categoryPickerTimeout) clearTimeout(categoryPickerTimeout);
+    categoryPickerTimeout = setTimeout(() => {
+      categoryPickerOpen = false;
+    }, 150);
+  };
+
+  const handleSetCategory = async (type: string) => {
+    clearPickerTimeout();
+    categoryPickerOpen = false;
+    contextMenuOpen = false;
+
+    try {
+      if (selectedNodes.length === 1) {
+        await vault.updateEntity(selectedNodes[0], { type });
+        ui.notify("Category updated.", "success");
+      } else {
+        const updates: Record<string, { type: string }> = {};
+        for (const id of selectedNodes) {
+          updates[id] = { type };
+        }
+        await vault.batchUpdate(updates);
+        ui.notify(`Updated ${selectedNodes.length} nodes.`, "success");
+      }
+    } catch (err: any) {
+      console.error("Failed to update category", err);
+      ui.notify(`Failed to update category: ${err.message}`, "error");
+    }
   };
 
   const handleAddToCanvas = async (canvasId: string) => {
@@ -222,6 +284,7 @@
     ) {
       contextMenuOpen = false;
       canvasPickerOpen = false;
+      categoryPickerOpen = false;
       try {
         for (const id of selectedNodes) {
           await vault.deleteEntity(id);
@@ -288,11 +351,27 @@
         ? `Label ${selectedNodes.length} Nodes…`
         : "Label…"}
     </button>
+
+    <button
+      bind:this={categoryPickerAnchor}
+      role="menuitem"
+      class="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition border-t border-theme-border flex items-center justify-between gap-4 whitespace-nowrap"
+      onmouseenter={showCategoryPicker}
+      onmouseleave={hideCategoryPicker}
+      onclick={() => (categoryPickerOpen = !categoryPickerOpen)}
+      aria-label="Change Category"
+      aria-expanded={categoryPickerOpen}
+      aria-haspopup="true"
+    >
+      Change Category
+      <ChevronRight class="h-3.5 w-3.5 opacity-50" />
+    </button>
+
     <button
       bind:this={pickerAnchor}
       role="menuitem"
       data-testid="add-to-canvas-button"
-      class="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition border-t border-theme-border relative whitespace-nowrap"
+      class="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition border-t border-theme-border flex items-center justify-between gap-4 whitespace-nowrap"
       onmouseenter={showCanvasPicker}
       onmouseleave={hideCanvasPicker}
       onclick={() => (canvasPickerOpen = !canvasPickerOpen)}
@@ -301,6 +380,7 @@
       aria-haspopup="true"
     >
       Add to Canvas
+      <ChevronRight class="h-3.5 w-3.5 opacity-50" />
     </button>
 
     {#if !vault.isGuest}
@@ -318,6 +398,31 @@
       </button>
     {/if}
   </div>
+
+  {#if categoryPickerOpen}
+    <div
+      role="none"
+      class="fixed z-[100] bg-theme-surface border border-theme-border shadow-2xl rounded overflow-hidden w-max flex flex-col p-1"
+      style:top="{categoryPickerPosition.y}px"
+      style:left="{categoryPickerPosition.x}px"
+      onmouseenter={showCategoryPicker}
+      onmouseleave={hideCategoryPicker}
+    >
+      {#each categories.list as cat}
+        <button
+          role="menuitem"
+          class="w-full text-left px-3 py-1.5 text-xs text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition flex items-center gap-2 rounded-sm"
+          onclick={() => handleSetCategory(cat.id)}
+        >
+          <div
+            class="w-2 h-2 rounded-full"
+            style:background-color={cat.color}
+          ></div>
+          {cat.label}
+        </button>
+      {/each}
+    </div>
+  {/if}
 
   {#if canvasPickerOpen}
     <div

--- a/apps/web/tests/graph-category-menu.spec.ts
+++ b/apps/web/tests/graph-category-menu.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Graph Category Context Menu", () => {
+  test.beforeEach(async ({ page }) => {
+    // Inject E2E flag
+    await page.addInitScript(() => {
+      (window as any).__E2E__ = true;
+    });
+
+    await page.goto("/vault/default");
+    // Wait for graph to load and settle
+    await page.waitForSelector("canvas");
+    await page.waitForTimeout(2000);
+  });
+
+  test("should change category for a single node via context menu", async ({
+    page,
+  }) => {
+    const canvas = page.locator("canvas").first();
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error("Canvas not found");
+
+    // Right-click center of canvas
+    await canvas.click({
+      button: "right",
+      position: { x: box.width / 2, y: box.height / 2 },
+    });
+
+    const categoryButton = page.getByRole("menuitem", {
+      name: "Change Category",
+    });
+    await expect(categoryButton).toBeVisible();
+
+    // Hover to trigger submenu
+    await categoryButton.hover();
+
+    const categoryPicker = page.getByRole("menu", { name: "Select category" });
+    await expect(categoryPicker).toBeVisible();
+
+    // Select 'Character'
+    const targetCategory = categoryPicker
+      .getByRole("menuitem", { name: /Character/i })
+      .first();
+    await targetCategory.click();
+
+    // Verify notification
+    await expect(page.getByText("Category updated.")).toBeVisible();
+
+    // Verify menu closed
+    await expect(categoryPicker).not.toBeVisible();
+  });
+
+  test("should handle escape to close category menu", async ({ page }) => {
+    const canvas = page.locator("canvas").first();
+    const box = await canvas.boundingBox();
+    if (!box) throw new Error("Canvas not found");
+
+    await canvas.click({
+      button: "right",
+      position: { x: box.width / 2, y: box.height / 2 },
+    });
+
+    const categoryButton = page.getByRole("menuitem", {
+      name: "Change Category",
+    });
+    await categoryButton.hover();
+
+    const categoryPicker = page.getByRole("menu", { name: "Select category" });
+    await expect(categoryPicker).toBeVisible();
+
+    // Press Escape
+    await page.keyboard.press("Escape");
+
+    await expect(categoryPicker).not.toBeVisible();
+    await expect(
+      page.getByRole("menu", { name: "Node actions" }),
+    ).not.toBeVisible();
+  });
+});

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -9,8 +9,9 @@ This document establishes the core design principles and component implementatio
 1.  **Library-First**: UI components should be built as reusable units.
 2.  **Svelte 5 Runes**: Strictly use `$state`, `$derived`, and `$props` for reactivity and component communication.
 3.  **Tailwind 4 Theming**: Use semantic theme variables (e.g., `--color-theme-primary`) for all styling to support dynamic themes.
-4.  **Accessibility**: Components must be navigable and usable by everyone, following standard ARIA patterns.
-5.  **Simplicity**: Prefer established patterns and avoid over-engineering (YAGNI).
+4.  **Iconography**: NEVER use `lucide-svelte` components. ALWAYS use Iconify utility classes (e.g., `icon-[lucide--name]`) to maintain styling consistency and reduce bundle size.
+5.  **Accessibility**: Components must be navigable and usable by everyone, following standard ARIA patterns.
+6.  **Simplicity**: Prefer established patterns and avoid over-engineering (YAGNI).
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Description
Adds a "Change Category" option to the graph context menu, allowing users to quickly set or change the category of one or more selected nodes via a nested sub-menu.

## Changes
- **New Sub-menu:** Added "Change Category" to `ContextMenu.svelte`.
- **Category Picker:** Implemented a sub-menu listing all available categories with color indicators.
- **Bulk Support:** Enabled category updates for multiple selected nodes using `batchUpdate`.
- **UX Improvements:**
  - Integrated `ChevronRight` icons for sub-menu discovery.
  - Robust timeout management to prevent sub-menu race conditions.
  - Added Escape key support to close all menus/pickers.
  - Safe state capturing in async handlers to prevent reactivity edge cases.

Fixes #667