### PR TITLE
⚡ Bolt: [performance improvement] avoid intermediate filter array allocations

### DIFF
--- a/packages/vault-engine/src/services/ActivityService.ts
+++ b/packages/vault-engine/src/services/ActivityService.ts
@@ -90,10 +90,17 @@ export class ActivityServiceImplementation {
       .limit(candidateLimit)
       .toArray()) as GraphEntityRecord[];
 
-    const recent = [
-      ...pinnedRecords,
-      ...recentCandidates.filter((record) => !pinnedIds.has(record.id)),
-    ]
+    // ⚡ Bolt Optimization: Replace intermediate .filter() and spread with a single imperative loop
+    const recent = [...pinnedRecords];
+    const len = recentCandidates.length;
+    for (let i = 0; i < len; i++) {
+      const record = recentCandidates[i];
+      if (!pinnedIds.has(record.id)) {
+        recent.push(record);
+      }
+    }
+
+    const limitedRecent = recent
       .sort((a, b) => {
         const aPinned = pinnedIds.has(a.id);
         const bPinned = pinnedIds.has(b.id);
@@ -103,12 +110,12 @@ export class ActivityServiceImplementation {
       .slice(0, limit);
 
     const contents = await Promise.all(
-      recent.map((record) =>
+      limitedRecent.map((record) =>
         this.db.entityContent.get([vaultId, record.id]).catch(() => undefined),
       ),
     );
 
-    return recent.map((record, index) => ({
+    return limitedRecent.map((record, index) => ({
       id: record.id,
       title: record.title,
       path: record.filePath || (record as any)._path?.join("/") || "",

--- a/packages/vault-engine/src/services/WorldService.ts
+++ b/packages/vault-engine/src/services/WorldService.ts
@@ -246,10 +246,17 @@ export class WorldServiceImplementation {
       .limit(candidateLimit)
       .toArray()) as GraphEntityRecord[];
 
-    const recent = [
-      ...pinnedRecords,
-      ...recentCandidates.filter((record) => !pinnedIds.has(record.id)),
-    ]
+    // ⚡ Bolt Optimization: Replace intermediate .filter() and spread with a single imperative loop
+    const recent = [...pinnedRecords];
+    const len = recentCandidates.length;
+    for (let i = 0; i < len; i++) {
+      const record = recentCandidates[i];
+      if (!pinnedIds.has(record.id)) {
+        recent.push(record);
+      }
+    }
+
+    const limitedRecent = recent
       .sort((a, b) => {
         const aPinned = pinnedIds.has(a.id);
         const bPinned = pinnedIds.has(b.id);
@@ -259,12 +266,12 @@ export class WorldServiceImplementation {
       .slice(0, limit);
 
     const contentRecords = await Promise.all(
-      recent.map((record) =>
+      limitedRecent.map((record) =>
         this.db.entityContent.get([vaultId, record.id]).catch(() => null),
       ),
     );
 
-    return recent.map((record, index) => {
+    return limitedRecent.map((record, index) => {
       const content = contentRecords[index]?.content ?? "";
       const path = getEntityPath(record);
       return {


### PR DESCRIPTION
💡 What: Replaced `[...pinnedRecords, ...recentCandidates.filter(...)]` pattern with an imperative loop.
🎯 Why: Avoids unnecessary intermediate array allocation and GC overhead when merging frontpage entities and recent activity logs.
📊 Impact: Reduced memory pressure in the main IndexedDB callback loop, scaling better for large arrays.
🔬 Measurement: Verify with `npm run test -w packages/vault-engine`.

---
*PR created automatically by Jules for task [10780712507244938603](https://jules.google.com/task/10780712507244938603) started by @eserlan*