### PR TITLE
✨ feat(graph): add themed node styling #679

### DIFF
--- a/apps/web/static/themes/blood-180.svg
+++ b/apps/web/static/themes/blood-180.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+  <defs>
+    <!-- Add grit to the droplets to make them imperfect and organic -->
+    <filter id="roughEdge" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.1" numOctaves="3" result="noise" />
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="6" xChannelSelector="R" yChannelSelector="G" result="displaced" />
+      <feGaussianBlur in="displaced" stdDeviation="0.5" result="blurred" />
+      <!-- Boost contrast slightly to retain solid edges despite the blur -->
+      <feColorMatrix type="matrix" values="1 0 0 0 0
+                                           0 1 0 0 0
+                                           0 1 0 0 0
+                                           0 0 0 1.5 -0.2"/>
+    </filter>
+    
+    <pattern id="blood-spatter" x="0" y="0" width="300" height="300" patternUnits="userSpaceOnUse" patternTransform="rotate(180 150 150)">
+      <g fill="#5e0b0b" opacity="0.4" filter="url(#roughEdge)">
+        <!-- Splatter 1: Top Left -->
+        <circle cx="60" cy="60" r="14"/>
+        <circle cx="35" cy="45" r="4"/>
+        <circle cx="85" cy="40" r="6"/>
+        <circle cx="95" cy="80" r="3"/>
+        <path d="M 60,60 Q 100,110 110,120 Q 90,90 60,60 Z"/>
+        <circle cx="115" cy="130" r="4"/>
+        <circle cx="125" cy="142" r="2"/>
+
+        <!-- Drip: Top Right -->
+        <path d="M 260,10 Q 255,80 265,110 Q 275,70 260,10 Z"/>
+        <circle cx="266" cy="125" r="4"/>
+        <circle cx="265" cy="140" r="2"/>
+
+        <!-- Splatter 2: Bottom Right -->
+        <circle cx="210" cy="230" r="22"/>
+        <path d="M 210,230 Q 160,220 145,210 Q 170,205 210,230 Z"/>
+        <circle cx="130" cy="200" r="5"/>
+        <circle cx="110" cy="190" r="3"/>
+        <circle cx="250" cy="260" r="8"/>
+        <circle cx="270" cy="280" r="4"/>
+        <circle cx="195" cy="275" r="5"/>
+        <circle cx="160" cy="270" r="7"/>
+        <circle cx="225" cy="195" r="3"/>
+
+        <!-- Tiny scattered drops -->
+        <circle cx="20" cy="200" r="2" />
+        <circle cx="40" cy="180" r="3" />
+        <circle cx="30" cy="220" r="1.5" />
+        <circle cx="150" cy="40" r="3" />
+        <circle cx="170" cy="30" r="2" />
+        <circle cx="280" cy="80" r="1.5" />
+      </g>
+    </pattern>
+  </defs>
+
+  <!-- Add an incredibly faint, scratchy texture covering everything for ambience -->
+  <filter id="faintScratch">
+    <feTurbulence type="fractalNoise" baseFrequency="0.08" numOctaves="2" />
+    <feColorMatrix type="matrix" values="0 0 0 0 0.5
+                                         0 0 0 0 0
+                                         0 0 0 0 0
+                                         0 0 0 0.05 0" />
+  </filter>
+  <rect width="100%" height="100%" filter="url(#faintScratch)" />
+
+  <!-- Render the vector blood spatter pattern -->
+  <rect width="100%" height="100%" fill="url(#blood-spatter)" />
+</svg>

--- a/apps/web/static/themes/blood-270.svg
+++ b/apps/web/static/themes/blood-270.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+  <defs>
+    <!-- Add grit to the droplets to make them imperfect and organic -->
+    <filter id="roughEdge" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.1" numOctaves="3" result="noise" />
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="6" xChannelSelector="R" yChannelSelector="G" result="displaced" />
+      <feGaussianBlur in="displaced" stdDeviation="0.5" result="blurred" />
+      <!-- Boost contrast slightly to retain solid edges despite the blur -->
+      <feColorMatrix type="matrix" values="1 0 0 0 0
+                                           0 1 0 0 0
+                                           0 1 0 0 0
+                                           0 0 0 1.5 -0.2"/>
+    </filter>
+    
+    <pattern id="blood-spatter" x="0" y="0" width="300" height="300" patternUnits="userSpaceOnUse" patternTransform="rotate(270 150 150)">
+      <g fill="#5e0b0b" opacity="0.4" filter="url(#roughEdge)">
+        <!-- Splatter 1: Top Left -->
+        <circle cx="60" cy="60" r="14"/>
+        <circle cx="35" cy="45" r="4"/>
+        <circle cx="85" cy="40" r="6"/>
+        <circle cx="95" cy="80" r="3"/>
+        <path d="M 60,60 Q 100,110 110,120 Q 90,90 60,60 Z"/>
+        <circle cx="115" cy="130" r="4"/>
+        <circle cx="125" cy="142" r="2"/>
+
+        <!-- Drip: Top Right -->
+        <path d="M 260,10 Q 255,80 265,110 Q 275,70 260,10 Z"/>
+        <circle cx="266" cy="125" r="4"/>
+        <circle cx="265" cy="140" r="2"/>
+
+        <!-- Splatter 2: Bottom Right -->
+        <circle cx="210" cy="230" r="22"/>
+        <path d="M 210,230 Q 160,220 145,210 Q 170,205 210,230 Z"/>
+        <circle cx="130" cy="200" r="5"/>
+        <circle cx="110" cy="190" r="3"/>
+        <circle cx="250" cy="260" r="8"/>
+        <circle cx="270" cy="280" r="4"/>
+        <circle cx="195" cy="275" r="5"/>
+        <circle cx="160" cy="270" r="7"/>
+        <circle cx="225" cy="195" r="3"/>
+
+        <!-- Tiny scattered drops -->
+        <circle cx="20" cy="200" r="2" />
+        <circle cx="40" cy="180" r="3" />
+        <circle cx="30" cy="220" r="1.5" />
+        <circle cx="150" cy="40" r="3" />
+        <circle cx="170" cy="30" r="2" />
+        <circle cx="280" cy="80" r="1.5" />
+      </g>
+    </pattern>
+  </defs>
+
+  <!-- Add an incredibly faint, scratchy texture covering everything for ambience -->
+  <filter id="faintScratch">
+    <feTurbulence type="fractalNoise" baseFrequency="0.08" numOctaves="2" />
+    <feColorMatrix type="matrix" values="0 0 0 0 0.5
+                                         0 0 0 0 0
+                                         0 0 0 0 0
+                                         0 0 0 0.05 0" />
+  </filter>
+  <rect width="100%" height="100%" filter="url(#faintScratch)" />
+
+  <!-- Render the vector blood spatter pattern -->
+  <rect width="100%" height="100%" fill="url(#blood-spatter)" />
+</svg>

--- a/apps/web/static/themes/blood-90.svg
+++ b/apps/web/static/themes/blood-90.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300">
+  <defs>
+    <!-- Add grit to the droplets to make them imperfect and organic -->
+    <filter id="roughEdge" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.1" numOctaves="3" result="noise" />
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="6" xChannelSelector="R" yChannelSelector="G" result="displaced" />
+      <feGaussianBlur in="displaced" stdDeviation="0.5" result="blurred" />
+      <!-- Boost contrast slightly to retain solid edges despite the blur -->
+      <feColorMatrix type="matrix" values="1 0 0 0 0
+                                           0 1 0 0 0
+                                           0 1 0 0 0
+                                           0 0 0 1.5 -0.2"/>
+    </filter>
+    
+    <pattern id="blood-spatter" x="0" y="0" width="300" height="300" patternUnits="userSpaceOnUse" patternTransform="rotate(90 150 150)">
+      <g fill="#5e0b0b" opacity="0.4" filter="url(#roughEdge)">
+        <!-- Splatter 1: Top Left -->
+        <circle cx="60" cy="60" r="14"/>
+        <circle cx="35" cy="45" r="4"/>
+        <circle cx="85" cy="40" r="6"/>
+        <circle cx="95" cy="80" r="3"/>
+        <path d="M 60,60 Q 100,110 110,120 Q 90,90 60,60 Z"/>
+        <circle cx="115" cy="130" r="4"/>
+        <circle cx="125" cy="142" r="2"/>
+
+        <!-- Drip: Top Right -->
+        <path d="M 260,10 Q 255,80 265,110 Q 275,70 260,10 Z"/>
+        <circle cx="266" cy="125" r="4"/>
+        <circle cx="265" cy="140" r="2"/>
+
+        <!-- Splatter 2: Bottom Right -->
+        <circle cx="210" cy="230" r="22"/>
+        <path d="M 210,230 Q 160,220 145,210 Q 170,205 210,230 Z"/>
+        <circle cx="130" cy="200" r="5"/>
+        <circle cx="110" cy="190" r="3"/>
+        <circle cx="250" cy="260" r="8"/>
+        <circle cx="270" cy="280" r="4"/>
+        <circle cx="195" cy="275" r="5"/>
+        <circle cx="160" cy="270" r="7"/>
+        <circle cx="225" cy="195" r="3"/>
+
+        <!-- Tiny scattered drops -->
+        <circle cx="20" cy="200" r="2" />
+        <circle cx="40" cy="180" r="3" />
+        <circle cx="30" cy="220" r="1.5" />
+        <circle cx="150" cy="40" r="3" />
+        <circle cx="170" cy="30" r="2" />
+        <circle cx="280" cy="80" r="1.5" />
+      </g>
+    </pattern>
+  </defs>
+
+  <!-- Add an incredibly faint, scratchy texture covering everything for ambience -->
+  <filter id="faintScratch">
+    <feTurbulence type="fractalNoise" baseFrequency="0.08" numOctaves="2" />
+    <feColorMatrix type="matrix" values="0 0 0 0 0.5
+                                         0 0 0 0 0
+                                         0 0 0 0 0
+                                         0 0 0 0.05 0" />
+  </filter>
+  <rect width="100%" height="100%" filter="url(#faintScratch)" />
+
+  <!-- Render the vector blood spatter pattern -->
+  <rect width="100%" height="100%" fill="url(#blood-spatter)" />
+</svg>

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -415,4 +415,41 @@ describe("GraphTransformer", () => {
     const revealedStyle = style.find((s) => s.selector === "node[isRevealed]");
     expect(revealedStyle.style["border-width"]).toBe(11);
   });
+
+  it("should keep fantasy shield borders controlled for image and revealed nodes", () => {
+    const mockTemplate = {
+      id: "fantasy",
+      tokens: {
+        primary: "#5e3018",
+        background: "#fdf6e3",
+        text: "#2a2018",
+        surface: "#f0ddb8",
+        fontHeader: "Alegreya",
+        fontBody: "Alegreya",
+        texture: "parchment.svg",
+      },
+      graph: {
+        nodeShape: "ellipse",
+        nodeBorderWidth: 2,
+        edgeWidth: 3,
+        edgeColor: "#6b3820",
+        edgeStyle: "solid",
+      },
+    } as any;
+
+    const style = getGraphStyle(mockTemplate, [], true);
+
+    const baseStyle = style.find((s) => s.selector === "node");
+    expect(baseStyle.style["border-width"]).toBe(2);
+
+    const imageOverride = style.find(
+      (s) =>
+        s.selector.includes("resolvedImage") && s.style["border-width"] === 7,
+    );
+    expect(imageOverride).toBeDefined();
+
+    const revealedStyle = style.find((s) => s.selector === "node[isRevealed]");
+    expect(revealedStyle.style["border-width"]).toBe(4);
+    expect(revealedStyle.style["background-clip"]).toBe("node");
+  });
 });

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -378,4 +378,41 @@ describe("GraphTransformer", () => {
       "null",
     );
   });
+
+  it("should have thicker borders for nodes and even thicker for images", () => {
+    const mockTemplate = {
+      tokens: {
+        primary: "#000",
+        background: "#fff",
+        text: "#333",
+        surface: "#eee",
+        fontHeader: "Arial",
+        fontBody: "Arial",
+      },
+      graph: {
+        nodeShape: "ellipse",
+        nodeBorderWidth: 1,
+        edgeWidth: 1,
+        edgeColor: "#ccc",
+        edgeStyle: "solid",
+      },
+    } as any;
+
+    const style = getGraphStyle(mockTemplate, [], true);
+
+    // Base node should be +2
+    const baseStyle = style.find((s) => s.selector === "node");
+    expect(baseStyle.style["border-width"]).toBe(3);
+
+    // Image override should be +8
+    const imageOverride = style.find(
+      (s) =>
+        s.selector.includes("resolvedImage") && s.style["border-width"] === 9,
+    );
+    expect(imageOverride).toBeDefined();
+
+    // Revealed should be +10
+    const revealedStyle = style.find((s) => s.selector === "node[isRevealed]");
+    expect(revealedStyle.style["border-width"]).toBe(11);
+  });
 });

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -242,13 +242,16 @@ export const getGraphStyle = (
 ): any[] => {
   const { tokens, graph } = template;
 
+  const isFantasy = template.id === "fantasy";
+
   // Base styles (excluding revealed overrides which need to come last)
   const baseStyle: any[] = [
     {
       selector: "node",
       style: {
-        "background-color": tokens.background,
-        "border-width": graph.nodeBorderWidth,
+        // Force parchment-like background color for all nodes, matching theme surface/bg
+        "background-color": tokens.surface || tokens.background,
+        "border-width": graph.nodeBorderWidth + 2,
         "border-color": tokens.primary,
         width: 32,
         height: 32,
@@ -266,6 +269,13 @@ export const getGraphStyle = (
         "text-opacity": 1,
         "transition-property": "opacity, text-opacity, width, height",
         "transition-duration": 200,
+
+        // Depth effects for a more tactile feel
+        "shadow-blur": 4,
+        "shadow-color": "#000",
+        "shadow-opacity": 0.15,
+        "shadow-offset-x": 0,
+        "shadow-offset-y": 2,
       },
     },
     {
@@ -308,7 +318,7 @@ export const getGraphStyle = (
         "background-image": "data(resolvedImage)",
         "background-image-crossorigin": "null",
         "background-opacity": 1,
-        "border-width": graph.nodeBorderWidth + 1,
+        "border-width": graph.nodeBorderWidth + 6,
         "border-color": tokens.primary,
       },
     });
@@ -320,7 +330,7 @@ export const getGraphStyle = (
     {
       selector: ".selected-source",
       style: {
-        "border-width": graph.nodeBorderWidth + 1,
+        "border-width": graph.nodeBorderWidth + 4,
         "border-color": "#facc15", // Keep yellow for functional clarity
         "background-color": tokens.surface,
       },
@@ -401,11 +411,26 @@ export const getGraphStyle = (
     selector: `node[type="${cat.id}"]`,
     style: {
       "border-color": cat.color,
-      "border-width": graph.nodeBorderWidth + 2,
+      "border-width": graph.nodeBorderWidth + 4,
+      // For fantasy, we want the category color to overlay the parchment background
       "background-color": cat.color,
-      "background-opacity": 0.55,
+      "background-opacity": isFantasy ? 0.35 : 0.55,
     },
   }));
+
+  // Image width override ensures that nodes with images have thick borders
+  // even if category styles (which come before) set a thinner width.
+  const imageWidthOverride = showImages
+    ? [
+        {
+          selector:
+            "node[resolvedImage][resolvedImage != 'none'], node[image][resolvedImage][resolvedImage != 'none'], node[thumbnail][resolvedImage][resolvedImage != 'none']",
+          style: {
+            "border-width": graph.nodeBorderWidth + 8,
+          },
+        },
+      ]
+    : [];
 
   // Revealed styles come after category borders
   const revealedStyles: any[] = [
@@ -421,7 +446,7 @@ export const getGraphStyle = (
     {
       selector: "node[isRevealed]",
       style: {
-        "border-width": graph.nodeBorderWidth + 4,
+        "border-width": graph.nodeBorderWidth + 10,
         "background-clip": "none",
         "overlay-opacity": 0,
       },
@@ -436,7 +461,7 @@ export const getGraphStyle = (
         "background-clip": "node",
         "background-fit": "cover",
         "background-position-y": "50%",
-        "border-width": graph.nodeBorderWidth + 4,
+        "border-width": graph.nodeBorderWidth + 10,
       },
     });
   }
@@ -450,7 +475,7 @@ export const getGraphStyle = (
         "background-color": tokens.surface,
         "background-opacity": 1,
         "border-color": tokens.primary,
-        "border-width": graph.nodeBorderWidth + 1,
+        "border-width": graph.nodeBorderWidth + 4,
         color: "#fff",
         opacity: 1,
         "text-opacity": 1,
@@ -478,6 +503,7 @@ export const getGraphStyle = (
   return [
     ...baseStyle,
     ...categoryStyles,
+    ...imageWidthOverride,
     ...revealedStyles,
     ...selectionStyles,
   ];

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -21,6 +21,7 @@ export interface GraphNode {
     start_date?: TemporalMetadata;
     end_date?: TemporalMetadata;
     dateLabel?: string;
+    textureVariant?: number;
   };
   position?: { x: number; y: number };
 }
@@ -62,6 +63,18 @@ const formatDate = (date?: TemporalMetadata) => {
 };
 
 const EMPTY_LABELS: string[] = [];
+
+const hashId = (id: string): number => {
+  let hash = 0;
+  const len = id.length;
+  for (let i = 0; i < len; i++) {
+    hash = (hash << 5) - hash + id.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
+};
+
+const getTextureVariant = () => Math.floor(Math.random() * 4);
 
 export class GraphTransformer {
   static entitiesToElements(
@@ -111,6 +124,7 @@ export class GraphTransformer {
     for (let i = 0; i < entities.length; i++) {
       const entity = entities[i];
       if (!entity.id) continue;
+      const hash = hashId(entity.id);
 
       const dateLabel = formatDate(
         entity.date || entity.start_date || entity.end_date,
@@ -157,6 +171,7 @@ export class GraphTransformer {
         end_date: entity.end_date,
         dateLabel,
         labels: entity.labels ?? EMPTY_LABELS,
+        textureVariant: getTextureVariant(),
       };
       if (entity.image) nodeData.image = entity.image;
       if (entity.thumbnail) nodeData.thumbnail = entity.thumbnail;
@@ -172,16 +187,6 @@ export class GraphTransformer {
 
       // Assign a stable-ish random position based on ID if no coords exist.
       // Performance: Compute a simple hash in a single pass to avoid multiple split/reduce cycles.
-      let hash = 0;
-      if (!hasValidCoords) {
-        const id = entity.id;
-        const len = id.length;
-        for (let j = 0; j < len; j++) {
-          hash = (hash << 5) - hash + id.charCodeAt(j);
-          hash |= 0; // Convert to 32bit integer
-        }
-      }
-
       elements.push({
         group: "nodes",
         data: nodeData,
@@ -235,6 +240,84 @@ const sanitizeFontForCytoscape = (fontFamily?: string): string => {
   return firstFont || "sans-serif";
 };
 
+const getThemeTextureStyle = (texture?: string) => {
+  if (!texture) return {};
+
+  return {
+    "background-image": `url('/themes/${texture}')`,
+    "background-fit": "cover",
+    "background-clip": "node",
+    "background-image-crossorigin": "null",
+    "background-repeat": "no-repeat",
+  };
+};
+
+const getThemeTextureVariantStyles = (texture?: string) => {
+  if (texture !== "blood.svg") return [];
+
+  return [
+    {
+      selector: "node[textureVariant = 1]",
+      style: {
+        "background-image": "url('/themes/blood-90.svg')",
+      },
+    },
+    {
+      selector: "node[textureVariant = 2]",
+      style: {
+        "background-image": "url('/themes/blood-180.svg')",
+      },
+    },
+    {
+      selector: "node[textureVariant = 3]",
+      style: {
+        "background-image": "url('/themes/blood-270.svg')",
+      },
+    },
+  ];
+};
+
+const getFantasyNodeStyle = (
+  template: StylingTemplate,
+): Record<string, string | number | number[]> => {
+  if (template.id !== "fantasy") return {};
+
+  const borderWidth = template.graph.nodeBorderWidth ?? 1;
+
+  return {
+    shape: "polygon",
+    "shape-polygon-points": [
+      -0.82, -0.68, 0, -0.96, 0.82, -0.68, 0.72, 0.26, 0, 0.98, -0.72, 0.26,
+    ],
+    "background-fit": "cover",
+    "background-clip": "node",
+    "background-opacity": 0.5,
+    "border-width": borderWidth,
+    "border-color": template.tokens.primary,
+    "border-opacity": 0.68,
+  };
+};
+
+const getFantasyEdgeStyle = (
+  template: StylingTemplate,
+): Record<string, string | number | number[]> => {
+  if (template.id !== "fantasy") return {};
+
+  return {
+    width: (template.graph.edgeWidth ?? 1) + 1,
+    "line-style": "dashed",
+    "line-dash-pattern": [13, 4, 2, 5],
+    "line-dash-offset": 2,
+    "line-cap": "round",
+    "arrow-scale": 0.45,
+    opacity: 0.44,
+    "underlay-color": template.tokens.background,
+    "underlay-opacity": 0.18,
+    "underlay-padding": 2,
+    "text-background-opacity": 0.68,
+  };
+};
+
 export const getGraphStyle = (
   template: StylingTemplate,
   categories: Category[],
@@ -251,6 +334,7 @@ export const getGraphStyle = (
       style: {
         // Force parchment-like background color for all nodes, matching theme surface/bg
         "background-color": tokens.surface || tokens.background,
+        ...getThemeTextureStyle(tokens.texture),
         "border-width": graph.nodeBorderWidth + 2,
         "border-color": tokens.primary,
         width: 32,
@@ -269,15 +353,10 @@ export const getGraphStyle = (
         "text-opacity": 1,
         "transition-property": "opacity, text-opacity, width, height",
         "transition-duration": 200,
-
-        // Depth effects for a more tactile feel
-        "shadow-blur": 4,
-        "shadow-color": "#000",
-        "shadow-opacity": 0.15,
-        "shadow-offset-x": 0,
-        "shadow-offset-y": 2,
+        ...getFantasyNodeStyle(template),
       },
     },
+    ...getThemeTextureVariantStyles(tokens.texture),
     {
       selector: "node[weight <= 1]",
       style: {
@@ -318,7 +397,9 @@ export const getGraphStyle = (
         "background-image": "data(resolvedImage)",
         "background-image-crossorigin": "null",
         "background-opacity": 1,
-        "border-width": graph.nodeBorderWidth + 6,
+        "border-width": isFantasy
+          ? graph.nodeBorderWidth + 5
+          : graph.nodeBorderWidth + 6,
         "border-color": tokens.primary,
       },
     });
@@ -358,6 +439,7 @@ export const getGraphStyle = (
         "text-margin-y": -8,
         "transition-property": "opacity, text-opacity",
         "transition-duration": 200,
+        ...getFantasyEdgeStyle(template),
       },
     },
     {
@@ -411,10 +493,12 @@ export const getGraphStyle = (
     selector: `node[type="${cat.id}"]`,
     style: {
       "border-color": cat.color,
-      "border-width": graph.nodeBorderWidth + 4,
+      "border-width": isFantasy
+        ? graph.nodeBorderWidth + 1
+        : graph.nodeBorderWidth + 4,
       // For fantasy, we want the category color to overlay the parchment background
       "background-color": cat.color,
-      "background-opacity": isFantasy ? 0.35 : 0.55,
+      "background-opacity": isFantasy ? 0.58 : 0.55,
     },
   }));
 
@@ -426,7 +510,9 @@ export const getGraphStyle = (
           selector:
             "node[resolvedImage][resolvedImage != 'none'], node[image][resolvedImage][resolvedImage != 'none'], node[thumbnail][resolvedImage][resolvedImage != 'none']",
           style: {
-            "border-width": graph.nodeBorderWidth + 8,
+            "border-width": isFantasy
+              ? graph.nodeBorderWidth + 5
+              : graph.nodeBorderWidth + 8,
           },
         },
       ]
@@ -446,8 +532,10 @@ export const getGraphStyle = (
     {
       selector: "node[isRevealed]",
       style: {
-        "border-width": graph.nodeBorderWidth + 10,
-        "background-clip": "none",
+        "border-width": isFantasy
+          ? graph.nodeBorderWidth + 2
+          : graph.nodeBorderWidth + 10,
+        "background-clip": isFantasy ? "node" : "none",
         "overlay-opacity": 0,
       },
     },
@@ -461,7 +549,9 @@ export const getGraphStyle = (
         "background-clip": "node",
         "background-fit": "cover",
         "background-position-y": "50%",
-        "border-width": graph.nodeBorderWidth + 10,
+        "border-width": isFantasy
+          ? graph.nodeBorderWidth + 2
+          : graph.nodeBorderWidth + 10,
       },
     });
   }
@@ -483,8 +573,8 @@ export const getGraphStyle = (
         "text-outline-width": 2,
         "underlay-color": tokens.primary,
         "underlay-padding": 8,
-        "underlay-opacity": 0.3,
-        "underlay-shape": graph.nodeShape,
+        "underlay-opacity": isFantasy ? 0 : 0.3,
+        "underlay-shape": isFantasy ? "polygon" : graph.nodeShape,
         "z-index": 1000,
       },
     },

--- a/packages/graph-engine/tests/themes.test.ts
+++ b/packages/graph-engine/tests/themes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getGraphStyle } from "../src/transformer"; // Corrected import path for transformer functions
+import { getGraphStyle } from "../src/transformer";
 import { THEMES } from "schema";
 import type { Category } from "schema";
 
@@ -8,10 +8,14 @@ describe("Graph Theme Generation", () => {
     { id: "npc", label: "NPC", color: "#60a5fa", icon: "user" },
   ];
 
-  it("should generate same node shapes for all themes (standardized)", () => {
-    const scifiStyle = getGraphStyle(THEMES.scifi, mockCategories);
-    const fantasyStyle = getGraphStyle(THEMES.fantasy, mockCategories);
-    const cyberpunkStyle = getGraphStyle(THEMES.cyberpunk, mockCategories);
+  it("should generate appropriate node shapes for each theme", () => {
+    const scifiStyle = getGraphStyle(THEMES.scifi, mockCategories, false);
+    const fantasyStyle = getGraphStyle(THEMES.fantasy, mockCategories, false);
+    const cyberpunkStyle = getGraphStyle(
+      THEMES.cyberpunk,
+      mockCategories,
+      false,
+    );
 
     const scifiNode = scifiStyle.find((s) => s.selector === "node")?.style;
     const fantasyNode = fantasyStyle.find((s) => s.selector === "node")?.style;
@@ -25,8 +29,12 @@ describe("Graph Theme Generation", () => {
   });
 
   it("should generate different edge styles", () => {
-    const scifiStyle = getGraphStyle(THEMES.scifi, mockCategories);
-    const cyberpunkStyle = getGraphStyle(THEMES.cyberpunk, mockCategories);
+    const scifiStyle = getGraphStyle(THEMES.scifi, mockCategories, false);
+    const cyberpunkStyle = getGraphStyle(
+      THEMES.cyberpunk,
+      mockCategories,
+      false,
+    );
 
     const scifiEdge = scifiStyle.find((s) => s.selector === "edge")?.style;
     const cyberpunkEdge = cyberpunkStyle.find(

--- a/packages/graph-engine/tests/themes.test.ts
+++ b/packages/graph-engine/tests/themes.test.ts
@@ -24,12 +24,28 @@ describe("Graph Theme Generation", () => {
     )?.style;
 
     expect(scifiNode.shape).toBe("ellipse");
-    expect(fantasyNode.shape).toBe("ellipse");
+    expect(fantasyNode.shape).toBe("polygon");
+    expect(fantasyNode["shape-polygon-points"]).toEqual([
+      -0.82, -0.68, 0, -0.96, 0.82, -0.68, 0.72, 0.26, 0, 0.98, -0.72, 0.26,
+    ]);
+    expect(fantasyNode["background-image"]).toBe(
+      "url('/themes/parchment.svg')",
+    );
+    expect(fantasyNode["background-fit"]).toBe("cover");
+    expect(fantasyNode["background-clip"]).toBe("node");
+    expect(fantasyNode["border-width"]).toBe(
+      THEMES.fantasy.graph.nodeBorderWidth,
+    );
+    expect(fantasyNode["border-color"]).toBe(THEMES.fantasy.tokens.primary);
+    expect(fantasyNode["border-opacity"]).toBe(0.68);
+    expect(fantasyNode["shadow-color"]).toBeUndefined();
+    expect(fantasyNode["underlay-color"]).toBeUndefined();
     expect(cyberpunkNode.shape).toBe("ellipse");
   });
 
   it("should generate different edge styles", () => {
     const scifiStyle = getGraphStyle(THEMES.scifi, mockCategories, false);
+    const fantasyStyle = getGraphStyle(THEMES.fantasy, mockCategories, false);
     const cyberpunkStyle = getGraphStyle(
       THEMES.cyberpunk,
       mockCategories,
@@ -37,11 +53,49 @@ describe("Graph Theme Generation", () => {
     );
 
     const scifiEdge = scifiStyle.find((s) => s.selector === "edge")?.style;
+    const fantasyEdge = fantasyStyle.find((s) => s.selector === "edge")?.style;
     const cyberpunkEdge = cyberpunkStyle.find(
       (s) => s.selector === "edge",
     )?.style;
 
     expect(scifiEdge["line-style"]).toBe("solid");
+    expect(fantasyEdge["line-style"]).toBe("dashed");
+    expect(fantasyEdge["line-dash-pattern"]).toEqual([13, 4, 2, 5]);
+    expect(fantasyEdge["line-cap"]).toBe("round");
+    expect(fantasyEdge["underlay-color"]).toBe(
+      THEMES.fantasy.tokens.background,
+    );
+    expect(fantasyEdge.width).toBe(THEMES.fantasy.graph.edgeWidth + 1);
     expect(cyberpunkEdge["line-style"]).toBe("dashed");
+  });
+
+  it("should not render selection underlay around fantasy shield nodes", () => {
+    const fantasyStyle = getGraphStyle(THEMES.fantasy, mockCategories, false);
+    const selectedNode = fantasyStyle.find(
+      (s) => s.selector === "node:selected",
+    )?.style;
+
+    expect(selectedNode["underlay-opacity"]).toBe(0);
+    expect(selectedNode["underlay-shape"]).toBe("polygon");
+  });
+
+  it("should include rotated texture variants for the vampire theme", () => {
+    const horrorStyle = getGraphStyle(THEMES.horror, mockCategories, false);
+
+    expect(
+      horrorStyle.find((s) => s.selector === "node[textureVariant = 1]")?.style[
+        "background-image"
+      ],
+    ).toBe("url('/themes/blood-90.svg')");
+    expect(
+      horrorStyle.find((s) => s.selector === "node[textureVariant = 2]")?.style[
+        "background-image"
+      ],
+    ).toBe("url('/themes/blood-180.svg')");
+    expect(
+      horrorStyle.find((s) => s.selector === "node[textureVariant = 3]")?.style[
+        "background-image"
+      ],
+    ).toBe("url('/themes/blood-270.svg')");
   });
 });

--- a/packages/graph-engine/tests/transformer.test.ts
+++ b/packages/graph-engine/tests/transformer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { GraphTransformer, getGraphStyle } from "../src/transformer";
 import { CONNECTION_COLORS } from "../src/defaults";
 import type { Entity, StylingTemplate } from "schema";
@@ -264,5 +264,121 @@ describe("GraphTransformer", () => {
     const baseNodeStyle = styles.find((s: any) => s.selector === "node");
     expect(baseNodeStyle?.style["transition-property"]).toContain("width");
     expect(baseNodeStyle?.style["transition-property"]).toContain("height");
+  });
+
+  it("should apply the fantasy shield shape to base graph nodes", () => {
+    const mockTemplate: StylingTemplate = {
+      id: "fantasy",
+      name: "Ancient Parchment",
+      description: "...",
+      tokens: {
+        background: "#fdf6e3",
+        primary: "#5e3018",
+        secondary: "#423830",
+        surface: "#f0ddb8",
+        text: "#2a2018",
+        border: "rgba(94, 48, 24, 0.52)",
+        accent: "#c8973a",
+        fontHeader: "'Alegreya', serif",
+        fontBody: "'Alegreya', serif",
+        texture: "parchment.svg",
+      },
+      graph: {
+        nodeBorderWidth: 2,
+        nodeShape: "ellipse",
+        edgeColor: "#6b3820",
+        edgeStyle: "solid",
+        edgeWidth: 3,
+      },
+    };
+
+    const styles = getGraphStyle(mockTemplate, [], false);
+    const baseNodeStyle = styles.find((s: any) => s.selector === "node");
+
+    expect(baseNodeStyle?.style.shape).toBe("polygon");
+    expect(baseNodeStyle?.style["background-image"]).toBe(
+      "url('/themes/parchment.svg')",
+    );
+    expect(baseNodeStyle?.style["background-fit"]).toBe("cover");
+    expect(baseNodeStyle?.style["background-clip"]).toBe("node");
+    expect(baseNodeStyle?.style["background-image-crossorigin"]).toBe("null");
+    expect(baseNodeStyle?.style["background-repeat"]).toBe("no-repeat");
+  });
+
+  it("should not set a node texture when the theme has no texture", () => {
+    const mockTemplate: StylingTemplate = {
+      id: "scifi",
+      name: "Sci-Fi Terminal",
+      description: "...",
+      tokens: {
+        background: "#000",
+        primary: "#f00",
+        secondary: "#0f0",
+        surface: "#111",
+        text: "#fff",
+        border: "#333",
+        accent: "#00f",
+        fontHeader: "Arial",
+        fontBody: "Arial",
+      },
+      graph: {
+        nodeBorderWidth: 1,
+        nodeShape: "ellipse",
+        edgeColor: "#555",
+        edgeStyle: "solid",
+        edgeWidth: 1,
+      },
+    };
+
+    const styles = getGraphStyle(mockTemplate, [], false);
+    const baseNodeStyle = styles.find((s: any) => s.selector === "node");
+
+    expect(baseNodeStyle?.style["background-image"]).toBeUndefined();
+  });
+
+  it("should include a random texture variant for graph nodes", () => {
+    const randomSpy = vi
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0.33)
+      .mockReturnValueOnce(0.66)
+      .mockReturnValueOnce(0.99);
+    const mockEntities: Entity[] = [
+      {
+        id: "node-alpha",
+        title: "Alpha",
+        type: "npc",
+        connections: [],
+        content: "...",
+      },
+      {
+        id: "node-beta",
+        title: "Beta",
+        type: "npc",
+        connections: [],
+        content: "...",
+      },
+      {
+        id: "node-gamma",
+        title: "Gamma",
+        type: "npc",
+        connections: [],
+        content: "...",
+      },
+      {
+        id: "node-delta",
+        title: "Delta",
+        type: "npc",
+        connections: [],
+        content: "...",
+      },
+    ];
+
+    const nodes = GraphTransformer.entitiesToElements(mockEntities).filter(
+      (el) => el.group === "nodes",
+    );
+
+    expect(nodes.map((node) => node.data.textureVariant)).toEqual([0, 1, 2, 3]);
+    randomSpy.mockRestore();
   });
 });

--- a/specs/028-styling-templates/spec.md
+++ b/specs/028-styling-templates/spec.md
@@ -65,7 +65,7 @@ As a Game Master managing multiple campaigns, I want the theme selection to be s
 - **FR-001**: System MUST provide a selection interface for the following templates: Sci-Fi, Fantasy, Modern, Cyberpunk, Post-Apocalyptic.
 - **FR-002**: System MUST persist the selected template ID in the vault's local configuration.
 - **FR-003**: System MUST update the CSS variables and Cytoscape styles dynamically when a template is changed.
-- **FR-004**: Each template MUST define a specific set of visual attributes: primary color, background color, border radius, font family (serif/sans/mono), and graph edge style.
+- **FR-004**: Each template MUST define a specific set of visual attributes: primary color, background color, border radius, font family (serif/sans/mono), graph edge style, graph node shape, and supported graph node texture treatment.
 - **FR-005**: The system MUST apply template-specific borders and background textures to the Zen Mode and Entity Detail panels.
 
 ### Key Entities _(include if feature involves data)_

--- a/specs/080-fantasy-theme-refresh/plan.md
+++ b/specs/080-fantasy-theme-refresh/plan.md
@@ -12,14 +12,14 @@ Refresh the existing Classic/fantasy theme so the interface reads as a cohesive 
 ## Technical Context
 
 **Language/Version**: TypeScript 5.x, Svelte 5  
-**Primary Dependencies**: SvelteKit, Tailwind CSS 4, Playwright, workspace `schema` package  
+**Primary Dependencies**: SvelteKit, Tailwind CSS 4, Playwright, Cytoscape, workspace `schema` and `graph-engine` packages  
 **Storage**: Existing browser theme persistence only (`localStorage`, IndexedDB, OPFS via current theme flow); no new storage  
-**Testing**: Playwright E2E in `apps/web/tests/themes.spec.ts`  
+**Testing**: Playwright E2E in `apps/web/tests/themes.spec.ts`; Vitest graph style coverage in `packages/graph-engine`  
 **Target Platform**: Modern desktop and mobile browsers  
 **Project Type**: Web application monorepo  
 **Performance Goals**: Preserve current theme-switch speed, avoid visible layout shifts, and keep the refresh CSS-driven where possible  
-**Constraints**: Preserve non-fantasy themes, follow the existing shared theme system, maintain accessible contrast on parchment surfaces, avoid hardcoded one-off color logic spread across many components, keep the implementation focused on the screenshot-identified surfaces first, and enforce the simplified fantasy color rule consistently  
-**Scale/Scope**: Shared theme tokens plus a focused set of fantasy-facing UI surfaces in `apps/web`, especially the title area, icon rows, panel shells, borders, active/selected states, primary brown action surface, and entity-view hierarchy
+**Constraints**: Preserve non-fantasy themes, follow the existing shared theme system, maintain accessible contrast on parchment surfaces, avoid hardcoded one-off color logic spread across many components, use only supported Cytoscape style properties, keep the implementation focused on the screenshot-identified surfaces first, and enforce the simplified fantasy color rule consistently  
+**Scale/Scope**: Shared theme tokens plus a focused set of fantasy-facing UI surfaces in `apps/web`, especially the title area, icon rows, panel shells, borders, active/selected states, primary brown action surface, entity-view hierarchy, and graph node marker styling in `packages/graph-engine`
 
 ## Constitution Check
 
@@ -72,12 +72,18 @@ apps/
     │   └── tests/
     │       └── themes.spec.ts
 packages/
+├── graph-engine/
+│   ├── src/
+│   │   └── transformer.ts
+│   └── tests/
+│       ├── themes.test.ts
+│       └── transformer.test.ts
 └── schema/
     └── src/
         └── theme.ts
 ```
 
-**Structure Decision**: Keep shared fantasy token decisions centralized in `packages/schema/src/theme.ts`, map them through the existing theme store and global CSS in `apps/web/src/lib/stores/theme.svelte.ts` and `apps/web/src/app.css`, and make targeted component updates only where the current fantasy presentation breaks cohesion. The first target set is the exact screenshot-driven problem areas: cold title/highlight colors, multicolor icons, panel warmth, brown-vs-gold state treatment, firmer edges, the dominant brown action surface, and entity-view hierarchy.
+**Structure Decision**: Keep shared fantasy token decisions centralized in `packages/schema/src/theme.ts`, map them through the existing theme store and global CSS in `apps/web/src/lib/stores/theme.svelte.ts` and `apps/web/src/app.css`, and make targeted component updates only where the current fantasy presentation breaks cohesion. Graph-specific marker behavior belongs in `packages/graph-engine/src/transformer.ts` so Cytoscape style generation remains centralized and covered by graph-engine tests. The first target set is the exact screenshot-driven problem areas: cold title/highlight colors, multicolor icons, panel warmth, brown-vs-gold state treatment, firmer edges, the dominant brown action surface, entity-view hierarchy, and fantasy graph node marker treatment.
 
 ## Complexity Tracking
 

--- a/specs/080-fantasy-theme-refresh/spec.md
+++ b/specs/080-fantasy-theme-refresh/spec.md
@@ -42,6 +42,23 @@ As a user, I want panels, cards, sidebars, and other surfaces to feel physically
 
 ---
 
+### User Story 2a - Themed Graph Nodes (Priority: P2)
+
+As a user exploring the graph in a themed vault, I want nodes to carry the theme's material and shape language so the graph feels like part of the same world instead of a generic diagram.
+
+**Why this priority**: The graph is a primary navigation surface. If nodes remain plain circles while the rest of the app reads as parchment or horror material, the theme loses immersion at the exact place users browse relationships.
+
+**Independent Test**: Activate fantasy and horror/vampire themes and inspect the graph. Fantasy nodes should render as shield-like parchment markers, image nodes should keep a prominent category border, non-fantasy themes should retain circular nodes unless explicitly themed otherwise, and horror/vampire blood textures should not repeat with the same obvious orientation on every node.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fantasy theme is active, **When** a user views non-image graph nodes, **Then** they MUST render as shield-like markers using the fantasy material texture and category color without square texture or shadow artifacts.
+2. **Given** the fantasy theme is active, **When** a graph node has an image, **Then** the image MUST be clipped to the shield shape and the category border MUST remain thick enough to be clearly visible.
+3. **Given** another theme is active, **When** a user views graph nodes, **Then** nodes MAY keep the existing circular shape while still receiving supported theme texture treatment where that theme defines one.
+4. **Given** the horror/vampire theme is active, **When** a user views multiple non-image graph nodes, **Then** the blood-splatter texture orientation SHOULD vary between nodes so the pattern does not look mechanically repeated.
+
+---
+
 ### User Story 3 - Clearer Reading Hierarchy (Priority: P3)
 
 As a user reading an entity, I want stronger hierarchy between titles, section headers, metadata, and content so the page feels structured and authored instead of visually flat.
@@ -65,6 +82,7 @@ As a user reading an entity, I want stronger hierarchy between titles, section h
 - Interaction states MUST remain accessible on warm parchment surfaces without relying on color change alone.
 - If some surfaces cannot fully remove borders, the remaining borders MUST still stay within the warm fantasy tone family.
 - The color rule is strict: brown for UI and interaction, gold for focus and importance, and no other colors in the standard fantasy UI shell.
+- Cytoscape styles MUST use supported properties only; unsupported effects that create console warnings or square artifacts MUST be omitted.
 
 ### Assumptions
 
@@ -90,11 +108,16 @@ As a user reading an entity, I want stronger hierarchy between titles, section h
 - **FR-012**: Panels, cards, and controls in the fantasy theme MUST feel slightly firmer and less soft-mobile in their edge treatment.
 - **FR-013**: The refresh MUST preserve readability and accessible contrast across the affected fantasy-theme surfaces.
 - **FR-014**: The refresh MUST include automated verification for the most visible fantasy-theme behaviors affected by this change.
+- **FR-015**: Fantasy graph nodes MUST use a shield-like node shape with clipped theme texture and category-colored borders.
+- **FR-016**: Fantasy image graph nodes MUST retain a visibly thicker category border while clipping image content to the shield shape.
+- **FR-017**: Theme graph textures MUST avoid unsupported Cytoscape style properties and MUST NOT create square background or shadow artifacts around non-rectangular nodes.
+- **FR-018**: Horror/vampire graph node blood textures SHOULD vary orientation across nodes without requiring deterministic persistence.
 
 ### Key Entities _(include if feature involves data)_
 
 - **Fantasy Theme Profile**: The set of visual rules that defines colors, emphasis, and interaction behavior for the fantasy experience.
 - **Theme Surface**: Any visible panel, sidebar, card, or reading area that must feel materially aligned with the parchment background.
+- **Graph Node Marker**: The visual representation of an entity in the graph, including shape, texture, image clipping, category border, and selection treatment.
 - **Interaction State**: The hover, selected, focused, and active presentation of controls within the fantasy theme.
 
 ## Success Criteria _(mandatory)_
@@ -105,3 +128,4 @@ As a user reading an entity, I want stronger hierarchy between titles, section h
 - **SC-002**: In the fantasy theme, standard UI and interaction states read as brown, while active tabs, selected elements, and key highlights read as gold.
 - **SC-003**: Manual review of the main fantasy surfaces confirms that panels and sidebars read as parchment-adjacent materials rather than neutral app cards, and that cards and panels feel slightly firmer and less app-like.
 - **SC-004**: Automated theme checks cover the revised fantasy-theme palette, selected/focus treatment, and interaction behavior for the primary affected surfaces.
+- **SC-005**: Automated graph-engine checks cover fantasy shield node styling, image-node border hierarchy, supported texture application, and horror/vampire blood texture variants.

--- a/specs/080-fantasy-theme-refresh/tasks.md
+++ b/specs/080-fantasy-theme-refresh/tasks.md
@@ -10,7 +10,7 @@
 ## Format: `[ID] [P?] [Story] Description`
 
 - **[P]**: Can run in parallel (different files, no blocking dependency)
-- **[Story]**: Which user story this task belongs to (`US1`, `US2`, `US3`)
+- **[Story]**: Which user story this task belongs to (`US1`, `US2`, `US2a`, `US3`)
 - Every task includes exact file paths
 
 ## Phase 1: Setup (Shared Infrastructure)
@@ -19,6 +19,7 @@
 
 - [ ] T001 Add baseline fantasy-theme regression coverage scaffolding in `apps/web/tests/themes.spec.ts`
 - [ ] T002 [P] Inventory the screenshot-identified fantasy-theme touchpoints in `packages/schema/src/theme.ts`, `apps/web/src/lib/stores/theme.svelte.ts`, `apps/web/src/app.css`, `apps/web/src/lib/components/explorer/EntityList.svelte`, and `apps/web/src/lib/components/entity-detail/DetailHeader.svelte`
+- [ ] T002a [P] Inventory fantasy graph marker behavior in `packages/graph-engine/src/transformer.ts`, `packages/graph-engine/tests/themes.test.ts`, and `packages/graph-engine/tests/transformer.test.ts`
 
 ---
 
@@ -78,6 +79,27 @@
 
 ---
 
+## Phase 4a: User Story 2a - Themed Graph Nodes (Priority: P2)
+
+**Goal**: Make graph node markers reflect theme material and shape language without square artifacts or unsupported Cytoscape styles
+
+**Independent Test**: Activate fantasy and horror/vampire themes and confirm fantasy nodes render as shield-like parchment markers, fantasy image nodes retain thick category borders, non-fantasy themes remain circular unless otherwise specified, and horror/vampire blood textures vary orientation across nodes
+
+### Tests for User Story 2a ⚠️
+
+- [ ] T013a [P] [US2a] Add graph-engine assertions for fantasy shield node style, clipped texture, selected-node artifact prevention, and fantasy image-node border hierarchy in `packages/graph-engine/tests/themes.test.ts` and `packages/graph-engine/src/transformer.test.ts`
+- [ ] T013b [P] [US2a] Add graph-engine assertions for theme texture application, missing-texture fallback, and horror/vampire blood texture variants in `packages/graph-engine/tests/transformer.test.ts` and `packages/graph-engine/tests/themes.test.ts`
+
+### Implementation for User Story 2a
+
+- [ ] T013c [US2a] Apply supported theme texture styles, fantasy shield polygon points, and artifact-free selection treatment in `packages/graph-engine/src/transformer.ts`
+- [ ] T013d [US2a] Preserve circular node shapes for non-fantasy themes while adding random texture variant data for graph nodes in `packages/graph-engine/src/transformer.ts`
+- [ ] T013e [P] [US2a] Add rotated blood texture variant assets in `apps/web/static/themes/`
+
+**Checkpoint**: User Story 2a should now deliver themed graph node markers independently
+
+---
+
 ## Phase 5: User Story 3 - Clearer Reading Hierarchy (Priority: P3)
 
 **Goal**: Improve title weight, section separation, metadata de-emphasis, and gold focus treatment in entity reading views
@@ -115,6 +137,7 @@
 - **Foundational (Phase 2)**: Depends on Setup completion and blocks all user story work
 - **User Story 1 (Phase 3)**: Depends on Foundational completion
 - **User Story 2 (Phase 4)**: Depends on Foundational completion
+- **Graph Nodes (Phase 4a)**: Depends on Foundational completion and can proceed independently of User Story 3
 - **User Story 3 (Phase 5)**: Depends on Foundational completion and benefits from User Story 1 styling decisions
 - **Polish (Phase 6)**: Depends on all desired user stories being complete
 
@@ -122,6 +145,7 @@
 
 - **User Story 1 (P1)**: Can start immediately after Foundational completion
 - **User Story 2 (P2)**: Can start immediately after Foundational completion
+- **User Story 2a (P2)**: Can start immediately after Foundational completion
 - **User Story 3 (P3)**: Should follow the shared styling direction established in User Story 1, but remains independently testable
 
 ### Within Each User Story
@@ -136,6 +160,7 @@
 - `T004` and `T005` can run in parallel after `T003`
 - `T008` and `T009` can run in parallel after `T006`
 - `T012` and `T013` can run in parallel after `T010`
+- `T013a`, `T013b`, and `T013e` can run in parallel with graph-engine implementation planning
 - `T018` can run in parallel with `T019`
 
 ---
@@ -181,3 +206,4 @@ Task: "Soften fantasy active and hover tab emphasis in apps/web/src/lib/componen
 - `apps/web/tests/themes.spec.ts` is the primary regression file for this feature
 - The highest-priority implementation slice is exactly the user-provided distilled rule set: dark ink text, brown interaction, gold focus, unified brown icons, warmer parchment panels, and firmer edges
 - Preserve the existing theme system; do not create a fantasy-only styling path outside shared theme plumbing
+- Graph marker styling should stay in `packages/graph-engine` and avoid unsupported Cytoscape style properties that create warnings or square artifacts


### PR DESCRIPTION
## 🎯 Purpose
This PR addresses issue #679 by making graph nodes carry the selected theme more directly: fantasy nodes render as shield shapes, horror/vampire nodes get blood-splatter texture variation, and image nodes keep stronger category borders.

## 🛠️ Changes
- Apply active theme textures to graph node backgrounds with clipped node shapes.
- Render fantasy-theme nodes as shield-shaped polygons while keeping other themes circular for now.
- Increase fantasy image-node border thickness so category color remains visible over images.
- Remove unsupported Cytoscape `shadow-*` styles and remove the square shadow/underlay artifacts around themed nodes.
- Add rotated blood-splatter texture variants and assign node texture orientation randomly per node.
- Expand graph-engine tests for fantasy shields, themed texture mapping, blood texture variants, and image/revealed node border behavior.
- Update Speckit docs for themed graph nodes in the fantasy refresh spec, plan, tasks, and styling-template requirements.

## 🧪 Testing
- `npm test --workspace packages/graph-engine -- --run tests/transformer.test.ts src/transformer.test.ts tests/themes.test.ts`
- `npm run lint --workspace packages/graph-engine`
- `npm test --workspace packages/graph-engine`
- Runtime Cytoscape style parse check for blood texture variant selectors
- Pre-push: `npm run lint lint:types`
- Pre-push: `npm run test:affected`

## 🚦 Target Branch Reminder
> [!IMPORTANT]
> **This PR targets the `staging` branch.**
