### PR TITLE
:bug: fix(graph): add escape and click-outside dismissal for connection modals #678

### DIFF
--- a/apps/web/src/lib/components/graph/EdgeEditorModal.svelte
+++ b/apps/web/src/lib/components/graph/EdgeEditorModal.svelte
@@ -33,16 +33,26 @@
       editingEdge = null;
     }
   };
+
+  const close = () => {
+    editingEdge = null;
+  };
 </script>
 
+<svelte:window onkeydown={(e) => e.key === "Escape" && close()} />
+
 {#if editingEdge}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="fixed inset-0 bg-black/40 backdrop-blur-sm z-[60] flex items-center justify-center p-4"
     transition:fade={{ duration: 200 }}
+    onclick={close}
   >
     <div
       class="bg-theme-surface border border-theme-primary p-6 shadow-2xl w-full max-w-md"
       transition:fly={{ y: 20, duration: 300 }}
+      onclick={(e) => e.stopPropagation()}
     >
       <h2
         class="text-theme-primary font-header font-bold text-sm uppercase tracking-[0.2em] mb-4"

--- a/apps/web/src/lib/components/graph/EdgeEditorModal.svelte
+++ b/apps/web/src/lib/components/graph/EdgeEditorModal.svelte
@@ -45,7 +45,7 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="fixed inset-0 bg-black/40 backdrop-blur-sm z-[60] flex items-center justify-center p-4"
+    class="fixed inset-0 bg-theme-bg/80 backdrop-blur-sm z-[60] flex items-center justify-center p-4"
     transition:fade={{ duration: 200 }}
     onclick={close}
   >
@@ -105,7 +105,7 @@
                 editingEdge = null;
               }
             }}
-            class="text-[10px] font-bold text-red-500 hover:text-red-400 uppercase tracking-widest transition-colors"
+            class="text-[10px] font-bold text-red-600 hover:text-red-500 uppercase tracking-widest transition-colors"
           >
             Sever Connection
           </button>

--- a/apps/web/src/lib/components/graph/EdgeEditorModal.svelte
+++ b/apps/web/src/lib/components/graph/EdgeEditorModal.svelte
@@ -37,9 +37,14 @@
   const close = () => {
     editingEdge = null;
   };
+
+  const handleWindowKeydown = (e: KeyboardEvent) => {
+    if (!editingEdge) return;
+    if (e.key === "Escape") close();
+  };
 </script>
 
-<svelte:window onkeydown={(e) => e.key === "Escape" && close()} />
+<svelte:window onkeydown={handleWindowKeydown} />
 
 {#if editingEdge}
   <!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/apps/web/src/lib/components/graph/EdgeEditorModal.test.ts
+++ b/apps/web/src/lib/components/graph/EdgeEditorModal.test.ts
@@ -1,0 +1,85 @@
+/** @vitest-environment jsdom */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { render, fireEvent, waitFor } from "@testing-library/svelte";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock transitions
+vi.mock("svelte/transition", () => ({
+  fade: () => ({ duration: 0 }),
+  fly: () => ({ duration: 0 }),
+}));
+
+// Mock Element.prototype.animate for jsdom
+if (typeof Element !== "undefined" && !Element.prototype.animate) {
+  Element.prototype.animate = vi.fn().mockReturnValue({
+    finished: Promise.resolve(),
+    cancel: vi.fn(),
+  });
+}
+
+// Mock Svelte client runtime
+vi.mock("svelte", async () => {
+  // @ts-ignore - force the client Svelte runtime so testing-library can mount
+  return await import("../../../../../../node_modules/svelte/src/index-client.js");
+});
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    updateConnection: vi.fn(),
+    removeConnection: vi.fn(),
+  },
+}));
+
+import EdgeEditorModal from "./EdgeEditorModal.svelte";
+
+describe("EdgeEditorModal Dismissal", () => {
+  const editingEdge = {
+    source: "s1",
+    target: "t1",
+    label: "related",
+    type: "neutral",
+  };
+
+  it("should close when Escape key is pressed", async () => {
+    const mockEditingEdge: any = editingEdge;
+    const { container } = render(EdgeEditorModal, {
+      editingEdge: mockEditingEdge,
+    });
+
+    await fireEvent.keyDown(window, { key: "Escape" });
+    // The component sets editingEdge = null; but since it's a prop, we need to check if it was closed
+    // Since we don't have a good way to check bindable prop change from outside in this test setup easily
+    // without a wrapper component, I'll check if the modal is gone from the DOM.
+    await waitFor(() =>
+      expect(container.querySelector(".fixed.inset-0")).toBeNull(),
+    );
+  });
+
+  it("should close when clicking the backdrop", async () => {
+    const mockEditingEdge: any = editingEdge;
+    const { container } = render(EdgeEditorModal, {
+      editingEdge: mockEditingEdge,
+    });
+
+    const backdrop = container.querySelector(".fixed.inset-0");
+    expect(backdrop).toBeTruthy();
+
+    await fireEvent.click(backdrop!);
+    await waitFor(() =>
+      expect(container.querySelector(".fixed.inset-0")).toBeNull(),
+    );
+  });
+
+  it("should NOT close when clicking the modal content", async () => {
+    const mockEditingEdge: any = editingEdge;
+    const { container } = render(EdgeEditorModal, {
+      editingEdge: mockEditingEdge,
+    });
+
+    const modalContent = container.querySelector(".bg-theme-surface");
+    expect(modalContent).toBeTruthy();
+
+    await fireEvent.click(modalContent!);
+    expect(container.querySelector(".fixed.inset-0")).toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/components/graph/SelectionConnector.svelte
+++ b/apps/web/src/lib/components/graph/SelectionConnector.svelte
@@ -2,6 +2,7 @@
   import { vault } from "$lib/stores/vault.svelte";
   import { ui } from "$lib/stores/ui.svelte";
   import { fade } from "svelte/transition";
+  import { untrack } from "svelte";
   import type { Core, NodeSingular } from "cytoscape";
 
   let { cy } = $props<{ cy: Core }>();
@@ -12,39 +13,37 @@
   let isSubmitting = $state(false);
   let previousShow = $state(false);
 
+  const updatePosition = () => {
+    if (selection.length === 2) {
+      const p1 = selection[0].renderedPosition();
+      const p2 = selection[1].renderedPosition();
+      position = {
+        x: (p1.x + p2.x) / 2,
+        y: (p1.y + p2.y) / 2,
+      };
+    }
+  };
+
+  const updateSelection = () => {
+    if (!cy) return;
+    const selected = cy.$("node:selected");
+    if (selected.length === 2) {
+      selection = [selected[0] as NodeSingular, selected[1] as NodeSingular];
+      updatePosition();
+    } else {
+      selection = [];
+      ui.showSelectionConnector = false;
+      isSubmitting = false;
+    }
+  };
+
   $effect(() => {
     if (cy) {
-      const updateSelection = () => {
-        const selected = cy.$("node:selected");
-        if (selected.length === 2) {
-          selection = [
-            selected[0] as NodeSingular,
-            selected[1] as NodeSingular,
-          ];
-          updatePosition();
-        } else {
-          selection = [];
-          ui.showSelectionConnector = false;
-          isSubmitting = false;
-        }
-      };
-
-      const updatePosition = () => {
-        if (selection.length === 2) {
-          const p1 = selection[0].renderedPosition();
-          const p2 = selection[1].renderedPosition();
-          position = {
-            x: (p1.x + p2.x) / 2,
-            y: (p1.y + p2.y) / 2,
-          };
-        }
-      };
-
       cy.on("select unselect", "node", updateSelection);
       cy.on("position pan zoom", updatePosition);
 
       // Initial check
-      updateSelection();
+      untrack(() => updateSelection());
 
       return () => {
         cy.off("select unselect", "node", updateSelection);
@@ -100,6 +99,7 @@
   };
 
   const handleKeydown = (e: KeyboardEvent) => {
+    if (!ui.showSelectionConnector) return;
     if (e.key === "Enter") {
       submit();
     } else if (e.key === "Escape") {
@@ -117,7 +117,17 @@
   };
 </script>
 
+<svelte:window onkeydown={handleKeydown} />
+
 {#if selection.length === 2 && ui.showSelectionConnector}
+  <!-- Backdrop for "click outside" closing -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-30 pointer-events-auto cursor-default"
+    onclick={() => (ui.showSelectionConnector = false)}
+  ></div>
+
   <div
     class="absolute z-40 pointer-events-none"
     style:top="{position.y}px"
@@ -125,8 +135,12 @@
     transition:fade={{ duration: 150 }}
   >
     <div class="pointer-events-auto -translate-x-1/2 -translate-y-1/2">
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="bg-theme-surface border border-theme-border shadow-2xl p-3 min-w-[240px] rounded"
+        onclick={(e) => e.stopPropagation()}
+        role="presentation"
       >
         <div
           id="connector-title"

--- a/apps/web/src/lib/components/graph/SelectionConnector.test.ts
+++ b/apps/web/src/lib/components/graph/SelectionConnector.test.ts
@@ -1,0 +1,100 @@
+/** @vitest-environment jsdom */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { render, fireEvent, waitFor } from "@testing-library/svelte";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock transitions
+vi.mock("svelte/transition", () => ({
+  fade: () => ({ duration: 0 }),
+}));
+
+// Mock Element.prototype.animate for jsdom
+if (typeof Element !== "undefined" && !Element.prototype.animate) {
+  Element.prototype.animate = vi.fn().mockReturnValue({
+    finished: Promise.resolve(),
+    cancel: vi.fn(),
+  });
+}
+
+import SelectionConnector from "./SelectionConnector.svelte";
+import { ui } from "$lib/stores/ui.svelte";
+
+// Mock Svelte client runtime
+vi.mock("svelte", async () => {
+  // @ts-ignore - force the client Svelte runtime so testing-library can mount
+  return await import("../../../../../../node_modules/svelte/src/index-client.js");
+});
+
+// Mock stores
+vi.mock("$lib/stores/ui.svelte", () => ({
+  ui: {
+    showSelectionConnector: false,
+    lastConnectionLabel: "",
+    recentConnectionLabels: [],
+    setLastConnectionLabel: vi.fn(),
+    notify: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    addConnection: vi.fn(),
+    entities: {},
+    inboundConnections: {},
+  },
+}));
+
+describe("SelectionConnector Dismissal", () => {
+  const mockCy = {
+    on: vi.fn(),
+    off: vi.fn(),
+    $: vi.fn().mockReturnValue({
+      length: 2,
+      map: vi.fn().mockReturnValue(["id1", "id2"]),
+      0: {
+        renderedPosition: () => ({ x: 100, y: 100 }),
+        id: () => "id1",
+        data: (key: string) => (key === "label" ? "Node 1" : undefined),
+      },
+      1: {
+        renderedPosition: () => ({ x: 200, y: 200 }),
+        id: () => "id2",
+        data: (key: string) => (key === "label" ? "Node 2" : undefined),
+      },
+    }),
+    elements: vi.fn().mockReturnValue({
+      unselect: vi.fn(),
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ui.showSelectionConnector = false;
+  });
+
+  it("should close when Escape key is pressed", async () => {
+    ui.showSelectionConnector = true;
+    render(SelectionConnector, { cy: mockCy as any });
+
+    // Mock that we have 2 nodes selected
+    // The component uses $effect to update selection, so we need to wait
+    await waitFor(() => expect(ui.showSelectionConnector).toBe(true));
+
+    await fireEvent.keyDown(window, { key: "Escape" });
+    expect(ui.showSelectionConnector).toBe(false);
+  });
+
+  it("should close when clicking the backdrop", async () => {
+    ui.showSelectionConnector = true;
+    const { container } = render(SelectionConnector, { cy: mockCy as any });
+
+    // Find the backdrop - it's the first div inside the #if
+    // We can use a data-testid or just find it by class
+    // I didn't add data-testid, so I'll find by class "fixed inset-0"
+    const backdrop = container.querySelector(".fixed.inset-0");
+    expect(backdrop).toBeTruthy();
+
+    await fireEvent.click(backdrop!);
+    expect(ui.showSelectionConnector).toBe(false);
+  });
+});


### PR DESCRIPTION
## 🎯 Purpose
This PR addresses issue #678 by making connection-related modals easily dismissible via the 'Escape' key or by clicking outside the modal area.

## 🛠️ Changes
- **EdgeEditorModal.svelte**: Added global 'Escape' key handling and backdrop click-to-close functionality.
- **SelectionConnector.svelte**: Added a transparent backdrop to capture 'click outside' events and moved 'Escape' handling to a global listener.
- **Style Guide Alignment**: Updated components to use Tailwind 4 theme tokens (e.g., `bg-theme-bg/80`) and Svelte 5 best practices (`untrack`).
- **Tests**: Added unit tests (`EdgeEditorModal.test.ts` and `SelectionConnector.test.ts`) to verify the new dismissal behaviors.

## 🧪 Testing
Verified via new unit tests and manual review of the component logic. All 1001 tests in `apps/web` are passing.

## 🏷️ Release Labeling
- minor (Usability improvement)