### PR TITLE
🎨 Palette: [Add aria-label to copy button in NodeReadModal]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 
 **Learning:** Svelte `a11y_click_events_have_key_events` and `a11y_no_static_element_interactions` warnings on clickable `<div>` elements are best resolved by converting them to semantic `<button type="button">` elements.
 **Action:** When creating clickable overlays (like map entries) with `group-hover:opacity-100`, use a `<button>`, add an `aria-label`, and include `focus:opacity-100` plus a strong visible focus style such as `focus-visible:ring-2 focus-visible:ring-offset-2` so keyboard users can navigate to and trigger them natively without `svelte-ignore` comments.
+
+## 2024-05-18 - Icon-Only Buttons Require Explicit aria-label
+**Learning:** While the `title` attribute provides a tooltip for sighted users on hover, it is not consistently read by all screen readers or in all contexts as an accessible name for an element. For icon-only buttons, especially in modals or highly interactive components, relying solely on `title` can result in empty or unhelpful announcements for assistive technologies.
+**Action:** Always provide an explicit `aria-label` attribute on icon-only `<button>` elements, even if a `title` attribute is already present. This ensures robust accessibility across different screen readers.

--- a/apps/web/src/lib/components/modals/NodeReadModal.svelte
+++ b/apps/web/src/lib/components/modals/NodeReadModal.svelte
@@ -181,6 +181,7 @@
               onclick={copyToClipboard}
               class="p-2 text-green-700 hover:text-green-500 transition rounded hover:bg-green-900/20"
               title="Copy Content"
+              aria-label="Copy Content"
             >
               {#if copyStatus === "success"}
                 <span class="icon-[lucide--check] w-6 h-6"></span>


### PR DESCRIPTION
💡 What: Added `aria-label="Copy Content"` to the icon-only "Copy Content" button in `NodeReadModal.svelte`.
🎯 Why: While the button had a `title` attribute for hover tooltips, screen readers inconsistently announce `title` attributes alone on icon-only buttons. Providing an explicit `aria-label` ensures all users can understand the button's purpose.
♿ Accessibility: Ensures robust screen reader support for the copy action within the Node Read Modal. This is a critical learning logged to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [435631982690628106](https://jules.google.com/task/435631982690628106) started by @eserlan*