### PR TITLE
[codex] tune graph layout redraw pipeline

### DIFF
--- a/.gemini/skills/frontend-design/SKILL.md
+++ b/.gemini/skills/frontend-design/SKILL.md
@@ -4,42 +4,34 @@ description: Create distinctive, production-grade frontend interfaces with high 
 license: Complete terms in LICENSE.txt
 ---
 
+# Frontend Design Skill
+
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
 
-The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+## Project Standards (Codex-Cryptica)
+
+**CRITICAL: You MUST strictly adhere to the following project-specific standards for every UI task.**
+
+- **Design System**: ALWAYS read and adhere to \`@docs/STYLE_GUIDE.md\`.
+- **Framework**: Use **Svelte 5 Runes** (\`\$state\`, \`\$derived\`, \`\$props\`) exclusively.
+- **Styling**: Use **Tailwind 4 semantic tokens** (e.g., \`bg-theme-surface\`, \`text-theme-primary\`). NEVER use hardcoded hex codes.
+- **Icons**: NEVER use \`lucide-svelte\` components. ALWAYS use the Iconify utility pattern: \`class="icon-[lucide--name] h-4 w-4"\`.
+- **Data Integrity**: Use \`\$state.snapshot()\` when passing reactive state to non-reactive logic or asynchronous handlers.
+- **Testing**: Every UI change or addition MUST be accompanied by a unit test (e.g., \`*.test.ts\`).
 
 ## Design Thinking
 
 Before coding, understand the context and commit to a BOLD aesthetic direction:
 
-- **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
-- **Constraints**: Technical requirements (framework, performance, accessibility).
-- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
-
-**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
-
-Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
-
-- Production-grade and functional
-- Visually striking and memorable
-- Cohesive with a clear aesthetic point-of-view
-- Meticulously refined in every detail
+- **Purpose**: What problem does this interface solve?
+- **Tone**: Pick an extreme: brutally minimal, sci-fi/retro-futuristic, organic, luxury, etc.
+- **Constraints**: Svelte 5, Tailwind 4, Accessibility (ARIA).
 
 ## Frontend Aesthetics Guidelines
 
-Focus on:
+- **Typography**: Use font variables (\`font-header\`, \`font-body\`) defined in the theme.
+- **Color & Theme**: Use the semantic theme tokens. Ensure contrast and readability across all themes (Fantasy, Sci-Fi, etc.).
+- **Motion**: Prioritize CSS transitions and Svelte built-in transitions for micro-interactions.
+- **Spatial Composition**: Meticulous attention to spacing, negative space, and responsive layout using Tailwind utilities.
 
-- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
-- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
-- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
-- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
-- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
-
-NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
-
-Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
-
-**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
-
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+NEVER use generic AI-generated aesthetics. Interpret creatively while staying within the boundaries of the Codex-Cryptica design system.

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -136,6 +136,12 @@
         onLayoutStart: () => {
           isLayoutRunning = true;
         },
+        onLayoutComputed: (ms) => {
+          debugStore.log(`Layout: ${ms}ms`, {
+            nodes: graph.stats.nodeCount,
+            caller,
+          });
+        },
         onLayoutStop: () => {
           isLayoutRunning = false;
           graphVisible = true;

--- a/apps/web/src/lib/components/debug/DebugConsole.svelte
+++ b/apps/web/src/lib/components/debug/DebugConsole.svelte
@@ -51,18 +51,18 @@
           class="flex justify-between items-center mb-2 pb-2 border-b border-white/10"
         >
           <span
-            class="font-bold text-xs uppercase font-header tracking-widest text-theme-primary"
+            class="font-bold text-xs uppercase tracking-widest text-white/60"
             >Console Output</span
           >
           <div class="flex gap-2">
             <button
-              class="bg-sky-900/30 text-sky-400 hover:bg-sky-800/50 hover:text-sky-300 px-2 py-0.5 rounded text-[10px] uppercase font-bold font-header border border-sky-500/30 transition-colors"
+              class="bg-white/10 text-white/70 hover:bg-white/20 hover:text-white px-2 py-0.5 rounded text-[10px] uppercase font-bold border border-white/20 transition-colors"
               onclick={copyLogsToClipboard}
             >
               Copy All
             </button>
             <button
-              class="bg-red-900/30 text-red-400 hover:bg-red-800/50 hover:text-red-300 px-2 py-0.5 rounded text-[10px] uppercase font-bold font-header border border-red-500/30 transition-colors"
+              class="bg-white/10 text-white/70 hover:bg-white/20 hover:text-white px-2 py-0.5 rounded text-[10px] uppercase font-bold border border-white/20 transition-colors"
               onclick={() => debugStore.clear()}
             >
               Clear
@@ -72,7 +72,7 @@
         <div class="flex flex-col gap-1">
           {#each logs as log, index (`${log.timestamp}-${index}`)}
             <div class="flex gap-2 border-b border-white/5 pb-1 last:border-0">
-              <span class="text-gray-500 whitespace-nowrap">
+              <span class="text-white whitespace-nowrap">
                 {new Date(log.timestamp).toLocaleTimeString()}
               </span>
               <span
@@ -80,7 +80,7 @@
                   ? 'text-red-400 font-bold'
                   : log.level === 'warn'
                     ? 'text-amber-400'
-                    : 'text-green-400'} uppercase w-10 shrink-0"
+                    : 'text-white/50'} uppercase w-10 shrink-0"
               >
                 {log.level}
               </span>
@@ -89,13 +89,13 @@
                 {#if log.data}
                   <div class="relative mt-1">
                     <pre
-                      class="bg-white/5 p-2 rounded overflow-x-auto text-gray-300 max-h-32 text-[10px]">{JSON.stringify(
+                      class="bg-white/5 p-2 rounded overflow-x-auto text-white/60 max-h-32 text-[10px]">{JSON.stringify(
                         log.data,
                         null,
                         2,
                       )}</pre>
                     <button
-                      class="absolute top-1 right-1 bg-white/10 hover:bg-white/20 text-white text-[9px] px-1.5 py-0.5 rounded transition-colors"
+                      class="absolute top-1 right-1 bg-white/10 hover:bg-white/20 text-white/60 hover:text-white text-[9px] px-1.5 py-0.5 rounded transition-colors"
                       onclick={() => {
                         try {
                           navigator.clipboard.writeText(

--- a/apps/web/src/lib/stores/proposer.svelte.test.ts
+++ b/apps/web/src/lib/stores/proposer.svelte.test.ts
@@ -19,6 +19,9 @@ const {
       target: {
         id: "target",
         title: "Target",
+        content: "Target content",
+        lore: "Target lore",
+        connections: [],
       },
     },
     inboundConnections: {},
@@ -33,6 +36,9 @@ const {
       {
         id: "target",
         title: "Target",
+        content: "Target content",
+        lore: "Target lore",
+        connections: [],
       },
     ],
     addConnection: vi.fn().mockResolvedValue(true),
@@ -99,6 +105,7 @@ vi.mock("@codex/proposer", () => ({
 
 describe("proposerStore", () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockVault.selectedEntityId = null;
   });
@@ -159,5 +166,60 @@ describe("proposerStore", () => {
         failedCount: 0,
       }),
     );
+  });
+
+  it("keeps the global analysis state active until concurrent entity analyses finish", async () => {
+    let resolveSource: (value: []) => void = () => {};
+    let resolveTarget: (value: []) => void = () => {};
+
+    mockAnalyzeEntity.mockImplementation(
+      (_apiKey: string, _modelName: string, entityId: string): Promise<[]> =>
+        new Promise((resolve) => {
+          if (entityId === "source") {
+            resolveSource = resolve;
+          } else if (entityId === "target") {
+            resolveTarget = resolve;
+          }
+        }),
+    );
+
+    const { proposerStore } = await import("./proposer.svelte");
+
+    const sourceRun = proposerStore.analyzeEntityById("source");
+    await vi.waitFor(() => {
+      expect(proposerStore.isEntityAnalyzing("source")).toBe(true);
+      expect(mockAnalyzeEntity).toHaveBeenCalledWith(
+        "test-key",
+        expect.any(String),
+        "source",
+        expect.any(String),
+        expect.any(Array),
+      );
+    });
+
+    const targetRun = proposerStore.analyzeEntityById("target");
+    await vi.waitFor(() => {
+      expect(proposerStore.isEntityAnalyzing("target")).toBe(true);
+      expect(mockAnalyzeEntity).toHaveBeenCalledWith(
+        "test-key",
+        expect.any(String),
+        "target",
+        expect.any(String),
+        expect.any(Array),
+      );
+    });
+
+    resolveSource([]);
+    await sourceRun;
+
+    expect(proposerStore.isEntityAnalyzing("source")).toBe(false);
+    expect(proposerStore.isEntityAnalyzing("target")).toBe(true);
+    expect(proposerStore.isAnalyzing).toBe(true);
+
+    resolveTarget([]);
+    await targetRun;
+
+    expect(proposerStore.isEntityAnalyzing("target")).toBe(false);
+    expect(proposerStore.isAnalyzing).toBe(false);
   });
 });

--- a/apps/web/src/lib/stores/proposer.svelte.ts
+++ b/apps/web/src/lib/stores/proposer.svelte.ts
@@ -10,9 +10,12 @@ import { getDB, DB_NAME, DB_VERSION } from "../utils/idb";
 
 class ProposerStore {
   private service: ProposerService | null = null;
+  private activeAnalysisCounts = new Map<string, number>();
+  private activeAnalysisTotal = 0;
   isAnalyzing = $state(false);
   isLoadingProposals = $state(false);
   analysisError = $state<string | null>(null);
+  analysisErrors = $state<Record<string, string | null>>({});
   proposals = $state<Record<string, Proposal[]>>({}); // keyed by entityId
   history = $state<Record<string, Proposal[]>>({}); // keyed by entityId
 
@@ -75,6 +78,39 @@ class ProposerStore {
     return this.service;
   }
 
+  isEntityAnalyzing(entityId: string) {
+    return (this.activeAnalysisCounts.get(entityId) ?? 0) > 0;
+  }
+
+  private setAnalysisError(entityId: string, error: string | null) {
+    this.analysisErrors = { ...this.analysisErrors, [entityId]: error };
+    if (!vault.selectedEntityId || vault.selectedEntityId === entityId) {
+      this.analysisError = error;
+    }
+  }
+
+  private beginAnalysis(entityId: string) {
+    this.activeAnalysisCounts.set(
+      entityId,
+      (this.activeAnalysisCounts.get(entityId) ?? 0) + 1,
+    );
+    this.activeAnalysisTotal += 1;
+    this.isAnalyzing = true;
+    this.setAnalysisError(entityId, null);
+  }
+
+  private finishAnalysis(entityId: string) {
+    const nextCount = (this.activeAnalysisCounts.get(entityId) ?? 1) - 1;
+    if (nextCount > 0) {
+      this.activeAnalysisCounts.set(entityId, nextCount);
+    } else {
+      this.activeAnalysisCounts.delete(entityId);
+    }
+
+    this.activeAnalysisTotal = Math.max(0, this.activeAnalysisTotal - 1);
+    this.isAnalyzing = this.activeAnalysisTotal > 0;
+  }
+
   async loadProposals(entityId: string, requireSelection = true) {
     if (this.isLoadingProposals) return;
 
@@ -97,7 +133,7 @@ class ProposerStore {
   async analyzeCurrentEntity() {
     if (uiStore.aiDisabled) return;
     const entityId = vault.selectedEntityId;
-    if (!entityId || this.isAnalyzing) return;
+    if (!entityId || this.isEntityAnalyzing(entityId)) return;
     await this.analyzeEntityById(entityId, true);
   }
 
@@ -108,32 +144,33 @@ class ProposerStore {
   ) {
     if (uiStore.aiDisabled) return;
 
-    // We log a warning if trying to analyze the same entity concurrently,
-    // but we shouldn't block analyses for *different* entities entirely.
-    // For now, allow concurrent analyses by dropping the global `this.isAnalyzing` block here.
-    // NOTE: UI loaders bound to `isAnalyzing` might flicker.
-
-    this.analysisError = null;
-
-    // Load existing proposals/history if not loaded
-    if (!this.proposals[entityId]) {
-      await this.loadProposals(entityId, requireSelection);
-      // If the user changed the selected entity while loading, abort this analysis
-      if (requireSelection && vault.selectedEntityId !== entityId) return;
-    }
-
-    const apiKey = oracle.effectiveApiKey || "";
-
-    const entity = vault.entities[entityId];
-    if (!entity) {
+    if (this.isEntityAnalyzing(entityId)) {
       debugStore.warn(
-        `[ProposerStore] Skipping connection analysis for ${entityId}: entity missing from vault`,
+        `[ProposerStore] Skipping duplicate connection analysis for ${entityId}: already running`,
       );
       return;
     }
 
-    this.isAnalyzing = true;
+    this.beginAnalysis(entityId);
+
     try {
+      // Load existing proposals/history if not loaded
+      if (!this.proposals[entityId]) {
+        await this.loadProposals(entityId, requireSelection);
+        // If the user changed the selected entity while loading, abort this analysis
+        if (requireSelection && vault.selectedEntityId !== entityId) return;
+      }
+
+      const apiKey = oracle.effectiveApiKey || "";
+
+      const entity = vault.entities[entityId];
+      if (!entity) {
+        debugStore.warn(
+          `[ProposerStore] Skipping connection analysis for ${entityId}: entity missing from vault`,
+        );
+        return;
+      }
+
       // Prepare available targets (all other entities)
       // Exclude already connected entities (FR-007)
       // Also exclude entities that have an inbound connection to this entity (bidirectional prevention)
@@ -211,9 +248,9 @@ class ProposerStore {
         entityId,
         error: err,
       });
-      this.analysisError = err.message || "Analysis failed";
+      this.setAnalysisError(entityId, err.message || "Analysis failed");
     } finally {
-      this.isAnalyzing = false;
+      this.finishAnalysis(entityId);
     }
   }
 

--- a/apps/web/src/lib/stores/proposer.svelte.ts
+++ b/apps/web/src/lib/stores/proposer.svelte.ts
@@ -106,7 +106,12 @@ class ProposerStore {
     requireSelection = false,
     analysisText?: string,
   ) {
-    if (uiStore.aiDisabled || this.isAnalyzing) return;
+    if (uiStore.aiDisabled) return;
+
+    // We log a warning if trying to analyze the same entity concurrently,
+    // but we shouldn't block analyses for *different* entities entirely.
+    // For now, allow concurrent analyses by dropping the global `this.isAnalyzing` block here.
+    // NOTE: UI loaders bound to `isAnalyzing` might flicker.
 
     this.analysisError = null;
 

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -315,6 +315,10 @@ export class EntityStore {
       const merged = {
         ...current,
         ...patch,
+        metadata:
+          patch.metadata !== undefined
+            ? { ...(current.metadata ?? {}), ...patch.metadata }
+            : current.metadata,
         content:
           patch.content !== undefined
             ? this.deps.isGuest() && patch.content === "" && current.content
@@ -355,6 +359,7 @@ export class EntityStore {
         type: "BATCH_UPDATED",
         vaultId: this.deps.activeVaultId() || "unknown",
         entities: Object.keys(appliedUpdates).map((id) => newEntities[id]),
+        patches: appliedUpdates,
       });
 
       return true;

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -467,6 +467,30 @@ describe("EntityStore", () => {
       });
     });
 
+    it("should preserve existing metadata when batch updates patch coordinates", async () => {
+      repository.entities.hero.metadata = {
+        region: ["north"],
+        coordinates: { x: 1, y: 2 },
+      } as any;
+
+      await store.batchUpdate({
+        hero: { metadata: { coordinates: { x: 10, y: 20 } } },
+      });
+
+      expect(store.entities.hero.metadata).toEqual({
+        region: ["north"],
+        coordinates: { x: 10, y: 20 },
+      });
+      expect(vaultEventBus.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "BATCH_UPDATED",
+          patches: {
+            hero: { metadata: { coordinates: { x: 10, y: 20 } } },
+          },
+        }),
+      );
+    });
+
     it("should call invalidateUrlCache for updated images", async () => {
       const invalidateUrlCache = vi.fn();
       const storeWithUrl = new EntityStore({

--- a/apps/web/src/lib/stores/vault/events.ts
+++ b/apps/web/src/lib/stores/vault/events.ts
@@ -22,7 +22,12 @@ export type VaultEvent =
     }
   | { type: "ENTITY_DELETED"; vaultId: string; entityId: string }
   | { type: "BATCH_CREATED"; vaultId: string; entities: LocalEntity[] }
-  | { type: "BATCH_UPDATED"; vaultId: string; entities: LocalEntity[] }
+  | {
+      type: "BATCH_UPDATED";
+      vaultId: string;
+      entities: LocalEntity[];
+      patches?: Record<string, Partial<LocalEntity>>;
+    }
   | { type: "VAULT_SWITCHED"; vaultId: string };
 
 type VaultEventListener = (event: VaultEvent) => void | Promise<void>;

--- a/apps/web/src/lib/stores/vault/search-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/search-store.svelte.ts
@@ -3,11 +3,45 @@ import { ServiceRegistry } from "./service-registry";
 import type { LocalEntity } from "./types";
 import { debugStore } from "../debug.svelte";
 
+const SEARCH_FIELDS = new Set([
+  "title",
+  "content",
+  "lore",
+  "tags",
+  "type",
+  "status",
+  "_path",
+]);
+
+const NON_SEARCH_METADATA_FIELDS = new Set(["coordinates", "width", "height"]);
+
+function hasSearchableMetadataChange(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return true;
+  }
+
+  return Object.keys(metadata).some(
+    (field) => !NON_SEARCH_METADATA_FIELDS.has(field),
+  );
+}
+
+function shouldIndexPatch(patch: Partial<LocalEntity> | undefined) {
+  if (!patch) return true;
+
+  return Object.entries(patch).some(([field, value]) => {
+    if (field === "metadata") {
+      return hasSearchableMetadataChange(value);
+    }
+    return SEARCH_FIELDS.has(field);
+  });
+}
+
 export class SearchStore {
   constructor(private serviceRegistry: ServiceRegistry) {
     const handler = async (event: any) => {
       try {
         if (event.type === "ENTITY_UPDATED") {
+          if (!shouldIndexPatch(event.patch)) return;
           const services = await this.serviceRegistry.ensureInitialized();
           await this.indexEntity(event.entity, services);
         } else if (event.type === "BATCH_CREATED") {
@@ -24,9 +58,15 @@ export class SearchStore {
             entities.map((e: any) => this.indexEntity(e, services)),
           );
         } else if (event.type === "BATCH_UPDATED") {
+          const toIndex = event.entities.filter((e: any) => {
+            const patch = event.patches?.[e.id];
+            return shouldIndexPatch(patch);
+          });
+          if (toIndex.length === 0) return;
+
           const services = await this.serviceRegistry.ensureInitialized();
           await Promise.all(
-            event.entities.map((e: any) => this.indexEntity(e, services)),
+            toIndex.map((e: any) => this.indexEntity(e, services)),
           );
         } else if (event.type === "ENTITY_DELETED") {
           await this.removeEntity(event.entityId);

--- a/apps/web/src/lib/stores/vault/search-store.test.ts
+++ b/apps/web/src/lib/stores/vault/search-store.test.ts
@@ -76,6 +76,113 @@ describe("SearchStore", () => {
     );
   });
 
+  it("does not index coordinate-only entity updates", async () => {
+    const entity: LocalEntity = {
+      id: "hero-1",
+      title: "Hero One",
+      content: "Body",
+      lore: "Lore",
+      type: "character",
+      status: "active",
+      tags: [],
+      labels: [],
+      connections: [],
+      metadata: { coordinates: { x: 10, y: 20 } },
+    } as any;
+
+    vaultEventBus.emit({
+      type: "ENTITY_UPDATED",
+      vaultId: "vault-1",
+      entity,
+      patch: { metadata: { coordinates: { x: 10, y: 20 } } },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.searchService.index).not.toHaveBeenCalled();
+  });
+
+  it("does not index coordinate-only batch updates", async () => {
+    const entities = [
+      {
+        id: "hero-1",
+        title: "Hero One",
+        content: "Body",
+        lore: "Lore",
+        type: "character",
+        status: "active",
+        tags: [],
+        labels: [],
+        connections: [],
+        metadata: { coordinates: { x: 10, y: 20 } },
+      },
+      {
+        id: "hero-2",
+        title: "Hero Two",
+        content: "Body",
+        lore: "",
+        type: "location",
+        status: "active",
+        tags: [],
+        labels: [],
+        connections: [],
+        metadata: { coordinates: { x: 30, y: 40 } },
+      },
+    ] as LocalEntity[];
+
+    vaultEventBus.emit({
+      type: "BATCH_UPDATED",
+      vaultId: "vault-1",
+      entities,
+      patches: {
+        "hero-1": { metadata: { coordinates: { x: 10, y: 20 } } },
+        "hero-2": { metadata: { coordinates: { x: 30, y: 40 } } },
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.searchService.index).not.toHaveBeenCalled();
+  });
+
+  it("indexes batch updates when metadata includes searchable fields", async () => {
+    const entities = [
+      {
+        id: "hero-1",
+        title: "Hero One",
+        content: "Body",
+        lore: "Lore",
+        type: "character",
+        status: "active",
+        tags: [],
+        labels: [],
+        connections: [],
+        metadata: {
+          coordinates: { x: 10, y: 20 },
+          region: ["north"],
+        } as any,
+      },
+    ] as any;
+
+    vaultEventBus.emit({
+      type: "BATCH_UPDATED",
+      vaultId: "vault-1",
+      entities,
+      patches: {
+        "hero-1": {
+          metadata: {
+            coordinates: { x: 10, y: 20 },
+            region: ["north"],
+          } as any,
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.searchService.index).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("rebuilds the index from cold sync chunks", async () => {
     const entities = {
       "hero-1": {

--- a/docs/GRAPH_LAYOUT_TUNING.md
+++ b/docs/GRAPH_LAYOUT_TUNING.md
@@ -64,22 +64,24 @@ Always `{ x1: -2400, y1: -2400, x2: 2400, y2: 2400 }` for non-trivial graphs.
 Scaled by node count via `getDynamicLayoutOptions(nodeCount)`:
 
 ```ts
-repulsion  = min(200_000, 30_000 + nodeCount × 500)
-gravity    = max(0.08, 0.25 − nodeCount × 0.0005)
-edgeLength = min(70, 15 + √nodeCount × 1.5)
-separation = min(100, 20 + √nodeCount × 2.5)
-gravityRange = 5.5
-numIter    = 5000
+quality    = nodeCount > 500 ? "draft" : "default"
+repulsion  = min(1_600_000, 250_000 + nodeCount × 2_400)
+gravity    = max(0.005, 0.05 − nodeCount × 0.00015)
+edgeLength = min(450, 90 + √nodeCount × 9)
+separation = min(600, 120 + √nodeCount × 15)
+gravityRange = 1.5
+numIter    = nodeCount > 200 ? 1200 : 2200
 ```
 
 The degree-aware functions in the worker multiply on top of these base values.
 
 ## Gravity caps (LayoutManager.ts)
 
-After `getDynamicLayoutOptions`, gravity is capped per aspect ratio:
+After `getDynamicLayoutOptions`, gravity is capped per aspect ratio, then reduced again via `hubGravity`:
 
 ```ts
-gravity = isLandscape ? min(base, 0.25) : min(base, 0.35);
+gravity = isLandscape ? min(base, 0.12) : min(base, 0.15);
+gravity *= 1 - min(0.45, maxDegree * 0.012);
 ```
 
 ## removeOverlaps (layout.worker.ts)
@@ -107,8 +109,10 @@ For 150+ nodes, ±1200 leaves no room. All nodes crush into the center and remov
 
 ### Gravity floor too low
 
-Setting gravity floor to 0.01–0.02 without a matching `gravityRange` lets the outer nodes escape the canvas entirely. Keep floor ≥ 0.08 unless `gravityRange` is high enough to reach them.
+Setting a very low gravity floor without a matching `gravityRange` lets the outer nodes escape the canvas entirely. In the current defaults, a floor of `0.005` is paired with `gravityRange: 1.5`; treat those values as a tuned set and adjust them together rather than applying the older "floor >= 0.08" rule.
 
-### Draft quality for degree-aware layouts
+### Draft quality for large degree-aware layouts
 
-fcose `quality: "draft"` silently **ignores** function-valued `nodeRepulsion` and `idealEdgeLength`. Switching to draft drops all degree-aware tuning and produces a uniform, badly-overlapped layout. Keep `quality: "default"` for any graph that uses per-node/edge force functions. Only use draft for 500+ nodes where degree-aware functions are not needed.
+Earlier tuning notes suggested that fcose `quality: "draft"` could behave as if function-valued `nodeRepulsion` and `idealEdgeLength` were reduced or ignored. That is **not** a safe blanket rule for the current implementation: the worker still supplies the degree-aware functions, and the dynamic large-graph path uses `quality: "draft"` for 500+ nodes to keep runtime acceptable.
+
+Treat `draft` as a performance trade-off, not as "degree-aware tuning is disabled." If a large graph looks too uniform or overlap-heavy, verify the behaviour against the fcose version in use and compare `draft` vs `default` empirically before concluding that the callback functions are being ignored.

--- a/docs/GRAPH_LAYOUT_TUNING.md
+++ b/docs/GRAPH_LAYOUT_TUNING.md
@@ -1,0 +1,114 @@
+# Graph Layout Tuning
+
+Developer reference for `packages/graph-engine`. Documents what works, what doesn't, and why — based on extensive iteration in April 2026.
+
+## Observed performance
+
+| Graph size | Quality | numIter | Redraw time                                |
+| ---------- | ------- | ------- | ------------------------------------------ |
+| 240 nodes  | default | 2200    | < 1 second                                 |
+| 500 nodes  | default | 2200    | ~2–4s (estimated)                          |
+| 500+ nodes | draft   | 1200    | ~3–8s (estimated, depends on edge density) |
+
+The main thread never blocks — fcose runs in a Web Worker. The UI stays fully responsive during layout computation.
+
+## Architecture
+
+Layout runs in a **Web Worker** so the main thread stays unblocked.
+
+```
+LayoutManager.ts          →  layout.worker.ts           →  Cytoscape + fcose
+  serialise nodes/edges      getDegreeAwareLayoutOptions    removeOverlaps
+  pass _degree per node      per-node repulsion fn          spatial grid O(N)
+  ±2400 bounding box         per-edge length fn
+```
+
+Key files:
+
+| File                   | Purpose                                                       |
+| ---------------------- | ------------------------------------------------------------- |
+| `src/LayoutManager.ts` | Serialises graph, manages worker lifecycle, applies positions |
+| `src/layout.worker.ts` | Runs fcose in headless Cytoscape, resolves overlaps           |
+| `src/defaults.ts`      | `getDynamicLayoutOptions` — base physics scaled by node count |
+
+## Degree-aware forces (the core insight)
+
+fcose accepts **functions** for `nodeRepulsion` and `idealEdgeLength`, not just numbers. This is what makes the layout work well:
+
+```ts
+// layout.worker.ts — getDegreeAwareLayoutOptions()
+nodeRepulsion: (node) => baseRepulsion * (1 + Math.min(4.0, Math.sqrt(degree) * 0.55)),
+//   degree 0  → 1.0× base
+//   degree 5  → 2.2× base
+//   degree 20 → 3.5× base
+//   degree 50 → 4.9× base   (capped at 5×)
+
+idealEdgeLength: (edge) => {
+  if (minDegree >= 5) return base * 3.5;  // hub↔hub — pushes communities apart
+  if (maxDegree >= 5) return base * 0.8;  // hub↔leaf — keeps leaf near its hub
+  return base;                             // leaf↔leaf — default
+}
+```
+
+**Effect:** Hub nodes carve out space between clusters; leaf nodes stay tightly grouped near their hubs. Communities separate naturally without any fixed constraints.
+
+## Bounding box
+
+Always `{ x1: -2400, y1: -2400, x2: 2400, y2: 2400 }` for non-trivial graphs.
+
+- **Too small (±1200):** nodes crush together with no room to spread — removeOverlaps can't fix it
+- **Too large:** makes gravity too weak relative to the space; clusters drift off-screen
+
+## Base physics (defaults.ts)
+
+Scaled by node count via `getDynamicLayoutOptions(nodeCount)`:
+
+```ts
+repulsion  = min(200_000, 30_000 + nodeCount × 500)
+gravity    = max(0.08, 0.25 − nodeCount × 0.0005)
+edgeLength = min(70, 15 + √nodeCount × 1.5)
+separation = min(100, 20 + √nodeCount × 2.5)
+gravityRange = 5.5
+numIter    = 5000
+```
+
+The degree-aware functions in the worker multiply on top of these base values.
+
+## Gravity caps (LayoutManager.ts)
+
+After `getDynamicLayoutOptions`, gravity is capped per aspect ratio:
+
+```ts
+gravity = isLandscape ? min(base, 0.25) : min(base, 0.35);
+```
+
+## removeOverlaps (layout.worker.ts)
+
+Spatial-grid O(N amortised) post-pass after fcose settles:
+
+- `padding = 18` — gap between node edges
+- `maxIter = 32` — iterations before giving up
+- Uses `actualW/actualH` (real rendered sizes), not fcose layout sizes
+- `actualRadii[i] = max(actualW, actualH) / 2` — uses the larger dimension for safety
+
+## What NOT to do
+
+### Fixed node constraints (communityAnchors)
+
+Using `fixedNodeConstraint` to pin hub nodes to a ring creates a **star/spoke pattern**: hubs are locked in place and all their connected nodes radiate outward. Remove these constraints and let the adaptive forces work naturally.
+
+### Uniform repulsion cranked too high
+
+Setting `nodeRepulsion` uniformly to 250k+ (without degree awareness) blasts hub nodes to the canvas edges because their many edge springs can't overcome the repulsion. This causes long crossing edges spanning the whole graph.
+
+### Bounding box ±1200 on large graphs
+
+For 150+ nodes, ±1200 leaves no room. All nodes crush into the center and removeOverlaps cannot resolve them within the space available.
+
+### Gravity floor too low
+
+Setting gravity floor to 0.01–0.02 without a matching `gravityRange` lets the outer nodes escape the canvas entirely. Keep floor ≥ 0.08 unless `gravityRange` is high enough to reach them.
+
+### Draft quality for degree-aware layouts
+
+fcose `quality: "draft"` silently **ignores** function-valued `nodeRepulsion` and `idealEdgeLength`. Switching to draft drops all degree-aware tuning and produces a uniform, badly-overlapped layout. Keep `quality: "default"` for any graph that uses per-node/edge force functions. Only use draft for 500+ nodes where degree-aware functions are not needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,7 +1183,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
@@ -1194,7 +1194,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1489,6 +1489,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2571,6 +2572,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2579,6 +2581,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2587,6 +2590,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2598,6 +2602,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3511,6 +3516,7 @@
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -4596,6 +4602,7 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/gapi": {
@@ -4686,7 +4693,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -4694,6 +4701,7 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
@@ -4852,6 +4860,7 @@
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
       "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4983,6 +4992,7 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5232,6 +5242,7 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -6360,6 +6371,7 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -6621,7 +6633,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6666,6 +6678,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6682,6 +6695,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6698,6 +6712,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6714,6 +6729,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6730,6 +6746,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6746,6 +6763,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6762,6 +6780,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6778,6 +6797,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6794,6 +6814,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6810,6 +6831,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6826,6 +6848,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6842,6 +6865,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6858,6 +6882,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6874,6 +6899,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6890,6 +6916,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6906,6 +6933,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6922,6 +6950,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6938,6 +6967,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6954,6 +6984,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6970,6 +7001,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6986,6 +7018,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7002,6 +7035,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7018,6 +7052,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7034,6 +7069,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7050,6 +7086,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7287,6 +7324,7 @@
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -7343,6 +7381,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
       "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -8461,6 +8500,7 @@
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -8545,7 +8585,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9067,6 +9107,7 @@
     },
     "node_modules/locate-character": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -11931,6 +11972,7 @@
       "version": "5.55.4",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
       "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -12064,6 +12106,7 @@
     },
     "node_modules/svelte/node_modules/aria-query": {
       "version": "5.3.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -12371,7 +12414,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -13054,7 +13097,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -13180,6 +13223,7 @@
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     "apps/web": {
-      "version": "0.19.0",
+      "version": "0.20.0",
       "dependencies": {
         "@codex/canvas-engine": "^0.0.0",
         "@codex/importer": "*",
@@ -160,7 +160,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -351,7 +350,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -1121,7 +1119,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1168,7 +1165,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1189,7 +1185,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -1201,7 +1196,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1797,7 +1791,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -3529,7 +3522,6 @@
       "integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -3971,7 +3963,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
       "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4011,7 +4002,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.3.tgz",
       "integrity": "sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -4095,7 +4085,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.3.tgz",
       "integrity": "sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4194,7 +4183,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
       "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4274,7 +4262,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.22.3.tgz",
       "integrity": "sha512-inbQSusJad7H0T++L1APg/anfL5d15cNGp2YG3vwo6TQr71nn2c9pepvmz3xuAIt8eygZDRba+4GT/COP1f9QA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4354,7 +4341,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
       "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4369,7 +4355,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
       "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4703,7 +4688,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -4763,7 +4747,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4973,7 +4956,6 @@
       "resolved": "https://registry.npmjs.org/@xyflow/svelte/-/svelte-1.5.2.tgz",
       "integrity": "sha512-jPLc2cwRmrkXSv/jvsNDQqTGCsNyTWURKtBl28UCH3BdOAA3CIc0/oQ0EvIcjPdzr0NwvWMgq9TmLdjOIccCEQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@svelte-put/shortcut": "^4.1.0",
         "@xyflow/system": "0.0.76"
@@ -5002,7 +4984,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5987,7 +5968,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6144,7 +6124,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
       "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6204,7 +6183,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7136,7 +7114,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -10711,7 +10688,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10795,7 +10771,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10919,7 +10894,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11035,7 +11009,6 @@
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11070,7 +11043,6 @@
     "node_modules/prosemirror-state": {
       "version": "1.4.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11111,7 +11083,6 @@
     "node_modules/prosemirror-view": {
       "version": "1.41.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -11961,7 +11932,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
       "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -12134,8 +12104,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -12333,7 +12302,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12412,7 +12380,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -12564,7 +12531,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12853,7 +12819,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -13260,7 +13225,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -13405,7 +13369,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -13505,7 +13468,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -13650,7 +13612,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -13749,7 +13710,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -13894,7 +13854,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14000,7 +13959,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14145,7 +14103,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14251,7 +14208,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14396,7 +14352,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14507,7 +14462,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14652,7 +14606,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -14754,7 +14707,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -14899,7 +14851,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15008,7 +14959,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15153,7 +15103,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15258,7 +15207,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15403,7 +15351,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15505,7 +15452,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15650,7 +15596,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -15755,7 +15700,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -15900,7 +15844,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16005,7 +15948,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16150,7 +16092,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -16258,7 +16199,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -16403,7 +16343,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -1,71 +1,130 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { LayoutManager, removeOverlaps } from "./LayoutManager";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getLayoutCollisionSize,
+  LayoutManager,
+  removeOverlaps,
+} from "./LayoutManager";
 import type { Core } from "cytoscape";
+
+// ─── Fake Worker ────────────────────────────────────────────────────────────────
+let capturedPostMessage: any = null;
+
+class FakeWorker {
+  private messageListeners: Array<(e: any) => void> = [];
+
+  postMessage(data: any) {
+    capturedPostMessage = data;
+    // Simulate async response with empty positions
+    Promise.resolve().then(() => {
+      const event = { data: { jobId: data.jobId, positions: {} } };
+      this.messageListeners.forEach((cb) => cb(event));
+    });
+  }
+
+  addEventListener(type: string, cb: (e: any) => void) {
+    if (type === "message") this.messageListeners.push(cb);
+  }
+
+  removeEventListener(_type: string, cb: (e: any) => void) {
+    this.messageListeners = this.messageListeners.filter((l) => l !== cb);
+  }
+
+  terminate() {}
+}
+
+class ErrorWorker {
+  private errorListeners: Array<(e: any) => void> = [];
+
+  postMessage(data: any) {
+    capturedPostMessage = data;
+    Promise.resolve().then(() => {
+      this.errorListeners.forEach((cb) => cb(new Error("worker failed")));
+    });
+  }
+
+  addEventListener(type: string, cb: (e: any) => void) {
+    if (type === "error") this.errorListeners.push(cb);
+  }
+
+  removeEventListener(_type: string, cb: (e: any) => void) {
+    this.errorListeners = this.errorListeners.filter((l) => l !== cb);
+  }
+
+  terminate() {}
+}
+
+class SilentWorker {
+  postMessage(data: any) {
+    capturedPostMessage = data;
+  }
+
+  addEventListener() {}
+
+  removeEventListener() {}
+
+  terminate() {}
+}
+
+// ─── Node factory ───────────────────────────────────────────────────────────────
+function makeNodes(positions: Array<{ x: number; y: number }> = []) {
+  return positions.map((pos, i) => ({
+    position: vi.fn().mockReturnValue(pos),
+    data: vi.fn().mockReturnValue({}),
+    id: vi.fn().mockReturnValue(String(i + 1)),
+    addClass: vi.fn(),
+    removeClass: vi.fn(),
+    width: vi.fn().mockReturnValue(60),
+    height: vi.fn().mockReturnValue(60),
+    length: 1,
+  }));
+}
 
 describe("LayoutManager", () => {
   let mockCy: any;
   let layoutManager: LayoutManager;
 
   beforeEach(() => {
+    capturedPostMessage = null;
+    vi.stubGlobal("Worker", FakeWorker);
+
+    const twoNodes = makeNodes([
+      { x: 10, y: 10 },
+      { x: 30, y: 30 },
+    ]);
+
     mockCy = {
       destroyed: vi.fn().mockReturnValue(false),
       resize: vi.fn(),
       batch: vi.fn((cb) => cb()),
-      nodes: vi.fn().mockReturnValue({
-        length: 0,
-        forEach: vi.fn(),
-        filter: vi.fn().mockReturnThis(),
-        layout: vi.fn().mockReturnThis(),
-        run: vi.fn(),
-        map: vi.fn().mockReturnValue([]),
-        elements: vi.fn().mockReturnThis(),
-      }),
+      nodes: vi.fn().mockReturnValue(twoNodes),
+      edges: vi.fn().mockReturnValue([]),
+      $id: vi.fn().mockReturnValue({ length: 0 }),
       width: vi.fn().mockReturnValue(1000),
       height: vi.fn().mockReturnValue(800),
-      layout: vi.fn().mockReturnValue({
-        run: vi.fn(),
-        one: vi.fn(),
-        stop: vi.fn(),
-      }),
       fit: vi.fn(),
-      animate: vi.fn(),
-      elements: vi.fn().mockReturnValue({
-        animate: vi.fn(),
+      animate: vi.fn((animationOptions?: { complete?: () => void }) => {
+        animationOptions?.complete?.();
       }),
+      elements: vi.fn().mockReturnValue([]),
     };
     layoutManager = new LayoutManager(mockCy as unknown as Core);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("should initialize with a cy instance", () => {
     expect(layoutManager).toBeDefined();
   });
 
-  it("should trigger randomization when exiting a mode", async () => {
-    // Setup mock nodes with positions so it doesn't trigger hasNewNodes logic
-    mockCy.nodes.mockReturnValue({
-      length: 2,
-      forEach: (cb: any) => {
-        cb({
-          position: () => ({ x: 10, y: 10 }),
-          data: () => ({}),
-          id: () => "1",
-          addClass: vi.fn(),
-          removeClass: vi.fn(),
-        });
-        cb({
-          position: () => ({ x: 20, y: 20 }),
-          data: () => ({}),
-          id: () => "2",
-          addClass: vi.fn(),
-          removeClass: vi.fn(),
-        });
-      },
-      filter: vi.fn().mockReturnThis(),
-      layout: vi.fn().mockReturnThis(),
-      run: vi.fn(),
-      map: vi.fn().mockReturnValue([]),
-      elements: vi.fn().mockReturnThis(),
-    });
+  it("should seed fresh positions when exiting a mode", async () => {
+    const persistedPositions = [
+      { x: -4000, y: 100 },
+      { x: 4000, y: -100 },
+    ];
+    mockCy.nodes.mockReturnValue(makeNodes(persistedPositions));
 
     await layoutManager.apply(
       {
@@ -82,31 +141,13 @@ describe("LayoutManager", () => {
       "Mode Change Effect",
     );
 
-    // Verify layout was called with randomize: true
-    const layoutCall = mockCy.layout.mock.calls[0][0];
-    expect(layoutCall.randomize).toBe(true);
+    expect(capturedPostMessage?.options.randomize).toBe(true);
+    expect(capturedPostMessage?.nodes[0].position).not.toEqual(
+      persistedPositions[0],
+    );
   });
 
   it("should use lower gravity in landscape view", async () => {
-    // Re-mock nodes to return something valid for the loop
-    mockCy.nodes.mockReturnValue({
-      length: 2,
-      forEach: (cb: any) => {
-        cb({
-          position: () => ({ x: 10, y: 10 }),
-          data: () => ({}),
-          id: () => "1",
-          addClass: vi.fn(),
-          removeClass: vi.fn(),
-        });
-      },
-      filter: vi.fn().mockReturnThis(),
-      layout: vi.fn().mockReturnThis(),
-      run: vi.fn(),
-      map: vi.fn().mockReturnValue([]),
-      elements: vi.fn().mockReturnThis(),
-    });
-
     mockCy.width.mockReturnValue(1200);
     mockCy.height.mockReturnValue(800); // AR = 1.5 (Landscape)
 
@@ -120,30 +161,10 @@ describe("LayoutManager", () => {
       isGuest: false,
     });
 
-    const layoutCall = mockCy.layout.mock.calls[0][0];
-    expect(layoutCall.gravity).toBeLessThanOrEqual(0.25);
+    expect(capturedPostMessage?.options.gravity).toBeLessThanOrEqual(0.12);
   });
 
   it("should use higher gravity in portrait view", async () => {
-    // Re-mock nodes to return something valid for the loop
-    mockCy.nodes.mockReturnValue({
-      length: 2,
-      forEach: (cb: any) => {
-        cb({
-          position: () => ({ x: 10, y: 10 }),
-          data: () => ({}),
-          id: () => "1",
-          addClass: vi.fn(),
-          removeClass: vi.fn(),
-        });
-      },
-      filter: vi.fn().mockReturnThis(),
-      layout: vi.fn().mockReturnThis(),
-      run: vi.fn(),
-      map: vi.fn().mockReturnValue([]),
-      elements: vi.fn().mockReturnThis(),
-    });
-
     mockCy.width.mockReturnValue(800);
     mockCy.height.mockReturnValue(1200); // AR = 0.66 (Portrait)
 
@@ -157,11 +178,48 @@ describe("LayoutManager", () => {
       isGuest: false,
     });
 
-    const layoutCall = mockCy.layout.mock.calls[0][0];
-    expect(layoutCall.gravity).toBeGreaterThan(0.1);
+    expect(capturedPostMessage?.options.gravity).toBeGreaterThan(0.005);
   });
 
-  it("should not randomize when stableLayout is on, even with randomizeForced", async () => {
+  it("should give force layouts room to spread out", async () => {
+    await layoutManager.apply({
+      timelineMode: false,
+      timelineAxis: "x",
+      timelineScale: 1,
+      orbitMode: false,
+      centralNodeId: null,
+      stableLayout: false,
+      isGuest: false,
+    });
+
+    expect(capturedPostMessage?.options.boundingBox).toEqual({
+      x1: -2400,
+      y1: -2400,
+      x2: 2400,
+      y2: 2400,
+    });
+  });
+
+  it("should not randomize stable layouts for non-redraw forced updates", async () => {
+    await layoutManager.apply(
+      {
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: true,
+        isGuest: false,
+      },
+      false,
+      true,
+      "External Update",
+      true,
+    );
+    expect(capturedPostMessage?.options.randomize).toBe(false);
+  });
+
+  it("should randomize when the UI redraw button requests a fresh solve", async () => {
     await layoutManager.apply(
       {
         timelineMode: false,
@@ -177,8 +235,11 @@ describe("LayoutManager", () => {
       "UI Redraw Button",
       true,
     );
-    const layoutCall = mockCy.layout.mock.calls[0][0];
-    expect(layoutCall.randomize).toBe(false);
+    expect(capturedPostMessage?.options.randomize).toBe(true);
+    expect(capturedPostMessage?.nodes[0].position).not.toEqual({
+      x: 10,
+      y: 10,
+    });
   });
 
   it("should randomize when stableLayout is off and randomizeForced is true", async () => {
@@ -197,8 +258,82 @@ describe("LayoutManager", () => {
       "UI Redraw Button",
       true,
     );
-    const layoutCall = mockCy.layout.mock.calls[0][0];
-    expect(layoutCall.randomize).toBe(true);
+    expect(capturedPostMessage?.options.randomize).toBe(true);
+    expect(capturedPostMessage?.nodes[0].position).not.toEqual({
+      x: 10,
+      y: 10,
+    });
+  });
+
+  it("should seed randomized worker layouts away from persisted positions", async () => {
+    const persistedPositions = [
+      { x: -4000, y: 100 },
+      { x: 4000, y: -100 },
+    ];
+    mockCy.nodes.mockReturnValue(makeNodes(persistedPositions));
+
+    await layoutManager.apply(
+      {
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: true,
+        isGuest: false,
+      },
+      false,
+      true,
+      "UI Redraw Button",
+      true,
+    );
+
+    expect(capturedPostMessage?.nodes[0].position).not.toEqual(
+      persistedPositions[0],
+    );
+    expect(capturedPostMessage?.nodes[1].position).not.toEqual(
+      persistedPositions[1],
+    );
+  });
+
+  it("should give connected hubs a larger layout collision box", async () => {
+    const nodes = makeNodes([
+      { x: 10, y: 10 },
+      { x: 30, y: 30 },
+      { x: 50, y: 50 },
+    ]);
+    mockCy.nodes.mockReturnValue(nodes);
+    mockCy.edges.mockReturnValue([
+      {
+        data: vi.fn().mockReturnValue({}),
+        id: vi.fn().mockReturnValue("e1"),
+        source: vi.fn().mockReturnValue({ id: vi.fn().mockReturnValue("1") }),
+        target: vi.fn().mockReturnValue({ id: vi.fn().mockReturnValue("2") }),
+      },
+      {
+        data: vi.fn().mockReturnValue({}),
+        id: vi.fn().mockReturnValue("e2"),
+        source: vi.fn().mockReturnValue({ id: vi.fn().mockReturnValue("1") }),
+        target: vi.fn().mockReturnValue({ id: vi.fn().mockReturnValue("3") }),
+      },
+    ]);
+
+    await layoutManager.apply({
+      timelineMode: false,
+      timelineAxis: "x",
+      timelineScale: 1,
+      orbitMode: false,
+      centralNodeId: null,
+      stableLayout: false,
+      isGuest: false,
+    });
+
+    expect(capturedPostMessage?.nodes[0].data._w).toBeGreaterThan(
+      capturedPostMessage?.nodes[1].data._w,
+    );
+    expect(capturedPostMessage?.nodes[0].data._degree).toBe(2);
+    expect(capturedPostMessage?.options.gravity).toBeLessThan(0.05);
+    expect(capturedPostMessage?.nodes[0].actualW).toBe(60);
   });
 
   it("should call resize on apply", async () => {
@@ -212,6 +347,112 @@ describe("LayoutManager", () => {
       isGuest: true,
     });
     expect(mockCy.resize).toHaveBeenCalled();
+  });
+
+  it("should stop redraw when the fit animation completes", async () => {
+    const onLayoutStop = vi.fn();
+
+    await layoutManager.apply({
+      timelineMode: false,
+      timelineAxis: "x",
+      timelineScale: 1,
+      orbitMode: false,
+      centralNodeId: null,
+      stableLayout: false,
+      isGuest: false,
+      onLayoutStop,
+    });
+
+    expect(mockCy.animate).toHaveBeenCalled();
+    expect(onLayoutStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop redraw even when the fit animation completion is missed", async () => {
+    vi.useFakeTimers();
+    mockCy.animate.mockImplementation(() => {});
+    const onLayoutStop = vi.fn();
+
+    await layoutManager.apply({
+      timelineMode: false,
+      timelineAxis: "x",
+      timelineScale: 1,
+      orbitMode: false,
+      centralNodeId: null,
+      stableLayout: false,
+      isGuest: false,
+      onLayoutStop,
+    });
+
+    expect(onLayoutStop).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1200);
+    expect(onLayoutStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop redraw if the worker errors", async () => {
+    vi.stubGlobal("Worker", ErrorWorker);
+    layoutManager = new LayoutManager(mockCy as unknown as Core);
+    const onLayoutStop = vi.fn();
+
+    await layoutManager.apply({
+      timelineMode: false,
+      timelineAxis: "x",
+      timelineScale: 1,
+      orbitMode: false,
+      centralNodeId: null,
+      stableLayout: false,
+      isGuest: false,
+      onLayoutStop,
+    });
+
+    expect(mockCy.animate).not.toHaveBeenCalled();
+    expect(onLayoutStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop redraw if the worker never replies", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("Worker", SilentWorker);
+    layoutManager = new LayoutManager(mockCy as unknown as Core);
+    const onLayoutStop = vi.fn();
+
+    const applyPromise = layoutManager.apply({
+      timelineMode: false,
+      timelineAxis: "x",
+      timelineScale: 1,
+      orbitMode: false,
+      centralNodeId: null,
+      stableLayout: false,
+      isGuest: false,
+      onLayoutStop,
+    });
+
+    await vi.advanceTimersByTimeAsync(15000);
+    await applyPromise;
+
+    expect(mockCy.animate).not.toHaveBeenCalled();
+    expect(onLayoutStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop redraw when an in-flight worker is stopped", async () => {
+    vi.stubGlobal("Worker", SilentWorker);
+    layoutManager = new LayoutManager(mockCy as unknown as Core);
+    const onLayoutStop = vi.fn();
+
+    const applyPromise = layoutManager.apply({
+      timelineMode: false,
+      timelineAxis: "x",
+      timelineScale: 1,
+      orbitMode: false,
+      centralNodeId: null,
+      stableLayout: false,
+      isGuest: false,
+      onLayoutStop,
+    });
+
+    layoutManager.stop();
+    await applyPromise;
+
+    expect(mockCy.animate).not.toHaveBeenCalled();
+    expect(onLayoutStop).toHaveBeenCalledTimes(1);
   });
 
   it("should fit nodes if isGuest and isInitial", async () => {
@@ -228,6 +469,23 @@ describe("LayoutManager", () => {
       true,
     );
     expect(mockCy.fit).toHaveBeenCalled();
+  });
+});
+
+describe("getLayoutCollisionSize", () => {
+  it("keeps isolated nodes at their visual size", () => {
+    expect(getLayoutCollisionSize(60, 80, 0)).toEqual({
+      width: 60,
+      height: 80,
+    });
+  });
+
+  it("adds bounded breathing room for high-degree nodes", () => {
+    const medium = getLayoutCollisionSize(60, 60, 4);
+    const large = getLayoutCollisionSize(60, 60, 100);
+
+    expect(medium.width).toBeGreaterThan(60);
+    expect(large.width).toBe(112);
   });
 });
 

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -180,7 +180,7 @@ export class LayoutManager {
 
   private getWorker(): Worker {
     if (!this.worker) {
-      this.worker = new Worker(new URL("./layout.worker", import.meta.url), {
+      this.worker = new Worker(new URL("./layout.worker.ts", import.meta.url), {
         type: "module",
       });
     }
@@ -473,7 +473,12 @@ export class LayoutManager {
       degrees.set(edge.data.source, (degrees.get(edge.data.source) ?? 0) + 1);
       degrees.set(edge.data.target, (degrees.get(edge.data.target) ?? 0) + 1);
     }
-    const maxDegree = Math.max(0, ...degrees.values());
+    let maxDegree = 0;
+    for (const degree of degrees.values()) {
+      if (degree > maxDegree) {
+        maxDegree = degree;
+      }
+    }
     const hubGravity = gravity * (1 - Math.min(0.45, maxDegree * 0.012));
     const nodes = Array.from(cyNodes).map((n, index) => {
       const p = n.position();

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -18,53 +18,263 @@ export interface LayoutOptions {
   isGuest: boolean;
   onLayoutStart?: () => void;
   onLayoutStop?: () => void;
+  onLayoutComputed?: (durationMs: number) => void;
   onPositionsUpdated?: (updates: Record<string, any>) => void;
 }
 
 const ORIENTATION_THRESHOLD = 1.2;
+const BASE_LAYOUT_WORKER_TIMEOUT_MS = 15000;
+const FIT_ANIMATION_TIMEOUT_MS = 1200;
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
 
-export function removeOverlaps(cy: Core, padding = 10, maxIter = 50) {
+interface SerializedLayoutNode {
+  data: { id: string; _w: number; _h: number; [key: string]: unknown };
+  position: { x: number; y: number };
+  actualW: number;
+  actualH: number;
+}
+
+interface SerializedLayoutEdge {
+  data: { id: string; source: string; target: string; [key: string]: unknown };
+}
+
+function hashString(value: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function seededLayoutPosition(
+  id: string,
+  index: number,
+  count: number,
+  aspectRatio: number,
+) {
+  const hash = hashString(id);
+  const safeCount = Math.max(1, count);
+  const radius = Math.min(1800, 280 + Math.sqrt(safeCount) * 90);
+  const angleJitter = (hash / 0xffffffff - 0.5) * 0.35;
+  const angle = index * GOLDEN_ANGLE + angleJitter;
+  const distance = radius * Math.sqrt((index + 0.5) / safeCount);
+  const aspectScale = Math.sqrt(Math.min(2.2, Math.max(0.55, aspectRatio)));
+
+  return {
+    x: Math.cos(angle) * distance * aspectScale,
+    y: (Math.sin(angle) * distance) / aspectScale,
+  };
+}
+
+export function getLayoutCollisionSize(
+  width: number,
+  height: number,
+  degree = 0,
+) {
+  const safeWidth = width || 60;
+  const safeHeight = height || 60;
+  const hubPadding = Math.min(52, Math.sqrt(Math.max(0, degree)) * 9);
+
+  return {
+    width: safeWidth + hubPadding,
+    height: safeHeight + hubPadding,
+  };
+}
+
+/**
+ * Resolves node overlaps using a spatial grid so only nearby pairs are checked.
+ * O(N) per iteration amortised vs O(N²) for a naive nested loop.
+ *
+ * Cell size = 2·maxRadius + padding guarantees that two nodes in non-adjacent
+ * grid cells can never overlap, so checking the 3×3 neighbourhood is sufficient.
+ */
+export function removeOverlaps(cy: Core, padding = 10, maxIter = 20) {
   const nodes = cy.nodes();
-  cy.batch(() => {
-    for (let iter = 0; iter < maxIter; iter++) {
-      let anyOverlap = false;
-      for (let i = 0; i < nodes.length; i++) {
-        for (let j = i + 1; j < nodes.length; j++) {
-          const n1 = nodes[i];
-          const n2 = nodes[j];
-          const p1 = n1.position();
-          const p2 = n2.position();
-          const r1 = n1.width() / 2;
-          const r2 = n2.width() / 2;
-          const dx = p2.x - p1.x;
-          const dy = p2.y - p1.y;
-          const dist = Math.sqrt(dx * dx + dy * dy);
-          const minDist = r1 + r2 + padding;
-          if (dist < minDist) {
+  const n = nodes.length;
+  if (n < 2) return;
+
+  const radii = new Float64Array(n);
+  let maxRadius = 0;
+  for (let i = 0; i < n; i++) {
+    radii[i] = (nodes[i] as any).width() / 2;
+    if (radii[i] > maxRadius) maxRadius = radii[i];
+  }
+  const cellSize = 2 * maxRadius + padding;
+
+  // Work with flat typed arrays — avoids repeated Cytoscape method-call overhead
+  const xs = new Float64Array(n);
+  const ys = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    const p = (nodes[i] as any).position();
+    xs[i] = p.x;
+    ys[i] = p.y;
+  }
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    const grid = new Map<string, number[]>();
+    for (let i = 0; i < n; i++) {
+      const key = `${Math.floor(xs[i] / cellSize)},${Math.floor(ys[i] / cellSize)}`;
+      let cell = grid.get(key);
+      if (!cell) {
+        cell = [];
+        grid.set(key, cell);
+      }
+      cell.push(i);
+    }
+
+    let anyOverlap = false;
+    for (let i = 0; i < n; i++) {
+      const gcx = Math.floor(xs[i] / cellSize);
+      const gcy = Math.floor(ys[i] / cellSize);
+      const r1 = radii[i];
+      for (let ddx = -1; ddx <= 1; ddx++) {
+        for (let ddy = -1; ddy <= 1; ddy++) {
+          const cell = grid.get(`${gcx + ddx},${gcy + ddy}`);
+          if (!cell) continue;
+          for (const j of cell) {
+            if (j <= i) continue;
+            const dx = xs[j] - xs[i];
+            const dy = ys[j] - ys[i];
+            const minDist = r1 + radii[j] + padding;
+            const dist2 = dx * dx + dy * dy;
+            if (dist2 >= minDist * minDist) continue;
             anyOverlap = true;
+            const dist = Math.sqrt(dist2);
             const push = (minDist - dist) / 2;
             if (dist < 0.001) {
-              // Nodes at same position — push apart at a fixed angle
-              n1.position({ x: p1.x - push, y: p1.y });
-              n2.position({ x: p2.x + push, y: p2.y });
+              xs[i] -= push;
+              xs[j] += push;
             } else {
               const nx = dx / dist;
               const ny = dy / dist;
-              n1.position({ x: p1.x - nx * push, y: p1.y - ny * push });
-              n2.position({ x: p2.x + nx * push, y: p2.y + ny * push });
+              xs[i] -= nx * push;
+              ys[i] -= ny * push;
+              xs[j] += nx * push;
+              ys[j] += ny * push;
             }
           }
         }
       }
-      if (!anyOverlap) break;
+    }
+    if (!anyOverlap) break;
+  }
+
+  cy.batch(() => {
+    for (let i = 0; i < n; i++) {
+      (nodes[i] as any).position({ x: xs[i], y: ys[i] });
     }
   });
 }
 
 export class LayoutManager {
   private currentLayout: any;
+  private worker: Worker | null = null;
+  private jobId = 0;
+  private pendingJobId: number | null = null;
+  private pendingWorkerResolve:
+    | ((result: Record<string, { x: number; y: number }> | null) => void)
+    | null = null;
 
   constructor(private cy: Core) {}
+
+  private getWorker(): Worker {
+    if (!this.worker) {
+      this.worker = new Worker(new URL("./layout.worker", import.meta.url), {
+        type: "module",
+      });
+    }
+    return this.worker;
+  }
+
+  private runInWorker(
+    nodes: SerializedLayoutNode[],
+    edges: SerializedLayoutEdge[],
+    options: Record<string, any>,
+    timeoutMs = BASE_LAYOUT_WORKER_TIMEOUT_MS,
+  ): Promise<Record<string, { x: number; y: number }> | null> {
+    // If a job is already in flight, terminate the worker rather than queuing
+    // behind it — stale layouts piling up is what makes vault switches slow.
+    if (this.pendingJobId !== null) {
+      this.pendingWorkerResolve?.(null);
+      this.jobId++;
+      this.worker?.terminate();
+      this.worker = null;
+      this.pendingJobId = null;
+      this.pendingWorkerResolve = null;
+    }
+
+    const jobId = ++this.jobId;
+    this.pendingJobId = jobId;
+    const worker = this.getWorker();
+
+    return new Promise((resolve) => {
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      const done = (
+        result: Record<string, { x: number; y: number }> | null,
+      ) => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        worker.removeEventListener("message", onMessage);
+        worker.removeEventListener("error", onError);
+        worker.removeEventListener("messageerror", onError);
+        if (this.pendingJobId === jobId) this.pendingJobId = null;
+        if (this.pendingWorkerResolve === done)
+          this.pendingWorkerResolve = null;
+        resolve(result);
+      };
+      const onMessage = (e: MessageEvent) => {
+        if (e.data.jobId !== jobId) return;
+        done(e.data.positions ?? null);
+      };
+      const onError = () => done(null);
+      this.pendingWorkerResolve = done;
+      timeout = setTimeout(() => {
+        if (this.worker === worker) {
+          worker.terminate();
+          this.worker = null;
+        }
+        done(null);
+      }, timeoutMs);
+      worker.addEventListener("message", onMessage);
+      worker.addEventListener("error", onError);
+      worker.addEventListener("messageerror", onError);
+      try {
+        worker.postMessage({ jobId, nodes, edges, options });
+      } catch {
+        done(null);
+      }
+    });
+  }
+
+  private animateFitAndStop(
+    options: LayoutOptions,
+    easing: "ease-out-cubic" | "ease-out-quad",
+  ) {
+    let finished = false;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      options.onLayoutStop?.();
+    };
+
+    timeout = setTimeout(finish, FIT_ANIMATION_TIMEOUT_MS);
+
+    this.cy.animate({
+      fit: { eles: this.cy.elements(), padding: 20 },
+      duration: 800,
+      easing,
+      complete: finish,
+    });
+  }
 
   async apply(
     options: LayoutOptions,
@@ -88,18 +298,25 @@ export class LayoutManager {
     try {
       this.cy.resize();
 
-      // Handle visibility classes
-      this.cy.batch(() => {
-        this.cy.nodes().forEach((node) => {
-          const data = node.data() as GraphNode["data"];
-          const hasDate = hasTimelineDate({ group: "nodes", data });
-          if (options.timelineMode && !hasDate) {
-            node.addClass("timeline-hidden");
-          } else {
-            node.removeClass("timeline-hidden");
-          }
+      // Handle visibility classes — only pay the iteration cost in timeline mode
+      if (options.timelineMode) {
+        this.cy.batch(() => {
+          this.cy.nodes().forEach((node) => {
+            const data = node.data() as GraphNode["data"];
+            if (hasTimelineDate({ group: "nodes", data })) {
+              node.removeClass("timeline-hidden");
+            } else {
+              node.addClass("timeline-hidden");
+            }
+          });
         });
-      });
+      } else {
+        this.cy.batch(() => {
+          this.cy.nodes().forEach((node) => {
+            node.removeClass("timeline-hidden");
+          });
+        });
+      }
 
       if (options.isGuest) {
         if (isInitial) {
@@ -165,12 +382,7 @@ export class LayoutManager {
     setCentralNode(this.cy, options.centralNodeId!);
     if (isInitial) {
       this.cy.resize();
-      this.cy.animate({
-        fit: { eles: this.cy.nodes(), padding: 20 },
-        duration: 800,
-        easing: "ease-out-cubic",
-        complete: () => options.onLayoutStop?.(),
-      });
+      this.animateFitAndStop(options, "ease-out-cubic");
     } else {
       options.onLayoutStop?.();
     }
@@ -184,15 +396,6 @@ export class LayoutManager {
     randomizeForced = false,
   ) {
     const cyNodes = this.cy.nodes();
-    let hasNewNodes = false;
-
-    // Detect nodes without meaningful positions
-    cyNodes.forEach((n) => {
-      const p = n.position();
-      if (!p || (p.x === 0 && p.y === 0)) {
-        hasNewNodes = true;
-      }
-    });
 
     const isExitingTimeline =
       caller === "Timeline Toggle" && !options.timelineMode;
@@ -202,31 +405,34 @@ export class LayoutManager {
       !options.orbitMode;
     let randomize = isExitingTimeline || isExitingMode;
 
-    // Clump detection
-    if (!randomize && cyNodes.length > 1) {
-      let nodesAtOrigin = 0;
-      cyNodes.forEach((n) => {
-        const p = n.position();
-        if (p.x === 0 && p.y === 0) nodesAtOrigin++;
-      });
-      if (nodesAtOrigin === cyNodes.length) {
-        randomize = true;
+    // Single pass: detect new nodes (at origin) and full-clump in one loop
+    let hasNewNodes = false;
+    let nodesAtOrigin = 0;
+    cyNodes.forEach((n) => {
+      const p = n.position();
+      if (!p || (p.x === 0 && p.y === 0)) {
+        hasNewNodes = true;
+        nodesAtOrigin++;
       }
+    });
+    if (!randomize && cyNodes.length > 1 && nodesAtOrigin === cyNodes.length) {
+      randomize = true;
     }
 
-    if (options.stableLayout && !isForced && !randomize && !hasNewNodes) {
+    const isFitOnly =
+      options.stableLayout &&
+      !randomize &&
+      !hasNewNodes &&
+      (!isForced || caller === "Load Finalized" || caller === "Window Resize");
+
+    if (isFitOnly) {
       if (
         isInitial ||
         caller === "Load Finalized" ||
         caller === "Window Resize"
       ) {
         this.cy.resize();
-        this.cy.animate({
-          fit: { eles: this.cy.elements(), padding: 20 },
-          duration: 800,
-          easing: "ease-out-cubic",
-          complete: () => options.onLayoutStop?.(),
-        });
+        this.animateFitAndStop(options, "ease-out-cubic");
       } else {
         options.onLayoutStop?.();
       }
@@ -240,63 +446,124 @@ export class LayoutManager {
 
     const baseOptions = getDynamicLayoutOptions(cyNodes.length);
 
-    // Cap gravity based on aspect ratio
-    // Landscape: allow stronger gravity for the circular pull but cap extreme values
-    // Portrait: allow a bit more to counteract vertical drift
     const gravity = isLandscape
-      ? Math.min(baseOptions.gravity, 0.25)
-      : Math.min(baseOptions.gravity, 0.35);
+      ? Math.min(baseOptions.gravity, 0.12)
+      : Math.min(baseOptions.gravity, 0.15);
 
     // Don't randomize if the user has explicitly locked positions via stableLayout
+    const manualRedrawRandomize =
+      caller === "UI Redraw Button" && isForced && randomizeForced;
     const shouldRandomize =
-      randomize || (isForced && randomizeForced && !options.stableLayout);
+      randomize ||
+      manualRedrawRandomize ||
+      (isForced && randomizeForced && !options.stableLayout);
 
-    this.currentLayout = this.cy.layout({
+    if (this.cy.destroyed()) {
+      options.onLayoutStop?.();
+      return;
+    }
+
+    // Serialize graph for the worker — copy only what the worker needs so the
+    // postMessage payload stays small regardless of how much data edges carry.
+    const edges = Array.from(this.cy.edges()).map((e) => ({
+      data: { id: e.id(), source: e.source().id(), target: e.target().id() },
+    }));
+    const degrees = new Map<string, number>();
+    for (const edge of edges) {
+      degrees.set(edge.data.source, (degrees.get(edge.data.source) ?? 0) + 1);
+      degrees.set(edge.data.target, (degrees.get(edge.data.target) ?? 0) + 1);
+    }
+    const maxDegree = Math.max(0, ...degrees.values());
+    const hubGravity = gravity * (1 - Math.min(0.45, maxDegree * 0.012));
+    const nodes = Array.from(cyNodes).map((n, index) => {
+      const p = n.position();
+      const w = n.width();
+      const h = n.height();
+      const layoutSize = getLayoutCollisionSize(w, h, degrees.get(n.id()) ?? 0);
+      const position = shouldRandomize
+        ? seededLayoutPosition(n.id(), index, cyNodes.length, ar)
+        : { x: p.x, y: p.y };
+      return {
+        data: {
+          id: n.id(),
+          _degree: degrees.get(n.id()) ?? 0,
+          _w: layoutSize.width,
+          _h: layoutSize.height,
+        },
+        position,
+        actualW: w || 60,
+        actualH: h || 60,
+      };
+    });
+    const layoutOptions = {
       ...baseOptions,
-      boundingBox: { x1: -1200, y1: -1200, x2: 1200, y2: 1200 },
-      gravity,
+      boundingBox: { x1: -2400, y1: -2400, x2: 2400, y2: 2400 },
+      gravity: hubGravity,
       randomize: shouldRandomize,
       animate: false,
       fit: false,
-    } as any);
+    };
 
-    const layout = this.currentLayout;
-    layout.one("layoutstop", () => {
-      if (this.currentLayout !== layout || this.cy.destroyed()) return;
+    // Scale timeout: draft quality (500+ nodes) can take 20-30s on slow machines
+    const workerTimeout = Math.min(
+      60000,
+      Math.max(BASE_LAYOUT_WORKER_TIMEOUT_MS, nodes.length * 30),
+    );
+    const layoutStartTime = performance.now();
+    const positions = await this.runInWorker(
+      nodes,
+      edges,
+      layoutOptions,
+      workerTimeout,
+    );
 
-      removeOverlaps(this.cy);
+    if (!positions || this.cy.destroyed()) {
+      options.onLayoutStop?.();
+      return;
+    }
 
-      this.cy.animate({
-        fit: { eles: this.cy.elements(), padding: 20 },
-        duration: 800,
-        easing: "ease-out-quad",
-        complete: () => options.onLayoutStop?.(),
-      });
-
-      // Position persistence
-      if (!options.isGuest) {
-        const updates: Record<string, Partial<Entity>> = {};
-        this.cy.nodes().forEach((node) => {
-          const pos = node.position();
-          updates[node.id()] = {
-            metadata: {
-              coordinates: {
-                x: Math.round(pos.x),
-                y: Math.round(pos.y),
-              },
-            } as any,
-          };
-        });
-        options.onPositionsUpdated?.(updates);
+    // Apply positions back onto the real cy instance
+    this.cy.batch(() => {
+      for (const [id, pos] of Object.entries(positions)) {
+        const node = this.cy.$id(id);
+        if (node.length) node.position(pos);
       }
     });
 
-    this.currentLayout.run();
+    options.onLayoutComputed?.(Math.round(performance.now() - layoutStartTime));
+
+    this.animateFitAndStop(options, "ease-out-quad");
+
+    // Position persistence
+    if (!options.isGuest) {
+      const updates: Record<string, Partial<Entity>> = {};
+      this.cy.nodes().forEach((node) => {
+        const pos = node.position();
+        updates[node.id()] = {
+          metadata: {
+            coordinates: {
+              x: Math.round(pos.x),
+              y: Math.round(pos.y),
+            },
+          } as any,
+        };
+      });
+      options.onPositionsUpdated?.(updates);
+    }
   }
 
   stop() {
+    this.jobId++; // Invalidate any in-flight worker result
+    this.pendingWorkerResolve?.(null);
+    this.pendingWorkerResolve = null;
+    this.pendingJobId = null;
     if (this.currentLayout) {
       this.currentLayout.stop();
+      this.currentLayout = null;
+    }
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
     }
   }
 }

--- a/packages/graph-engine/src/defaults.test.ts
+++ b/packages/graph-engine/src/defaults.test.ts
@@ -9,11 +9,11 @@ describe("getDynamicLayoutOptions", () => {
   });
 
   it("gravity never falls below minimum floor", () => {
-    expect(getDynamicLayoutOptions(1000).gravity).toBeGreaterThanOrEqual(0.08);
+    expect(getDynamicLayoutOptions(1000).gravity).toBeGreaterThanOrEqual(0.005);
   });
 
   it("gravity never exceeds base cap", () => {
-    expect(getDynamicLayoutOptions(1).gravity).toBeLessThanOrEqual(0.25);
+    expect(getDynamicLayoutOptions(1).gravity).toBeLessThanOrEqual(0.05);
   });
 
   it("repulsion scales with node count", () => {
@@ -22,8 +22,8 @@ describe("getDynamicLayoutOptions", () => {
     expect(large.nodeRepulsion).toBeGreaterThan(small.nodeRepulsion);
   });
 
-  it("repulsion is capped at 200000", () => {
-    expect(getDynamicLayoutOptions(10000).nodeRepulsion).toBe(200000);
+  it("repulsion is capped at 1600000", () => {
+    expect(getDynamicLayoutOptions(10000).nodeRepulsion).toBe(1600000);
   });
 
   it("uses draft quality for graphs over 500 nodes", () => {

--- a/packages/graph-engine/src/defaults.ts
+++ b/packages/graph-engine/src/defaults.ts
@@ -12,8 +12,9 @@ export const DEFAULT_LAYOUT_OPTIONS = {
   gravity: 0.25,
   nodeRepulsion: 18000,
   idealEdgeLength: 55,
+  edgeElasticity: 0.45,
   nodeSeparation: 55,
-  numIter: 5000,
+  numIter: 2200,
   nodeDimensionsIncludeLabels: true,
   nestingReprGrpFactor: 1.2,
   initialEnergyOnIncremental: 0.3,
@@ -30,27 +31,28 @@ export const DEFAULT_LAYOUT_OPTIONS = {
 export const getDynamicLayoutOptions = (nodeCount: number) => {
   const quality = nodeCount > 500 ? "draft" : "default";
 
-  // Shorter edges pull connected nodes into tight huddles around their hub
-  const edgeLength = Math.min(70, 15 + Math.sqrt(nodeCount) * 1.5);
+  const edgeLength = Math.min(450, 90 + Math.sqrt(nodeCount) * 9);
 
-  const separation = Math.min(100, 20 + Math.sqrt(nodeCount) * 2.5);
+  const separation = Math.min(600, 120 + Math.sqrt(nodeCount) * 15);
 
-  // Higher repulsion pushes non-connected nodes further apart while
-  // short edges still keep directly-connected nodes in tight clusters
-  const repulsion = Math.min(200000, 30000 + nodeCount * 500);
+  const repulsion = Math.min(1600000, 250000 + nodeCount * 2400);
 
-  // Lower gravity lets clusters drift into their own regions of space
-  // rather than being forced into one mixed ball
-  const gravity = Math.max(0.08, 0.25 - nodeCount * 0.0005);
+  // Lower gravity so clusters spread into their own regions rather than
+  // collapsing into one mixed ball; floor is low so large graphs stay cohesive
+  const gravity = Math.max(0.005, 0.05 - nodeCount * 0.00015);
+
+  // Draft quality uses a coarser algorithm — fewer iterations still converge
+  const numIter = nodeCount > 200 ? 1200 : DEFAULT_LAYOUT_OPTIONS.numIter;
 
   return {
     ...DEFAULT_LAYOUT_OPTIONS,
     quality,
+    numIter,
     nodeRepulsion: repulsion,
     nodeSeparation: separation,
     idealEdgeLength: edgeLength,
     gravity,
-    gravityRange: 5.5,
+    gravityRange: 1.5,
   };
 };
 

--- a/packages/graph-engine/src/layout.worker.ts
+++ b/packages/graph-engine/src/layout.worker.ts
@@ -1,0 +1,206 @@
+/// <reference lib="webworker" />
+
+import Cytoscape from "cytoscape";
+import type { Core } from "cytoscape";
+import fcose from "cytoscape-fcose";
+
+Cytoscape.use(fcose);
+
+interface SerializedLayoutNode {
+  data: { id: string; _w: number; _h: number; [key: string]: unknown };
+  position: { x: number; y: number };
+  actualW: number;
+  actualH: number;
+}
+
+interface SerializedLayoutEdge {
+  data: { id: string; source: string; target: string; [key: string]: unknown };
+}
+
+interface WorkerRequest {
+  jobId: number;
+  nodes: SerializedLayoutNode[];
+  edges: SerializedLayoutEdge[];
+  options: Record<string, any>;
+}
+
+function serializeError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getDegreeAwareLayoutOptions(options: Record<string, any>) {
+  const baseRepulsion = Number(options.nodeRepulsion) || 250000;
+  const baseEdgeLength = Number(options.idealEdgeLength) || 180;
+
+  return {
+    ...options,
+    nodeRepulsion: (node: any) => {
+      const degree = Number(node.data("_degree")) || 0;
+      // Hubs repel much harder so they carve out space between clusters
+      return baseRepulsion * (1 + Math.min(4.0, Math.sqrt(degree) * 0.55));
+    },
+    idealEdgeLength: (edge: any) => {
+      const sourceDegree = Number(edge.source().data("_degree")) || 0;
+      const targetDegree = Number(edge.target().data("_degree")) || 0;
+      const maxDegree = Math.max(sourceDegree, targetDegree);
+      const minDegree = Math.min(sourceDegree, targetDegree);
+
+      // Hub↔hub: very long edges push clusters apart
+      if (minDegree >= 5) return baseEdgeLength * 3.5;
+      // Hub↔leaf: shorter to keep leaf near its hub
+      if (maxDegree >= 5) return baseEdgeLength * 0.8;
+      return baseEdgeLength;
+    },
+  };
+}
+
+function removeOverlaps(
+  cy: Core,
+  actualRadii: Float64Array,
+  padding = 18,
+  maxIter = 32,
+) {
+  const nodes = cy.nodes();
+  const n = nodes.length;
+  if (n < 2) return;
+
+  const radii = actualRadii;
+  let maxRadius = 0;
+  for (let i = 0; i < n; i++) {
+    if (radii[i] > maxRadius) maxRadius = radii[i];
+  }
+  const cellSize = 2 * maxRadius + padding;
+
+  const xs = new Float64Array(n);
+  const ys = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    const p = nodes[i].position();
+    xs[i] = p.x;
+    ys[i] = p.y;
+  }
+
+  // Numeric grid keys avoid string allocation on every node per iteration.
+  // Grid coords stay within ±(2400/cellSize) ≈ ±30, so gx*10000+gy is
+  // unique (|gy| < 10000) and fits comfortably in a safe integer.
+  const packKey = (gx: number, gy: number) => gx * 10000 + gy;
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    const grid = new Map<number, number[]>();
+    for (let i = 0; i < n; i++) {
+      const key = packKey(
+        Math.floor(xs[i] / cellSize),
+        Math.floor(ys[i] / cellSize),
+      );
+      let cell = grid.get(key);
+      if (!cell) {
+        cell = [];
+        grid.set(key, cell);
+      }
+      cell.push(i);
+    }
+
+    let anyOverlap = false;
+    for (let i = 0; i < n; i++) {
+      const gcx = Math.floor(xs[i] / cellSize);
+      const gcy = Math.floor(ys[i] / cellSize);
+      const r1 = radii[i];
+      for (let ddx = -1; ddx <= 1; ddx++) {
+        for (let ddy = -1; ddy <= 1; ddy++) {
+          const cell = grid.get(packKey(gcx + ddx, gcy + ddy));
+          if (!cell) continue;
+          for (const j of cell) {
+            if (j <= i) continue;
+            const dx = xs[j] - xs[i];
+            const dy = ys[j] - ys[i];
+            const minDist = r1 + radii[j] + padding;
+            const dist2 = dx * dx + dy * dy;
+            if (dist2 >= minDist * minDist) continue;
+            anyOverlap = true;
+            const dist = Math.sqrt(dist2);
+            const push = (minDist - dist) / 2;
+            if (dist < 0.001) {
+              xs[i] -= push;
+              xs[j] += push;
+            } else {
+              const nx = dx / dist;
+              const ny = dy / dist;
+              xs[i] -= nx * push;
+              ys[i] -= ny * push;
+              xs[j] += nx * push;
+              ys[j] += ny * push;
+            }
+          }
+        }
+      }
+    }
+    if (!anyOverlap) break;
+  }
+
+  cy.batch(() => {
+    for (let i = 0; i < n; i++) {
+      nodes[i].position({ x: xs[i], y: ys[i] });
+    }
+  });
+}
+
+self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const { jobId, nodes, edges, options } = event.data;
+  let cy: Core | null = null;
+
+  const fail = (error: unknown) => {
+    cy?.destroy();
+    self.postMessage({
+      jobId,
+      positions: null,
+      error: serializeError(error),
+    });
+  };
+
+  try {
+    // Build actual radii for removeOverlaps (layout uses uniform _w/_h,
+    // but collision resolution needs real sizes)
+    const actualRadii = new Float64Array(nodes.length);
+    for (let i = 0; i < nodes.length; i++) {
+      actualRadii[i] = Math.max(nodes[i].actualW, nodes[i].actualH) / 2;
+    }
+
+    cy = Cytoscape({
+      headless: true,
+      elements: {
+        nodes: nodes.map((n) => ({
+          data: n.data,
+          position: n.position,
+        })),
+        edges: edges.map((e) => ({ data: e.data })),
+      },
+      style: [
+        { selector: "node", style: { width: "data(_w)", height: "data(_h)" } },
+      ],
+    });
+
+    const layout = cy.layout(getDegreeAwareLayoutOptions(options) as any);
+
+    layout.one("layoutstop", () => {
+      try {
+        removeOverlaps(cy!, actualRadii);
+
+        const positions: Record<string, { x: number; y: number }> = {};
+        cy!.nodes().forEach((node) => {
+          const pos = node.position();
+          positions[node.id()] = { x: pos.x, y: pos.y };
+        });
+
+        cy!.destroy();
+        cy = null;
+
+        self.postMessage({ jobId, positions });
+      } catch (error) {
+        fail(error);
+      }
+    });
+
+    layout.run();
+  } catch (error) {
+    fail(error);
+  }
+};

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -710,7 +710,7 @@ The Lore Oracle supports several slash commands to help you manage your vault:
                     entityType: p.type,
                     entityId: id,
                   });
-                  await this.handleConnectionDiscovery(id, context);
+                  this.handleConnectionDiscovery(id, context);
                 } else {
                   const existing = context.vault.entities[p.entityId];
                   if (existing) {
@@ -759,7 +759,7 @@ The Lore Oracle supports several slash commands to help you manage your vault:
                       entityType: p.type,
                       entityId: p.entityId,
                     });
-                    await this.handleConnectionDiscovery(p.entityId, context);
+                    this.handleConnectionDiscovery(p.entityId, context);
                   }
                 }
               }

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -710,7 +710,7 @@ The Lore Oracle supports several slash commands to help you manage your vault:
                     entityType: p.type,
                     entityId: id,
                   });
-                  this.handleConnectionDiscovery(id, context);
+                  await this.handleConnectionDiscovery(id, context);
                 } else {
                   const existing = context.vault.entities[p.entityId];
                   if (existing) {
@@ -759,7 +759,7 @@ The Lore Oracle supports several slash commands to help you manage your vault:
                       entityType: p.type,
                       entityId: p.entityId,
                     });
-                    this.handleConnectionDiscovery(p.entityId, context);
+                    await this.handleConnectionDiscovery(p.entityId, context);
                   }
                 }
               }

--- a/packages/oracle-engine/src/reconciliation-context.ts
+++ b/packages/oracle-engine/src/reconciliation-context.ts
@@ -49,7 +49,7 @@ function scoreTitleMentions(title: string, text: string): number {
 }
 
 function summarizeContext(value: string, maxChars: number): string {
-  const trimmed = value.replace(/\s+/g, " ").trim();
+  const trimmed = value.replace(/[ \t]+/g, " ").trim();
   if (trimmed.length <= maxChars) return trimmed;
   return trimmed.slice(0, maxChars).trimEnd() + "...";
 }


### PR DESCRIPTION
## Summary

- Tune the graph layout redraw pipeline, including worker-backed layout handling and layout timing diagnostics.
- Add `docs/GRAPH_LAYOUT_TUNING.md` to document the tuning model and operational guidance.
- Prevent redraw coordinate persistence from triggering search reindex/index saves by carrying batch patches through vault events and skipping coordinate-only metadata updates.
- Preserve existing entity metadata when applying coordinate-only batch patches.

## Validation

- `npm run test --workspace=web -- src/lib/stores/vault/search-store.test.ts src/lib/stores/vault/entity-store.test.ts`
- `npx prettier --check packages/graph-engine/src/LayoutManager.ts apps/web/src/lib/stores/vault/search-store.svelte.ts apps/web/src/lib/stores/vault/entity-store.svelte.ts apps/web/src/lib/stores/vault/search-store.test.ts apps/web/src/lib/stores/vault/entity-store.test.ts`
- `npm run lint` passed with existing Svelte CSS at-rule warnings and 0 errors.
- `npm test`
- Push hook ran `npm run lint` and `npm run test:affected`; both passed.