### PR TITLE
[codex] Fix duplicate Oracle clear confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ This file is the Codex-facing instruction layer for this repository.
 
 - Follow the constitution's library-first, TDD, privacy, DI, and documentation principles.
 - Do not commit implementation changes without tests for the affected behavior.
+- When adding or updating tests for changed behavior, cover both the expected success path and at least one meaningful negative, cancellation, or failure path.
 - Use constructor-based dependency injection for services and stores.
 - Prefer local-first and client-side solutions when the architecture allows it.
 - Keep user-facing language clear and plain.

--- a/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
+++ b/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
@@ -89,19 +89,7 @@
       {#if activeTab === "oracle" && oracle.messages.length > 0}
         <button
           class="w-8 h-8 flex items-center justify-center text-theme-muted hover:text-red-400 transition-colors"
-          onclick={async () => {
-            if (
-              await uiStore.confirm({
-                title: "Clear History",
-                message:
-                  "Are you sure you want to clear the conversation history?",
-                confirmLabel: "Clear",
-                isDangerous: true,
-              })
-            ) {
-              oracle.clearMessages();
-            }
-          }}
+          onclick={() => oracle.clearMessages()}
           title="Clear conversation history"
           aria-label="Clear conversation history"
         >

--- a/apps/web/src/lib/components/oracle/OracleWindow.svelte
+++ b/apps/web/src/lib/components/oracle/OracleWindow.svelte
@@ -92,19 +92,7 @@
         {#if oracle.messages.length > 0}
           <button
             class="w-8 h-8 flex items-center justify-center text-theme-muted hover:text-red-400 transition-colors"
-            onclick={async () => {
-              if (
-                await uiStore.confirm({
-                  title: "Clear History",
-                  message:
-                    "Are you sure you want to clear the conversation history?",
-                  confirmLabel: "Clear",
-                  isDangerous: true,
-                })
-              ) {
-                oracle.clearMessages();
-              }
-            }}
+            onclick={() => oracle.clearMessages()}
             title="Clear conversation history"
             aria-label="Clear conversation history"
           >

--- a/apps/web/src/lib/config/chat-commands.test.ts
+++ b/apps/web/src/lib/config/chat-commands.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { chatCommands } from "./chat-commands";
 import { oracle } from "../stores/oracle.svelte";
-import { uiStore } from "../stores/ui.svelte";
 
 // Mock the oracle store
 vi.mock("../stores/oracle.svelte", () => ({
@@ -9,13 +8,6 @@ vi.mock("../stores/oracle.svelte", () => ({
     ask: vi.fn(),
     startWizard: vi.fn(),
     clearMessages: vi.fn(),
-  },
-}));
-
-// Mock uiStore
-vi.mock("../stores/ui.svelte", () => ({
-  uiStore: {
-    confirm: vi.fn(),
   },
 }));
 
@@ -91,18 +83,10 @@ describe("chatCommands", () => {
   });
 
   describe("/clear", () => {
-    it("should clear messages if confirmed", async () => {
-      vi.mocked(uiStore.confirm).mockResolvedValue(true);
+    it("should clear messages", async () => {
       const cmd = chatCommands.find((c) => c.name === "/clear");
       await cmd?.handler("");
       expect(oracle.clearMessages).toHaveBeenCalled();
-    });
-
-    it("should NOT clear messages if cancelled", async () => {
-      vi.mocked(uiStore.confirm).mockResolvedValue(false);
-      const cmd = chatCommands.find((c) => c.name === "/clear");
-      await cmd?.handler("");
-      expect(oracle.clearMessages).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/lib/config/chat-commands.ts
+++ b/apps/web/src/lib/config/chat-commands.ts
@@ -1,5 +1,4 @@
 import { oracle } from "../stores/oracle.svelte";
-import { uiStore } from "../stores/ui.svelte";
 
 export interface ChatCommand {
   name: string;
@@ -64,16 +63,6 @@ export const chatCommands: ChatCommand[] = [
   {
     name: "/clear",
     description: "Clear conversation history",
-    handler: async () => {
-      if (
-        await uiStore.confirm({
-          title: "Clear History",
-          message: "Are you sure you want to clear the conversation history?",
-          isDangerous: true,
-        })
-      ) {
-        oracle.clearMessages();
-      }
-    },
+    handler: () => oracle.clearMessages(),
   },
 ];

--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -334,6 +334,12 @@ describe("OracleStore", () => {
       });
 
       await oracle.clearMessages();
+      expect(mockUiStore.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Clear History",
+          isDangerous: true,
+        }),
+      );
       expect(mockChatHistory.clear).toHaveBeenCalled();
     });
 

--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -118,6 +118,7 @@ describe("OracleStore", () => {
   let mockSettings: any;
   let mockUndoRedo: any;
   let mockExecutor: any;
+  let mockSessionActivity: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -220,10 +221,16 @@ describe("OracleStore", () => {
       init: vi.fn(),
     };
 
+    mockSessionActivity = {
+      addEvent: vi.fn(),
+      clear: vi.fn(),
+    };
+
     oracle = new OracleStore({
       vault: mockVault as any,
       uiStore: mockUiStore as any,
       diceHistory: mockDiceHistory as any,
+      sessionActivity: mockSessionActivity as any,
     });
 
     // Inject mocks into private fields to align with internal services refactor
@@ -341,6 +348,22 @@ describe("OracleStore", () => {
         }),
       );
       expect(mockChatHistory.clear).toHaveBeenCalled();
+      expect(mockSessionActivity.clear).toHaveBeenCalled();
+    });
+
+    it("should not clear messages when confirmation is cancelled", async () => {
+      vi.mocked(mockUiStore.confirm).mockResolvedValue(false);
+
+      await oracle.clearMessages();
+
+      expect(mockUiStore.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Clear History",
+          isDangerous: true,
+        }),
+      );
+      expect(mockChatHistory.clear).not.toHaveBeenCalled();
+      expect(mockSessionActivity.clear).not.toHaveBeenCalled();
     });
 
     it("should pass related entity context into reconciliation updates", async () => {

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -273,7 +273,7 @@ export class OracleStore {
     return Boolean(messageId && this.visualizingMessageId === messageId);
   }
 
-  async clearHistory() {
+  async clearMessages() {
     if (
       await this.uiStore.confirm({
         title: "Clear History",
@@ -286,11 +286,6 @@ export class OracleStore {
       await this.chatHistoryService.clear();
       this.sessionActivity.clear();
     }
-  }
-
-  /** Alias for clearHistory */
-  async clearMessages() {
-    return this.clearHistory();
   }
 
   async removeMessage(id: string) {

--- a/apps/web/src/routes/(app)/oracle/+page.svelte
+++ b/apps/web/src/routes/(app)/oracle/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import OracleChat from "$lib/components/oracle/OracleChat.svelte";
   import { oracle } from "$lib/stores/oracle.svelte";
-  import { uiStore } from "$lib/stores/ui.svelte";
   import { onMount } from "svelte";
 
   onMount(() => {
@@ -39,18 +38,7 @@
       {#if oracle.messages.length > 0}
         <button
           class="px-3 py-1 flex items-center gap-2 text-[10px] font-bold text-oracle-primary hover:text-red-400 border border-oracle-dim/30 hover:border-red-500/50 transition-all uppercase font-header tracking-widest bg-oracle-dark/20"
-          onclick={async () => {
-            if (
-              await uiStore.confirm({
-                title: "Clear Chat",
-                message:
-                  "Are you sure you want to clear the conversation history?",
-                isDangerous: true,
-              })
-            ) {
-              oracle.clearMessages();
-            }
-          }}
+          onclick={() => oracle.clearMessages()}
           aria-label="Clear conversation history"
         >
           <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>


### PR DESCRIPTION
## What changed
- collapsed the Oracle clear flow to a single `clearMessages()` API
- moved the confirmation prompt into `oracle.clearMessages()`
- removed duplicated confirmation logic from the Oracle window, sidebar, standalone page, and `/clear` command
- updated Oracle store and chat command tests to match the new behavior

## Why
Deleting Oracle chat history was prompting twice. The UI confirmed first, then the store path confirmed again through a second wrapper method.

## Impact
- Oracle chat clear actions now show one confirmation dialog instead of two
- the clear behavior is owned in one place, which reduces drift between UI entry points

## Root cause
The code had two overlapping APIs for the same underlying chat data:
- `clearHistory()` handled confirmation and clear
- `clearMessages()` forwarded into `clearHistory()`

Several UI call sites were already confirming before calling `clearMessages()`, which caused the duplicate prompt.

## Validation
- `npm run test --workspace=web -- src/lib/config/chat-commands.test.ts src/lib/stores/oracle.svelte.test.ts`
- push hook `lint`
- push hook `test:affected` (14 tasks, 1005 passed, 3 skipped)

Closes #690