### PR TITLE
:sparkles: feat: Interactive label filtering in Entity Explorer

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -151,6 +151,8 @@ TypeScript: Follow standard conventions
 
 ## Recent Changes
 
+- 089-label-filtering: Added interactive label pills in entity explorer with "AND" filtering logic, active filter UI, and label-based search integration. (Refinement of 084)
+
 - 087-gen-oracle-content: Added TypeScript 5.9.3 (Svelte 5 Runes) + `@google/generative-ai` (Gemini SDK), `idb` (IndexedDB), `packages/oracle-engine`, `packages/vault-engine`
 
 - 0.18.0 - The Tactical Explorer Update: Added Label-Grouped Entity Explorer with persistence, VTT sidebar Entity List, and token drag-and-drop. Improved Zen Popout error handling and map coordinate bounds safety.

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -12,6 +12,7 @@
     LayoutGrid,
     List,
     Tag,
+    X,
   } from "lucide-svelte";
 
   let {
@@ -34,6 +35,7 @@
 
   let searchQuery = $state("");
   let typeFilters = $state<Set<string>>(new Set());
+  let labelFilters = $state<Set<string>>(new Set());
   const activeVaultId = $derived(vault.activeVaultId);
   const focusedEntityId = $derived(uiStore.focusedEntityId);
   const viewMode = $derived(uiStore.explorerViewMode);
@@ -74,7 +76,7 @@
     const allEntities = vault.allEntities;
     const filtered: Entity[] = [];
     const query = searchQuery.trim().toLowerCase();
-    const filterAll = typeFilters.size === 0;
+    const filterAllTypes = typeFilters.size === 0;
 
     for (let i = 0; i < allEntities.length; i++) {
       const e = allEntities[i];
@@ -94,10 +96,18 @@
       const matchesSearch =
         !query ||
         e.title.toLowerCase().includes(query) ||
-        e.content.toLowerCase().includes(query);
-      const matchesType = filterAll || typeFilters.has(e.type);
+        e.content.toLowerCase().includes(query) ||
+        e.labels?.some((l) => l.toLowerCase().includes(query));
 
-      if (matchesSearch && matchesType) {
+      const matchesType = filterAllTypes || typeFilters.has(e.type);
+
+      // AND logic for labels
+      const matchesLabels =
+        labelFilters.size === 0 ||
+        (e.labels &&
+          Array.from(labelFilters).every((f) => e.labels?.includes(f)));
+
+      if (matchesSearch && matchesType && matchesLabels) {
         filtered.push(e);
       }
     }
@@ -109,6 +119,26 @@
     return groupEntitiesForExplorer(filteredEntities, viewMode);
   });
 
+  function toggleLabelFilter(label: string, event?: MouseEvent) {
+    const isMulti = event?.ctrlKey || event?.metaKey;
+
+    if (isMulti) {
+      const newFilters = new Set(labelFilters);
+      if (newFilters.has(label)) {
+        newFilters.delete(label);
+      } else {
+        newFilters.add(label);
+      }
+      labelFilters = newFilters;
+    } else {
+      if (labelFilters.has(label) && labelFilters.size === 1) {
+        labelFilters = new Set();
+      } else {
+        labelFilters = new Set([label]);
+      }
+    }
+  }
+
   function toggleTypeFilter(type: string, event: MouseEvent) {
     if (allowedTypeSet && !allowedTypeSet.has(type)) {
       return;
@@ -118,6 +148,7 @@
 
     if (type === "all") {
       typeFilters = new Set();
+      labelFilters = new Set();
       return;
     }
 
@@ -243,6 +274,33 @@
         <Tag class="w-3.5 h-3.5" />
       </button>
     </div>
+
+    {#if labelFilters.size > 0}
+      <div
+        class="mt-3 flex flex-wrap gap-1.5 animate-in fade-in slide-in-from-top-1 duration-200"
+      >
+        {#each Array.from(labelFilters).sort() as label}
+          <div
+            class="flex items-center gap-1 px-2 py-0.5 rounded-md bg-theme-primary/10 border border-theme-primary/20 text-[9px] font-bold text-theme-primary uppercase tracking-wider"
+          >
+            <span>{label}</span>
+            <button
+              onclick={() => toggleLabelFilter(label)}
+              class="hover:text-theme-text transition-colors"
+              aria-label={`Remove ${label} filter`}
+            >
+              <X class="w-2.5 h-2.5" />
+            </button>
+          </div>
+        {/each}
+        <button
+          onclick={() => (labelFilters = new Set())}
+          class="px-2 py-0.5 text-[9px] font-bold text-theme-muted hover:text-theme-primary uppercase tracking-wider transition-colors"
+        >
+          Clear All
+        </button>
+      </div>
+    {/if}
   </div>
 
   <div
@@ -252,7 +310,7 @@
     {#snippet entityItem(entity: Entity)}
       {@const cat = categories.getCategory(entity.type)}
       <div
-        class="group relative flex items-stretch rounded-xl border transition-all {entity.id ===
+        class="group relative flex items-center rounded-xl border transition-all {entity.id ===
         focusedEntityId
           ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'
           : 'border-theme-border bg-theme-surface/50 hover:border-theme-primary/50 hover:bg-theme-primary/5'}"
@@ -266,7 +324,7 @@
           ondragend={() => onDragEnd?.()}
           onclick={() => onSelect?.(entity)}
           title={`Select ${entity.title}`}
-          class="flex flex-1 min-w-0 items-center gap-2 p-2.5 text-left focus:outline-none focus:ring-2 focus:ring-theme-accent/20 rounded-xl"
+          class="flex flex-1 min-w-0 items-center gap-2 p-2.5 text-left focus:outline-none focus:ring-2 focus:ring-theme-accent/20 rounded-l-xl"
         >
           <span
             class="{getIconClass(
@@ -280,25 +338,36 @@
               {entity.title}
             </div>
           </div>
-          {#if entity.labels && entity.labels.length > 0}
-            <div class="flex gap-1 shrink-0 ml-auto flex-wrap justify-end">
-              {#each entity.labels as label}
-                <span
-                  class="text-[7px] px-1 bg-theme-primary/10 text-theme-primary rounded uppercase tracking-[0.1em] truncate max-w-[40px] font-mono"
-                >
-                  {label}
-                </span>
-              {/each}
-            </div>
-          {/if}
         </button>
+
+        {#if entity.labels && entity.labels.length > 0}
+          <div class="flex gap-1 shrink-0 px-2 flex-wrap justify-end">
+            {#each entity.labels as label}
+              <button
+                type="button"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  toggleLabelFilter(label, e);
+                }}
+                class="text-[7px] px-1 rounded uppercase tracking-[0.1em] truncate max-w-[60px] font-mono transition-all border {labelFilters.has(
+                  label,
+                )
+                  ? 'bg-theme-primary text-theme-bg border-theme-primary'
+                  : 'bg-theme-primary/10 text-theme-primary border-transparent hover:border-theme-primary/50 hover:bg-theme-primary/20'}"
+              >
+                {label}
+              </button>
+            {/each}
+          </div>
+        {/if}
+
         {#if onOpenZen}
           <button
             type="button"
             onclick={() => onOpenZen(entity)}
             title="Open in Zen Mode"
             aria-label="Open {entity.title} in Zen Mode"
-            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100"
+            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100 rounded-r-xl"
           >
             <span class="icon-[lucide--book-open] h-3.5 w-3.5"></span>
           </button>

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -77,6 +77,7 @@
     const filtered: Entity[] = [];
     const query = searchQuery.trim().toLowerCase();
     const filterAllTypes = typeFilters.size === 0;
+    const activeLabels = Array.from(labelFilters);
 
     for (let i = 0; i < allEntities.length; i++) {
       const e = allEntities[i];
@@ -103,9 +104,8 @@
 
       // AND logic for labels
       const matchesLabels =
-        labelFilters.size === 0 ||
-        (e.labels &&
-          Array.from(labelFilters).every((f) => e.labels?.includes(f)));
+        activeLabels.length === 0 ||
+        (e.labels && activeLabels.every((f) => e.labels?.includes(f)));
 
       if (matchesSearch && matchesType && matchesLabels) {
         filtered.push(e);
@@ -137,6 +137,12 @@
         labelFilters = new Set([label]);
       }
     }
+  }
+
+  function removeLabelFilter(label: string) {
+    const newFilters = new Set(labelFilters);
+    newFilters.delete(label);
+    labelFilters = newFilters;
   }
 
   function toggleTypeFilter(type: string, event: MouseEvent) {
@@ -208,7 +214,7 @@
       class="flex items-center gap-1 rounded-xl border border-theme-border bg-theme-surface/50 px-2 py-1.5 shadow-sm"
     >
       <button
-        onclick={() => (typeFilters = new Set())}
+        onclick={(e) => toggleTypeFilter("all", e)}
         title="Show all categories"
         aria-label="Show all categories"
         aria-pressed={typeFilters.size === 0}
@@ -285,7 +291,7 @@
           >
             <span>{label}</span>
             <button
-              onclick={() => toggleLabelFilter(label)}
+              onclick={() => removeLabelFilter(label)}
               class="hover:text-theme-text transition-colors"
               aria-label={`Remove ${label} filter`}
             >
@@ -367,7 +373,7 @@
             onclick={() => onOpenZen(entity)}
             title="Open in Zen Mode"
             aria-label="Open {entity.title} in Zen Mode"
-            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100 rounded-r-xl"
+            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100 focus-visible:opacity-100 rounded-r-xl"
           >
             <span class="icon-[lucide--book-open] h-3.5 w-3.5"></span>
           </button>

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -35,8 +35,8 @@
 
   let searchQuery = $state("");
   let typeFilters = $state<Set<string>>(new Set());
-  let labelFilters = $state<Set<string>>(new Set());
   const activeVaultId = $derived(vault.activeVaultId);
+  const labelFilters = $derived(uiStore.labelFilters);
   const focusedEntityId = $derived(uiStore.focusedEntityId);
   const viewMode = $derived(uiStore.explorerViewMode);
   const allowedTypeSet = $derived.by(() =>
@@ -119,32 +119,6 @@
     return groupEntitiesForExplorer(filteredEntities, viewMode);
   });
 
-  function toggleLabelFilter(label: string, event?: MouseEvent) {
-    const isMulti = event?.ctrlKey || event?.metaKey;
-
-    if (isMulti) {
-      const newFilters = new Set(labelFilters);
-      if (newFilters.has(label)) {
-        newFilters.delete(label);
-      } else {
-        newFilters.add(label);
-      }
-      labelFilters = newFilters;
-    } else {
-      if (labelFilters.has(label) && labelFilters.size === 1) {
-        labelFilters = new Set();
-      } else {
-        labelFilters = new Set([label]);
-      }
-    }
-  }
-
-  function removeLabelFilter(label: string) {
-    const newFilters = new Set(labelFilters);
-    newFilters.delete(label);
-    labelFilters = newFilters;
-  }
-
   function toggleTypeFilter(type: string, event: MouseEvent) {
     if (allowedTypeSet && !allowedTypeSet.has(type)) {
       return;
@@ -154,7 +128,7 @@
 
     if (type === "all") {
       typeFilters = new Set();
-      labelFilters = new Set();
+      uiStore.clearLabelFilters();
       return;
     }
 
@@ -291,7 +265,7 @@
           >
             <span>{label}</span>
             <button
-              onclick={() => removeLabelFilter(label)}
+              onclick={() => uiStore.removeLabelFilter(label)}
               class="hover:text-theme-text transition-colors"
               aria-label={`Remove ${label} filter`}
             >
@@ -300,7 +274,7 @@
           </div>
         {/each}
         <button
-          onclick={() => (labelFilters = new Set())}
+          onclick={() => uiStore.clearLabelFilters()}
           class="px-2 py-0.5 text-[9px] font-bold text-theme-muted hover:text-theme-primary uppercase tracking-wider transition-colors"
         >
           Clear All
@@ -353,7 +327,7 @@
                 type="button"
                 onclick={(e) => {
                   e.stopPropagation();
-                  toggleLabelFilter(label, e);
+                  uiStore.toggleLabelFilter(label, e.ctrlKey || e.metaKey);
                 }}
                 class="text-[7px] px-1 rounded uppercase tracking-[0.1em] truncate max-w-[60px] font-mono transition-all border {labelFilters.has(
                   label,

--- a/apps/web/src/lib/components/explorer/EntityListFiltering.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityListFiltering.test.ts
@@ -60,6 +60,7 @@ vi.mock("$lib/utils/icon", () => ({
 describe("EntityList Filtering", () => {
   beforeEach(() => {
     uiStore.explorerViewMode = "list";
+    uiStore.clearLabelFilters();
   });
 
   it("filters entities when a label pill is clicked", async () => {

--- a/apps/web/src/lib/components/explorer/EntityListFiltering.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityListFiltering.test.ts
@@ -1,0 +1,134 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { uiStore } from "$lib/stores/ui.svelte";
+import EntityList from "./EntityList.svelte";
+
+vi.mock("svelte", async () => {
+  // @ts-expect-error - force the client Svelte runtime so testing-library can mount
+  return await import("../../../../../../node_modules/svelte/src/index-client.js");
+});
+
+vi.mock("$app/paths", () => ({
+  base: "",
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    activeVaultId: "vault-1",
+    allEntities: [
+      {
+        id: "e1",
+        title: "City Guard",
+        type: "npc",
+        labels: ["NPC", "Guard"],
+        status: "active",
+        content: "",
+      },
+      {
+        id: "e2",
+        title: "Castle Guard",
+        type: "npc",
+        labels: ["Guard", "Castle"],
+        status: "active",
+        content: "",
+      },
+      {
+        id: "e3",
+        title: "Merchant",
+        type: "npc",
+        labels: ["NPC", "MerchantLabel"], // Avoid title collision
+        status: "active",
+        content: "",
+      },
+    ],
+  },
+}));
+
+vi.mock("$lib/stores/categories.svelte", () => ({
+  categories: {
+    list: [{ id: "npc", label: "NPC", icon: "user", color: "#fff" }],
+    getCategory: () => ({ icon: "user" }),
+  },
+}));
+
+vi.mock("$lib/utils/icon", () => ({
+  getIconClass: () => "",
+}));
+
+describe("EntityList Filtering", () => {
+  beforeEach(() => {
+    uiStore.explorerViewMode = "list";
+  });
+
+  it("filters entities when a label pill is clicked", async () => {
+    render(EntityList);
+
+    // Initial state: all 3 entities visible
+    expect(screen.getByText("City Guard")).not.toBeNull();
+    expect(screen.getByText("Castle Guard")).not.toBeNull();
+    expect(screen.getByText("Merchant")).not.toBeNull();
+
+    // Find and click "MerchantLabel" label pill
+    const merchantPill = screen.getByText("MerchantLabel");
+    await fireEvent.click(merchantPill);
+
+    // Should only show Merchant
+    expect(screen.queryByText("City Guard")).toBeNull();
+    expect(screen.queryByText("Castle Guard")).toBeNull();
+    expect(screen.getByText("Merchant")).not.toBeNull();
+  });
+
+  it("applies AND logic for multiple label filters", async () => {
+    render(EntityList);
+
+    // Click "Guard" pill
+    const guardPill = screen.getAllByText("Guard")[0];
+    await fireEvent.click(guardPill);
+
+    // Shows both guards
+    expect(screen.getByText("City Guard")).not.toBeNull();
+    expect(screen.getByText("Castle Guard")).not.toBeNull();
+    expect(screen.queryByText("Merchant")).toBeNull();
+
+    // Ctrl+Click "NPC" pill
+    const npcPill = screen.getAllByText("NPC")[0];
+    await fireEvent.click(npcPill, { ctrlKey: true });
+
+    // Should only show "City Guard" (has both Guard and NPC)
+    expect(screen.getByText("City Guard")).not.toBeNull();
+    expect(screen.queryByText("Castle Guard")).toBeNull();
+    expect(screen.queryByText("Merchant")).toBeNull();
+  });
+
+  it("surfaces entities when searching for their labels", async () => {
+    render(EntityList);
+
+    const searchInput = screen.getByPlaceholderText("Search entities...");
+    await fireEvent.input(searchInput, { target: { value: "MerchantLabel" } });
+
+    // Should show "Merchant" because it has the "MerchantLabel" label
+    // "Merchant" title doesn't contain "MerchantLabel"
+    expect(screen.queryByText("City Guard")).toBeNull();
+    expect(screen.queryByText("Castle Guard")).toBeNull();
+    expect(screen.getByText("Merchant")).not.toBeNull();
+  });
+
+  it("clears label filters when removal button is clicked", async () => {
+    render(EntityList);
+
+    // Apply filter
+    await fireEvent.click(screen.getByText("MerchantLabel"));
+    expect(screen.queryByText("City Guard")).toBeNull();
+
+    // Find removal button (X) for the active filter pill
+    const clearButton = screen.getByLabelText("Remove MerchantLabel filter");
+    await fireEvent.click(clearButton);
+
+    // All should be back
+    expect(screen.getByText("City Guard")).not.toBeNull();
+    expect(screen.getByText("Castle Guard")).not.toBeNull();
+    expect(screen.getByText("Merchant")).not.toBeNull();
+  });
+});

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -303,7 +303,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "entity-explorer",
     title: "Entity Explorer",
     content:
-      "Quickly browse and filter all your world entities via the persistent sidebar. Clicking an entity opens it in Focus Mode, replacing the main view with a spacious detail panel.",
+      "Quickly browse and filter all your world entities via the persistent sidebar. Switch between List and Label views to group entities by their labels. Click label pills to filter the explorer, or use Ctrl+Click to combine multiple labels for a focused drill-down.",
     icon: "icon-[lucide--database]",
   },
   "activity-bar": {

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -303,7 +303,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "entity-explorer",
     title: "Entity Explorer",
     content:
-      "Quickly browse and filter all your world entities via the persistent sidebar. Switch between List and Label views to group entities by their labels. Click label pills to filter the explorer, or use Ctrl+Click to combine multiple labels for a focused drill-down.",
+      "Quickly browse and filter all your world entities via the persistent sidebar. Switch between List and Label views to group entities by their labels. Click label pills to filter the explorer, or use Ctrl/Cmd+Click to combine multiple labels for a focused drill-down.",
     icon: "icon-[lucide--database]",
   },
   "activity-bar": {

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -18,7 +18,12 @@ export class GraphStore {
   }
 
   // Svelte 5 derived state
-  activeLabels = $state(new Set<string>());
+  get activeLabels() {
+    return this.ui.labelFilters;
+  }
+  set activeLabels(value: Set<string>) {
+    this.ui.labelFilters = value;
+  }
   activeCategories = $state(new Set<string>());
 
   elements = $derived.by(() => {
@@ -173,17 +178,11 @@ export class GraphStore {
   }
 
   toggleLabelFilter(label: string) {
-    if (this.activeLabels.has(label)) {
-      this.activeLabels.delete(label);
-    } else {
-      this.activeLabels.add(label);
-    }
-    // Svelte Set reactivity trigger
-    this.activeLabels = new Set(this.activeLabels);
+    this.ui.toggleLabelFilter(label, this.ui.isModifierPressed);
   }
 
   clearLabelFilters() {
-    this.activeLabels = new Set();
+    this.ui.clearLabelFilters();
   }
 
   toggleCategoryFilter(categoryId: string) {

--- a/apps/web/src/lib/stores/graph.test.ts
+++ b/apps/web/src/lib/stores/graph.test.ts
@@ -37,11 +37,29 @@ vi.mock("./vault.svelte", () => ({
 }));
 
 // Mock ui store
-vi.mock("./ui.svelte", () => ({
-  ui: {
-    sharedMode: false,
-  },
-}));
+vi.mock("./ui.svelte", () => {
+  const labelFilters = new Set<string>();
+  return {
+    ui: {
+      sharedMode: false,
+      isModifierPressed: false,
+      labelFilters: labelFilters,
+      toggleLabelFilter: vi.fn((label: string, isMulti: boolean) => {
+        if (!isMulti) {
+          labelFilters.clear();
+          labelFilters.add(label);
+        } else {
+          if (labelFilters.has(label)) {
+            labelFilters.delete(label);
+          } else {
+            labelFilters.add(label);
+          }
+        }
+      }),
+      clearLabelFilters: vi.fn(() => labelFilters.clear()),
+    },
+  };
+});
 
 // Mock graph-engine
 vi.mock("graph-engine", () => ({

--- a/apps/web/src/lib/stores/graph.test.ts
+++ b/apps/web/src/lib/stores/graph.test.ts
@@ -37,27 +37,16 @@ vi.mock("./vault.svelte", () => ({
 }));
 
 // Mock ui store
-vi.mock("./ui.svelte", () => {
-  const labelFilters = new Set<string>();
+vi.mock("./ui.svelte", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  const mockUi = new actual.UIStore();
+  // Ensure we can track calls if needed, though real logic is better for state tests
+  mockUi.toggleLabelFilter = vi.fn(mockUi.toggleLabelFilter.bind(mockUi));
+  mockUi.clearLabelFilters = vi.fn(mockUi.clearLabelFilters.bind(mockUi));
+
   return {
-    ui: {
-      sharedMode: false,
-      isModifierPressed: false,
-      labelFilters: labelFilters,
-      toggleLabelFilter: vi.fn((label: string, isMulti: boolean) => {
-        if (!isMulti) {
-          labelFilters.clear();
-          labelFilters.add(label);
-        } else {
-          if (labelFilters.has(label)) {
-            labelFilters.delete(label);
-          } else {
-            labelFilters.add(label);
-          }
-        }
-      }),
-      clearLabelFilters: vi.fn(() => labelFilters.clear()),
-    },
+    ...actual,
+    ui: mockUi,
   };
 });
 

--- a/apps/web/src/lib/stores/ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui.svelte.ts
@@ -54,6 +54,7 @@ export class UIStore {
   archiveActivityLog = $state<ActivityEvent[]>([]);
   explorerViewMode = $state<"list" | "label">("list");
   explorerCollapsedLabelGroups = $state<ExplorerCollapsedLabelGroups>({});
+  labelFilters = $state<Set<string>>(new Set());
 
   // Sidebar State
   leftSidebarOpen = $state(false);
@@ -368,6 +369,34 @@ export class UIStore {
     if (typeof window !== "undefined") {
       localStorage.setItem("codex_explorer_view_mode", mode);
     }
+  }
+
+  toggleLabelFilter(label: string, isMulti = false) {
+    if (isMulti) {
+      const next = new Set(this.labelFilters);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      this.labelFilters = next;
+    } else {
+      if (this.labelFilters.has(label) && this.labelFilters.size === 1) {
+        this.labelFilters = new Set();
+      } else {
+        this.labelFilters = new Set([label]);
+      }
+    }
+  }
+
+  removeLabelFilter(label: string) {
+    const next = new Set(this.labelFilters);
+    next.delete(label);
+    this.labelFilters = next;
+  }
+
+  clearLabelFilters() {
+    this.labelFilters = new Set();
   }
 
   getCollapsedLabelGroups(vaultId: string | null) {

--- a/specs/084-label-grouped-explorer/data-model.md
+++ b/specs/084-label-grouped-explorer/data-model.md
@@ -28,9 +28,17 @@ Represents the saved collapsed state for label sections in the explorer.
 - **Persistence Scope**: Browser-local preference for the current user environment.
 - **Behavior**: Updated whenever a label section is collapsed or expanded and restored when the UI store initializes.
 
+### Label Filter Set
+
+Represents the collection of labels currently active as filters in the explorer.
+
+- **Labels**: A set of unique label strings.
+- **Filtering Logic**: Matches entities that contain ALL labels in the set ("AND" logic).
+- **Behavior**: Clicking a label pill selects it exclusively; Ctrl/Cmd+Click toggles inclusion.
+
 ### Filtered Explorer Result
 
-Represents the existing explorer result set after search and category filters are applied.
+Represents the explorer result set after search, category, and label filters are applied.
 
 - **Source Entities**: The current vault entity collection.
 - **Applied Filters**: Search query and selected entity-type filters.

--- a/specs/084-label-grouped-explorer/plan.md
+++ b/specs/084-label-grouped-explorer/plan.md
@@ -1,36 +1,35 @@
-# Implementation Plan: Label-Grouped Entity Explorer
+# Implementation Plan: Label-Grouped Entity Explorer & Filtering
 
-**Branch**: `084-label-grouped-explorer` | **Date**: 2026-04-15 | **Spec**: [./spec.md](./spec.md)
+**Branch**: `issue/701-label-filtering` | **Date**: 2026-04-23 | **Spec**: [./spec.md](./spec.md)
 **Input**: Feature specification from `./spec.md`
 
 ## Summary
 
-Add label grouping as an alternate explorer layout on top of the existing flat list. Preserve the current explorer selection flow, let users collapse label sections, and persist both the chosen view mode and collapsed-group state in local storage.
+Add label grouping as an alternate explorer layout and implement a robust label-based filtering system. Make label pills interactive to allow quick drilling down into sub-collections using "AND" logic. Preserve the current explorer selection flow, let users collapse label sections, and persist both the chosen view mode and collapsed-group state.
 
 ## Technical Context
 
-**Language/Version**: TypeScript 6.0.2, Svelte 5.55.2  
-**Primary Dependencies**: SvelteKit web app, Lucide Svelte, workspace `schema` types  
-**Storage**: Existing vault entity state in memory plus browser `localStorage` for the explorer view preference and per-vault collapsed label sections  
-**Testing**: Vitest unit tests plus manual explorer verification  
-**Target Platform**: Web application on desktop and mobile browsers  
-**Project Type**: Monorepo web application  
-**Performance Goals**: Explorer mode switches should feel immediate for normal vault browsing with no noticeable delay compared with the existing flat list  
-**Constraints**: Preserve search/category filtering, keep behavior client-side, and avoid introducing a new explorer subsystem for a UI-only enhancement  
-**Scale/Scope**: Sidebar explorer rendering, explorer UI state, and validation for label grouping and per-vault collapse behavior
+**Language/Version**: TypeScript 5.9.3, Svelte 5 (Runes)
+**Primary Dependencies**: SvelteKit web app, Lucide Svelte, workspace `schema` types, `uiStore`
+**Storage**: Existing vault entity state in memory plus browser `localStorage` for the explorer view preference, per-vault collapsed label sections, and active label filters (if persistence is desired).
+**Testing**: Vitest unit tests for filtering logic and UI interactions.
+**Target Platform**: Web application on desktop and mobile browsers.
+**Performance Goals**: Explorer mode switches and label filtering should feel immediate (<100ms) for normal vault browsing.
+**Constraints**: Preserve search/category filtering, keep behavior client-side, and avoid introducing a new explorer subsystem.
+**Scale/Scope**: Sidebar explorer rendering, explorer UI state, filtering logic in `EntityList.svelte`, and validation for label grouping and filtering behavior.
 
 ## Constitution Check
 
 _GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 
-1. **Library-First**: Pass. This is an explorer presentation enhancement inside the existing web layer and does not introduce new domain logic that warrants a standalone workspace package.
-2. **TDD**: Pass. The implementation includes a dedicated grouping test for the new explorer grouping behavior.
-3. **Simplicity & YAGNI**: Pass. The feature extends the existing `uiStore` and `EntityList.svelte` instead of creating a separate explorer state system.
-4. **Privacy & Client-Side Processing**: Pass. Grouping and preference persistence remain entirely client-side.
-5. **User Documentation**: Pass for this scope. The existing entity explorer help entry remains the user-facing entry point, and the feature stays focused on label grouping without inventing new organizational concepts.
-6. **Dependency Injection**: Pass. No new services or stores requiring constructor DI were introduced.
-7. **Natural Language**: Pass. View labels remain simple and user-facing terms are limited to list and label.
-8. **Quality & Coverage Enforcement**: Pass. The feature adds focused automated coverage for the new grouping behavior and keeps the change set inside the existing explorer surface.
+1. **Library-First**: Pass. This is an explorer presentation and filtering enhancement inside the existing web layer.
+2. **TDD**: Pass. The implementation will include tests for the new "AND" filtering logic and label search integration.
+3. **Simplicity & YAGNI**: Pass. The feature extends the existing `EntityList.svelte` filtering logic instead of creating a separate system.
+4. **Privacy & Client-Side Processing**: Pass. Filtering and preference persistence remain entirely client-side.
+5. **User Documentation**: Pass. The feature stays focused on label discovery without inventing new concepts.
+6. **Dependency Injection**: Pass. Uses existing `uiStore` and `vault` store.
+7. **Natural Language**: Pass. Uses standard terminology like "labels" and "filters".
+8. **Quality & Coverage Enforcement**: Pass. Adds focused automated coverage for the new filtering behavior.
 
 ## Project Structure
 
@@ -58,12 +57,9 @@ apps/web/src/lib/components/explorer/
 
 apps/web/src/lib/stores/
 └── ui.svelte.ts
-
-apps/web/src/lib/config/
-└── help-content.ts
 ```
 
-**Structure Decision**: Keep the implementation inside the existing explorer component and shared UI store because the feature only changes explorer presentation and persisted UI preference. Supporting documentation lives entirely in the feature spec directory.
+**Structure Decision**: Keep the implementation inside the existing explorer component because the filtering logic is tightly coupled with the list rendering. Supporting documentation lives entirely in the feature spec directory.
 
 ## Generated Artifacts
 

--- a/specs/084-label-grouped-explorer/quickstart.md
+++ b/specs/084-label-grouped-explorer/quickstart.md
@@ -85,15 +85,18 @@ In label mode, a multi-labeled entity can appear in more than one section. The e
 2. Confirm it still opens normally in the main app view.
 3. If drag-and-drop is enabled in your current workflow, confirm grouped entries still start drag operations correctly.
 
-### 7. Verify Label Filtering
+### 7. Verify Label Filtering & Graph Synchronization
 
 1. Click on a label pill on any entity.
 2. Confirm that the list filters to show only entities with that label.
 3. Confirm an "Active Filters" bar appears below the search bar showing the selected label.
-4. Ctrl/Cmd+Click on another label pill.
-5. Confirm that the list now shows only entities containing BOTH labels (AND logic).
-6. Click the 'X' on an active filter pill to remove it.
-7. Confirm that the filter is removed and the list updates accordingly.
+4. **Confirm that the Graph View (if visible) also filters to show only nodes matching that label.**
+5. Ctrl/Cmd+Click on another label pill.
+6. Confirm that the list now shows only entities containing BOTH labels (AND logic).
+7. **Confirm that the Graph View also reflects the combined "AND" filter.**
+8. Click the 'X' on an active filter pill to remove it.
+9. Confirm that the filter is removed and both the list and graph update accordingly.
+10. **Add a label filter from the Graph HUD and confirm it appears in the Explorer.**
 
 ### 8. Verify Search Integration
 

--- a/specs/084-label-grouped-explorer/quickstart.md
+++ b/specs/084-label-grouped-explorer/quickstart.md
@@ -85,7 +85,23 @@ In label mode, a multi-labeled entity can appear in more than one section. The e
 2. Confirm it still opens normally in the main app view.
 3. If drag-and-drop is enabled in your current workflow, confirm grouped entries still start drag operations correctly.
 
-### 7. Verify Persistence
+### 7. Verify Label Filtering
+
+1. Click on a label pill on any entity.
+2. Confirm that the list filters to show only entities with that label.
+3. Confirm an "Active Filters" bar appears below the search bar showing the selected label.
+4. Ctrl/Cmd+Click on another label pill.
+5. Confirm that the list now shows only entities containing BOTH labels (AND logic).
+6. Click the 'X' on an active filter pill to remove it.
+7. Confirm that the filter is removed and the list updates accordingly.
+
+### 8. Verify Search Integration
+
+1. Clear all filters.
+2. Type the name of a label into the search bar.
+3. Confirm that entities with that label are surfaced, even if the label name is not in their title or content.
+
+### 9. Verify Persistence
 
 1. Leave the explorer in label view.
 2. Collapse one label section.

--- a/specs/084-label-grouped-explorer/research.md
+++ b/specs/084-label-grouped-explorer/research.md
@@ -34,6 +34,20 @@ GitHub Issue #606 asks for better organization inside the Entity Explorer once a
 - **Alternatives Considered**:
   - **Hide entities without grouping metadata**: Rejected because it would make grouped views incomplete and confusing.
 
+### Apply "AND" Logic for Multi-Label Filtering
+
+- **Decision**: Use "AND" logic when multiple labels are selected for filtering.
+- **Rationale**: Labels are used to categorize and tag entities with multiple traits. "AND" logic allows users to "drill down" into intersections (e.g., "NPC" and "Merchant"), whereas "OR" logic would broaden the results and make discovery harder in large vaults.
+- **Alternatives Considered**:
+  - **"OR" Logic**: Rejected because it doesn't support narrowing down results effectively.
+
+### Extend Search to Include Labels
+
+- **Decision**: Match the search query against entity labels.
+- **Rationale**: Users often remember a label but not the specific title. Extending search to labels makes the search bar a unified entry point for text-based discovery.
+- **Alternatives Considered**:
+  - **Strict title/content search**: Rejected because it misses a key metadata field that users deliberately assign.
+
 ## Validation Notes
 
 - The branch includes targeted automated coverage in `apps/web/src/lib/components/explorer/EntityListGrouping.test.ts` for label grouping.

--- a/specs/084-label-grouped-explorer/spec.md
+++ b/specs/084-label-grouped-explorer/spec.md
@@ -54,6 +54,23 @@ As a returning user, I want collapsed label sections to stay collapsed so I can 
 
 ---
 
+### User Story 4 - Filter Explorer by Clicking Labels (Priority: P2)
+
+As a vault maintainer, I want to click on a label pill in the explorer to filter the list by that label, so I can quickly drill down into specific sub-collections without typing into the search bar.
+
+**Why this priority**: It complements the label-grouped view by making labels interactive and functional for discovery across both view modes.
+
+**Independent Test**: Click a label pill on an entity item, verify the list filters to show only entities with that label. Ctrl+Click another label and verify the list shows entities containing BOTH labels.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am in the entity explorer, **When** I click a label pill on an entity, **Then** the explorer should apply an exclusive filter for that label.
+2. **Given** an active label filter, **When** I Ctrl/Cmd+Click another label pill, **Then** the explorer should show only entities that match BOTH labels (AND logic).
+3. **Given** active label filters, **When** I click the "Clear" button or the main "All Categories" button, **Then** all label filters should be removed.
+4. **Given** a search query is active, **When** I apply a label filter, **Then** the results should match both the search text AND the selected labels.
+
+---
+
 ### Edge Cases
 
 - Search and category filters must apply before grouping so alternate explorer views only show matching entities.
@@ -61,6 +78,7 @@ As a returning user, I want collapsed label sections to stay collapsed so I can 
 - Entities with multiple labels intentionally appear in multiple sections and must remain selectable in each location.
 - Entities without labels must remain discoverable through an explicit fallback group.
 - Collapsed label state must survive browser reloads without hiding the unlabeled fallback by mistake.
+- If a label filter is applied that excludes all entities in a collapsed group, that group should not be rendered at all.
 
 ## Requirements _(mandatory)_
 
@@ -74,12 +92,17 @@ As a returning user, I want collapsed label sections to stay collapsed so I can 
 - **FR-006**: The system MUST remember collapsed label sections across browser reloads and sessions for the same user.
 - **FR-007**: The system MUST scope collapsed label state to the active vault so one vault does not change another vault's explorer layout.
 - **FR-008**: The system MUST preserve existing search, category filtering, selection, and drag-start behavior in every explorer view.
+- **FR-009**: The system MUST make label pills in the explorer interactive.
+- **FR-010**: The system MUST apply "AND" logic when multiple label filters are active.
+- **FR-011**: The system MUST display active label filters in the UI with a clear way to remove them.
+- **FR-012**: The search query MUST be extended to match against entity labels in addition to title and content.
 
 ### Key Entities
 
 - **Explorer View Preference**: The user's saved explorer layout choice (`list` or `label`) that persists between sessions.
 - **Explorer Group**: A rendered section of entities produced from the current filtered explorer result set using a label key.
 - **Explorer Group Visibility Preference**: The per-vault saved set of label sections that are currently collapsed in label view.
+- **Label Filter Set**: A collection of labels currently used to narrow down the entity list.
 
 ## Success Criteria _(mandatory)_
 
@@ -90,3 +113,6 @@ As a returning user, I want collapsed label sections to stay collapsed so I can 
 - **SC-003**: Multi-labeled entities remain discoverable from every relevant label section.
 - **SC-004**: Grouped views hide empty sections when search or category filters remove all matching entities from that group.
 - **SC-005**: Users can collapse a label section with a single click and see it stay collapsed after a reload.
+- **SC-006**: Clicking a label pill reduces the explorer list to entities matching that label within 100ms.
+- **SC-007**: Active label filters are clearly visible and can be dismissed individually.
+- **SC-008**: The search bar correctly surfaces entities when searching for one of their labels.

--- a/specs/084-label-grouped-explorer/spec.md
+++ b/specs/084-label-grouped-explorer/spec.md
@@ -64,9 +64,9 @@ As a vault maintainer, I want to click on a label pill in the explorer to filter
 
 **Acceptance Scenarios**:
 
-1. **Given** I am in the entity explorer, **When** I click a label pill on an entity, **Then** the explorer should apply an exclusive filter for that label.
-2. **Given** an active label filter, **When** I Ctrl/Cmd+Click another label pill, **Then** the explorer should show only entities that match BOTH labels (AND logic).
-3. **Given** active label filters, **When** I click the "Clear" button or the main "All Categories" button, **Then** all label filters should be removed.
+1. **Given** I am in the entity explorer, **When** I click a label pill on an entity, **Then** the explorer should apply an exclusive filter for that label, AND the graph view should update to show only nodes matching that label.
+2. **Given** an active label filter, **When** I Ctrl/Cmd+Click another label pill, **Then** both the explorer and graph should show only entities that match BOTH labels (AND logic).
+3. **Given** active label filters, **When** I click the "Clear" button in the explorer or the graph filter HUD, **Then** all label filters should be removed from both views.
 4. **Given** a search query is active, **When** I apply a label filter, **Then** the results should match both the search text AND the selected labels.
 
 ---
@@ -96,6 +96,7 @@ As a vault maintainer, I want to click on a label pill in the explorer to filter
 - **FR-010**: The system MUST apply "AND" logic when multiple label filters are active.
 - **FR-011**: The system MUST display active label filters in the UI with a clear way to remove them.
 - **FR-012**: The search query MUST be extended to match against entity labels in addition to title and content.
+- **FR-013**: Label filters MUST be synchronized between the entity explorer and the graph view.
 
 ### Key Entities
 
@@ -116,3 +117,4 @@ As a vault maintainer, I want to click on a label pill in the explorer to filter
 - **SC-006**: Clicking a label pill reduces the explorer list to entities matching that label within 100ms.
 - **SC-007**: Active label filters are clearly visible and can be dismissed individually.
 - **SC-008**: The search bar correctly surfaces entities when searching for one of their labels.
+- **SC-009**: Label filter changes in the explorer are reflected in the graph view HUD and vice versa.

--- a/specs/084-label-grouped-explorer/tasks.md
+++ b/specs/084-label-grouped-explorer/tasks.md
@@ -126,6 +126,7 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 - [x] T026 [US4] Update label pill rendering on entity items to be interactive (hover states, click handlers)
 - [x] T027 [US4] Implement `toggleLabelFilter` handler with exclusive click and additive Ctrl+Click behavior
 - [x] T028 [US4] Update help content in `apps/web/src/lib/config/help-content.ts` to describe label filtering
+- [x] T029 [US4] Synchronize label filtering with graph view via `uiStore`
 
 **Checkpoint**: Label-based filtering is functional, integrated with search/categories, and documented.
 

--- a/specs/084-label-grouped-explorer/tasks.md
+++ b/specs/084-label-grouped-explorer/tasks.md
@@ -106,6 +106,31 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 
 ---
 
+## Phase 7: User Story 4 - Filter Explorer by Clicking Labels (Priority: P2)
+
+**Goal**: Implement interactive label pills and "AND" filtering logic for drill-down discovery.
+
+**Independent Test**: Click labels to filter, use Ctrl+Click for multi-select, and verify "AND" logic surfaces only entities matching all selected labels.
+
+### Tests for User Story 4
+
+- [x] T020 [P] [US4] Add unit tests for "AND" label filtering logic in `apps/web/src/lib/components/explorer/EntityListFiltering.test.ts`
+- [x] T021 [P] [US4] Add unit tests for label text search integration in `apps/web/src/lib/components/explorer/EntityListFiltering.test.ts`
+
+### Implementation for User Story 4
+
+- [x] T022 [US4] Add `labelFilters` set to state in `apps/web/src/lib/components/explorer/EntityList.svelte`
+- [x] T023 [US4] Update `filteredEntities` derivation to apply "AND" logic for `labelFilters`
+- [x] T024 [US4] Update `filteredEntities` derivation to match `searchQuery` against entity labels
+- [x] T025 [US4] Render active label filter pills below the search bar with removal buttons
+- [x] T026 [US4] Update label pill rendering on entity items to be interactive (hover states, click handlers)
+- [x] T027 [US4] Implement `toggleLabelFilter` handler with exclusive click and additive Ctrl+Click behavior
+- [x] T028 [US4] Update help content in `apps/web/src/lib/config/help-content.ts` to describe label filtering
+
+**Checkpoint**: Label-based filtering is functional, integrated with search/categories, and documented.
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies
@@ -116,6 +141,7 @@ description: "Actionable, dependency-ordered tasks for the Label-Grouped Entity 
 - **User Story 2 (Phase 4)**: Depends on the foundational explorer state from Phase 2
 - **User Story 3 (Phase 5)**: Depends on the grouped explorer rendering from Phase 3
 - **Polish (Phase 6)**: Depends on all desired grouped views being complete
+- **User Story 4 (Phase 7)**: Depends on Phase 3 completion (requires entity list/label rendering)
 
 ### Parallel Opportunities
 


### PR DESCRIPTION
## Overview
This PR implements GitHub Issue #701, adding interactive label-based filtering to the Entity Explorer.

## Changes
- **AND Filtering Logic**: Multiple label filters now narrow results (AND logic).
- **Interactive Pills**: Label pills on entity items are now clickable.
  - `Click`: Filter exclusively by this label.
  - `Ctrl/Cmd+Click`: Add/remove label from active filters.
- **Search Extension**: Search bar now matches against entity labels.
- **Active Filter UI**: Added a removable filter pill bar below the search input.
- **Refactoring**: Cleaned up `EntityItem` snippet to avoid nested button warnings.

## Verification
- Added `EntityListFiltering.test.ts` with 4 new test cases.
- Verified all explorer tests pass (7 total).
- Updated `084-label-grouped-explorer` spec and help content.