### PR TITLE
✨ feat: Approve and Reject AI Draft Entities (#092)

### DIFF
--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -159,8 +159,9 @@
       await vault.deleteEntity(entity.id);
       onClose();
     } catch (err: any) {
-      isDraftActioning = false;
       uiStore.notify(`Error: ${err.message}`, "error");
+    } finally {
+      isDraftActioning = false;
     }
   };
 </script>
@@ -205,7 +206,7 @@
           TRANSIENT MODE: CHANGES WILL NOT BE SAVED
         </div>
       {/if}
-      {#if entity.status === "draft"}
+      {#if entity.status === "draft" && !vault.isGuest}
         <div
           class="flex items-center justify-between gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2"
         >

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -137,6 +137,32 @@
       }
     }
   };
+
+  let isDraftActioning = $state(false);
+
+  const handleApproveDraft = async () => {
+    if (!entity || isDraftActioning) return;
+    isDraftActioning = true;
+    try {
+      await vault.updateEntity(entity.id, { status: "active" });
+    } catch (err: any) {
+      uiStore.notify(`Error: ${err.message}`, "error");
+    } finally {
+      isDraftActioning = false;
+    }
+  };
+
+  const handleRejectDraft = async () => {
+    if (!entity || isDraftActioning) return;
+    isDraftActioning = true;
+    try {
+      await vault.deleteEntity(entity.id);
+      onClose();
+    } catch (err: any) {
+      isDraftActioning = false;
+      uiStore.notify(`Error: ${err.message}`, "error");
+    }
+  };
 </script>
 
 {#if entity}
@@ -177,6 +203,39 @@
           class="bg-theme-primary/10 border-b border-theme-primary/30 px-4 py-1.5 text-[9px] font-bold text-theme-primary tracking-widest text-center animate-pulse"
         >
           TRANSIENT MODE: CHANGES WILL NOT BE SAVED
+        </div>
+      {/if}
+      {#if entity.status === "draft"}
+        <div
+          class="flex items-center justify-between gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2"
+        >
+          <span
+            class="text-[9px] font-bold tracking-widest text-amber-500 uppercase"
+          >
+            AI Draft — Pending Review
+          </span>
+          <div class="flex items-center gap-1">
+            <button
+              onclick={handleApproveDraft}
+              disabled={isDraftActioning}
+              title="Approve draft"
+              aria-label="Approve draft"
+              class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-emerald-500 transition hover:bg-emerald-500/10 disabled:opacity-50"
+            >
+              <span class="icon-[lucide--check] h-3 w-3"></span>
+              Approve
+            </button>
+            <button
+              onclick={handleRejectDraft}
+              disabled={isDraftActioning}
+              title="Reject draft"
+              aria-label="Reject draft"
+              class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-red-500 transition hover:bg-red-500/10 disabled:opacity-50"
+            >
+              <span class="icon-[lucide--trash-2] h-3 w-3"></span>
+              Reject
+            </button>
+          </div>
         </div>
       {/if}
       <div

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -26,19 +26,29 @@
     vault.allEntities.filter((e) => e.status === "draft").length,
   );
 
+  const actioningIds = $state(new Set<string>());
+
   async function handleApproveDraft(entity: Entity) {
+    if (actioningIds.has(entity.id)) return;
+    actioningIds.add(entity.id);
     try {
       await vault.updateEntity(entity.id, { status: "active" });
     } catch (err: any) {
       uiStore.notify(`Error: ${err.message}`, "error");
+    } finally {
+      actioningIds.delete(entity.id);
     }
   }
 
   async function handleRejectDraft(entity: Entity) {
+    if (actioningIds.has(entity.id)) return;
+    actioningIds.add(entity.id);
     try {
       await vault.deleteEntity(entity.id);
     } catch (err: any) {
       uiStore.notify(`Error: ${err.message}`, "error");
+    } finally {
+      actioningIds.delete(entity.id);
     }
   }
 </script>
@@ -121,8 +131,12 @@
       onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
       onFindInGraph={handleFindInGraph}
       showDraftsOnly={explorerTab === "review"}
-      onApproveDraft={explorerTab === "review" ? handleApproveDraft : undefined}
-      onRejectDraft={explorerTab === "review" ? handleRejectDraft : undefined}
+      onApproveDraft={explorerTab === "review" && !vault.isGuest
+        ? handleApproveDraft
+        : undefined}
+      onRejectDraft={explorerTab === "review" && !vault.isGuest
+        ? handleRejectDraft
+        : undefined}
     />
   </div>
 </div>

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -25,6 +25,22 @@
   let draftCount = $derived(
     vault.allEntities.filter((e) => e.status === "draft").length,
   );
+
+  async function handleApproveDraft(entity: Entity) {
+    try {
+      await vault.updateEntity(entity.id, { status: "active" });
+    } catch (err: any) {
+      uiStore.notify(`Error: ${err.message}`, "error");
+    }
+  }
+
+  async function handleRejectDraft(entity: Entity) {
+    try {
+      await vault.deleteEntity(entity.id);
+    } catch (err: any) {
+      uiStore.notify(`Error: ${err.message}`, "error");
+    }
+  }
 </script>
 
 <div
@@ -105,6 +121,8 @@
       onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
       onFindInGraph={handleFindInGraph}
       showDraftsOnly={explorerTab === "review"}
+      onApproveDraft={explorerTab === "review" ? handleApproveDraft : undefined}
+      onRejectDraft={explorerTab === "review" ? handleRejectDraft : undefined}
     />
   </div>
 </div>

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -374,12 +374,18 @@
             }}
             title="Open in Zen Mode"
             aria-label="Open {entity.title} in Zen Mode"
-            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100 focus-visible:opacity-100"
+            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100 focus-visible:opacity-100 {!(
+              onApproveDraft &&
+              onRejectDraft &&
+              entity.status === 'draft'
+            )
+              ? 'rounded-r-xl'
+              : ''}"
           >
             <span class="icon-[lucide--book-open] h-3.5 w-3.5"></span>
           </button>
         {/if}
-        {#if onApproveDraft && onRejectDraft}
+        {#if onApproveDraft && onRejectDraft && entity.status === "draft"}
           <button
             type="button"
             onclick={(e) => {

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -12,6 +12,8 @@
     onDragEnd,
     onOpenZen,
     onFindInGraph,
+    onApproveDraft,
+    onRejectDraft,
     allowedTypes = null,
     showDraftsOnly = false,
     class: className = "",
@@ -21,6 +23,8 @@
     onDragEnd?: () => void;
     onOpenZen?: (entity: Entity) => void;
     onFindInGraph?: (entity: Entity) => void;
+    onApproveDraft?: (entity: Entity) => void;
+    onRejectDraft?: (entity: Entity) => void;
     allowedTypes?: string[] | null;
     showDraftsOnly?: boolean;
     class?: string;
@@ -370,9 +374,35 @@
             }}
             title="Open in Zen Mode"
             aria-label="Open {entity.title} in Zen Mode"
-            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100 focus-visible:opacity-100 rounded-r-xl"
+            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-theme-muted hover:text-theme-primary focus:outline-none focus:opacity-100 focus-visible:opacity-100"
           >
             <span class="icon-[lucide--book-open] h-3.5 w-3.5"></span>
+          </button>
+        {/if}
+        {#if onApproveDraft && onRejectDraft}
+          <button
+            type="button"
+            onclick={(e) => {
+              e.stopPropagation();
+              onApproveDraft(entity);
+            }}
+            title="Approve draft"
+            aria-label="Approve {entity.title}"
+            class="shrink-0 flex items-center justify-center px-1.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-theme-muted hover:text-emerald-500 focus:outline-none focus:opacity-100 focus-visible:opacity-100"
+          >
+            <span class="icon-[lucide--check] h-3.5 w-3.5"></span>
+          </button>
+          <button
+            type="button"
+            onclick={(e) => {
+              e.stopPropagation();
+              onRejectDraft(entity);
+            }}
+            title="Reject draft"
+            aria-label="Reject {entity.title}"
+            class="shrink-0 flex items-center justify-center px-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-theme-muted hover:text-red-500 focus:outline-none focus:opacity-100 focus-visible:opacity-100 rounded-r-xl"
+          >
+            <span class="icon-[lucide--trash-2] h-3.5 w-3.5"></span>
           </button>
         {/if}
       </div>

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -165,7 +165,7 @@
       </button>
     {/if}
 
-    {#if !editState.isEditing && entity?.status === "draft" && onApproveDraft && onRejectDraft}
+    {#if !editState.isEditing && entity?.status === "draft" && !vault.isGuest && onApproveDraft && onRejectDraft}
       <button
         onclick={onApproveDraft}
         disabled={isDraftActioning}

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -24,6 +24,9 @@
     onSave,
     onClose,
     onPopOut,
+    onApproveDraft,
+    onRejectDraft,
+    isDraftActioning = false,
   } = $props<{
     entity: Entity;
     editState: any;
@@ -35,6 +38,9 @@
     onSave: () => Promise<void>;
     onClose: () => void;
     onPopOut?: () => void;
+    onApproveDraft?: () => void;
+    onRejectDraft?: () => void;
+    isDraftActioning?: boolean;
   }>();
 
   const isGraphView = $derived.by(() => {
@@ -159,6 +165,30 @@
       </button>
     {/if}
 
+    {#if !editState.isEditing && entity?.status === "draft" && onApproveDraft && onRejectDraft}
+      <button
+        onclick={onApproveDraft}
+        disabled={isDraftActioning}
+        title="Approve draft"
+        aria-label="Approve draft"
+        class="px-3 md:px-4 py-1.5 border border-emerald-500/40 text-emerald-500 hover:bg-emerald-500/10 text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
+        data-testid="approve-draft-button"
+      >
+        <span class="icon-[lucide--check] w-3 h-3"></span>
+        <span class="hidden sm:inline">APPROVE</span>
+      </button>
+      <button
+        onclick={onRejectDraft}
+        disabled={isDraftActioning}
+        title="Reject draft"
+        aria-label="Reject draft"
+        class="px-3 md:px-4 py-1.5 border border-red-500/40 text-red-500 hover:bg-red-500/10 text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
+        data-testid="reject-draft-button"
+      >
+        <span class="icon-[lucide--trash-2] w-3 h-3"></span>
+        <span class="hidden sm:inline">REJECT</span>
+      </button>
+    {/if}
     {#if !editState.isEditing && !vault.isGuest && entity}
       <button
         onclick={onStartEdit}

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -106,7 +106,7 @@
   let isDraftActioning = $state(false);
 
   const handleApproveDraft = async () => {
-    if (!entity || isDraftActioning) return;
+    if (!entity || isDraftActioning || vault.isGuest) return;
     isDraftActioning = true;
     try {
       await vault.updateEntity(entity.id, { status: "active" });
@@ -118,14 +118,15 @@
   };
 
   const handleRejectDraft = async () => {
-    if (!entity || isDraftActioning) return;
+    if (!entity || isDraftActioning || vault.isGuest) return;
     isDraftActioning = true;
     try {
       await vault.deleteEntity(entity.id);
       onClose();
     } catch (err: any) {
-      isDraftActioning = false;
       uiStore.notify(`Error: ${err.message}`, "error");
+    } finally {
+      isDraftActioning = false;
     }
   };
 

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -103,6 +103,32 @@
     }
   };
 
+  let isDraftActioning = $state(false);
+
+  const handleApproveDraft = async () => {
+    if (!entity || isDraftActioning) return;
+    isDraftActioning = true;
+    try {
+      await vault.updateEntity(entity.id, { status: "active" });
+    } catch (err: any) {
+      uiStore.notify(`Error: ${err.message}`, "error");
+    } finally {
+      isDraftActioning = false;
+    }
+  };
+
+  const handleRejectDraft = async () => {
+    if (!entity || isDraftActioning) return;
+    isDraftActioning = true;
+    try {
+      await vault.deleteEntity(entity.id);
+      onClose();
+    } catch (err: any) {
+      isDraftActioning = false;
+      uiStore.notify(`Error: ${err.message}`, "error");
+    }
+  };
+
   const navigateTo = async (id: string) => {
     if (editState.isEditing) {
       if (
@@ -244,6 +270,9 @@
         : onPopOut
           ? handlePopOutClick
           : undefined}
+      onApproveDraft={handleApproveDraft}
+      onRejectDraft={handleRejectDraft}
+      {isDraftActioning}
     />
 
     <!-- Navigation Tabs -->

--- a/specs/092-approve-draft-entities/data-model.md
+++ b/specs/092-approve-draft-entities/data-model.md
@@ -1,0 +1,19 @@
+# Data Model: Approve Draft Entities
+
+The underlying entity schema already supports `status: z.enum(["active", "draft"])`. No schema changes are required.
+
+## Actions
+
+### Approve Draft
+
+Transitions an entity from `draft` to `active`.
+
+- **Function**: `vault.updateEntity(id, { status: "active" })`
+- **Result**: Entity disappears from the "Review" tab (which filters for `draft`) and becomes a standard entity.
+
+### Reject Draft
+
+Deletes the entity permanently.
+
+- **Function**: `vault.deleteEntity(id)`
+- **Result**: Entity is removed from the store and all UI lists.

--- a/specs/092-approve-draft-entities/plan.md
+++ b/specs/092-approve-draft-entities/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: Approve / Reject Draft Entities
+
+**Branch**: `092-approve-draft-entities` | **Date**: 2026-04-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/092-approve-draft-entities/spec.md`
+
+## Summary
+
+Add UI controls to approve or reject AI-generated draft entities across three surfaces: the Entity Explorer Review tab, the Entity Detail Panel, and the Zen Mode Header. Approving updates the status to "active", while rejecting deletes the entity immediately.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9.3, Svelte 5 (Runes)  
+**Primary Dependencies**: SvelteKit, Tailwind 4  
+**Storage**: IndexedDB/OPFS (via `vault` store)  
+**Testing**: Vitest, Playwright  
+**Target Platform**: Web app  
+**Project Type**: Web application  
+**Performance Goals**: UI updates < 16ms, actions complete < 3s  
+**Constraints**: Client-side logic, no confirmation dialogs on reject  
+**Scale/Scope**: Add UI elements to 3 existing components
+
+## Constitution Check
+
+- **Library-First**: N/A (UI-only feature)
+- **Test-Driven Development (TDD)**: Must add tests for the new UI components and conditional rendering.
+- **Simplicity & YAGNI**: No new libraries needed. Using existing `vault` actions.
+- **AI-First Extraction**: N/A
+- **Privacy & Client-Side Processing**: Operates entirely on the local `vault` store.
+- **Clean Implementation**: Must use Iconify `icon-[lucide--...]` instead of `lucide-svelte` components. Must use `npm test` and `npm run lint`.
+- **User Documentation**: Will add a feature hint if necessary, but UI should be self-explanatory.
+- **Dependency Injection (DI)**: N/A (using existing stores)
+- **Natural Language**: "Approve" and "Reject" are clear.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/092-approve-draft-entities/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/web/
+├── src/
+│   ├── lib/
+│   │   ├── components/
+│   │   │   ├── explorer/
+│   │   │   │   └── EntityList.svelte
+│   │   │   ├── entity-detail/
+│   │   │   │   └── DetailHeader.svelte
+│   │   │   └── zen/
+│   │   │       └── ZenHeader.svelte
+```
+
+**Structure Decision**: Modifying existing Svelte components in the web application.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A       |            |                                      |

--- a/specs/092-approve-draft-entities/quickstart.md
+++ b/specs/092-approve-draft-entities/quickstart.md
@@ -1,0 +1,19 @@
+# Quickstart: Approve Draft Entities
+
+## Verification Steps
+
+1. Create a draft entity (or use the AI to generate one).
+2. Open the **Entity Explorer** and click the **Review** tab.
+3. Verify that the draft entity appears in the list.
+4. Hover over the entity and verify the checkmark and trash icons appear.
+5. Click the checkmark (Approve).
+6. Verify the entity instantly disappears from the Review tab.
+7. Switch to the **All Entities** tab and verify the entity is present.
+8. Create another draft entity.
+9. Open the entity in the **Entity Detail Panel** (Right Sidebar).
+10. Verify the "AI DRAFT — PENDING REVIEW" banner is visible at the top.
+11. Click Reject. Verify the panel closes and the entity is deleted.
+12. Create a final draft entity.
+13. Open it in **Zen Mode**.
+14. Verify Approve and Reject buttons appear in the header.
+15. Click Approve. Verify the buttons disappear and the entity remains open.

--- a/specs/092-approve-draft-entities/research.md
+++ b/specs/092-approve-draft-entities/research.md
@@ -1,0 +1,25 @@
+# Research: Approve Draft Entities
+
+## Context
+
+Implementation of draft approval flows for AI-generated entities (Issue #706). Requires adding UI actions to Explorer List, Detail Panel, and Zen Mode header.
+
+## Findings
+
+### Tech Stack Integration
+
+- **Decision**: Use Svelte 5 Runes and existing `vault.updateEntity` / `vault.deleteEntity` methods.
+- **Rationale**: Stays consistent with the rest of the Codex-Cryptica application.
+- **Alternatives considered**: Calling backend APIs (rejected, app is local-first/client-side).
+
+### Iconography
+
+- **Decision**: Use `icon-[lucide--check]` for approve and `icon-[lucide--trash-2]` for reject.
+- **Rationale**: The constitution mandates using the Iconify utility pattern (`class="icon-[lucide--name] h-4 w-4"`) instead of importing `lucide-svelte` components directly.
+- **Alternatives considered**: Importing lucide components directly (violates Constitution VI.1).
+
+### Animation and Feedback
+
+- **Decision**: Do not add confirmation dialogs to rejection; make deletion immediate.
+- **Rationale**: Directly requested in out-of-scope for the feature spec to speed up batch review.
+- **Alternatives considered**: Confirm dialogs (rejected based on spec).

--- a/specs/092-approve-draft-entities/spec.md
+++ b/specs/092-approve-draft-entities/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Approve / Reject Draft Entities
+
+**Feature Branch**: `092-approve-draft-entities`  
+**Created**: 2026-04-24  
+**Status**: In Progress  
+**Input**: https://github.com/eserlan/Codex-Cryptica/issues/706
+
+## Clarifications
+
+### Session 2026-04-24
+
+- Q: Should there be a bulk "Approve All" action? → A: Out of Scope. AI-generated content should be reviewed individually.
+- Q: Should rejecting a draft ask for confirmation? → A: No. Drafts are AI proposals — treat rejection as dismissing a suggestion, not deleting user work. Immediate delete, no dialog.
+- Q: What does "approve" do to the data model? → A: Sets `status` from `"draft"` to `"active"`. Schema already supports this via `z.enum(["active", "draft"])`.
+- Q: Should the entity panel close after approving? → A: No. The entity stays open, now showing as an active entity.
+- Q: Should the entity panel close after rejecting? → A: Yes. The entity is deleted, so the panel must close.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Quick Approve/Reject from the Review List (Priority: P1)
+
+As a vault maintainer, I want to approve or reject AI-generated draft entities directly from the Entity Explorer's Review tab, so I can process multiple proposals quickly without opening each one.
+
+**Why this priority**: The primary workflow for batch-reviewing AI output. Speed is the key value here.
+
+**Independent Test**: Open the Review tab in the Entity Explorer. Hover over a draft entity and click the checkmark button. Verify the entity disappears from the Review list and reappears in the main entity list with no draft status. Then create another draft and click the trash button — verify it is permanently deleted and no longer appears anywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on the Review tab and hover over a draft entity, **When** I see the action buttons, **Then** a green checkmark button and a red trash button MUST be visible alongside the existing Zen Mode and Find-in-Graph buttons.
+2. **Given** I click the checkmark button on a draft entity, **When** the action completes, **Then** the entity's status MUST be set to `"active"` and it MUST immediately disappear from the Review list.
+3. **Given** I click the trash button on a draft entity, **When** the action completes, **Then** the entity MUST be permanently deleted with no confirmation dialog and MUST disappear from the Review list.
+
+---
+
+### User Story 2 — Approve/Reject from the Entity Detail Panel (Priority: P2)
+
+As a vault maintainer, I want to approve or reject a draft after reading it in the sidebar panel, so I can make an informed decision based on the full generated content.
+
+**Why this priority**: Ensures users who review content carefully have a clear call-to-action after reading.
+
+**Independent Test**: Open a draft entity in the Entity Detail Panel (right sidebar). Verify a draft banner is visible at the top of the content area. Click Approve and confirm the banner disappears and the entity is now active. Open another draft, click Reject, and confirm the panel closes and the entity is gone.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Entity Detail Panel is open for a draft entity, **When** I view the panel, **Then** a clearly styled "AI DRAFT — PENDING REVIEW" banner MUST appear at the top of the scrollable content area with Approve and Reject buttons.
+2. **Given** I click Approve in the banner, **When** the action completes, **Then** the entity's status MUST be set to `"active"`, the banner MUST disappear, and the panel MUST remain open showing the now-active entity.
+3. **Given** I click Reject in the banner, **When** the action completes, **Then** the entity MUST be permanently deleted and the panel MUST close immediately.
+4. **Given** the entity does not have `status: "draft"`, **When** I view the panel, **Then** no draft banner MUST be shown.
+
+---
+
+### User Story 3 — Approve/Reject from Zen Mode (Priority: P2)
+
+As a vault maintainer, I want to approve or reject a draft after reading it in Zen Mode, so that the full reading experience has a natural completion action.
+
+**Why this priority**: Zen Mode is the primary reading surface; leaving no action there would create a dead end for users who open drafts from the list.
+
+**Independent Test**: Open a draft entity in Zen Mode. Verify approve and reject buttons appear in the header. Click Approve and confirm the buttons disappear and the entity is active. Open another draft in Zen Mode, click Reject, and confirm Zen Mode closes and the entity is gone.
+
+**Acceptance Scenarios**:
+
+1. **Given** Zen Mode is open for a draft entity and I am not in edit mode, **When** I view the header, **Then** Approve and Reject buttons MUST be visible in the header action area.
+2. **Given** I click Approve in Zen Mode, **When** the action completes, **Then** the entity's status MUST be set to `"active"` and the Approve/Reject buttons MUST disappear from the header.
+3. **Given** I click Reject in Zen Mode, **When** the action completes, **Then** the entity MUST be permanently deleted and Zen Mode MUST close.
+4. **Given** I am in edit mode for a draft entity, **When** I view the header, **Then** the Approve/Reject buttons MUST NOT be visible (edit mode controls take precedence).
+
+---
+
+### Out of Scope
+
+- **Bulk Approval**: No "Approve All" button. Each draft must be actioned individually.
+- **Rejection Confirmation**: No confirmation dialog on reject. Immediate delete.
+- **Rejection Reason / Feedback**: No mechanism to log why a draft was rejected.
+- **Schema Changes**: `status: z.enum(["active", "draft"])` already exists. No changes needed.
+- **Draft Status for User-Created Entities**: This workflow is only surfaced in the Review tab and on entities where `status === "draft"`. Users cannot manually assign draft status through this UI.
+
+### Edge Cases
+
+- **Reject while panel is animating**: The delete must be idempotent; double-clicking reject should not throw.
+- **Entity deleted externally while panel is open**: If the entity disappears from the store while the banner is visible, the panel should close gracefully (already handled by existing derived store logic).
+- **Draft entity focused in graph**: After approval the graph node should update to reflect active status without a full reload.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: When `explorerTab === "review"`, `EntityList` MUST render Approve and Reject icon buttons on each list item.
+- **FR-002**: Clicking Approve in any surface MUST call `vault.updateEntity(id, { status: "active" })`.
+- **FR-003**: Clicking Reject in any surface MUST call `vault.deleteEntity(id)` with no confirmation dialog.
+- **FR-004**: After rejection in the Detail Panel or Zen Mode, the view MUST close automatically.
+- **FR-005**: After approval in the Detail Panel or Zen Mode, the view MUST remain open showing the now-active entity.
+- **FR-006**: The draft banner in the Detail Panel MUST only render when `entity.status === "draft"`.
+- **FR-007**: Approve/Reject buttons in Zen Mode MUST be hidden while in edit mode.
+
+### Key Entities
+
+- **Entity**: `status` field transitions from `"draft"` → `"active"` on approval, or the entity is deleted on rejection.
+- **EntityList**: Gains two optional callback props `onApproveDraft` and `onRejectDraft`.
+- **EntityExplorer**: Passes those callbacks when `explorerTab === "review"`.
+- **EntityDetailPanel**: Renders a draft banner conditionally.
+- **ZenHeader**: Renders approve/reject buttons conditionally.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A user can approve a draft from the Review list in under 3 seconds (one hover + one click).
+- **SC-002**: A user can reject a draft from any surface in under 3 seconds with no additional dialogs.
+- **SC-003**: After approving a draft, the entity appears in the main entity list within one reactive render cycle — no manual refresh required.
+- **SC-004**: After rejecting a draft, the entity is not recoverable and does not appear in any list or search result.

--- a/specs/092-approve-draft-entities/tasks.md
+++ b/specs/092-approve-draft-entities/tasks.md
@@ -1,0 +1,64 @@
+---
+description: "Actionable, dependency-ordered tasks for the Approve / Reject Draft Entities feature"
+---
+
+# Tasks: Approve / Reject Draft Entities
+
+**Input**: Design documents from `/specs/092-approve-draft-entities/`
+**Prerequisites**: Core entity storage and UI shell must be active.
+
+## Phase 1: Setup & Foundational
+
+Goal: Prepare the environment for the draft approval UI.
+Independent Test: N/A
+
+- [ ] T001 Verify the testing environment for UI components is ready in `apps/web/`.
+
+## Phase 2: [US1] Quick Approve/Reject from the Review List
+
+Goal: Allow users to approve or reject draft entities directly from the Explorer list.
+Independent Test: Hover over a draft in the Review tab, click approve to see it turn active, click reject to see it deleted.
+
+- [ ] T002 [US1] Add `onApproveDraft` and `onRejectDraft` optional callback props to `apps/web/src/lib/components/explorer/EntityList.svelte`.
+- [ ] T003 [US1] Add "Approve" (`icon-[lucide--check]`) and "Reject" (`icon-[lucide--trash-2]`) buttons to the item snippet in `apps/web/src/lib/components/explorer/EntityList.svelte`, visible when callbacks are provided.
+- [ ] T004 [US1] Update `apps/web/src/lib/components/explorer/EntityExplorer.svelte` to pass `onApproveDraft` and `onRejectDraft` callbacks to `EntityList` when `explorerTab === "review"`.
+- [ ] T005 [US1] Implement the callback logic in `EntityExplorer.svelte`: `vault.updateEntity(id, { status: "active" })` for approve, and `vault.deleteEntity(id)` for reject.
+- [ ] T006 [US1] Write or update unit tests for `EntityList` in `apps/web/src/lib/components/explorer/EntityList.test.ts` (if it exists) to verify conditional rendering of approve/reject buttons.
+
+## Phase 3: [US2] Approve/Reject from the Entity Detail Panel
+
+Goal: Provide an informed approval flow after reading the full draft in the right sidebar.
+Independent Test: Open a draft in the right sidebar, verify the banner appears, click approve or reject and verify the status changes or the panel closes.
+
+- [ ] T007 [P] [US2] Add a draft banner ("AI DRAFT — PENDING REVIEW") to `apps/web/src/lib/components/EntityDetailPanel.svelte`, rendered only when `entity.status === "draft"`.
+- [ ] T008 [P] [US2] Add "Approve" and "Reject" buttons to the draft banner in `apps/web/src/lib/components/EntityDetailPanel.svelte`.
+- [ ] T009 [P] [US2] Implement approval logic in `EntityDetailPanel.svelte` that updates the entity status to "active".
+- [ ] T010 [P] [US2] Implement rejection logic in `EntityDetailPanel.svelte` that deletes the entity and calls `onClose()`.
+- [ ] T011 [US2] Write or update unit tests for `EntityDetailPanel` to verify banner visibility and button actions.
+
+## Phase 4: [US3] Approve/Reject from Zen Mode
+
+Goal: Provide an approval flow in the full-screen Zen Mode reading experience.
+Independent Test: Open a draft in Zen Mode, verify header buttons, click approve or reject.
+
+- [ ] T012 [P] [US3] Add "Approve" and "Reject" buttons to `apps/web/src/lib/components/zen/ZenHeader.svelte`.
+- [ ] T013 [P] [US3] Conditionally render the new buttons in `ZenHeader.svelte` only if `entity?.status === "draft"` and `!editState.isEditing`.
+- [ ] T014 [P] [US3] Implement approval logic in `ZenHeader.svelte` (`vault.updateEntity(id, { status: "active" })`).
+- [ ] T015 [P] [US3] Implement rejection logic in `ZenHeader.svelte` (`vault.deleteEntity(id)` and `onClose()`).
+- [ ] T016 [US3] Write or update unit tests for `ZenHeader` to verify button visibility and actions.
+
+## Phase 5: Polish & Cross-Cutting
+
+Goal: Ensure the implementation is clean, robust, and matches the style guide.
+
+- [ ] T017 Run `npm run lint` and fix any style or typing issues across the modified files.
+- [ ] T018 Run `npm test` to ensure all tests pass and coverage is maintained.
+- [ ] T019 Verify that clicking approve/reject rapidly does not crash the application (idempotency).
+
+## Implementation Strategy & Dependencies
+
+- **Dependencies**:
+  - Phase 3 (US2) and Phase 4 (US3) can be executed in parallel [P] with each other as they modify different components (`EntityDetailPanel` vs `ZenHeader`).
+  - Phase 2 (US1) is independent and modifies `EntityExplorer`.
+- **MVP**: The MVP is completing Phase 2 to unblock rapid batch review.
+- **Parallel Opportunities**: The detailed UI integrations in US2 and US3 can be built simultaneously by different agents/developers.


### PR DESCRIPTION
## Summary

- Adds **approve** (set `status: active`) and **reject** (delete) actions for AI-generated draft entities across all three review surfaces
- **Review list** (Entity Explorer): hover checkmark/trash icon buttons on each draft item
- **Entity Detail Panel**: amber "AI Draft — Pending Review" banner with Approve/Reject buttons
- **Zen Mode header**: APPROVE/REJECT buttons visible when viewing a draft in read mode, hidden during edit mode
- All actions are guarded against double-fire with `isDraftActioning` state and include error handling via `uiStore.notify`

## Test plan

- [ ] Open the Review tab in Entity Explorer — hover a draft and click the checkmark; verify it moves to the main entity list
- [ ] Hover a draft in the Review tab and click the trash icon; verify it is deleted immediately with no confirmation dialog
- [ ] Open a draft in the Entity Detail Panel; verify the amber banner appears and Approve/Reject buttons work correctly
- [ ] Open a draft in Zen Mode; verify APPROVE/REJECT buttons appear in the header and are hidden while in edit mode
- [ ] Verify that clicking approve/reject while a request is in flight does nothing (buttons are disabled)
- [ ] Verify that non-draft entities show no banner or extra buttons in any surface

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)