### PR TITLE
:bug: fix(graph-engine): stable layout no longer triggers FCOSE on add/delete

### DIFF
--- a/docs/GRAPH_RENDER_FLOW.md
+++ b/docs/GRAPH_RENDER_FLOW.md
@@ -1,0 +1,255 @@
+# Graph Rendering Flow
+
+Traces the complete data flow from vault entities through layout computation to the Cytoscape DOM, including all re-render triggers.
+
+---
+
+## Flow Diagram
+
+```mermaid
+flowchart TD
+    subgraph Data["Data Layer"]
+        VA[vault.allEntities<br/><i>$state reactive array</i>]
+        ES[entity-store<br/>createEntity / updateEntity / deleteEntity]
+        VEB[vaultEventBus<br/>CACHE_LOADED · ENTITY_UPDATED · BATCH_UPDATED]
+    end
+
+    subgraph GraphStore["graph.svelte.ts — Graph Store"]
+        GE["graph.elements<br/><i>$derived.by</i><br/>isEntityVisible filter → GraphTransformer"]
+        GM[graph mode flags<br/>showLabels · showImages · stableLayout<br/>timelineMode · orbitMode · centralNodeId]
+        GF[graph filters<br/>activeLabels · activeCategories · labelFilterMode]
+    end
+
+    subgraph Transform["packages/graph-engine — Transformer"]
+        GT["GraphTransformer.entitiesToElements()<br/>weight precompute → node sizing<br/>phyllotaxis spiral for unplaced nodes<br/>edge validation"]
+    end
+
+    subgraph Component["GraphView.svelte — Component"]
+        OM["onMount (+50ms)<br/>initGraph() → cy instance<br/>LayoutManager instantiated<br/>ImageManager instantiated<br/>setupGraphEvents()"]
+        SE["$effect: graph.elements change<br/>syncGraphElements()"]
+        SM["$effect: style/theme change<br/>cy.style(newStyle)"]
+        SF["$effect: selectedId change<br/>applyFocus() — dimmed / neighborhood classes"]
+        SL["$effect: mode flags change<br/>applyCurrentLayout(forced=true)"]
+    end
+
+    subgraph Sync["packages/graph-engine — useGraphSync"]
+        SG["syncGraphElements()<br/>1. detect removals → cy.remove()<br/>2. add new nodes (pending-layout class)<br/>3. add new edges<br/>4. patch-update changed data fields<br/>5. apply category / label filters<br/>6. recalculate weights"]
+        OLU["onLayoutUpdate callback<br/>→ applyCurrentLayout()"]
+    end
+
+    subgraph Layout["packages/graph-engine — LayoutManager"]
+        LA["layoutManager.apply()<br/>isInitial · isForced · caller · hasNewNodes"]
+        FO{"fit-only path?<br/>stableLayout=true<br/>no new nodes<br/>not forced"}
+        TM{"timelineMode?"}
+        OM2{"orbitMode?"}
+        FD["Force-Directed<br/>FCOSE via Web Worker"]
+        TL["Timeline Layout<br/>chronological axis<br/>gap-compressed years<br/>jitter for concurrent events"]
+        OL["Orbit Layout<br/>BFS distances → concentric rings"]
+    end
+
+    subgraph Worker["layout.worker.ts — Web Worker"]
+        WM["receive job message<br/>cancel pending jobs"]
+        FC["cytoscape-fcose<br/>getDynamicLayoutOptions(nodeCount)<br/>quality · edgeLength · repulsion · gravity"]
+        OR["overlap removal<br/>spatial grid O(N)<br/>max 32 iterations"]
+        WR["return positions → main thread"]
+    end
+
+    subgraph PostLayout["Post-Layout"]
+        CP["cy.batch() → apply positions<br/>remove pending-layout class (reveal nodes)"]
+        AN["cy.animate(fit, 800ms, ease-out-quad)"]
+        PU["onPositionsUpdated()<br/>vault.batchUpdate({ id: { metadata: { coordinates } } })<br/>persisted to IndexedDB"]
+    end
+
+    subgraph Images["packages/graph-engine — ImageManager"]
+        IM["imageManager.sync()<br/>batch resolve blob URLs (10 at a time)<br/>apply as node background-image"]
+    end
+
+    subgraph Viewport["Viewport Management"]
+        LOD["pan/zoom → LOD classes<br/>zoom<0.2: lod-low<br/>zoom<0.5: lod-medium<br/>else: full detail"]
+        RSZ["window resize (250ms debounce)<br/>orientation change → randomize=true"]
+        SCF["SEARCH_ENTITY_FOCUS_EVENT<br/>pendingSearchFocus → animate center+zoom"]
+    end
+
+    %% Data flow
+    ES --> VA
+    VEB --> VA
+    VA --> GE
+    GF --> GE
+    GE --> GT
+    GT --> GE
+
+    %% Store → Component
+    GE --> SE
+    GM --> SL
+    GF --> SE
+
+    %% Component init
+    OM --> SE
+
+    %% Sync
+    SE --> SG
+    SG --> OLU
+    OLU --> LA
+
+    %% Style / selection
+    SM --> Component
+    SF --> Component
+
+    %% Layout routing
+    LA --> FO
+    FO -- yes --> AN
+    FO -- no --> TM
+    TM -- yes --> TL
+    TM -- no --> OM2
+    OM2 -- yes --> OL
+    OM2 -- no --> FD
+
+    %% Worker path
+    FD --> WM
+    WM --> FC
+    FC --> OR
+    OR --> WR
+    WR --> CP
+
+    %% Post-layout
+    TL --> CP
+    OL --> CP
+    CP --> AN
+    AN --> PU
+
+    %% Images
+    SE --> IM
+
+    %% Viewport
+    AN --> LOD
+    RSZ --> LA
+    SCF --> Viewport
+```
+
+---
+
+## Initialization Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as +layout.svelte
+    participant VS as vault.svelte
+    participant GS as graph.svelte
+    participant GV as GraphView.svelte
+    participant LM as LayoutManager
+    participant W as layout.worker
+
+    App->>VS: bootSystem()
+    VS->>VS: load entities from IDB (CACHE_LOADED)
+    VS-->>GS: vault.allEntities reactive update
+    GS->>GS: graph.elements $derived recomputes<br/>(GraphTransformer runs)
+
+    App->>GV: mount component
+    Note over GV: 50ms delay
+    GV->>GV: initGraph() → new cy instance
+    GV->>LM: new LayoutManager(cy)
+    GV->>GV: $effect fires: syncGraphElements()
+    GV->>LM: applyCurrentLayout(isInitial=true)
+    LM->>W: postMessage(job, nodes, edges)
+    W-->>LM: positions[]
+    LM->>GV: cy.batch(applyPositions)
+    LM->>GV: cy.animate(fit)
+    LM->>VS: onPositionsUpdated() → batchUpdate
+```
+
+---
+
+## Re-render Decision Tree
+
+```mermaid
+flowchart TD
+    T[trigger fires]
+    T --> Q1{structural change?<br/>nodes/edges added or removed}
+    Q1 -- yes --> Q2{stableLayout?}
+    Q2 -- no --> FULL[full FCOSE layout<br/>in worker]
+    Q2 -- yes --> Q3{hasNewNodes?}
+    Q3 -- yes --> FULL
+    Q3 -- no --> FIT[fit viewport only<br/>cy.animate]
+
+    Q1 -- no --> Q4{mode changed?<br/>timeline / orbit toggle}
+    Q4 -- yes --> FORCED[forced layout<br/>randomize=true if exiting mode]
+    Q4 -- no --> Q5{data patch only?<br/>label / image / category}
+    Q5 -- yes --> STYLE[style / filter update<br/>no layout]
+    Q5 -- no --> FIT
+```
+
+---
+
+## Key Subsystems
+
+### GraphTransformer (`packages/graph-engine/src/transformer.ts`)
+
+Converts vault entities to Cytoscape elements in a single pass:
+
+1. **Weight pass** — counts visible connections per node to determine size (48px – 128px)
+2. **Node creation** — assigns phyllotaxis spiral positions to unplaced nodes; marks them `pending-layout` (opacity 0) until the worker returns
+3. **Edge creation** — filters edges whose target no longer exists in the vault
+
+### Element Sync (`packages/graph-engine/src/sync/useGraphSync.ts`)
+
+Incremental diffing — avoids full cy teardown on every vault change:
+
+- O(1) map lookups for existing nodes
+- Patch updates: only changed fields written to cy data
+- Special equality checks for coordinates, arrays, temporal metadata
+- Batched `cy.batch()` writes for DOM efficiency
+
+### Layout Worker (`packages/graph-engine/src/layout.worker.ts`)
+
+Job-based, cancellable. Timeout scales at 30ms/node (min 15s, max 60s).
+
+Dynamic options scale with graph size:
+
+| Parameter      | Formula                                        |
+| -------------- | ---------------------------------------------- |
+| Edge length    | `90 + √nodeCount × 9`                          |
+| Node repulsion | `250000 + nodeCount × 2400`                    |
+| Gravity        | `max(0.005, 0.05 − nodeCount × 0.00015)`       |
+| Quality        | `"draft"` if nodeCount ≥ 500, else `"default"` |
+
+After worker positions are applied, a grid-based overlap removal pass runs (O(N) per iteration, max 32 rounds).
+
+### Image Manager (`packages/graph-engine/src/sync/ImageManager.ts`)
+
+Lazy, batched blob URL resolution: resolves 10 nodes per tick, caches resolved URLs, revokes stale blob URLs on data change or image toggle.
+
+### Level-of-Detail
+
+Zoom thresholds: `< 0.2` → `lod-low`, `< 0.5` → `lod-medium`, else full detail. Applied via CSS classes on pan/zoom events.
+
+---
+
+## Re-render Trigger Reference
+
+| Trigger                  | Source                      | Layout?     | Type                         |
+| ------------------------ | --------------------------- | ----------- | ---------------------------- |
+| Entity created           | `vault.createEntity()`      | Yes         | FCOSE (hasNewNodes=true)     |
+| Entity deleted           | `vault.deleteEntity()`      | Yes         | FCOSE                        |
+| Entity data updated      | `vault.updateEntity()`      | No          | data patch only              |
+| Connection added/removed | entity.connections change   | Yes         | FCOSE                        |
+| Label filter changed     | `graph.activeLabels`        | No          | CSS class toggle             |
+| Category filter changed  | `graph.activeCategories`    | No          | CSS class toggle             |
+| Timeline mode toggled    | `graph.timelineMode`        | Yes         | Timeline layout (forced)     |
+| Orbit mode toggled       | `graph.orbitMode`           | Yes         | Orbit layout (forced)        |
+| Show labels toggled      | `graph.showLabels`          | No          | style update                 |
+| Show images toggled      | `graph.showImages`          | No          | ImageManager sync            |
+| Stable layout toggled    | `graph.stableLayout`        | No          | affects next layout decision |
+| Vault load complete      | `vault.status → idle`       | Yes         | FCOSE (forced)               |
+| Window resize            | ResizeObserver              | Conditional | fit-only or FCOSE            |
+| Orientation change       | resize handler              | Yes         | FCOSE (randomize=true)       |
+| Search focus             | `SEARCH_ENTITY_FOCUS_EVENT` | No          | animate center+zoom          |
+| Theme change             | `themeStore.activeTheme`    | No          | `cy.style()` update          |
+| Manual redraw            | UI button                   | Yes         | FCOSE (forced)               |
+
+---
+
+## Related Documents
+
+- [`GRAPH_LAYOUT_TUNING.md`](./GRAPH_LAYOUT_TUNING.md) — FCOSE parameter reference and tuning guide
+- [`GRAPH_STABILITY.md`](./GRAPH_STABILITY.md) — stable layout mode and position persistence
+- [`VAULT_INIT_FLOW.md`](./VAULT_INIT_FLOW.md) — vault boot sequence that precedes graph initialization

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -91,6 +91,9 @@ describe("LayoutManager", () => {
       { x: 10, y: 10 },
       { x: 30, y: 30 },
     ]);
+    // Cytoscape collections returned by cy.nodes() need these in the fit-only path
+    (twoNodes as any).removeData = vi.fn();
+    (twoNodes as any).removeClass = vi.fn();
 
     mockCy = {
       destroyed: vi.fn().mockReturnValue(false),
@@ -147,13 +150,15 @@ describe("LayoutManager", () => {
     );
   });
 
-  it("should trigger layout when hasNewNodes is true even if stableLayout is true", async () => {
-    // Current positions are NOT at origin (so manual detection would fail)
+  it("should use fit-only when stableLayout is true, even with new nodes", async () => {
     const currentPositions = [
       { x: 100, y: 100 },
       { x: 200, y: 200 },
     ];
-    mockCy.nodes.mockReturnValue(makeNodes(currentPositions));
+    const nodes = makeNodes(currentPositions);
+    (nodes as any).removeData = vi.fn();
+    (nodes as any).removeClass = vi.fn();
+    mockCy.nodes.mockReturnValue(nodes);
 
     await layoutManager.apply(
       {
@@ -172,9 +177,9 @@ describe("LayoutManager", () => {
       true, // hasNewNodes = true
     );
 
-    // Should have triggered a worker postMessage (not just a fitOnly stop)
-    expect(capturedPostMessage).not.toBeNull();
-    expect(capturedPostMessage.jobId).toBeGreaterThan(0);
+    // stableLayout=true → fit-only; worker must NOT be called
+    expect(capturedPostMessage).toBeNull();
+    expect(mockCy.animate).toHaveBeenCalled();
   });
 
   it("should use lower gravity in landscape view", async () => {
@@ -230,7 +235,7 @@ describe("LayoutManager", () => {
     });
   });
 
-  it("should not randomize stable layouts for non-redraw forced updates", async () => {
+  it("should use fit-only for forced updates when stableLayout is true", async () => {
     await layoutManager.apply(
       {
         timelineMode: false,
@@ -246,7 +251,9 @@ describe("LayoutManager", () => {
       "External Update",
       true,
     );
-    expect(capturedPostMessage?.options.randomize).toBe(false);
+    // stableLayout=true + non-redraw forced update → fit-only; worker must NOT be called
+    expect(capturedPostMessage).toBeNull();
+    expect(mockCy.animate).toHaveBeenCalled();
   });
 
   it("should randomize when the UI redraw button requests a fresh solve", async () => {

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -407,7 +407,7 @@ export class LayoutManager {
     isForced: boolean,
     caller: string,
     randomizeForced = false,
-    hasNewNodesParam = false,
+    _hasNewNodesParam = false,
   ) {
     const cyNodes = this.cy.nodes();
 
@@ -419,38 +419,22 @@ export class LayoutManager {
       !options.orbitMode;
     let randomize = isExitingTimeline || isExitingMode;
 
-    // Single pass: detect new nodes (at origin) and full-clump in one loop
-    let hasNewNodes = hasNewNodesParam;
+    // Detect full-clump (all nodes at origin) — force randomize so fcose can spread them
     let nodesAtOrigin = 0;
     cyNodes.forEach((n) => {
       const p = n.position();
-      if (!p || (p.x === 0 && p.y === 0)) {
-        hasNewNodes = true;
-        nodesAtOrigin++;
-      }
+      if (!p || (p.x === 0 && p.y === 0)) nodesAtOrigin++;
     });
     if (!randomize && cyNodes.length > 1 && nodesAtOrigin === cyNodes.length) {
       randomize = true;
     }
 
-    const isFitOnly =
-      options.stableLayout &&
-      !randomize &&
-      !hasNewNodes &&
-      !isForced &&
-      (caller === "Load Finalized" || caller === "Window Resize");
+    const isManualRedraw = caller === "UI Redraw Button" && isForced;
+    const isFitOnly = options.stableLayout && !randomize && !isManualRedraw;
 
     if (isFitOnly) {
-      if (
-        isInitial ||
-        caller === "Load Finalized" ||
-        caller === "Window Resize"
-      ) {
-        this.cy.resize();
-        this.animateFitAndStop(options, "ease-out-cubic");
-      } else {
-        options.onLayoutStop?.();
-      }
+      this.cy.resize();
+      this.animateFitAndStop(options, "ease-out-cubic");
       // Safety: ensure any newly added nodes are visible even in fit-only paths
       this.cy.nodes().removeData("isPendingLayout");
       this.cy.nodes(".pending-layout").removeClass("pending-layout");


### PR DESCRIPTION
## Summary

- With `stableLayout` ON, adding or deleting a node was incorrectly running a full FCOSE re-layout in the web worker, moving all existing nodes
- Root cause: the `isFitOnly` guard in `LayoutManager.applyForceLayout` excluded `hasNewNodes` and any `isForced` caller — deletions are always forced, so they always fell through to FCOSE
- Fix: simplified `isFitOnly` to `stableLayout && !randomize && !isManualRedraw` — the only exception is the explicit **Redraw** button, which is already documented as overriding stable layout

## Changes

- `packages/graph-engine/src/LayoutManager.ts` — simplified `isFitOnly` logic (3 conditions → 2); removed now-unused `hasNewNodes` local variable
- `packages/graph-engine/src/LayoutManager.test.ts` — updated two tests that encoded the old broken behavior; added missing mock methods for the fit-only code path

## Test plan

- [ ] Add a node with stableLayout ON → existing nodes don't move, new node appears at its phyllotaxis position
- [ ] Delete a node with stableLayout ON → remaining nodes stay in place, viewport fits
- [ ] Press Redraw with stableLayout ON → full FCOSE runs as expected
- [ ] Add/delete with stableLayout OFF → FCOSE still runs normally
- [ ] All 25 unit tests pass (`vitest run src/LayoutManager.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)