### PR TITLE
🎨 Palette: Add aria-busy to async action buttons in VaultSwitcherModal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,6 @@
 ## 2024-05-18 - Icon-Only Buttons Require Explicit aria-label
 **Learning:** While the `title` attribute provides a tooltip for sighted users on hover, it is not consistently read by all screen readers or in all contexts as an accessible name for an element. For icon-only buttons, especially in modals or highly interactive components, relying solely on `title` can result in empty or unhelpful announcements for assistive technologies.
 **Action:** Always provide an explicit `aria-label` attribute on icon-only `<button>` elements, even if a `title` attribute is already present. This ensures robust accessibility across different screen readers.
+## 2025-04-25 - Async Button Attributes
+**Learning:** For components executing async operations like Vault creation or importing, the `isLoading` state was properly disabling the button and changing its text visually, but lacked semantic context for screen readers.
+**Action:** Always complement the `disabled={isLoading}` attribute with `aria-busy={isLoading}` to ensure screen readers correctly interpret and announce the loading state.

--- a/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
+++ b/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
@@ -354,6 +354,7 @@
                 type="submit"
                 class="px-6 py-2 bg-theme-primary hover:bg-theme-primary-hover text-black font-bold text-sm rounded shadow-[0_0_15px_rgba(var(--theme-primary-rgb),0.3)] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={isLoading || !newVaultName.trim()}
+                aria-busy={isLoading}
               >
                 {isLoading ? "CREATING..." : "CREATE"}
               </button>
@@ -362,6 +363,7 @@
                 class="px-6 py-2 bg-theme-accent hover:bg-theme-accent-hover text-black font-bold text-sm rounded shadow-[0_0_15px_rgba(var(--theme-accent-rgb),0.3)] transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                 onclick={handleImport}
                 disabled={isLoading || !newVaultName.trim()}
+                aria-busy={isLoading}
               >
                 {#if isLoading && vault.status === "loading"}
                   <span class="icon-[lucide--loader-2] w-3.5 h-3.5 animate-spin"
@@ -387,6 +389,7 @@
           onclick={handleLoadFromFolder}
           disabled={isLoading}
           title="Open a local folder as a new vault"
+          aria-busy={isLoading}
         >
           <span class="icon-[lucide--folder-open] w-4 h-4"></span> OPEN FOLDER
         </button>


### PR DESCRIPTION
💡 What: Added `aria-busy={isLoading}` to the Create, Import, and Open Folder buttons in the VaultSwitcherModal.
🎯 Why: These buttons perform asynchronous operations and go into an `isLoading` state. Adding `aria-busy` ensures that screen readers are explicitly aware of the loading state while the actions are in progress.
📸 Before/After: Visuals unchanged, semantics improved.
♿ Accessibility: Better screen reader context for asynchronous loading states on actionable elements.

---
*PR created automatically by Jules for task [10743547106070380293](https://jules.google.com/task/10743547106070380293) started by @eserlan*