### PR TITLE
feat: add clear button to entity explorer search

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -178,8 +178,18 @@
         bind:value={searchQuery}
         placeholder="Search entities..."
         aria-label="Search entities"
-        class="w-full rounded-lg border border-theme-border bg-theme-bg/50 py-2 pl-9 pr-3 text-sm text-theme-text placeholder-theme-muted transition-all focus:border-theme-accent focus:outline-none focus:ring-2 focus:ring-theme-accent/20"
+        class="w-full rounded-lg border border-theme-border bg-theme-bg/50 py-2 pl-9 pr-9 text-sm text-theme-text placeholder-theme-muted transition-all focus:border-theme-accent focus:outline-none focus:ring-2 focus:ring-theme-accent/20"
       />
+      {#if searchQuery}
+        <button
+          onclick={() => (searchQuery = "")}
+          class="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 text-theme-muted hover:text-theme-text transition-colors"
+          title="Clear search"
+          aria-label="Clear search"
+        >
+          <span class="icon-[lucide--x] w-3.5 h-3.5"></span>
+        </button>
+      {/if}
     </div>
 
     <div

--- a/apps/web/src/lib/components/explorer/EntityList.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityList.test.ts
@@ -107,4 +107,17 @@ describe("EntityList", () => {
     expect(screen.getByText("Broken Seal")).not.toBeNull();
     expect(uiStore.getCollapsedLabelGroups("vault-1").has("Quest")).toBe(false);
   });
+
+  it("clears the search query when the clear button is clicked", async () => {
+    render(EntityList);
+
+    const input = screen.getByLabelText("Search entities") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "Mira" } });
+    expect(input.value).toBe("Mira");
+
+    const clearButton = screen.getByLabelText("Clear search");
+    await fireEvent.click(clearButton);
+
+    expect(input.value).toBe("");
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1243,6 +1243,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,6 +2326,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2333,6 +2335,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2341,6 +2344,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2352,6 +2356,7 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3240,6 +3245,7 @@
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -4383,6 +4389,7 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/gapi": {
@@ -4473,7 +4480,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -4481,6 +4488,7 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
@@ -4639,6 +4647,7 @@
       "version": "8.59.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
       "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4914,6 +4923,7 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5163,6 +5173,7 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -6287,6 +6298,7 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -6550,7 +6562,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6595,6 +6607,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6611,6 +6624,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6627,6 +6641,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6643,6 +6658,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6659,6 +6675,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6675,6 +6692,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6691,6 +6709,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6707,6 +6726,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6723,6 +6743,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6739,6 +6760,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6755,6 +6777,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6771,6 +6794,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6787,6 +6811,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6803,6 +6828,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6819,6 +6845,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6835,6 +6862,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6851,6 +6879,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6867,6 +6896,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6883,6 +6913,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6899,6 +6930,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6915,6 +6947,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6931,6 +6964,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6947,6 +6981,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6963,6 +6998,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6979,6 +7015,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7217,6 +7254,7 @@
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -7273,6 +7311,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
       "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -8391,6 +8430,7 @@
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -8475,7 +8515,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -8997,6 +9037,7 @@
     },
     "node_modules/locate-character": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -11836,6 +11877,7 @@
       "version": "5.55.4",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
       "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -11969,6 +12011,7 @@
     },
     "node_modules/svelte/node_modules/aria-query": {
       "version": "5.3.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -12280,7 +12323,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -13053,7 +13096,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -13179,6 +13222,7 @@
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     "apps/web": {
-      "version": "0.20.0",
+      "version": "0.20.1",
       "dependencies": {
         "@codex/canvas-engine": "^0.0.0",
         "@codex/importer": "*",
@@ -1243,7 +1243,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2326,7 +2325,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2335,7 +2333,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2344,7 +2341,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2356,7 +2352,6 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3245,7 +3240,6 @@
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -4389,7 +4383,6 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/gapi": {
@@ -4480,7 +4473,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -4488,7 +4481,6 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/turndown": {
@@ -4647,7 +4639,6 @@
       "version": "8.59.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
       "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4923,7 +4914,6 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5173,7 +5163,6 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -6298,7 +6287,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -6562,7 +6550,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6607,7 +6595,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6624,7 +6611,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6641,7 +6627,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6658,7 +6643,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6675,7 +6659,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6692,7 +6675,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6709,7 +6691,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6726,7 +6707,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6743,7 +6723,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6760,7 +6739,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6777,7 +6755,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6794,7 +6771,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6811,7 +6787,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6828,7 +6803,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6845,7 +6819,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6862,7 +6835,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6879,7 +6851,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6896,7 +6867,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6913,7 +6883,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6930,7 +6899,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6947,7 +6915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6964,7 +6931,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6981,7 +6947,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6998,7 +6963,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7015,7 +6979,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7254,7 +7217,6 @@
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -7311,7 +7273,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
       "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -8430,7 +8391,6 @@
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -8515,7 +8475,7 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9037,7 +8997,6 @@
     },
     "node_modules/locate-character": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -11877,7 +11836,6 @@
       "version": "5.55.4",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
       "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -12011,7 +11969,6 @@
     },
     "node_modules/svelte/node_modules/aria-query": {
       "version": "5.3.1",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -12323,7 +12280,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -13096,7 +13053,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -13222,7 +13179,6 @@
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/zod": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://v2-9-6.turborepo.dev/schema.json",
   "globalEnv": ["VITE_SHARED_GEMINI_KEY", "NODE_ENV"],
   "tasks": {
     "build": {


### PR DESCRIPTION
This PR adds a clear button (`x`) to the Entity Explorer search input to improve UX by allowing users to quickly reset their search query.

### Changes:
- **`EntityList.svelte`**: 
    - Implemented an absolute-positioned clear button that appears when `searchQuery` is not empty.
    - Updated input padding (`pr-9`) to ensure text does not overlap the button.
    - Follows project standards for iconography (Iconify utility classes) and theming (semantic theme tokens).
- **`EntityList.test.ts`**: 
    - Added a unit test to verify the clearing functionality.
- **Turborepo**:
    - Updated `turbo` to `v2.9.6` and updated the schema in `turbo.json`.

Closes #718