### PR TITLE
feat(oracle): persist chat history per vault (#691)

### DIFF
--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -170,6 +170,7 @@ describe("OracleStore", () => {
       updateMessageEntity: vi.fn(),
       addTestImageMessage: vi.fn(),
       addProposal: vi.fn(),
+      destroy: vi.fn(),
     };
 
     mockSettings = {
@@ -754,6 +755,7 @@ describe("OracleStore", () => {
 
       expect(mockBus.close).toHaveBeenCalled();
       expect((oracle as any).eventBus).toBeNull();
+      expect(mockChatHistory.destroy).toHaveBeenCalled();
     });
 
     it("should ignore unhandled worker event types", () => {

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -112,6 +112,8 @@ export class OracleStore {
   private undoRedo: UndoRedoService;
   private executor: OracleActionExecutor;
   private eventBus: BroadcastChannel | null = null;
+  private isChatHistoryReady = false;
+  private vaultSwitchedHandler: ((e: Event) => void) | null = null;
 
   constructor(
     deps: {
@@ -167,12 +169,13 @@ export class OracleStore {
 
     // Reload chat history when the active vault changes
     if (typeof window !== "undefined") {
-      window.addEventListener("vault-switched", (e: Event) => {
+      this.vaultSwitchedHandler = (e: Event) => {
         const newVaultId = (e as CustomEvent<{ id: string }>).detail?.id;
-        if (newVaultId && this.isInitialized) {
+        if (newVaultId && this.isChatHistoryReady) {
           void this.chatHistoryService.switchVault(newVaultId);
         }
-      });
+      };
+      window.addEventListener("vault-switched", this.vaultSwitchedHandler);
     }
   }
 
@@ -182,6 +185,11 @@ export class OracleStore {
   public destroy() {
     this.eventBus?.close();
     this.eventBus = null;
+    this.chatHistoryService.destroy();
+    if (this.vaultSwitchedHandler && typeof window !== "undefined") {
+      window.removeEventListener("vault-switched", this.vaultSwitchedHandler);
+      this.vaultSwitchedHandler = null;
+    }
   }
 
   private handleWorkerEvent(event: any) {
@@ -209,6 +217,7 @@ export class OracleStore {
       entityDb as any,
       this.vault.activeVaultId ?? "default",
     );
+    this.isChatHistoryReady = true;
     await this.settingsService.init(entityDb as any);
 
     this.isInitialized = true;

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -164,6 +164,16 @@ export class OracleStore {
       this.eventBus = new BroadcastChannel("codex-oracle-events");
       this.eventBus.onmessage = (event) => this.handleWorkerEvent(event.data);
     }
+
+    // Reload chat history when the active vault changes
+    if (typeof window !== "undefined") {
+      window.addEventListener("vault-switched", (e: Event) => {
+        const newVaultId = (e as CustomEvent<{ id: string }>).detail?.id;
+        if (newVaultId && this.isInitialized) {
+          void this.chatHistoryService.switchVault(newVaultId);
+        }
+      });
+    }
   }
 
   /**
@@ -195,7 +205,10 @@ export class OracleStore {
   async init() {
     if (this.isInitialized) return;
 
-    await this.chatHistoryService.init(entityDb as any);
+    await this.chatHistoryService.init(
+      entityDb as any,
+      this.vault.activeVaultId ?? "default",
+    );
     await this.settingsService.init(entityDb as any);
 
     this.isInitialized = true;

--- a/docs/VAULT_SYNC_PROPOSALS.md
+++ b/docs/VAULT_SYNC_PROPOSALS.md
@@ -1,0 +1,146 @@
+# Vault Operations — Proposals
+
+_Analysis date: 2026-04-25_
+
+---
+
+## Storage layers (clarified)
+
+| Layer                 | What it is                          | Who writes it             |
+| --------------------- | ----------------------------------- | ------------------------- |
+| **Dexie (IndexedDB)** | In-browser cache of entity metadata | Auto-save (invisible)     |
+| **OPFS**              | Canonical in-browser file store     | Auto-save (invisible)     |
+| **Local folder**      | User-visible file system            | Explicit user action only |
+
+Auto-save is purely about keeping Dexie + OPFS in sync with in-memory state.
+It runs in the background, is always on, and users never need to think about it.
+
+The local folder is a separate concern entirely. It is only touched when the user
+explicitly asks to push to or pull from it.
+
+---
+
+## Proposed model: three operations
+
+### Auto-save (no user action)
+
+Memory → Dexie + OPFS. Debounced 400 ms per entity. Already works. No change needed.
+
+### Save to filesystem (explicit button)
+
+OPFS → local folder. Pure write. Always visible (same position as today's SYNC button),
+but only enabled when there are changes that have not yet been pushed to the local folder.
+
+```
+[SAVE]  ← disabled + greyed when nothing to push
+[SAVE]  ← enabled when OPFS has changes the local folder doesn't have yet
+  ↓
+saveToLocalFolder(opfs → localFolder)
+  ↓
+mark as clean
+```
+
+**Hover text (always shown):**
+
+> "Save to file system — writes all changes from the internal archive to your linked folder."
+
+**Dirty tracking:** a `lastSavedToFolder` timestamp is updated each time a successful push
+completes. Any entity save to OPFS after that timestamp marks the vault as dirty and enables
+the button. If no local folder is linked, button is always disabled with a different tooltip:
+
+> "No folder linked — connect a local folder first to enable saving."
+
+This is today's SYNC button renamed and made write-only. No reading from the local folder happens here.
+
+### Load from filesystem (explicit button)
+
+Local folder → OPFS → memory. Pure read. Only relevant if user has linked a local folder.
+
+```
+[LOAD FROM FOLDER]
+  ↓
+loadFromLocalFolder(localFolder → opfs)
+  ↓
+loadFiles()   ← opfs → memory
+  ↓
+done
+```
+
+The reverse direction. Use this after editing files externally.
+
+---
+
+## Vault switch (simplified)
+
+Because auto-save keeps OPFS current at all times, switching only needs to drain the
+in-memory debounce queue — it does not need to wait for any filesystem operation.
+
+```
+[Switch to X]
+  ↓
+flushPendingSaves()     ← drain 400 ms queue into OPFS (fast, already there)
+clearCurrentVaultState()
+loadVault(X)            ← OPFS/cache → memory for new vault
+  ↓
+done
+```
+
+No change to today's switch logic except removing `syncWithLocalFolder()` from the flow
+(it was never the right thing to do on a switch anyway — the user didn't ask for it).
+
+---
+
+## Button placement
+
+| Action               | Location                                                | Visibility               |
+| -------------------- | ------------------------------------------------------- | ------------------------ |
+| **SAVE TO FOLDER**   | `VaultControls.svelte` (replaces SYNC)                  | High — always visible    |
+| **LOAD FROM FOLDER** | `VaultSwitcherModal.svelte` (next to active vault name) | Low — maintenance action |
+
+Load is intentionally tucked away in the vault selector. It's a deliberate pull for users
+who edit files externally (Obsidian, etc.) — not something most users need on every session.
+
+---
+
+## What changes in the code
+
+### Engine (`sync-engine`)
+
+Add a `direction` parameter to `SyncPlanner.plan()`:
+
+```ts
+type SyncDirection = "push" | "pull";
+
+// Push mode — OPFS → local folder
+// Keeps:  EXPORT_TO_FS, DELETE_FS
+// Drops:  IMPORT_TO_OPFS, DELETE_OPFS, HANDLE_CONFLICT
+
+// Pull mode — local folder → OPFS
+// Keeps:  IMPORT_TO_OPFS, DELETE_OPFS
+// Drops:  EXPORT_TO_FS, DELETE_FS, HANDLE_CONFLICT
+```
+
+`HANDLE_CONFLICT` is dropped in both modes — conflicts are structurally impossible
+when only one direction is ever written at a time.
+
+### Store (`apps/web`)
+
+| Current                                              | Proposed                                                   |
+| ---------------------------------------------------- | ---------------------------------------------------------- |
+| `syncWithLocalFolder()` — bidirectional              | `vault.push()` and `vault.pull()`                          |
+| SYNC button (bidirectional)                          | SAVE TO FOLDER (push) in VaultControls                     |
+| _(missing)_                                          | LOAD FROM FOLDER (pull) in VaultSwitcherModal              |
+| Switch calls flush + sync                            | Switch calls flush only (no filesystem touch)              |
+| Two independent status fields                        | One shared `VaultStatus = "idle" \| "saving" \| "loading"` |
+| `window CustomEvent` + `vaultEventBus` (dual events) | Consolidate to `vaultEventBus` only                        |
+
+---
+
+## Small fixes to land alongside
+
+| Fix                                                                      | Where                    | Effort |
+| ------------------------------------------------------------------------ | ------------------------ | ------ |
+| Vault ID guard in `_persistEntity()` — discard if vault changed mid-save | `entity-store.svelte.ts` | 5 min  |
+| Set `status → idle` only after maps + canvases finish loading            | `sync-store.svelte.ts`   | 15 min |
+| Parallelize `loadMaps()` + `loadCanvases()`                              | `sync-store.svelte.ts`   | 10 min |
+| Per-vault Oracle chat save/restore (issue #691)                          | `oracle.svelte.ts`       | 2–3 h  |

--- a/packages/oracle-engine/src/chat-history.svelte.ts
+++ b/packages/oracle-engine/src/chat-history.svelte.ts
@@ -26,6 +26,7 @@ export class ChatHistoryService {
   private db: AppSettingsStore | null = null;
   private vaultId: string | null = null;
   private debounceTimeout: ReturnType<typeof setTimeout> | null = null;
+  private switchSequence = 0;
 
   private get key() {
     return `chat_history_${this.vaultId ?? "default"}`;
@@ -40,16 +41,26 @@ export class ChatHistoryService {
   async init(db: AppSettingsStore, vaultId: string) {
     this.db = db;
     this.vaultId = vaultId;
-    const savedMessages = await db.appSettings.get(this.key);
-    if (savedMessages?.value && Array.isArray(savedMessages.value)) {
-      // Restore blob URLs for persisted blobs
-      const messages = savedMessages.value.map((msg: ChatHistoryRecord) => {
+    let saved = await db.appSettings.get(this.key);
+    // One-time migration from the legacy flat key used before per-vault scoping
+    if (!saved?.value) {
+      const legacy = await db.appSettings.get("chat_history");
+      if (legacy?.value && Array.isArray(legacy.value)) {
+        saved = legacy;
+        await db.appSettings.put({
+          key: this.key,
+          value: legacy.value,
+          updatedAt: Date.now(),
+        });
+      }
+    }
+    if (saved?.value && Array.isArray(saved.value)) {
+      this.messages = saved.value.map((msg: ChatHistoryRecord) => {
         if (msg.imageBlob && !msg.imageUrl) {
           msg.imageUrl = URL.createObjectURL(msg.imageBlob);
         }
         return msg;
       });
-      this.messages = messages;
     }
   }
 
@@ -58,18 +69,27 @@ export class ChatHistoryService {
    * chat history. Current messages are already persisted (saved on every mutation).
    */
   async switchVault(newVaultId: string) {
+    const seq = ++this.switchSequence;
+
     if (this.debounceTimeout) {
       clearTimeout(this.debounceTimeout);
       this.debounceTimeout = null;
       await this.saveToDB();
     }
+
+    if (seq !== this.switchSequence) return;
+
     this.messages.forEach((m) => {
       if (m.imageUrl?.startsWith("blob:")) URL.revokeObjectURL(m.imageUrl);
     });
     this.messages = [];
     this.vaultId = newVaultId;
     if (!this.db) return;
+
     const saved = await this.db.appSettings.get(this.key);
+
+    if (seq !== this.switchSequence) return;
+
     if (saved?.value && Array.isArray(saved.value)) {
       this.messages = saved.value.map((msg: ChatHistoryRecord) => {
         if (msg.imageBlob && !msg.imageUrl) {

--- a/packages/oracle-engine/src/chat-history.svelte.ts
+++ b/packages/oracle-engine/src/chat-history.svelte.ts
@@ -24,16 +24,23 @@ export class ChatHistoryService {
   messages = $state<ChatMessage[]>([]);
   lastUpdated = $state<number>(0);
   private db: AppSettingsStore | null = null;
+  private vaultId: string | null = null;
   private debounceTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  private get key() {
+    return `chat_history_${this.vaultId ?? "default"}`;
+  }
 
   /**
    * Initialize the chat history service by loading saved messages from IndexedDB.
    * Restores blob URLs for any persisted image blobs.
    * @param db - The EntityDb instance for persistence
+   * @param vaultId - The active vault ID, used to scope the IDB key
    */
-  async init(db: AppSettingsStore) {
+  async init(db: AppSettingsStore, vaultId: string) {
     this.db = db;
-    const savedMessages = await db.appSettings.get("chat_history");
+    this.vaultId = vaultId;
+    const savedMessages = await db.appSettings.get(this.key);
     if (savedMessages?.value && Array.isArray(savedMessages.value)) {
       // Restore blob URLs for persisted blobs
       const messages = savedMessages.value.map((msg: ChatHistoryRecord) => {
@@ -43,6 +50,33 @@ export class ChatHistoryService {
         return msg;
       });
       this.messages = messages;
+    }
+  }
+
+  /**
+   * Called on vault switch. Clears in-memory messages and loads the new vault's
+   * chat history. Current messages are already persisted (saved on every mutation).
+   */
+  async switchVault(newVaultId: string) {
+    if (this.debounceTimeout) {
+      clearTimeout(this.debounceTimeout);
+      this.debounceTimeout = null;
+      await this.saveToDB();
+    }
+    this.messages.forEach((m) => {
+      if (m.imageUrl?.startsWith("blob:")) URL.revokeObjectURL(m.imageUrl);
+    });
+    this.messages = [];
+    this.vaultId = newVaultId;
+    if (!this.db) return;
+    const saved = await this.db.appSettings.get(this.key);
+    if (saved?.value && Array.isArray(saved.value)) {
+      this.messages = saved.value.map((msg: ChatHistoryRecord) => {
+        if (msg.imageBlob && !msg.imageUrl) {
+          msg.imageUrl = URL.createObjectURL(msg.imageBlob);
+        }
+        return msg;
+      });
     }
   }
 
@@ -138,7 +172,7 @@ export class ChatHistoryService {
    * Failures are silently ignored as chat history is non-critical.
    */
   async saveToDB() {
-    if (!this.db) return;
+    if (!this.db || !this.vaultId) return;
     try {
       const messagesToPersist = $state.snapshot(this.messages).map((msg) => {
         const toPersist = { ...msg };
@@ -150,7 +184,7 @@ export class ChatHistoryService {
         return toPersist;
       });
       await this.db.appSettings.put({
-        key: "chat_history",
+        key: this.key,
         value: messagesToPersist,
         updatedAt: Date.now(),
       });

--- a/packages/oracle-engine/src/chat-history.test.ts
+++ b/packages/oracle-engine/src/chat-history.test.ts
@@ -132,6 +132,124 @@ describe("ChatHistoryService", () => {
     expect(() => service.destroy()).not.toThrow();
   });
 
+  it("should save to DB using the per-vault scoped key", async () => {
+    await service.init(mockDB, "vault-abc");
+    await service.addMessage({
+      id: "1",
+      role: "user",
+      content: "hello",
+    } as any);
+    const putCall = mockDB.appSettings.put.mock.calls.at(-1)[0];
+    expect(putCall.key).toBe("chat_history_vault-abc");
+  });
+
+  it("should migrate messages from the legacy flat key on first init", async () => {
+    const legacyMessages = [
+      { id: "legacy-1", role: "user", content: "old msg" },
+    ];
+    mockDB.appSettings.get.mockImplementation(async (key: string) => {
+      if (key === "chat_history") return { value: legacyMessages };
+      return undefined;
+    });
+
+    await service.init(mockDB, "vault-1");
+
+    expect(service.messages).toHaveLength(1);
+    expect(service.messages[0].id).toBe("legacy-1");
+    expect(mockDB.appSettings.put).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "chat_history_vault-1" }),
+    );
+  });
+
+  describe("switchVault", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should flush a pending debounced save before switching vault", async () => {
+      await service.init(mockDB, "vault-1");
+      const msg = { id: "m1", role: "assistant", content: "c" } as any;
+      await service.addMessage(msg);
+      mockDB.appSettings.put.mockClear();
+
+      // Trigger debounce (timer not yet fired)
+      await service.addProposal("m1", { title: "P1" });
+      expect(mockDB.appSettings.put).not.toHaveBeenCalled();
+
+      mockDB.appSettings.get.mockResolvedValue(undefined);
+      await service.switchVault("vault-2");
+
+      // Flush must have saved under the OLD vault key
+      expect(mockDB.appSettings.put).toHaveBeenCalledWith(
+        expect.objectContaining({ key: "chat_history_vault-1" }),
+      );
+    });
+
+    it("should load messages for the new vault after switching", async () => {
+      await service.init(mockDB, "vault-1");
+      mockDB.appSettings.get.mockResolvedValue({
+        value: [{ id: "m2", role: "user", content: "vault-2 msg" }],
+      });
+
+      await service.switchVault("vault-2");
+
+      expect(service.messages).toHaveLength(1);
+      expect(service.messages[0].id).toBe("m2");
+    });
+
+    it("should revoke blob URLs from the old vault on switch", async () => {
+      vi.stubGlobal("URL", {
+        revokeObjectURL: vi.fn(),
+        createObjectURL: vi.fn(() => "new-url"),
+      });
+
+      await service.init(mockDB, "vault-1");
+      service.messages = [
+        {
+          id: "old",
+          role: "assistant",
+          content: "c",
+          imageUrl: "blob:old",
+        } as any,
+      ];
+
+      mockDB.appSettings.get.mockResolvedValue(undefined);
+      await service.switchVault("vault-2");
+
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:old");
+      vi.unstubAllGlobals();
+    });
+
+    it("should only apply results from the last concurrent switch call", async () => {
+      await service.init(mockDB, "vault-1");
+
+      // Two rapid switches: vault-2 then vault-3
+      let resolveVault2: (v: any) => void;
+      const vault2Promise = new Promise((res) => (resolveVault2 = res));
+      mockDB.appSettings.get.mockImplementationOnce(() => vault2Promise);
+      mockDB.appSettings.get.mockResolvedValue({
+        value: [{ id: "v3-msg", role: "user", content: "from vault 3" }],
+      });
+
+      const switch2 = service.switchVault("vault-2");
+      const switch3 = service.switchVault("vault-3");
+
+      // Resolve vault-2 after vault-3 has already won the sequence
+      resolveVault2!({
+        value: [{ id: "v2-msg", role: "user", content: "from vault 2" }],
+      });
+
+      await Promise.all([switch2, switch3]);
+
+      // vault-3 wins; vault-2 result must be discarded
+      expect(service.messages.every((m) => m.id !== "v2-msg")).toBe(true);
+    });
+  });
+
   describe("addProposal", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/packages/oracle-engine/src/chat-history.test.ts
+++ b/packages/oracle-engine/src/chat-history.test.ts
@@ -27,12 +27,12 @@ describe("ChatHistoryService", () => {
   });
 
   it("should initialize with empty messages", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     expect(service.messages).toEqual([]);
   });
 
   it("should add a message and save to DB", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     const msg = { id: "1", role: "user", content: "hello" } as any;
     await service.addMessage(msg);
     expect(service.messages.length).toBe(1);
@@ -41,7 +41,7 @@ describe("ChatHistoryService", () => {
   });
 
   it("should remove a message", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     const msg = { id: "1", role: "user", content: "hello" } as any;
     await service.addMessage(msg);
     await service.removeMessage("1");
@@ -55,14 +55,14 @@ describe("ChatHistoryService", () => {
         { id: "1", role: "assistant", imageBlob: new Blob([]), content: "img" },
       ],
     });
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     expect(service.messages[0].imageUrl).toBe("restored-url");
     vi.unstubAllGlobals();
   });
 
   it("should handle removeMessage with blob URL", async () => {
     vi.stubGlobal("URL", { revokeObjectURL: vi.fn() });
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     const msg = { id: "1", role: "assistant", imageUrl: "blob:123" } as any;
     await service.addMessage(msg);
     await service.removeMessage("1");
@@ -71,7 +71,7 @@ describe("ChatHistoryService", () => {
   });
 
   it("should strip blob URLs when saving to DB", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     const msg = {
       id: "1",
       role: "assistant",
@@ -86,21 +86,21 @@ describe("ChatHistoryService", () => {
   });
 
   it("should start wizard", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     await service.startWizard("connection");
     expect(service.messages[0].type).toBe("wizard");
     expect(service.messages[0].wizardType).toBe("connection");
   });
 
   it("should update message entity", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     await service.addMessage({ id: "m1", role: "user", content: "c" } as any);
     service.updateMessageEntity("m1", "e1");
     expect(service.messages[0].archiveTargetId).toBe("e1");
   });
 
   it("should handle saveToDB error gracefully", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
     mockDB.appSettings.put.mockImplementation(() => {
       throw new Error("IDB fail");
     });
@@ -111,7 +111,7 @@ describe("ChatHistoryService", () => {
 
   it("should revoke blob URLs on destroy", async () => {
     vi.stubGlobal("URL", { revokeObjectURL: vi.fn() });
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
 
     const msg = { id: "1", role: "assistant", imageUrl: "blob:test123" } as any;
     await service.addMessage(msg);
@@ -123,7 +123,7 @@ describe("ChatHistoryService", () => {
   });
 
   it("should handle destroy with no blob URLs", async () => {
-    await service.init(mockDB);
+    await service.init(mockDB, "vault-1");
 
     const msg = { id: "1", role: "user", content: "hello" } as any;
     await service.addMessage(msg);
@@ -142,7 +142,7 @@ describe("ChatHistoryService", () => {
     });
 
     it("should add proposal to message and debounce persistence", async () => {
-      await service.init(mockDB);
+      await service.init(mockDB, "vault-1");
       const msg = { id: "m1", role: "assistant", content: "c" } as any;
       await service.addMessage(msg);
       mockDB.appSettings.put.mockClear();
@@ -160,7 +160,7 @@ describe("ChatHistoryService", () => {
     });
 
     it("should ignore duplicate proposals by title", async () => {
-      await service.init(mockDB);
+      await service.init(mockDB, "vault-1");
       const msg = {
         id: "m1",
         role: "assistant",
@@ -174,7 +174,7 @@ describe("ChatHistoryService", () => {
     });
 
     it("should clear debounce timeout on destroy", async () => {
-      await service.init(mockDB);
+      await service.init(mockDB, "vault-1");
       const msg = { id: "m1", role: "assistant", content: "c" } as any;
       await service.addMessage(msg);
 

--- a/specs/039-multi-campaign-switch/data-model.md
+++ b/specs/039-multi-campaign-switch/data-model.md
@@ -41,7 +41,7 @@ A global collection of all `VaultRecord` entries.
 CodexCryptica (v5)
 ├── settings        # key-value pairs (activeVaultId, defaultVisibility, etc.)
 ├── vault_cache     # file-level caching (path → lastModified + entity)
-├── chat_history    # oracle chat messages
+├── chat_history_{vaultId}  # oracle chat messages, scoped per vault (e.g. chat_history_abc123)
 ├── world_eras      # timeline era data
 └── vaults          # VaultRecord entries (keyPath: id)
 ```

--- a/specs/067-oracle-store-refactor/contracts/chat-history.ts
+++ b/specs/067-oracle-store-refactor/contracts/chat-history.ts
@@ -2,7 +2,8 @@ export interface IChatHistoryService {
   messages: ChatMessage[];
   lastUpdated: number;
 
-  init(): Promise<void>;
+  init(db: AppSettingsStore, vaultId: string): Promise<void>;
+  switchVault(newVaultId: string): Promise<void>;
   addMessage(msg: ChatMessage): Promise<void>;
   removeMessage(id: string): Promise<void>;
   clearMessages(): Promise<void>;


### PR DESCRIPTION
## Summary

- Oracle chat history is now scoped per vault — messages no longer bleed across vault switches
- IDB key changed from `chat_history` to `chat_history_{vaultId}`
- `ChatHistoryService` gains a `switchVault()` method that flushes any pending debounced save, revokes stale blob URLs, then loads the new vault's history
- `oracle.svelte.ts` subscribes to the `vault-switched` window event and calls `switchVault()` accordingly
- Two stale speckit specs updated to reflect the new key schema and interface signature
- `docs/VAULT_SYNC_PROPOSALS.md` added — analysis of the vault save/load architecture with directional push/pull proposal

## Test plan

- [ ] Create two vaults, add chat messages in each, switch between them — messages should stay separate
- [ ] Reload the app — chat history should persist per vault
- [ ] Verify no blob URL leaks when switching vaults (DevTools Memory tab)
- [ ] Run unit tests: `pnpm test --filter oracle-engine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)