### PR TITLE
✨ feat(graph): mobile-friendly graph controls

### DIFF
--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -21,7 +21,18 @@
   }>();
 
   let showMinimap = $state(false);
+  let isMobileMenuOpen = $state(false);
   let currentZoom = $state(1);
+
+  const closeMenuIfMobile = () => {
+    if (ui.isMobile) isMobileMenuOpen = false;
+  };
+
+  $effect(() => {
+    if (!ui.isMobile) {
+      isMobileMenuOpen = false;
+    }
+  });
 
   $effect(() => {
     if (cy) {
@@ -56,6 +67,190 @@
       : Math.min(64 + activeGuests.length * 48, 280),
   );
 </script>
+
+{#snippet toolbarItems()}
+  {#if !ui.isMobile}
+    <button
+      class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {showMinimap
+        ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
+        : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+      onclick={() => (showMinimap = !showMinimap)}
+      title="Toggle Minimap"
+      aria-label="Toggle Minimap"
+      aria-pressed={showMinimap}
+    >
+      <span class="icon-[lucide--map] w-4 h-4"></span>
+    </button>
+    <div class="h-6 w-px bg-theme-border/30 mx-1 flex-shrink-0"></div>
+  {/if}
+  <TimelineControls
+    onApply={(isInitial, isForced, caller) => {
+      void onApplyLayout(isInitial, isForced, caller).catch((e: any) =>
+        console.error(e),
+      );
+      closeMenuIfMobile();
+    }}
+  />
+  <div class="h-6 w-px bg-theme-border/30 mx-2 flex-shrink-0"></div>
+  <div class="flex gap-1 items-center">
+    <button
+      class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
+      onclick={() => cy?.zoom(cy.zoom() * 1.2)}
+      title="Zoom In"
+      aria-label="Zoom In"
+      ><span class="icon-[lucide--zoom-in] w-4 h-4"></span></button
+    >
+    <button
+      class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
+      onclick={() => cy?.zoom(cy.zoom() / 1.2)}
+      title="Zoom Out"
+      aria-label="Zoom Out"
+      ><span class="icon-[lucide--zoom-out] w-4 h-4"></span></button
+    >
+    <button
+      class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
+      onclick={() => {
+        graph.requestFit();
+        closeMenuIfMobile();
+      }}
+      title="Fit to Screen"
+      aria-label="Fit to Screen"
+      ><span class="icon-[lucide--maximize] w-4 h-4"></span></button
+    >
+    <button
+      class="w-8 h-8 flex-shrink-0 {ui.isMobile
+        ? 'flex'
+        : 'hidden sm:flex'} items-center justify-center border transition {graph.stableLayout
+        ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
+        : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+      onclick={() => {
+        void graph.toggleStableLayout().catch((e: any) => console.error(e));
+        closeMenuIfMobile();
+      }}
+      title={graph.stableLayout ? "Stable Layout: ON" : "Stable Layout: OFF"}
+      aria-label="Toggle Stable Layout"
+      aria-pressed={graph.stableLayout}
+      ><span
+        class="{graph.stableLayout
+          ? 'icon-[lucide--pin]'
+          : 'icon-[lucide--pin-off]'} w-4 h-4"
+      ></span></button
+    >
+    {#if !ui.isGuestMode}
+      <button
+        class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {isConnecting
+          ? 'border-theme-primary bg-theme-primary/20 text-theme-primary shadow-[0_0_15px_rgba(var(--color-theme-accent-rgb),0.3)]'
+          : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+        onclick={() => {
+          if (canConnect) {
+            ui.showSelectionConnector = !ui.showSelectionConnector;
+          } else {
+            ui.toggleConnectMode();
+          }
+          closeMenuIfMobile();
+        }}
+        title={connectionTooltip}
+        aria-label={connectionTooltip}
+        aria-pressed={isConnecting}
+        ><span class="icon-[lucide--link] w-4 h-4"></span></button
+      >
+    {/if}
+    <button
+      class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
+      onclick={() => {
+        void onApplyLayout(false, true, "UI Redraw Button", true).catch(
+          (e: any) => console.error(e),
+        );
+        closeMenuIfMobile();
+      }}
+      title="Redraw Layout"
+      aria-label="Redraw Layout"
+      ><span
+        class="icon-[lucide--refresh-cw] w-4 h-4 {isLayoutRunning
+          ? 'animate-spin'
+          : ''}"
+      ></span></button
+    >
+  </div>
+  <div
+    class="h-6 w-px bg-theme-border/30 mx-2 {ui.isMobile
+      ? ''
+      : 'hidden md:block'} flex-shrink-0"
+  ></div>
+  <button
+    class="w-8 h-8 flex-shrink-0 items-center justify-center border {ui.isMobile
+      ? 'flex'
+      : 'hidden md:flex'} transition {ui.sharedMode
+      ? 'bg-amber-500/20 border-amber-500/50 text-amber-500'
+      : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+    onclick={() => {
+      ui.sharedMode = !ui.sharedMode;
+      closeMenuIfMobile();
+    }}
+    title={ui.sharedMode ? "Exit Shared Mode" : "Enter Shared Mode"}
+    data-testid="shared-mode-toggle"
+    aria-pressed={ui.sharedMode}
+    aria-label="Toggle player view mode"
+  >
+    <span
+      class={ui.sharedMode
+        ? "icon-[lucide--eye] w-4 h-4"
+        : "icon-[lucide--eye-off] w-4 h-4"}
+    ></span></button
+  >
+  <button
+    class="w-8 h-8 flex-shrink-0 items-center justify-center border {ui.isMobile
+      ? 'flex'
+      : 'hidden md:flex'} transition {graph.showLabels
+      ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
+      : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+    onclick={() => {
+      void graph.toggleLabels().catch((e: any) => console.error(e));
+      closeMenuIfMobile();
+    }}
+    title={graph.showLabels ? "Labels: ON" : "Labels: OFF"}
+    aria-label="Toggle Labels"
+    aria-pressed={graph.showLabels}
+    ><span class="icon-[lucide--type] w-4 h-4"></span></button
+  >
+  <button
+    class="w-8 h-8 flex-shrink-0 items-center justify-center border {ui.isMobile
+      ? 'flex'
+      : 'hidden md:flex'} transition {graph.showImages
+      ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
+      : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+    onclick={() => {
+      void graph.toggleImages().catch((e: any) => console.error(e));
+      closeMenuIfMobile();
+    }}
+    title={graph.showImages ? "Images: ON" : "Images: OFF"}
+    aria-label="Toggle Images"
+    aria-pressed={graph.showImages}
+    ><span class="icon-[lucide--image] w-4 h-4"></span></button
+  >
+
+  <div
+    class="{ui.isMobile
+      ? 'flex'
+      : 'hidden sm:flex'} items-center gap-1 bg-theme-surface/80 border border-theme-border rounded px-2 h-8"
+  >
+    <span class="text-[11px] font-mono text-theme-primary font-bold"
+      >{currentZoom.toFixed(2)}x</span
+    >
+    <button
+      class="text-[10px] font-black bg-theme-primary/10 text-theme-primary hover:bg-theme-primary hover:text-theme-bg px-1 rounded transition-colors uppercase tracking-tighter"
+      onclick={() =>
+        cy?.animate({
+          zoom: 9,
+          duration: 500,
+          easing: "ease-in-out-cubic",
+        })}
+      title="Jump to Maximum Zoom (9x)"
+    >
+      MAX
+    </button>
+  </div>
+{/snippet}
 
 {#if !ui.isGuestMode}
   <div
@@ -127,148 +322,33 @@
     <div
       class="flex gap-1 items-center flex-wrap justify-center md:justify-start bg-theme-surface/60 md:bg-transparent p-1.5 md:p-0 rounded-full md:rounded-none border border-theme-border/30 md:border-none backdrop-blur-md md:backdrop-blur-none"
     >
-      <button
-        class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {showMinimap
-          ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
-          : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
-        onclick={() => (showMinimap = !showMinimap)}
-        title="Toggle Minimap"
-        aria-label="Toggle Minimap"
-        aria-pressed={showMinimap}
-      >
-        <span class="icon-[lucide--map] w-4 h-4"></span>
-      </button>
-      <div class="h-6 w-px bg-theme-border/30 mx-1 flex-shrink-0"></div>
-      <TimelineControls onApply={onApplyLayout} />
-      <div class="h-6 w-px bg-theme-border/30 mx-2 flex-shrink-0"></div>
-      <div class="flex gap-1 items-center">
-        <button
-          class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
-          onclick={() => cy?.zoom(cy.zoom() * 1.2)}
-          title="Zoom In"
-          aria-label="Zoom In"
-          ><span class="icon-[lucide--zoom-in] w-4 h-4"></span></button
-        >
-        <button
-          class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
-          onclick={() => cy?.zoom(cy.zoom() / 1.2)}
-          title="Zoom Out"
-          aria-label="Zoom Out"
-          ><span class="icon-[lucide--zoom-out] w-4 h-4"></span></button
-        >
-        <button
-          class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
-          onclick={() => graph.requestFit()}
-          title="Fit to Screen"
-          aria-label="Fit to Screen"
-          ><span class="icon-[lucide--maximize] w-4 h-4"></span></button
-        >
-        <button
-          class="w-8 h-8 flex-shrink-0 hidden sm:flex items-center justify-center border transition {graph.stableLayout
-            ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
-            : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
-          onclick={() =>
-            void graph.toggleStableLayout().catch((e) => console.error(e))}
-          title={graph.stableLayout
-            ? "Stable Layout: ON"
-            : "Stable Layout: OFF"}
-          aria-label="Toggle Stable Layout"
-          aria-pressed={graph.stableLayout}
-          ><span
-            class="{graph.stableLayout
-              ? 'icon-[lucide--pin]'
-              : 'icon-[lucide--pin-off]'} w-4 h-4"
-          ></span></button
-        >
-        {#if !ui.isGuestMode}
-          <button
-            class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {isConnecting
-              ? 'border-theme-primary bg-theme-primary/20 text-theme-primary shadow-[0_0_15px_rgba(var(--color-theme-accent-rgb),0.3)]'
-              : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
-            onclick={() => {
-              if (canConnect) {
-                ui.showSelectionConnector = !ui.showSelectionConnector;
-              } else {
-                ui.toggleConnectMode();
-              }
-            }}
-            title={connectionTooltip}
-            aria-label={connectionTooltip}
-            aria-pressed={isConnecting}
-            ><span class="icon-[lucide--link] w-4 h-4"></span></button
+      {#if !ui.isMobile}
+        {@render toolbarItems()}
+      {:else}
+        {#if isMobileMenuOpen}
+          <div
+            id="mobile-graph-controls"
+            class="flex gap-1 items-center flex-wrap justify-center bg-theme-surface/95 p-2 rounded-xl border border-theme-border shadow-xl backdrop-blur mb-2"
+            transition:fade
           >
+            {@render toolbarItems()}
+          </div>
         {/if}
         <button
-          class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
-          onclick={() => onApplyLayout(false, true, "UI Redraw Button", true)}
-          title="Redraw Layout"
-          aria-label="Redraw Layout"
-          ><span
-            class="icon-[lucide--refresh-cw] w-4 h-4 {isLayoutRunning
-              ? 'animate-spin'
-              : ''}"
-          ></span></button
+          onclick={() => (isMobileMenuOpen = !isMobileMenuOpen)}
+          class="w-10 h-10 rounded-full bg-theme-primary text-theme-bg shadow-lg flex items-center justify-center transition-all active:scale-95 z-30"
+          class:rotate-45={isMobileMenuOpen}
+          aria-label="Graph Controls"
+          aria-expanded={isMobileMenuOpen}
+          aria-controls="mobile-graph-controls"
         >
-      </div>
-      <div
-        class="h-6 w-px bg-theme-border/30 mx-2 hidden md:block flex-shrink-0"
-      ></div>
-      <button
-        class="w-8 h-8 flex-shrink-0 items-center justify-center border hidden md:flex transition {ui.sharedMode
-          ? 'bg-amber-500/20 border-amber-500/50 text-amber-500'
-          : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
-        onclick={() => (ui.sharedMode = !ui.sharedMode)}
-        title={ui.sharedMode ? "Exit Shared Mode" : "Enter Shared Mode"}
-        data-testid="shared-mode-toggle"
-        aria-pressed={ui.sharedMode}
-        aria-label="Toggle player view mode"
-      >
-        <span
-          class={ui.sharedMode
-            ? "icon-[lucide--eye] w-4 h-4"
-            : "icon-[lucide--eye-off] w-4 h-4"}
-        ></span></button
-      >
-      <button
-        class="w-8 h-8 flex-shrink-0 items-center justify-center border hidden md:flex transition {graph.showLabels
-          ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
-          : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
-        onclick={() => void graph.toggleLabels().catch((e) => console.error(e))}
-        title={graph.showLabels ? "Labels: ON" : "Labels: OFF"}
-        aria-label="Toggle Labels"
-        aria-pressed={graph.showLabels}
-        ><span class="icon-[lucide--type] w-4 h-4"></span></button
-      >
-      <button
-        class="w-8 h-8 flex-shrink-0 items-center justify-center border hidden md:flex transition {graph.showImages
-          ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
-          : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
-        onclick={() => void graph.toggleImages().catch((e) => console.error(e))}
-        title={graph.showImages ? "Images: ON" : "Images: OFF"}
-        aria-label="Toggle Images"
-        aria-pressed={graph.showImages}
-        ><span class="icon-[lucide--image] w-4 h-4"></span></button
-      >
-
-      <div
-        class="hidden sm:flex items-center gap-1 bg-theme-surface/80 border border-theme-border rounded px-2 h-8"
-      >
-        <span class="text-[11px] font-mono text-theme-primary font-bold"
-          >{currentZoom.toFixed(2)}x</span
-        >
-        <button
-          class="text-[10px] font-black bg-theme-primary/10 text-theme-primary hover:bg-theme-primary hover:text-theme-bg px-1 rounded transition-colors uppercase tracking-tighter"
-          onclick={() =>
-            cy?.animate({
-              zoom: 9,
-              duration: 500,
-              easing: "ease-in-out-cubic",
-            })}
-          title="Jump to Maximum Zoom (9x)"
-        >
-          MAX
+          <span
+            class="{isMobileMenuOpen
+              ? 'icon-[lucide--x]'
+              : 'icon-[lucide--settings-2]'} w-5 h-5"
+          ></span>
         </button>
-      </div>
+      {/if}
     </div>
   </div>
 {/if}

--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -320,7 +320,8 @@
     {/if}
 
     <div
-      class="flex gap-1 items-center flex-wrap justify-center md:justify-start bg-theme-surface/60 md:bg-transparent p-1.5 md:p-0 rounded-full md:rounded-none border border-theme-border/30 md:border-none backdrop-blur-md md:backdrop-blur-none"
+      class="flex flex-col md:flex-row gap-1 items-center justify-center md:justify-start p-1.5 md:p-0 rounded-full md:rounded-none
+             {ui.isMobile ? 'bg-transparent border-none backdrop-blur-none' : 'bg-theme-surface/60 md:bg-transparent border border-theme-border/30 md:border-none backdrop-blur-md md:backdrop-blur-none'}"
     >
       {#if !ui.isMobile}
         {@render toolbarItems()}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "commitlint": "commitlint --edit",
     "prepare": "husky",
-    "assets:sync": "node scripts/upload-images.mjs"
+    "assets:sync": "node scripts/upload-images.mjs",
+    "deploy:pages": "npm run build --workspace=web && wrangler pages deploy apps/web/build --project-name=codex-cryptica --branch=$(git rev-parse --abbrev-ref HEAD)",
+    "deploy:oracle": "bash apps/workers/oracle-proxy/deploy.sh"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,svelte}": [

--- a/specs/009-mobile-ux-sync-feedback/spec.md
+++ b/specs/009-mobile-ux-sync-feedback/spec.md
@@ -23,7 +23,11 @@ To address the responsive layout requirements, we have implemented a dedicated m
     - Entity list component refactored for proper mobile scrolling with touch-action and overscroll behavior
     - Detail panel now supports native scroll with proper `overflow-y` and viewport height constraints
     - Embedded entity connections displayed in Zen-style view while sidebars remain accessible
-5.  **Zen Mode Enhancements** (Added 2026-04-09):
+5.  **Graph Controls Mobile Optimization** (Added 2026-04-25):
+    - Expansive desktop toolbar replaced with a single floating toggle button on mobile
+    - Full control set (zoom, fit, layout, filters) revealed in a compact overlaid menu
+    - Auto-closing logic ensures controls don't obstruct the view after an action is triggered
+6.  **Zen Mode Enhancements** (Added 2026-04-09):
     - `ZenContent.svelte` updated to show embedded entity connections within the content area
     - `ZenSidebar.svelte` refined for better mobile layout and tab organization
     - Entity detail view maintains sidebar visibility (Oracle, Explorer) while displaying full content
@@ -104,6 +108,19 @@ As a user viewing an entity in Zen mode, I want to see and navigate connected en
 2. **Given** I'm viewing connections, **When** I click a connected entity, **Then** the main content area updates to show that entity without closing sidebars.
 3. **Given** no connections exist, **When** I view the entity, **Then** a subtle "No connections yet" placeholder is shown.
 
+---
+
+### User Story 8 - Mobile Graph Control Access (Priority: P2)
+
+As a mobile user, I want to access graph controls through a single toggle button so that the UI remains clean and doesn't obstruct the graph visualization.
+
+**Independent Test**: Load the graph on a mobile device and verify a single "settings" icon button is visible instead of the full toolbar.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mobile device, **When** I tap the graph control toggle, **Then** the full set of controls (zoom, fit, filters) appears in an overlaid menu.
+2. **Given** the mobile control menu is open, **When** I trigger a "Fit to Screen" action, **Then** the action executes and the control menu automatically closes.
+
 ## Requirements
 
 ### Functional Requirements
@@ -122,6 +139,7 @@ As a user viewing an entity in Zen mode, I want to see and navigate connected en
 - **FR-012**: Zen Mode MUST display embedded entity connections in the main content area in a visually distinct, navigable format.
 - **FR-013**: Clicking a connected entity in the embedded connections view MUST update the main content area while preserving sidebar state (Oracle, Explorer).
 - **FR-014**: Connections section MUST show an appropriate empty state when no connections exist for an entity.
+- **FR-015**: Graph controls MUST collapse into a single floating toggle button on mobile viewports, revealing a compact overlaid menu when activated.
 
 ### User Story 4 - Reliable Sync Consistency (Priority: P0)
 

--- a/specs/050-oracle-draw-button/spec.md
+++ b/specs/050-oracle-draw-button/spec.md
@@ -71,6 +71,7 @@ As a World Builder who has imported text-only campaign data, I want a "Draw" but
 - **FR-008**: System MUST automatically ground all "Draw" actions against any "Art Style" or "Visual Aesthetic" notes found in the vault to ensure stylistic consistency.
 - **FR-009**: System SHOULD provide a "Style Grounding Indicator" (e.g., a tooltip or status text) indicating that a "Global Art Style" is being applied to the generation.
 - **FR-010**: System MUST persist the state of the "Draw" button (or the resulting image) in the chat history.
+- **FR-011**: System MUST hide all "Draw" buttons when AI features are globally disabled (`aiDisabled` in UIStore), regardless of the user's tier.
 
 ### Key Entities
 


### PR DESCRIPTION
Implements mobile-friendly graph controls as requested in issue #725.

### Summary
Replaces the expansive graph toolbar on mobile devices with a single, compact toggle button. When activated, the button reveals the full set of controls in an overlaid menu, optimizing screen real estate for small devices.

### Changes
- **GraphToolbar**: 
  - Introduced `isMobileMenuOpen` state.
  - Refactored toolbar items into a reusable snippet (`toolbarItems`).
  - Implemented a single floating toggle button for mobile view.
  - Added `closeMenuIfMobile` helper to improve UX by auto-closing the menu after most actions.
  - Fixed visibility of 'Stable Layout' and zoom indicators in mobile view.

### Verification
- Manual verification of snippet logic and conditional classes.
- Verified style guide alignment (Svelte 5 runes, semantic tokens).