### PR TITLE
feat(map): drag entities from Explorer to create map pins (#714)

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -17,7 +17,7 @@
   function onDragStart(event: DragEvent, entityId: string) {
     if (event.dataTransfer) {
       event.dataTransfer.setData("application/codex-entity", entityId);
-      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.effectAllowed = "copyMove";
     }
   }
 

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1075,15 +1075,15 @@
   onwheel={onWheel}
   onkeydown={onKeyDown}
   onkeyup={onKeyUp}
+  ondragover={onMapDragOver}
+  ondragleave={onMapDragLeave}
+  ondrop={onMapDrop}
 >
   <canvas
     bind:this={canvas}
     class="absolute inset-0 {mapSession.gridFitMode && mapStore.isGMMode
       ? 'cursor-crosshair'
       : ''} {mapSession.gridMoveMode && mapStore.isGMMode ? 'cursor-move' : ''}"
-    ondragover={onMapDragOver}
-    ondragleave={onMapDragLeave}
-    ondrop={onMapDrop}
   ></canvas>
 
   {#if !mapImage}

--- a/apps/web/src/lib/content/help/map-mode.md
+++ b/apps/web/src/lib/content/help/map-mode.md
@@ -20,7 +20,8 @@ rank: 3
 Connect your geography directly to your notes:
 
 - **Double-Click** anywhere on the map to create a new pin.
-- Use the **Link Lore** search box to connect the pin to an existing NPC, Location, or Item.
+- **Drag an entity** from the **Entity Explorer** sidebar and drop it anywhere on the map to instantly create a pin linked to that entity.
+- Use the **Link Lore** search box on a pin to connect it to an existing NPC, Location, or Item.
 - **Click a Pin** to instantly open its associated chronicle in the side panel.
 
 ### Fog of War (GM Only)

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -123,6 +123,8 @@
         } else {
           mapSession.addToken(tokenInput);
         }
+      } else if (entity && activeMap && !uiStore.isGuestMode) {
+        mapStore.addPin(entityId, mapCoords);
       }
       return;
     }

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -109,19 +109,20 @@
       const entity = vault.entities[entityId];
       const activeMap = mapStore.activeMap;
 
-      if (entity && VTT_ENTITY_TYPES.includes(entity.type) && activeMap) {
-        const tokenInput = {
-          name: entity.title,
-          entityId: entity.id,
-          imageUrl: entity.image,
-          x: mapCoords.x,
-          y: mapCoords.y,
-        };
-
-        if (uiStore.isGuestMode) {
-          mapSession.requestTokenAdd(tokenInput);
-        } else {
-          mapSession.addToken(tokenInput);
+      if (mapSession.vttEnabled) {
+        if (entity && VTT_ENTITY_TYPES.includes(entity.type) && activeMap) {
+          const tokenInput = {
+            name: entity.title,
+            entityId: entity.id,
+            imageUrl: entity.image,
+            x: mapCoords.x,
+            y: mapCoords.y,
+          };
+          if (uiStore.isGuestMode) {
+            mapSession.requestTokenAdd(tokenInput);
+          } else {
+            mapSession.addToken(tokenInput);
+          }
         }
       } else if (entity && activeMap && !uiStore.isGuestMode) {
         mapStore.addPin(entityId, mapCoords);
@@ -145,21 +146,24 @@
     const dt = e.dataTransfer;
     if (isEntityDrag(dt)) {
       dt!.dropEffect = "copy";
-      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      const mapCoords = mapStore.unproject({ x, y });
-      const entityId =
-        dt?.getData("application/codex-entity") ||
-        mapSession.dragPreview?.entityId;
 
-      if (!entityId) return;
+      if (mapSession.vttEnabled) {
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        const mapCoords = mapStore.unproject({ x, y });
+        const entityId =
+          dt?.getData("application/codex-entity") ||
+          mapSession.dragPreview?.entityId;
 
-      mapSession.setDragPreview({
-        entityId,
-        x: mapCoords.x,
-        y: mapCoords.y,
-      });
+        if (!entityId) return;
+
+        mapSession.setDragPreview({
+          entityId,
+          x: mapCoords.x,
+          y: mapCoords.y,
+        });
+      }
     }
   }
 

--- a/specs/058-map-mode/spec.md
+++ b/specs/058-map-mode/spec.md
@@ -33,8 +33,9 @@ As a Lore Keeper, I want to drop pins on my map and link them directly to my exi
 **Acceptance Scenarios**:
 
 1. **Given** a map is active, **When** I double-click/long-press an area, **Then** a new pin is created at those coordinates.
-2. **Given** a pin exists, **When** I select an existing chronicle to link, **Then** the pin's metadata is updated and the link is persisted.
-3. **Given** a linked pin, **When** I click it, **Then** the linked note opens in the side-panel.
+2. **Given** a map is active, **When** I drag an entity from the Entity Explorer and drop it on the map, **Then** a pin pre-linked to that entity is created at the drop position.
+3. **Given** a pin exists, **When** I select an existing chronicle to link, **Then** the pin's metadata is updated and the link is persisted.
+4. **Given** a linked pin, **When** I click it, **Then** the linked note opens in the side-panel.
 
 ---
 
@@ -88,6 +89,7 @@ As a Lore Keeper, I want to attach maps to specific entities (like a city or a t
 - **FR-001**: System MUST support high-resolution image uploads (JPG, PNG, WebP).
 - **FR-002**: System MUST persist pin coordinates relative to map image dimensions.
 - **FR-003**: System MUST allow linking pins to exactly one primary Entity ID.
+- **FR-003a**: System MUST support creating a pre-linked pin by dragging an entity from the Entity Explorer onto the map.
 - **FR-004**: System MUST adapt UI borders and grids based on the active theme (Sci-Fi vs Fantasy).
 - **FR-005**: System MUST provide a toggleable tactical grid (Hex/Square) over the map.
 - **FR-006**: System MUST support "Jump to Location" search that pans/zooms to a specific pin.


### PR DESCRIPTION
## Summary

- Entities dragged from the Entity Explorer onto the map now create lore pins at the drop position
- In VTT mode, the same drag creates battle tokens (existing behavior preserved)
- Fixed `effectAllowed = "copyMove"` in Explorer so drags work on both the canvas (`move`) and map (`copy`) without conflict

## How it works

The map's `ondragover`/`ondrop` handlers were already in place, but the Explorer set `effectAllowed = "move"` while the map requested `dropEffect = "copy"` — a mismatch that causes browsers to silently refuse the drop. Changing to `"copyMove"` allows both targets to accept the drag.

## Test plan

- [ ] Drag an entity from the Entity Explorer onto a map — a pin should appear at the drop position
- [ ] Drag the same entity onto the canvas — node should still be created (no regression)
- [ ] In VTT mode, drag a character/creature/item from the sidebar entity list — token should appear as before
- [ ] Double-clicking the map to create pins still works

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)