### PR TITLE
chore: unify vault load/save language

### DIFF
--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -142,7 +142,7 @@
     {#if isOffline}
       <div
         class="flex items-center gap-1.5 px-2 py-1 border border-amber-900/50 bg-amber-950/20 text-amber-500 rounded text-[9px] font-bold tracking-tighter cursor-help justify-center"
-        title="Sovereign data remains accessible. Cloud sync and Lore Oracle are suspended while offline."
+        title="Sovereign data remains accessible. Cloud-backed features and Lore Oracle are suspended while offline."
       >
         <span class="icon-[lucide--wifi-off] w-3.5 h-3.5"></span>
         <span class={isVertical ? "inline" : "hidden md:inline"}>OFFLINE</span>
@@ -301,11 +301,11 @@
               : ''} {!vault.hasSyncHandle || !vault.isDirty
               ? 'opacity-50'
               : ''}"
-            onclick={() => vault.push()}
+            onclick={() => vault.saveToFolder()}
             title={!vault.hasSyncHandle
               ? "No folder linked — connect a local folder first to enable saving."
               : vault.isDirty
-                ? "Save to file system — writes all changes from the internal archive to your linked folder."
+                ? "Save to folder — writes all changes from the internal archive to your linked folder."
                 : "Up to date with local folder."}
             aria-label="SAVE TO FOLDER"
             aria-busy={vault.status === "saving"}

--- a/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
+++ b/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
@@ -281,7 +281,7 @@
                 <button
                   type="button"
                   class="p-1.5 hover:bg-theme-border rounded text-theme-accent hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
-                  onclick={() => vault.pull()}
+                  onclick={() => vault.loadFromFolder()}
                   title="Load from Folder — pulls changes from your linked folder into the archive."
                   aria-label="Load from Folder"
                   disabled={isLoading || !!editingId}

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -154,23 +154,23 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
   },
   "local-folder-sync": {
     id: "local-folder-sync",
-    title: "Local Folder Mirroring",
+    title: "Load and Save Folders",
     content:
-      "Maintain an external mirror of your world data. Use the 'SAVE TO FOLDER' button to export your internal archive to a local directory for backups or editing in tools like Obsidian. Use 'LOAD FROM FOLDER' in the Vault Selector to pull external changes back into the app.",
+      "Use the linked folder as an external copy of your world. Save writes your internal archive to the folder for backups or editing in tools like Obsidian. Load pulls folder changes back into the app when you want to bring them in.",
     icon: "icon-[lucide--folder-sync]",
   },
   "vault-save": {
     id: "vault-save",
-    title: "Saving to Folder",
+    title: "Save to Folder",
     content:
-      "The 'SAVE TO FOLDER' button explicitly pushes your internal work to your linked local folder. It only enables when you have unsaved changes, ensuring your external backup stays current.",
+      "The 'SAVE TO FOLDER' button writes your internal work to the linked folder. It only enables when you have unsaved changes, keeping the folder copy current.",
     icon: "icon-[lucide--upload-cloud]",
   },
   "vault-load": {
     id: "vault-load",
-    title: "Loading from Folder",
+    title: "Load from Folder",
     content:
-      "Use 'LOAD FROM FOLDER' in the Vault Selector to refresh your internal archive with changes from your linked local directory. A safety gate will warn you if you have unsaved internal work that would be overwritten.",
+      "Use 'LOAD FROM FOLDER' in the Vault Selector to refresh your internal archive with changes from the linked folder. A safety gate warns you if unsaved internal work would be overwritten.",
     icon: "icon-[lucide--download-cloud]",
   },
   "total-privacy": {

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -192,7 +192,7 @@ export class VaultStore {
       repository: this.repository,
       activeVaultId: () => this.activeVaultId,
       getActiveVaultHandle: () => this.getActiveVaultHandle(),
-      loadFiles: (skipSync) => this.syncStore.loadFiles(skipSync),
+      loadFiles: (skipSync) => this.loadFiles(skipSync),
       flushPendingSaves: () => this.entityStore.flushPendingSaves(),
       ensureServicesInitialized: async () => {
         await this.serviceRegistry.ensureInitialized();
@@ -294,7 +294,7 @@ export class VaultStore {
     }
   }
 
-  // --- External Sync Methods ---
+  // --- External Folder Methods ---
 
   broadcastVaultUpdate() {
     this.messenger.broadcastVaultUpdate();
@@ -302,6 +302,14 @@ export class VaultStore {
 
   async loadFiles(skipSyncIfWarm = true) {
     return this.syncStore.loadFiles(skipSyncIfWarm);
+  }
+
+  async loadFromFolder() {
+    return this.pull();
+  }
+
+  async saveToFolder() {
+    return this.syncStore.push();
   }
 
   async push() {
@@ -312,9 +320,9 @@ export class VaultStore {
     return this.syncStore.pull();
   }
 
-  /** @deprecated use push() or pull() instead */
+  /** @deprecated use saveToFolder() instead */
   async syncWithLocalFolder() {
-    return this.syncStore.push();
+    return this.saveToFolder();
   }
 
   async cleanupConflictFiles(signal?: AbortSignal) {

--- a/apps/web/src/lib/stores/vault.test.ts
+++ b/apps/web/src/lib/stores/vault.test.ts
@@ -850,7 +850,7 @@ describe("VaultStore", () => {
       ).toHaveBeenCalled();
     });
 
-    it("should handle syncWithLocalFolder", async () => {
+    it("should handle saveToFolder", async () => {
       testVault.syncCoordinator = {
         push: vi.fn().mockImplementation((_id, _h, _e, _w, onState) => {
           onState({ status: "saving", syncType: "local" });
@@ -860,9 +860,23 @@ describe("VaultStore", () => {
       vi.mocked(vaultRegistry).activeVaultId = "v1" as any;
       vi.spyOn(testVault, "getActiveVaultHandle").mockResolvedValue({} as any);
 
-      await testVault.syncWithLocalFolder();
+      await testVault.saveToFolder();
       expect(testVault.syncCoordinator!.push).toHaveBeenCalled();
       expect(testVault.status).toBe("saving");
+    });
+
+    it("should handle loadFromFolder", async () => {
+      testVault.syncCoordinator = {
+        pull: vi.fn().mockImplementation((_id, _h, _e, _w, onState) => {
+          onState({ status: "loading", syncType: "local" });
+          return Promise.resolve();
+        }),
+      } as any;
+      vi.mocked(vaultRegistry).activeVaultId = "v1" as any;
+      vi.spyOn(testVault, "getActiveVaultHandle").mockResolvedValue({} as any);
+
+      await testVault.loadFromFolder();
+      expect(testVault.syncCoordinator!.pull).toHaveBeenCalled();
     });
 
     it("should handle error in checkForConflicts", async () => {

--- a/docs/refactoring/LOAD_SAVE_LANGUAGE_ANALYSIS.md
+++ b/docs/refactoring/LOAD_SAVE_LANGUAGE_ANALYSIS.md
@@ -1,0 +1,80 @@
+# Load/Save Language Analysis
+
+Issue: [#731](https://github.com/eserlan/Codex-Cryptica/issues/731)
+
+## Situation
+
+The repo currently uses `sync` for several different concepts:
+
+- User-facing actions that actually mean `load from folder` or `save to folder`
+- Internal coordination between the vault, OPFS, IndexedDB, and local folder handles
+- Historical names in docs, help content, and store/service APIs
+
+That makes the codebase harder to read because the same word is doing too much work. In the UI, users are not performing a vague sync action; they are either loading data from a folder or saving data to a folder. The internal engine still does reconciliation work, so `sync` is not wrong everywhere, but it is too broad for the app-facing surface.
+
+## What Is Already Clear
+
+- The vault UI already expresses parts of the flow directionally.
+- The save and load buttons can be described in plain language without losing accuracy.
+- The low-level engine and coordinator names are still serviceable as internal implementation details.
+
+## Recommended Direction
+
+Use `load` and `save` for anything the user sees or triggers directly.
+
+Keep `sync` only where the code is truly doing bidirectional reconciliation or internal plumbing that does not leak into the UI.
+
+This leads to a clean split:
+
+- `Load from Folder` for pulling folder data into the app
+- `Save to Folder` for writing app data back to the linked folder
+- `sync` only for reconciliation logic, conflict handling, and internal engine helpers
+
+## Proposed Scope
+
+### Phase 1: User-Facing Language
+
+Update the visible language in the vault UI first:
+
+- Button labels
+- Tooltips and aria labels
+- Status text
+- Help articles and docs that explain the folder workflow
+
+This gives the biggest clarity gain with the lowest risk.
+
+### Phase 2: Store API Wrappers
+
+Add explicit wrapper methods at the vault store boundary:
+
+- `loadFromFolder()`
+- `saveToFolder()`
+
+Keep the current `pull()` / `push()` methods as compatibility aliases for now if existing code still depends on them. That avoids a large breaking refactor while the terminology settles.
+
+### Phase 3: Internal Renames Only If Needed
+
+After the public surface is consistent, decide whether the internal names still need cleanup:
+
+- `SyncStore`
+- `SyncCoordinator`
+- `syncHandle_*`
+- file names and package names
+
+These can stay as implementation terms unless they continue to leak confusing language into the app.
+
+## What Not To Do Yet
+
+- Do not bulk rename every `sync` token in the repository.
+- Do not rename stable internal engine packages unless the current name is actively confusing users or maintainers.
+- Do not change deep-link IDs or file names unless there is a concrete reason.
+
+## Risks
+
+- A broad rename can create mixed terminology if it is only partially applied.
+- Renaming public APIs too early can create unnecessary churn in tests and call sites.
+- Changing help/article IDs may break links, so content can be rewritten before identifiers are renamed.
+
+## Practical Next Step
+
+Start with a focused terminology pass over the vault UI and help content, then add explicit `loadFromFolder` / `saveToFolder` wrappers at the vault boundary. After that, review whether the internal `sync` names are still acceptable or should be scheduled for a separate cleanup.

--- a/docs/refactoring/LOAD_SAVE_LANGUAGE_ANALYSIS.md
+++ b/docs/refactoring/LOAD_SAVE_LANGUAGE_ANALYSIS.md
@@ -78,3 +78,7 @@ These can stay as implementation terms unless they continue to leak confusing la
 ## Practical Next Step
 
 Start with a focused terminology pass over the vault UI and help content, then add explicit `loadFromFolder` / `saveToFolder` wrappers at the vault boundary. After that, review whether the internal `sync` names are still acceptable or should be scheduled for a separate cleanup.
+
+## Current PR
+
+This branch implements the first phase described above. For the merge-ready summary of what is included now versus what should stay for a later PR, see [LOAD_SAVE_LANGUAGE_NEXT_PHASE.md](/home/espen/proj/Codex-Arcana/docs/refactoring/LOAD_SAVE_LANGUAGE_NEXT_PHASE.md).

--- a/docs/refactoring/LOAD_SAVE_LANGUAGE_NEXT_PHASE.md
+++ b/docs/refactoring/LOAD_SAVE_LANGUAGE_NEXT_PHASE.md
@@ -23,8 +23,63 @@ This PR does not rename the deeper internal sync implementation yet:
 
 Those names remain in place intentionally so the change stays focused and mergeable.
 
+## Codewise Next Step
+
+The follow-up should remove `sync` terminology from the vault-facing code in layers, not as one giant rename.
+
+### 1. Add A Thin Vault Facade
+
+Keep `VaultStore` as the public entry point and introduce directional method names there first:
+
+- `loadFromFolder()` for folder-to-app reads
+- `saveToFolder()` for app-to-folder writes
+
+Let those methods delegate to the existing sync engine for now. That keeps the behavior unchanged while the terminology changes.
+
+### 2. Rename Vault Store Call Sites
+
+Update app code to call the directional methods instead of `push()`, `pull()`, or `syncWithLocalFolder()`:
+
+- `VaultControls.svelte`
+- `VaultSwitcherModal.svelte`
+- `VaultLifecycleManager`
+- any other vault UI or orchestration code that triggers folder reads or writes
+
+Keep `push()` and `pull()` only as compatibility aliases until the whole surface has moved over.
+
+### 3. Split Internal Naming By Responsibility
+
+Rename the implementation boundary only after the public facade is stable:
+
+- `SyncStore` can become a more explicit vault-folder service/store name
+- `SyncCoordinator` can become a folder reconciliation coordinator
+- helper names like `syncHandle_*` should become `folderHandle_*` or `vaultFolderHandle_*`
+
+The goal is to make internal names describe the actual responsibility instead of repeating `sync` everywhere.
+
+### 4. Normalize Local Status Language
+
+After the method names move, update the remaining status strings and errors to match the directional verbs:
+
+- `loading`
+- `saving`
+- `Load failed`
+- `Save failed`
+- `Load from Folder`
+- `Save to Folder`
+
+This keeps the UI vocabulary consistent with the code vocabulary.
+
+### 5. Clean Up Tests And Docs Together
+
+The rename should land with matching test updates so the repo does not end up with mixed terms:
+
+- update test names to `load` / `save`
+- keep one compatibility test for any alias that remains temporarily
+- rewrite docs/help content that still says “sync” when it really means load/save
+
 ## Recommended Next Step
 
 If the repo wants to fully retire `sync` from the vault subsystem, do that in a separate follow-up PR after this one merges.
 
-That follow-up should be scoped to internal naming only, so it can be reviewed independently from the user-facing wording change.
+That follow-up should be scoped to internal naming and call-site migration only, so it can be reviewed independently from the user-facing wording change.

--- a/docs/refactoring/LOAD_SAVE_LANGUAGE_NEXT_PHASE.md
+++ b/docs/refactoring/LOAD_SAVE_LANGUAGE_NEXT_PHASE.md
@@ -1,0 +1,30 @@
+# Load/Save Language Next Phase
+
+Related issue: [#731](https://github.com/eserlan/Codex-Cryptica/issues/731)
+
+Related analysis: [LOAD_SAVE_LANGUAGE_ANALYSIS.md](/home/espen/proj/Codex-Arcana/docs/refactoring/LOAD_SAVE_LANGUAGE_ANALYSIS.md)
+
+## What This PR Covers
+
+This PR is the first phase of the terminology cleanup:
+
+- user-facing vault actions now say `load` and `save`
+- the vault boundary exposes explicit `loadFromFolder()` and `saveToFolder()` entry points
+- help content and button labels use the directional language
+
+## What It Does Not Cover
+
+This PR does not rename the deeper internal sync implementation yet:
+
+- `SyncStore`
+- `SyncCoordinator`
+- `syncHandle_*`
+- other internal `sync`-named helpers and files
+
+Those names remain in place intentionally so the change stays focused and mergeable.
+
+## Recommended Next Step
+
+If the repo wants to fully retire `sync` from the vault subsystem, do that in a separate follow-up PR after this one merges.
+
+That follow-up should be scoped to internal naming only, so it can be reviewed independently from the user-facing wording change.


### PR DESCRIPTION
Draft PR for issue #731.

This pass makes the vault-facing language explicit around load/save instead of generic sync wording:
- adds `loadFromFolder()` / `saveToFolder()` entry points at the vault boundary
- updates the visible vault UI and help copy to use load/save language
- keeps internal sync plumbing in place for now
- includes a short analysis note in `docs/refactoring/LOAD_SAVE_LANGUAGE_ANALYSIS.md`

Validation:
- `npm run lint --workspace web -- src/lib/components/VaultControls.svelte src/lib/components/vaults/VaultSwitcherModal.svelte src/lib/config/help-content.ts src/lib/stores/vault.svelte.ts src/lib/stores/vault/lifecycle.ts`
- `npm run test --workspace web -- src/lib/stores/vault.test.ts src/lib/stores/vault/lifecycle.test.ts src/lib/stores/vault/sync-store.test.ts`