### PR TITLE
fix(canvas): address unresolved review comments from PR #735

### DIFF
--- a/apps/web/src/lib/components/canvas/CanvasHUD.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasHUD.svelte
@@ -3,17 +3,13 @@
   import { uiStore } from "$lib/stores/ui.svelte";
   import { canvasRegistry } from "$lib/stores/canvas-registry.svelte";
 
-  let { 
-    canvasName, 
-    activeCategories, 
-    onToggleCategory, 
-    onClearCategories 
-  } = $props<{
-    canvasName: string;
-    activeCategories: Set<string>;
-    onToggleCategory: (categoryId: string) => void;
-    onClearCategories: () => void;
-  }>();
+  let { canvasName, activeCategories, onToggleCategory, onClearCategories } =
+    $props<{
+      canvasName: string;
+      activeCategories: Set<string>;
+      onToggleCategory: (categoryId: string) => void;
+      onClearCategories: () => void;
+    }>();
 </script>
 
 <div
@@ -35,11 +31,13 @@
     ></span>
   </button>
 
-  <CategoryFilter
-    {activeCategories}
-    onToggle={onToggleCategory}
-    onClear={onClearCategories}
-  />
+  <div class="pointer-events-auto">
+    <CategoryFilter
+      {activeCategories}
+      onToggle={onToggleCategory}
+      onClear={onClearCategories}
+    />
+  </div>
 
   {#if canvasRegistry.status === "saving"}
     <div

--- a/apps/web/src/lib/components/canvas/use-canvas-events.svelte.ts
+++ b/apps/web/src/lib/components/canvas/use-canvas-events.svelte.ts
@@ -2,27 +2,27 @@ import { onMount } from "svelte";
 import { uiStore } from "$lib/stores/ui.svelte";
 
 export function useCanvasEvents(params: {
-  onQuickSpawn: (entityId: string, position?: { x: number; y: number }, screenPosition?: { x: number; y: number }) => void;
+  onQuickSpawn: (
+    entityId: string,
+    position?: { x: number; y: number },
+    screenPosition?: { x: number; y: number },
+  ) => void;
   onEditLabel: (edgeId: string, currentLabel: string) => void;
   onFlushSave: () => void;
 }) {
   onMount(() => {
     const handleDown = (e: KeyboardEvent) => {
-      if (e.key === "Control" || e.metaKey || e.ctrlKey) {
-        uiStore.isModifierPressed = true;
-      }
+      uiStore.isModifierPressed = e.ctrlKey || e.metaKey;
     };
     const handleUp = (e: KeyboardEvent) => {
-      if (e.key === "Control" || e.metaKey || e.ctrlKey) {
-        uiStore.isModifierPressed = false;
-      }
+      uiStore.isModifierPressed = e.ctrlKey || e.metaKey;
     };
-    
+
     const handleQuickSpawn = (event: CustomEvent) => {
       const { entityId, position, screenPosition } = event.detail;
       params.onQuickSpawn(entityId, position, screenPosition);
     };
-    
+
     const handleEditLabel = (event: CustomEvent) => {
       const { edgeId, currentLabel } = event.detail;
       params.onEditLabel(edgeId, currentLabel);
@@ -38,7 +38,7 @@ export function useCanvasEvents(params: {
     window.addEventListener("add-to-canvas", handleQuickSpawn as any);
     window.addEventListener("edit-edge-label", handleEditLabel as any);
     window.addEventListener("beforeunload", handleBeforeUnload);
-    window.addEventListener("visibilitychange", handleVisibilityChange);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       window.removeEventListener("keydown", handleDown);
@@ -46,7 +46,7 @@ export function useCanvasEvents(params: {
       window.removeEventListener("add-to-canvas", handleQuickSpawn as any);
       window.removeEventListener("edit-edge-label", handleEditLabel as any);
       window.removeEventListener("beforeunload", handleBeforeUnload);
-      window.removeEventListener("visibilitychange", handleVisibilityChange);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       uiStore.isModifierPressed = false;
     };
   });

--- a/apps/web/src/lib/components/canvas/use-canvas-logic.svelte.ts
+++ b/apps/web/src/lib/components/canvas/use-canvas-logic.svelte.ts
@@ -1,10 +1,10 @@
 import { untrack, tick } from "svelte";
-import { 
-  addEdge as addXyEdge, 
+import {
+  addEdge as addXyEdge,
   useSvelteFlow,
-  type Node, 
-  type Edge, 
-  type Connection 
+  type Node,
+  type Edge,
+  type Connection,
 } from "@xyflow/svelte";
 import { CanvasStore } from "@codex/canvas-engine";
 import { vault } from "$lib/stores/vault.svelte";
@@ -27,7 +27,7 @@ export function createCanvasLogic(engine: CanvasStore) {
   let activeCategories = $state(new Set<string>());
   let isConnecting = $state(false);
   let hasInitialized = $state(false);
-  
+
   let contextMenu = $state<{
     x: number;
     y: number;
@@ -81,14 +81,22 @@ export function createCanvasLogic(engine: CanvasStore) {
     explicitCanvasId?: string,
   ) {
     await tick();
-    const currentVaultId = explicitVaultId || targetVaultId || vault.activeVaultId;
+    const currentVaultId =
+      explicitVaultId || targetVaultId || vault.activeVaultId;
     const currentCanvasId = explicitCanvasId || targetCanvasId;
 
-    if (!currentVaultId || !currentCanvasId) return;
+    if (!currentVaultId || !currentCanvasId) {
+      console.warn(
+        "[CanvasLogic] saveCanvas called before canvas initialization; skipping.",
+      );
+      return;
+    }
 
     const exportData = engine.export();
     const existing = untrack(() => vault.canvases[currentCanvasId] || {});
-    const canvas = canvasRegistry.allCanvases.find(c => c.id === currentCanvasId);
+    const canvas = canvasRegistry.allCanvases.find(
+      (c) => c.id === currentCanvasId,
+    );
 
     vault.canvases[currentCanvasId] = buildCanvasSavePayload({
       existing,
@@ -223,7 +231,7 @@ export function createCanvasLogic(engine: CanvasStore) {
   // Initialization & Sync logic (called by effects in the component)
   function initializeCanvas(canvasId: string) {
     if (!vault.isInitialized || !canvasRegistry.isLoaded) return;
-    
+
     if (targetCanvasId !== canvasId) {
       untrack(() => {
         hasInitialized = false;
@@ -272,7 +280,7 @@ export function createCanvasLogic(engine: CanvasStore) {
 
   function syncEngine() {
     if (!hasInitialized || !vault.isInitialized || !targetCanvasId) return;
-    
+
     // Sync edges
     const currentEdges = edges;
     engine.edges = currentEdges.map((e: Edge) => ({
@@ -296,25 +304,51 @@ export function createCanvasLogic(engine: CanvasStore) {
       width: n.data?.width as number,
       height: n.data?.height as number,
     }));
-    
+
     debouncedSave();
   }
 
   return {
-    get nodes() { return nodes; },
-    set nodes(val) { nodes = val; },
-    get edges() { return edges; },
-    set edges(val) { edges = val; },
-    get activeCategories() { return activeCategories; },
-    get isConnecting() { return isConnecting; },
-    set isConnecting(val) { isConnecting = val; },
-    get contextMenu() { return contextMenu; },
-    set contextMenu(val) { contextMenu = val; },
-    get labelModal() { return labelModal; },
-    set labelModal(val) { labelModal = val; },
-    get hasInitialized() { return hasInitialized; },
-    get screenToFlowPosition() { return screenToFlowPosition; },
-    
+    get nodes() {
+      return nodes;
+    },
+    set nodes(val) {
+      nodes = val;
+    },
+    get edges() {
+      return edges;
+    },
+    set edges(val) {
+      edges = val;
+    },
+    get activeCategories() {
+      return activeCategories;
+    },
+    get isConnecting() {
+      return isConnecting;
+    },
+    set isConnecting(val) {
+      isConnecting = val;
+    },
+    get contextMenu() {
+      return contextMenu;
+    },
+    set contextMenu(val) {
+      contextMenu = val;
+    },
+    get labelModal() {
+      return labelModal;
+    },
+    set labelModal(val) {
+      labelModal = val;
+    },
+    get hasInitialized() {
+      return hasInitialized;
+    },
+    get screenToFlowPosition() {
+      return screenToFlowPosition;
+    },
+
     toggleCategoryFilter,
     clearCategoryFilters,
     onConnect,
@@ -326,6 +360,6 @@ export function createCanvasLogic(engine: CanvasStore) {
     initializeCanvas,
     pruneNodes,
     syncEngine,
-    flushSave
+    flushSave,
   };
 }

--- a/apps/web/src/lib/components/canvas/use-canvas-logic.svelte.ts
+++ b/apps/web/src/lib/components/canvas/use-canvas-logic.svelte.ts
@@ -9,6 +9,7 @@ import {
 import { CanvasStore } from "@codex/canvas-engine";
 import { vault } from "$lib/stores/vault.svelte";
 import { canvasRegistry } from "$lib/stores/canvas-registry.svelte";
+import { debugStore } from "$lib/stores/debug.svelte";
 import {
   buildCanvasSavePayload,
   createFlowEdgeFromConnection,
@@ -86,7 +87,7 @@ export function createCanvasLogic(engine: CanvasStore) {
     const currentCanvasId = explicitCanvasId || targetCanvasId;
 
     if (!currentVaultId || !currentCanvasId) {
-      console.warn(
+      debugStore.warn(
         "[CanvasLogic] saveCanvas called before canvas initialization; skipping.",
       );
       return;

--- a/docs/GOD_FILES_ANALYSIS.md
+++ b/docs/GOD_FILES_ANALYSIS.md
@@ -79,7 +79,7 @@ This report identifies the top 10 potential "God Files" (files with excessive re
 
 **Status:** ✅ **COMPLETED (2026-04-27)**
 **Summary:** Extracted workspace logic into `useCanvasLogic` and `useCanvasEvents` hooks. Moved overlay HUD to `CanvasHUD` component. The main component now acts as a clean orchestration shell for SvelteFlow.
-**Outcome:** Reduced from 780 lines to 326 lines. Improved separation between UI state, persistence, and event handling.
+**Outcome:** Reduced from 835 lines to 326 lines. Improved separation between UI state, persistence, and event handling.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #735 (CanvasWorkspace decomposition). Addresses 5 inline review comments that were not resolved before merge.

- **CanvasHUD**: `CategoryFilter` was inside a `pointer-events-none` wrapper, making its buttons non-interactive. Wrapped it in `pointer-events-auto`.
- **use-canvas-events (modifier keys)**: `handleUp` incorrectly cleared `isModifierPressed` when any key with `e.ctrlKey=true` was released (e.g. releasing 'A' while holding Ctrl). Both handlers now derive state directly from `e.ctrlKey || e.metaKey`.
- **use-canvas-events (visibilitychange)**: Moved listener from `window` to `document` — the correct event target per spec.
- **use-canvas-logic**: `saveCanvas()` silently dropped saves when called before `initializeCanvas()` set `targetCanvasId`. Now logs a console warning so the drop is visible during development.
- **docs**: Reconciled CanvasWorkspace before-line-count to 835 in both the table and the prose section (was 835 in table, 780 in text).

## Test plan

- [ ] Open Canvas view — category filter buttons respond to clicks
- [ ] Hold Ctrl, press another key, release it — graph multi-select remains active (modifier not cleared)
- [ ] Alt-tab away from the tab — pending canvas save flushes (visibilitychange fires)
- [ ] No TypeScript errors (`tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)