### PR TITLE
fix(graph): lazy-load entity content on node hover

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -98,6 +98,11 @@
 
   let hoveredEntityId = $state<string | null>(null);
   let hoverPosition = $state<{ x: number; y: number } | null>(null);
+
+  $effect(() => {
+    if (hoveredEntityId) vault.loadEntityContent(hoveredEntityId);
+  });
+
   let findNodeCounter = $derived(ui.findNodeCounter);
   let pendingSearchFocus: {
     entityId: string;


### PR DESCRIPTION
## Summary

- Calls `vault.loadEntityContent(id)` via a `$effect` in `GraphView` whenever `hoveredEntityId` changes
- Matches the exact pattern already used by `EntityDetailPanel` for sidebar lazy-loading
- Content loads async; the tooltip re-renders automatically once data arrives from Dexie/OPFS

Closes #742

## Test plan

- [ ] Hover over a graph node that has never been opened in the detail panel — tooltip should show content instead of "No data available"
- [ ] Hover over a node with no content — tooltip should still show "No data available" gracefully
- [ ] Open detail panel for an entity, close it, hover again — content should still be present (no double-load regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)