### PR TITLE
:sparkles: feat(regen): integrate AI regeneration button into UI

### DIFF
--- a/apps/web/src/lib/components/canvas/CanvasContextMenu.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasContextMenu.svelte
@@ -25,11 +25,14 @@
   }>();
 
   const handleRegenerate = async () => {
-    if (targetId && targetType === "node") {
+    if (targetType !== "node") return;
+
+    if (targetId) {
       await regenerationService.regenerate(targetId);
       onClose();
     } else if (onRegenerate) {
       onRegenerate();
+      onClose();
     }
   };
 
@@ -132,7 +135,7 @@
     </button>
   {/if}
 
-  {#if targetType === "node"}
+  {#if targetType === "node" && (targetId || onRegenerate)}
     <button
       role="menuitem"
       class="w-full text-left px-4 py-2.5 text-xs text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary flex items-center gap-3 transition-colors uppercase font-header tracking-widest"

--- a/apps/web/src/lib/components/canvas/CanvasContextMenu.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasContextMenu.svelte
@@ -1,23 +1,37 @@
 <script lang="ts">
   import { Trash2, Type } from "lucide-svelte";
+  import { regenerationService } from "$lib/services/RegenerationService.svelte";
 
   let {
     x,
     y,
+    targetId,
     targetType = "node",
     onDelete,
     onRename,
+    onRegenerate,
     onCreateEntity,
     onClose,
   } = $props<{
     x: number;
     y: number;
+    targetId?: string;
     targetType?: "node" | "edge" | "pane";
     onDelete: () => void;
     onRename?: () => void;
+    onRegenerate?: () => void;
     onCreateEntity?: (type: string) => void;
     onClose: () => void;
   }>();
+
+  const handleRegenerate = async () => {
+    if (targetId && targetType === "node") {
+      await regenerationService.regenerate(targetId);
+      onClose();
+    } else if (onRegenerate) {
+      onRegenerate();
+    }
+  };
 
   let menuEl = $state<HTMLDivElement>();
 
@@ -116,6 +130,18 @@
     >
       Create Lore
     </button>
+  {/if}
+
+  {#if targetType === "node"}
+    <button
+      role="menuitem"
+      class="w-full text-left px-4 py-2.5 text-xs text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary flex items-center gap-3 transition-colors uppercase font-header tracking-widest"
+      onclick={handleRegenerate}
+    >
+      <span class="icon-[lucide--sparkles] w-3.5 h-3.5 opacity-70"></span>
+      Regenerate Content
+    </button>
+    <div class="border-t border-theme-border/30 my-1"></div>
   {/if}
 
   {#if targetType !== "pane"}

--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
@@ -220,6 +220,7 @@
     <CanvasContextMenu
       x={logic.contextMenu.x}
       y={logic.contextMenu.y}
+      targetId={logic.contextMenu?.id}
       targetType={logic.contextMenu.type}
       onDelete={logic.handleDelete}
       onRename={() => {

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -15,7 +15,6 @@
     dispatchSearchEntityFocus,
     DEFAULT_SEARCH_ENTITY_ZOOM,
   } from "$lib/components/search/search-focus";
-  import SidepanelRegenButton from "../entity/SidepanelRegenButton.svelte";
 
   let {
     entity,
@@ -119,7 +118,7 @@
               class="text-[9px] font-bold text-theme-muted uppercase tracking-widest self-center mr-0.5"
               >aka:</span
             >
-            {#each entity.aliases as alias}
+            {#each entity.aliases as alias (alias)}
               <div
                 class="px-1.5 py-0.5 rounded bg-theme-primary/5 border border-theme-primary/10 text-[9px] font-bold text-theme-secondary uppercase tracking-wider"
               >
@@ -145,7 +144,6 @@
             <span class="icon-[lucide--target] w-5 h-5"></span>
           </button>
         {/if}
-        <SidepanelRegenButton entityId={entity.id} />
         <button
           onclick={() => ui.openZenMode(entity.id)}
           class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
@@ -170,7 +168,7 @@
   <!-- Labels Section -->
   <div class="mt-4 mb-2 space-y-2">
     <div class="flex flex-wrap gap-1.5 min-h-[24px]">
-      {#each entity.labels || [] as label}
+      {#each entity.labels || [] as label (label)}
         <LabelBadge
           {label}
           removable={!vault.isGuest}

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -7,6 +7,7 @@
   import LabelBadge from "$lib/components/labels/LabelBadge.svelte";
   import LabelInput from "$lib/components/labels/LabelInput.svelte";
   import AliasInput from "$lib/components/labels/AliasInput.svelte";
+  import SidepanelRegenButton from "$lib/components/entity/SidepanelRegenButton.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import { page } from "$app/state";
   import { base } from "$app/paths";
@@ -144,6 +145,7 @@
             <span class="icon-[lucide--target] w-5 h-5"></span>
           </button>
         {/if}
+        <SidepanelRegenButton entityId={entity.id} />
         <button
           onclick={() => ui.openZenMode(entity.id)}
           class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -3,6 +3,7 @@
   import { ui } from "$lib/stores/ui.svelte";
   import { vault } from "$lib/stores/vault.svelte";
   import { oracle } from "$lib/stores/oracle.svelte";
+  import { regenerationService } from "$lib/services/RegenerationService.svelte";
   import { canvasRegistry } from "$lib/stores/canvas-registry.svelte";
   import { categories } from "$lib/stores/categories.svelte";
   import CanvasPicker from "$lib/components/canvas/CanvasPicker.svelte";
@@ -303,6 +304,23 @@
     }
   };
 
+  const handleRegenerateContent = async () => {
+    const nodesToUpdate = $state.snapshot(selectedNodes);
+    if (nodesToUpdate.length !== 1) return;
+
+    contextMenuOpen = false;
+    canvasPickerOpen = false;
+    categoryPickerOpen = false;
+    imagePickerOpen = false;
+
+    try {
+      await regenerationService.regenerate(nodesToUpdate[0]);
+    } catch (err: any) {
+      console.error("Failed to regenerate content", err);
+      ui.notify(`Failed to regenerate content: ${err.message}`, "error");
+    }
+  };
+
   const handleViewImage = async () => {
     const nodesToUpdate = $state.snapshot(selectedNodes);
     if (nodesToUpdate.length !== 1) return;
@@ -588,6 +606,14 @@
         >
           <span class="icon-[lucide--image-plus] h-3.5 w-3.5 opacity-70"></span>
           {imageActionLabel}
+        </button>
+        <button
+          role="menuitem"
+          class="w-full text-left px-3 py-1.5 text-xs text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition flex items-center gap-2 rounded-sm"
+          onclick={handleRegenerateContent}
+        >
+          <span class="icon-[lucide--sparkles] h-3.5 w-3.5 opacity-70"></span>
+          Regenerate Content
         </button>
       {/if}
     </div>

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -314,7 +314,13 @@
     imagePickerOpen = false;
 
     try {
-      await regenerationService.regenerate(nodesToUpdate[0]);
+      const ok = await regenerationService.regenerate(nodesToUpdate[0]);
+      if (!ok) {
+        ui.notify(
+          `Failed to regenerate content: ${regenerationService.error ?? "Unknown error"}`,
+          "error",
+        );
+      }
     } catch (err: any) {
       console.error("Failed to regenerate content", err);
       ui.notify(`Failed to regenerate content: ${err.message}`, "error");

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -5,6 +5,8 @@
   import LabelBadge from "$lib/components/labels/LabelBadge.svelte";
   import LabelInput from "$lib/components/labels/LabelInput.svelte";
   import AliasInput from "$lib/components/labels/AliasInput.svelte";
+  import SidepanelRegenButton from "$lib/components/entity/SidepanelRegenButton.svelte";
+  import { regenerationService } from "$lib/services/RegenerationService.svelte";
   import { isEntityVisible, type Entity } from "schema";
 
   let {
@@ -214,46 +216,7 @@
           >
         </div>
 
-        {#if oracle.tier === "advanced" && !uiStore.aiDisabled && entity}
-          <button
-            onclick={() => oracle.drawEntity(entity.id)}
-            disabled={isVisualizing}
-            class="bg-theme-surface/50 hover:bg-theme-surface border border-theme-primary/30 hover:border-theme-primary transition-all flex items-center justify-center gap-2 px-2 py-1 md:px-4 md:py-2 rounded shadow-sm group/btn relative overflow-hidden mt-1 md:mt-2"
-            aria-label="Draw visualization for {entity.title}"
-            aria-busy={isVisualizing}
-          >
-            {#if isVisualizing}
-              <span
-                class="icon-[lucide--loader-2] w-3 h-3 md:w-5 md:h-5 animate-spin text-theme-primary"
-                aria-hidden="true"
-              ></span>
-              <span
-                class="text-xs font-bold tracking-widest text-theme-primary text-center font-header uppercase"
-                aria-live="polite"
-              >
-                {#if oracle.activeStyleTitle}
-                  STYLE: {oracle.activeStyleTitle.toUpperCase()}
-                {:else}
-                  VISUALIZING...
-                {/if}
-              </span>
-            {:else}
-              <div
-                class="absolute inset-0 bg-theme-primary/10 opacity-0 group-hover/btn:opacity-100 transition-opacity"
-              ></div>
-              <span
-                class="icon-[lucide--palette] w-3 h-3 md:w-4 md:h-4 text-theme-primary"
-                aria-hidden="true"
-              ></span>
-              <span
-                class="text-xs font-bold tracking-widest font-header text-theme-primary relative z-10 uppercase"
-                >DRAW VISUAL</span
-              >
-            {/if}
-          </button>
-        {/if}
-
-        {#if isVisualizing}
+        {#if isVisualizing || regenerationService.isGenerating}
           <div
             class="absolute inset-0 bg-theme-bg/75 backdrop-blur-[2px] flex flex-col items-center justify-center gap-3 border border-theme-primary/20"
           >
@@ -265,14 +228,69 @@
               class="text-[9px] md:text-[10px] font-bold uppercase tracking-[0.2em] font-header text-theme-primary text-center px-6"
               aria-live="polite"
             >
-              {#if oracle.activeStyleTitle}
-                Visualizing in {oracle.activeStyleTitle}
+              {#if isVisualizing}
+                {#if oracle.activeStyleTitle}
+                  Visualizing in {oracle.activeStyleTitle}
+                {:else}
+                  Building Visual
+                {/if}
               {:else}
-                Building Visual
+                Expanding Lore
               {/if}
             </div>
           </div>
         {/if}
+      </div>
+    {/if}
+
+    {#if oracle.tier === "advanced" && !uiStore.aiDisabled && entity && !editState.isEditing}
+      <div class="flex flex-col gap-2 mt-4 w-full px-0">
+        <button
+          onclick={() => oracle.drawEntity(entity.id)}
+          disabled={isVisualizing}
+          class="bg-theme-surface/50 hover:bg-theme-surface border border-theme-primary/30 hover:border-theme-primary transition-all flex items-center justify-center gap-2 px-2 py-1 md:px-4 md:py-2 rounded shadow-sm group/btn relative overflow-hidden"
+          aria-label="Draw visualization for {entity.title}"
+          aria-busy={isVisualizing}
+        >
+          {#if isVisualizing}
+            <span
+              class="icon-[lucide--loader-2] w-3 h-3 md:w-5 md:h-5 animate-spin text-theme-primary"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="text-[10px] md:text-xs font-bold tracking-widest text-theme-primary text-center font-header uppercase"
+              aria-live="polite"
+            >
+              {#if oracle.activeStyleTitle}
+                STYLE: {oracle.activeStyleTitle.toUpperCase()}
+              {:else}
+                VISUALIZING...
+              {/if}
+            </span>
+          {:else}
+            <div
+              class="absolute inset-0 bg-theme-primary/10 opacity-0 group-hover/btn:opacity-100 transition-opacity"
+            ></div>
+            <span
+              class="icon-[lucide--palette] w-3 h-3 md:w-4 md:h-4 text-theme-primary"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="text-[10px] md:text-xs font-bold tracking-widest font-header text-theme-primary relative z-10 uppercase"
+              >DRAW VISUAL</span
+            >
+          {/if}
+        </button>
+
+        <div
+          class="bg-theme-surface/50 hover:bg-theme-surface border border-theme-primary/30 hover:border-theme-primary transition-all flex items-center justify-center gap-2 px-2 py-1 md:px-4 md:py-2 rounded shadow-sm group/btn relative overflow-hidden"
+        >
+          <SidepanelRegenButton entityId={entity.id} />
+          <span
+            class="text-[10px] md:text-xs font-bold tracking-widest font-header text-theme-primary relative z-10 uppercase pointer-events-none"
+            >REGENERATE</span
+          >
+        </div>
       </div>
     {/if}
   </div>

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -5,7 +5,6 @@
   import LabelBadge from "$lib/components/labels/LabelBadge.svelte";
   import LabelInput from "$lib/components/labels/LabelInput.svelte";
   import AliasInput from "$lib/components/labels/AliasInput.svelte";
-  import SidepanelRegenButton from "$lib/components/entity/SidepanelRegenButton.svelte";
   import { regenerationService } from "$lib/services/RegenerationService.svelte";
   import { isEntityVisible, type Entity } from "schema";
 
@@ -106,7 +105,7 @@
       <div class="space-y-2">
         {#if entity?.labels?.length}
           <div class="flex flex-wrap gap-1.5">
-            {#each entity.labels as label}
+            {#each entity.labels as label (label)}
               <LabelBadge
                 {label}
                 removable={!vault.isGuest}
@@ -126,7 +125,7 @@
 
         {#if entity?.aliases?.length}
           <div class="flex flex-wrap gap-1.5">
-            {#each entity.aliases as alias}
+            {#each entity.aliases as alias (alias)}
               <div
                 class="px-2 py-0.5 rounded bg-theme-primary/5 border border-theme-primary/10 text-[10px] font-bold text-theme-secondary uppercase tracking-wider"
               >
@@ -282,15 +281,22 @@
           {/if}
         </button>
 
-        <div
+        <button
+          type="button"
+          onclick={() => regenerationService.regenerate(entity.id)}
           class="bg-theme-surface/50 hover:bg-theme-surface border border-theme-primary/30 hover:border-theme-primary transition-all flex items-center justify-center gap-2 px-2 py-1 md:px-4 md:py-2 rounded shadow-sm group/btn relative overflow-hidden"
+          aria-label="Regenerate Chronicle and Lore"
+          title="Regenerate Chronicle and Lore"
         >
-          <SidepanelRegenButton entityId={entity.id} />
+          <span
+            class="icon-[lucide--sparkles] w-3 h-3 md:w-4 md:h-4 text-theme-primary"
+            aria-hidden="true"
+          ></span>
           <span
             class="text-[10px] md:text-xs font-bold tracking-widest font-header text-theme-primary relative z-10 uppercase pointer-events-none"
             >REGENERATE</span
           >
-        </div>
+        </button>
       </div>
     {/if}
   </div>
@@ -308,7 +314,7 @@
         </h3>
         {#if allConnections.length > 0}
           <div class="space-y-2">
-            {#each allConnections as conn}
+            {#each allConnections as conn (conn.id)}
               <div
                 class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
               >

--- a/apps/web/src/lib/services/RegenerationService.svelte.test.ts
+++ b/apps/web/src/lib/services/RegenerationService.svelte.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../stores/oracle.svelte", () => ({
+  oracle: {
+    regenerate: vi.fn(),
+  },
+}));
+
+vi.mock("../stores/vault.svelte", () => ({
+  vault: {
+    updateEntity: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../stores/ui.svelte", () => ({
+  uiStore: {
+    notify: vi.fn(),
+  },
+}));
+
+vi.mock("@codex/oracle-engine", () => ({
+  OracleCommandParser: {
+    parseRegenerationResponse: vi.fn(),
+  },
+}));
+
+import { oracle } from "../stores/oracle.svelte";
+import { vault } from "../stores/vault.svelte";
+import { uiStore } from "../stores/ui.svelte";
+import { OracleCommandParser } from "@codex/oracle-engine";
+import { regenerationService } from "./RegenerationService.svelte";
+
+describe("RegenerationService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    regenerationService.pendingDraft = null;
+    regenerationService.error = null;
+    regenerationService.isGenerating = false;
+  });
+
+  it("returns true and stores a draft when regeneration succeeds", async () => {
+    vi.mocked(oracle.regenerate).mockImplementation(
+      async (_entityId, onPartial) => {
+        onPartial?.(
+          "**Chronicle:** Hero returns.\n\n**Lore:** The hero returns.",
+        );
+      },
+    );
+    vi.mocked(OracleCommandParser.parseRegenerationResponse).mockReturnValue({
+      chronicle: "Hero returns.",
+      lore: "The hero returns.",
+    });
+
+    const result = await regenerationService.regenerate("e1");
+
+    expect(result).toBe(true);
+    expect(regenerationService.pendingDraft).toEqual(
+      expect.objectContaining({
+        entityId: "e1",
+        chronicle: "Hero returns.",
+        lore: "The hero returns.",
+      }),
+    );
+    expect(regenerationService.error).toBeNull();
+    expect(regenerationService.isGenerating).toBe(false);
+    expect(oracle.regenerate).toHaveBeenCalledWith("e1", expect.any(Function));
+  });
+
+  it("returns false and stores an error when regeneration fails", async () => {
+    vi.mocked(oracle.regenerate).mockRejectedValue(new Error("boom"));
+
+    const result = await regenerationService.regenerate("e1");
+
+    expect(result).toBe(false);
+    expect(regenerationService.pendingDraft).toBeNull();
+    expect(regenerationService.error).toBe("boom");
+    expect(regenerationService.isGenerating).toBe(false);
+    expect(uiStore.notify).not.toHaveBeenCalled();
+    expect(vault.updateEntity).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/services/RegenerationService.svelte.ts
+++ b/apps/web/src/lib/services/RegenerationService.svelte.ts
@@ -11,8 +11,8 @@ export class RegenerationService {
   isGenerating = $state(false);
   error = $state<string | null>(null);
 
-  async regenerate(entityId: string) {
-    if (this.isGenerating) return;
+  async regenerate(entityId: string): Promise<boolean> {
+    if (this.isGenerating) return false;
 
     this.isGenerating = true;
     this.error = null;
@@ -36,9 +36,11 @@ export class RegenerationService {
         lore: parsed.lore,
         timestamp: Date.now(),
       };
+      return true;
     } catch (err: any) {
       this.error = err.message;
       console.error("[RegenerationService] Failed to regenerate:", err);
+      return false;
     } finally {
       this.isGenerating = false;
     }

--- a/packages/oracle-engine/src/oracle-executor.test.ts
+++ b/packages/oracle-engine/src/oracle-executor.test.ts
@@ -18,6 +18,7 @@ describe("OracleActionExecutor - Detailed", () => {
         .mockResolvedValue({ primaryEntityId: "e1", sourceIds: ["e1"] }),
       generateEntityVisualization: vi.fn().mockResolvedValue(new Blob([])),
       generateMessageVisualization: vi.fn().mockResolvedValue(new Blob([])),
+      generateRegenerationResponse: vi.fn().mockResolvedValue(undefined),
     };
     executor = new OracleActionExecutor(mockGenerator);
     mockContext = {
@@ -37,7 +38,12 @@ describe("OracleActionExecutor - Detailed", () => {
           }
         }),
         clearMessages: vi.fn().mockResolvedValue(undefined),
-        setMessages: vi.fn(),
+        setMessages: vi.fn().mockImplementation(async (messages) => {
+          mockContext.chatHistory.messages = messages;
+        }),
+        getMessages: vi
+          .fn()
+          .mockImplementation(async () => mockContext.chatHistory.messages),
         messages: [],
       },
       uiStore: {
@@ -298,6 +304,63 @@ describe("OracleActionExecutor - Detailed", () => {
       expect(mockContext.chatHistory.addMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           content: expect.stringContaining("Restricted Mode Active"),
+        }),
+      );
+    });
+  });
+
+  describe("executeRegenerate", () => {
+    it("should regenerate an explicit entity id", async () => {
+      mockContext.vault.entities = {
+        e1: { id: "e1", title: "Hero" },
+      };
+
+      await executor.execute(
+        { type: "regenerate", entityId: "e1" },
+        mockContext,
+      );
+
+      expect(mockGenerator.generateRegenerationResponse).toHaveBeenCalledWith(
+        "e1",
+        mockContext,
+        expect.any(Function),
+      );
+      expect(mockContext.chatHistory.addMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: "assistant",
+          entityId: "e1",
+        }),
+      );
+      expect(mockContext.chatHistory.setMessages).toHaveBeenCalled();
+    });
+
+    it("should fall back to the selected entity id", async () => {
+      mockContext.vault.selectedEntityId = "e2";
+      mockContext.vault.entities = {
+        e2: { id: "e2", title: "Mage" },
+      };
+
+      await executor.execute({ type: "regenerate" }, mockContext);
+
+      expect(mockGenerator.generateRegenerationResponse).toHaveBeenCalledWith(
+        "e2",
+        mockContext,
+        expect.any(Function),
+      );
+    });
+
+    it("should show a system message when no entity is selected", async () => {
+      mockContext.vault.selectedEntityId = null;
+
+      await executor.execute({ type: "regenerate" }, mockContext);
+
+      expect(mockGenerator.generateRegenerationResponse).not.toHaveBeenCalled();
+      expect(mockContext.chatHistory.addMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining(
+            "Please select an entity in the graph or sidebar",
+          ),
         }),
       );
     });

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -188,7 +188,9 @@ The Lore Oracle supports several slash commands to help you manage your vault:
       const finalMsgs = (await context.chatHistory.getMessages?.()) ?? [
         ...context.chatHistory.messages,
       ];
-      const idx = finalMsgs.findIndex((m) => m.id === assistantMsg.id);
+      const idx = finalMsgs.findIndex(
+        (m: ChatMessage) => m.id === assistantMsg.id,
+      );
       if (idx !== -1) {
         finalMsgs[idx].content = assistantMsg.content;
       }
@@ -1012,50 +1014,6 @@ The Lore Oracle supports several slash commands to help you manage your vault:
     context: OracleExecutionContext,
     onPartialResponse?: (partial: string) => void,
   ) {
-    const entity = context.vault.entities[entityId];
-    if (!entity) return;
-
-    const assistantMsg: ChatMessage = {
-      id: crypto.randomUUID(),
-      role: "assistant",
-      content: "",
-      entityId,
-    };
-    await context.chatHistory.addMessage(assistantMsg);
-
-    const handlePartial = (partial: string) => {
-      assistantMsg.content = partial;
-      void context.chatHistory.updateMessage?.(
-        assistantMsg.id,
-        { content: partial },
-        false,
-      );
-      onPartialResponse?.(partial);
-    };
-
-    try {
-      await this.generator.generateRegenerationResponse(
-        entityId,
-        context,
-        handlePartial,
-      );
-
-      // Final update to set the proposals/metadata
-      const finalMsgs = (await context.chatHistory.getMessages?.()) ?? [
-        ...context.chatHistory.messages,
-      ];
-      const idx = finalMsgs.findIndex((m) => m.id === assistantMsg.id);
-      if (idx !== -1) {
-        finalMsgs[idx].content = assistantMsg.content;
-        // Optionally parse and add proposals here if we want proactive extraction during regen
-      }
-      await context.chatHistory.setMessages(finalMsgs);
-    } catch (err: any) {
-      await context.chatHistory.addMessage({
-        id: crypto.randomUUID(),
-        role: "system",
-        content: `❌ Regeneration failed for **${entity.title}**: ${err.message}`,
-      });
-    }
+    await this.executeRegenerate(entityId, context, onPartialResponse);
   }
 }

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -28,6 +28,21 @@ export class OracleActionExecutor {
       case "help":
         await this.executeHelp(context);
         break;
+      case "regenerate":
+        {
+          const entityId = intent.entityId || context.vault.selectedEntityId;
+          if (entityId) {
+            await this.executeRegenerate(entityId, context, onPartialResponse);
+          } else {
+            await context.chatHistory.addMessage({
+              id: crypto.randomUUID(),
+              role: "system",
+              content:
+                "❌ Please select an entity in the graph or sidebar to regenerate its content.",
+            });
+          }
+        }
+        break;
       case "clear":
         await context.chatHistory.clearMessages();
         break;
@@ -69,13 +84,6 @@ export class OracleActionExecutor {
         await this.executeChat(
           intent.query!,
           intent.isAIIntent!,
-          context,
-          onPartialResponse,
-        );
-        break;
-      case "regenerate":
-        await this.executeRegenerate(
-          intent.entityId!,
           context,
           onPartialResponse,
         );
@@ -145,20 +153,51 @@ The Lore Oracle supports several slash commands to help you manage your vault:
     context: OracleExecutionContext,
     onPartialResponse?: (partial: string) => void,
   ) {
+    const entity = context.vault.entities[entityId];
+    if (!entity) return;
+
     try {
       if (context.vault.isGuest)
         throw new Error("Guest users cannot regenerate content.");
 
+      const assistantMsg: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        content: "",
+        entityId,
+      };
+      await context.chatHistory.addMessage(assistantMsg);
+
+      const handlePartial = (partial: string) => {
+        assistantMsg.content = partial;
+        void context.chatHistory.updateMessage?.(
+          assistantMsg.id,
+          { content: partial },
+          false,
+        );
+        onPartialResponse?.(partial);
+      };
+
       await this.generator.generateRegenerationResponse(
         entityId,
         context,
-        onPartialResponse || (() => {}),
+        handlePartial,
       );
+
+      // Final update to set the proposals/metadata
+      const finalMsgs = (await context.chatHistory.getMessages?.()) ?? [
+        ...context.chatHistory.messages,
+      ];
+      const idx = finalMsgs.findIndex((m) => m.id === assistantMsg.id);
+      if (idx !== -1) {
+        finalMsgs[idx].content = assistantMsg.content;
+      }
+      await context.chatHistory.setMessages(finalMsgs);
     } catch (err: any) {
       await context.chatHistory.addMessage({
         id: crypto.randomUUID(),
         role: "system",
-        content: `❌ Regeneration failed: ${err.message}`,
+        content: `❌ Regeneration failed for **${entity.title}**: ${err.message}`,
       });
     }
   }
@@ -964,6 +1003,58 @@ The Lore Oracle supports several slash commands to help you manage your vault:
         id: crypto.randomUUID(),
         role: "system",
         content: `❌ Image generation failed: ${err.message}`,
+      });
+    }
+  }
+
+  async regenerateEntity(
+    entityId: string,
+    context: OracleExecutionContext,
+    onPartialResponse?: (partial: string) => void,
+  ) {
+    const entity = context.vault.entities[entityId];
+    if (!entity) return;
+
+    const assistantMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      content: "",
+      entityId,
+    };
+    await context.chatHistory.addMessage(assistantMsg);
+
+    const handlePartial = (partial: string) => {
+      assistantMsg.content = partial;
+      void context.chatHistory.updateMessage?.(
+        assistantMsg.id,
+        { content: partial },
+        false,
+      );
+      onPartialResponse?.(partial);
+    };
+
+    try {
+      await this.generator.generateRegenerationResponse(
+        entityId,
+        context,
+        handlePartial,
+      );
+
+      // Final update to set the proposals/metadata
+      const finalMsgs = (await context.chatHistory.getMessages?.()) ?? [
+        ...context.chatHistory.messages,
+      ];
+      const idx = finalMsgs.findIndex((m) => m.id === assistantMsg.id);
+      if (idx !== -1) {
+        finalMsgs[idx].content = assistantMsg.content;
+        // Optionally parse and add proposals here if we want proactive extraction during regen
+      }
+      await context.chatHistory.setMessages(finalMsgs);
+    } catch (err: any) {
+      await context.chatHistory.addMessage({
+        id: crypto.randomUUID(),
+        role: "system",
+        content: `❌ Regeneration failed for **${entity.title}**: ${err.message}`,
       });
     }
   }

--- a/packages/oracle-engine/src/oracle-parser.test.ts
+++ b/packages/oracle-engine/src/oracle-parser.test.ts
@@ -15,6 +15,12 @@ describe("OracleCommandParser", () => {
       });
     });
 
+    it("should parse /regenerate", () => {
+      expect(OracleCommandParser.parse("/regenerate", false)).toEqual({
+        type: "regenerate",
+      });
+    });
+
     it("should parse /roll", () => {
       expect(OracleCommandParser.parse("/roll 2d6+5", false)).toEqual({
         type: "roll",

--- a/packages/oracle-engine/src/oracle-parser.ts
+++ b/packages/oracle-engine/src/oracle-parser.ts
@@ -6,6 +6,7 @@ export class OracleCommandParser {
 
     if (q === "/help") return { type: "help" };
     if (q === "/clear") return { type: "clear" };
+    if (q === "/regenerate") return { type: "regenerate" };
 
     if (q.startsWith("/roll")) {
       const formula = query.slice(5).trim();

--- a/specs/095-ai-regen-button/spec.md
+++ b/specs/095-ai-regen-button/spec.md
@@ -58,7 +58,22 @@ As a world-builder working in Zen Mode, I want to regenerate descriptions withou
 
 **Acceptance Scenarios**:
 
-1. **Given** I am in Zen Mode with an entity open, **When** I click the "AI Regenerate" icon in the entity header, **Then** the AI should generate the description variants.
+1. **Given** I am in Zen Mode with an entity open, **When** I click the "AI Regenerate" icon in the entity sidebar, **Then** the AI should generate the description variants.
+
+---
+
+### User Story 5 - Triggering from Visualization (Priority: P2)
+
+As a GM exploring the world graph or a spatial canvas, I want to regenerate entity content directly from the visual node so that I don't have to open the detail panel first.
+
+**Why this priority**: Improves efficiency for bulk or rapid world-building.
+
+**Independent Test**: Right-click a node in the graph or canvas and verify "Regenerate Content" appears and works.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am viewing the Knowledge Graph, **When** I right-click an entity node and select "Regenerate Content", **Then** the Oracle should begin generating new content for that entity.
+2. **Given** I am working on a Spatial Canvas, **When** I right-click an entity node and select "Regenerate Content", **Then** the Oracle should begin generating new content for that entity.
 
 ---
 
@@ -90,6 +105,8 @@ As a user, I want to choose whether to keep the generated descriptions or discar
 
 - **FR-001**: System MUST provide a visible "AI Regenerate" button in the Entity Detail view (Sidepanel) for users with **Host/GM permissions**.
 - **FR-002**: System MUST provide an "AI Regenerate" action in the Zen Mode entity interface for users with **Host/GM permissions**.
+- **FR-008**: System MUST provide a "Regenerate Content" option in the Knowledge Graph context menu for entity nodes.
+- **FR-009**: System MUST provide a "Regenerate Content" option in the Spatial Canvas context menu for entity nodes.
 - **FR-003**: The regeneration process MUST use the following as context for the AI prompt:
   - Entity name and type.
   - Assigned labels.


### PR DESCRIPTION
## 🎯 Purpose

Integrate AI regeneration functionality for entity descriptions across the application as requested in issue #744. Ensures consistent behavior using the new `RegenerationService` and "Inline Preview" workflow.

## 🛠️ Changes

- Integrated `SidepanelRegenButton` into the Entity Detail sidebar.
- Added `SidepanelRegenButton` to the Zen Mode sidebar.
- Added "Regenerate Content" option to the Knowledge Graph context menu.
- Added "Regenerate Content" option to the Spatial Canvas context menu.
- Updated `OracleActionExecutor` and `OracleStore` to support the new regeneration flow and clean up redundant logic.
- Updated `CanvasContextMenu` to use `RegenerationService`.
- Updated `specs/095-ai-regen-button/spec.md` to reflect new integration points.

## 🚦 Target Branch Reminder

> [!IMPORTANT]
> **This PR must target the `staging` branch.**

## 🧪 Testing

- Verified core engine logic with Vitest: `packages/oracle-engine/src/oracle-generator.test.ts` and `oracle-parser.test.ts`.
- Manually verified UI integrations and service alignment.

## 🏷️ Release Labeling

- `minor`