### PR TITLE
⚡ Bolt: Optimize SYNC_CHUNK_READY array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -57,6 +57,7 @@
 
 **Learning:** When manually optimizing `.slice(0, limit)` with an imperative loop condition like `result.length < limit`, explicitly handle cases where `limit` might be `undefined`. Native `.slice(0, undefined)` safely copies the array, but a manual loop condition `0 < undefined` evaluates to `false`, causing the loop to terminate immediately and introducing bugs.
 **Action:** Be careful when replacing standard library functions. Ensure that all edge cases (like `undefined` parameters) are correctly handled.
+
 ## 2026-04-30 - Optimize event parsing with single pass loops
 
 **Learning:** When parsing large synchronization events in Svelte stores, using chained functional array methods like `.map().filter(Boolean)` creates intermediate arrays and increases garbage collection pressure.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -57,3 +57,7 @@
 
 **Learning:** When manually optimizing `.slice(0, limit)` with an imperative loop condition like `result.length < limit`, explicitly handle cases where `limit` might be `undefined`. Native `.slice(0, undefined)` safely copies the array, but a manual loop condition `0 < undefined` evaluates to `false`, causing the loop to terminate immediately and introducing bugs.
 **Action:** Be careful when replacing standard library functions. Ensure that all edge cases (like `undefined` parameters) are correctly handled.
+## 2026-04-30 - Optimize event parsing with single pass loops
+
+**Learning:** When parsing large synchronization events in Svelte stores, using chained functional array methods like `.map().filter(Boolean)` creates intermediate arrays and increases garbage collection pressure.
+**Action:** Replace `Array.prototype.map().filter()` chains with a single imperative loop (`for` loop with `push`) when parsing batch payloads, especially in hot paths like `SYNC_CHUNK_READY` in the vault engine.

--- a/apps/web/src/lib/stores/vault/events.ts
+++ b/apps/web/src/lib/stores/vault/events.ts
@@ -155,19 +155,26 @@ export class VaultEventBus {
           metadata: { timestamp, vaultId: event.vaultId },
         };
         break;
-      case "SYNC_CHUNK_READY":
+      case "SYNC_CHUNK_READY": {
+        // ⚡ Bolt Optimization: Replace chained .map().filter() with a single imperative loop
+        const entitiesChunk = [];
+        for (let i = 0; i < event.newOrChangedIds.length; i++) {
+          const entity = event.entities[event.newOrChangedIds[i]];
+          if (entity) {
+            entitiesChunk.push(entity);
+          }
+        }
         appEvent = {
           type: VAULT_EVENTS.SYNC_CHUNK_READY,
           domain: "vault",
           payload: {
             newOrChangedIds: event.newOrChangedIds,
-            entities: event.newOrChangedIds
-              .map((id) => event.entities[id])
-              .filter(Boolean),
+            entities: entitiesChunk,
           },
           metadata: { timestamp, vaultId: event.vaultId },
         };
         break;
+      }
       case "VAULT_DELETED":
         appEvent = {
           type: VAULT_EVENTS.VAULT_DELETED,

--- a/apps/web/src/lib/stores/vault/events.ts
+++ b/apps/web/src/lib/stores/vault/events.ts
@@ -157,7 +157,7 @@ export class VaultEventBus {
         break;
       case "SYNC_CHUNK_READY": {
         // ⚡ Bolt Optimization: Replace chained .map().filter() with a single imperative loop
-        const entitiesChunk = [];
+        const entitiesChunk: LocalEntity[] = [];
         for (let i = 0; i < event.newOrChangedIds.length; i++) {
           const entity = event.entities[event.newOrChangedIds[i]];
           if (entity) {


### PR DESCRIPTION
💡 What: Replaced a chained `.map().filter(Boolean)` in `apps/web/src/lib/stores/vault/events.ts` with a single imperative `for` loop.

🎯 Why: The original code iterated over the `event.newOrChangedIds` array twice and allocated an intermediate array during the `.map()` phase. By using a single pass, we reduce memory allocations and garbage collection pressure, which is particularly beneficial during large data synchronizations (e.g., initial syncs of large vaults).

📊 Impact: Eliminates O(N) intermediate array allocation and reduces iterations from 2N to N for parsing sync chunks.

🔬 Measurement: Run a large vault sync and observe the memory profile/GC frequency; verify tests pass with `npm run test`.

---
*PR created automatically by Jules for task [3459589270705042211](https://jules.google.com/task/3459589270705042211) started by @eserlan*