### PR TITLE
🎨 Palette: [a11y] Add aria attributes to MapView submenus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,6 @@
 
 **Learning:** Icon-only buttons that rely only on `title` are not announced reliably by screen readers, even when the hover tooltip looks correct for mouse users.
 **Action:** Always add an explicit `aria-label` to icon-only buttons, even if they already have a `title`, so assistive technology gets a stable accessible name.
+## 2024-05-18 - [Add aria-expanded to Submenu Triggers]
+**Learning:** Found that custom context menus and submenus in interactive canvas areas (like MapView) often lack standard accessibility attributes (`aria-haspopup`, `aria-expanded`). This makes it difficult for screen reader users to know if a button opens a menu and whether it is currently open.
+**Action:** Always add `aria-haspopup="menu"` and dynamically bind `aria-expanded={isOpen}` to buttons that toggle submenus or popups, especially in complex interactive components where standard HTML select/menu elements are not used.

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1315,6 +1315,8 @@
           >
             <button
               class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
+              aria-haspopup="menu"
+              aria-expanded={showResizeSubmenu}
             >
               <div class="flex items-center gap-2">
                 <span class="icon-[lucide--maximize] w-3.5 h-3.5"></span>
@@ -1389,6 +1391,8 @@
             >
               <button
                 class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
+                aria-haspopup="menu"
+                aria-expanded={showStatusSubmenu}
               >
                 <div class="flex items-center gap-2">
                   <span class="icon-[lucide--badge] w-3.5 h-3.5"></span>


### PR DESCRIPTION
💡 What: Added `aria-haspopup="menu"` and `aria-expanded` attributes to the "Resize" and "Status" submenu trigger buttons in the MapView component.
🎯 Why: To improve accessibility for screen reader users by properly identifying these buttons as submenu triggers and communicating their expanded/collapsed state.
♿ Accessibility: Improves screen reader experience for complex interactive map context menus.

---
*PR created automatically by Jules for task [15630019045981965899](https://jules.google.com/task/15630019045981965899) started by @eserlan*