### PR TITLE
🐛 fix(a11y): proper menu semantics for VTT toggles and splitters

### DIFF
--- a/apps/web/src/lib/components/layout/ResizerHandle.svelte
+++ b/apps/web/src/lib/components/layout/ResizerHandle.svelte
@@ -87,6 +87,8 @@
   });
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
   bind:this={handleRef}
   class="resizer-handle group absolute top-0 bottom-0 z-[100] w-6 cursor-col-resize transition-all focus:outline-none"

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1303,7 +1303,6 @@
         {#if mapStore.isGMMode && !uiStore.isGuestMode}
           <div
             class="relative group"
-            role="presentation"
             onmouseenter={() => {
               showResizeSubmenu = true;
               showStatusSubmenu = false;
@@ -1315,6 +1314,21 @@
           >
             <button
               class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
+              aria-haspopup="menu"
+              aria-expanded={showResizeSubmenu}
+              onclick={(e) => {
+                e.stopPropagation();
+                showResizeSubmenu = !showResizeSubmenu;
+                if (showResizeSubmenu) showStatusSubmenu = false;
+              }}
+              onkeydown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  showResizeSubmenu = !showResizeSubmenu;
+                  if (showResizeSubmenu) showStatusSubmenu = false;
+                }
+              }}
             >
               <div class="flex items-center gap-2">
                 <span class="icon-[lucide--maximize] w-3.5 h-3.5"></span>
@@ -1327,11 +1341,13 @@
             {#if showResizeSubmenu}
               <div
                 class="absolute left-full top-0 ml-px bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[100px]"
-                role="presentation"
+                role="menu"
+                aria-label="Resize options"
               >
                 {#each [1, 2, 3, 4] as scale (scale)}
                   <button
                     class="w-full text-left px-4 py-2 text-xs hover:bg-theme-primary/20 hover:text-theme-primary transition-colors font-mono"
+                    role="menuitem"
                     onclick={() => {
                       if (contextMenu?.tokenId) {
                         const gridSize = mapStore.gridSize || 50;
@@ -1377,7 +1393,6 @@
             {@const activeEffects = token?.statusEffects ?? []}
             <div
               class="relative group"
-              role="presentation"
               onmouseenter={() => {
                 showStatusSubmenu = true;
                 showResizeSubmenu = false;
@@ -1389,6 +1404,21 @@
             >
               <button
                 class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
+                aria-haspopup="menu"
+                aria-expanded={showStatusSubmenu}
+                onclick={(e) => {
+                  e.stopPropagation();
+                  showStatusSubmenu = !showStatusSubmenu;
+                  if (showStatusSubmenu) showResizeSubmenu = false;
+                }}
+                onkeydown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    showStatusSubmenu = !showStatusSubmenu;
+                    if (showStatusSubmenu) showResizeSubmenu = false;
+                  }
+                }}
               >
                 <div class="flex items-center gap-2">
                   <span class="icon-[lucide--badge] w-3.5 h-3.5"></span>
@@ -1401,7 +1431,8 @@
               {#if showStatusSubmenu}
                 <div
                   class="absolute left-full top-0 ml-px bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[160px]"
-                  role="presentation"
+                  role="menu"
+                  aria-label="Status options"
                 >
                   {#each TOKEN_STATUS_EFFECTS as effect (effect.id)}
                     {@const isActive = activeEffects.includes(effect.id)}
@@ -1409,6 +1440,7 @@
                       class="w-full text-left px-4 py-2 text-xs transition-colors flex items-center gap-2 {isActive
                         ? 'text-theme-primary hover:bg-theme-primary/20'
                         : 'text-theme-text hover:bg-theme-bg/50'}"
+                      role="menuitem"
                       onclick={() => {
                         if (contextMenu?.tokenId) {
                           const token = mapSession.tokens[contextMenu.tokenId];

--- a/apps/web/src/lib/components/map/VTTModeToggle.svelte
+++ b/apps/web/src/lib/components/map/VTTModeToggle.svelte
@@ -36,7 +36,7 @@
     oncontextmenu={(event) => event.preventDefault()}
     title={mapSession.vttEnabled ? "Disable VTT mode" : "Enable VTT mode"}
     aria-pressed={mapSession.vttEnabled}
-    aria-haspopup="menu"
+    aria-haspopup="true"
     aria-expanded={vttModeMenu.isOpen}
     aria-label="Toggle VTT mode"
   >


### PR DESCRIPTION
Separated out the a11y fixes for VTT toggles and resizer handles into their own PR as requested.