### PR TITLE
⚡ Bolt: Replace `.filter(...).length` with `.reduce()` in derived blocks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -72,3 +72,7 @@
 
 **Learning:** In contexts where we retrieve two separate lists from the database (`pinnedRecords` and `recentCandidates`), if both are already ordered by the target sorting metric (e.g., `lastModified` descending), combining them with array spreads followed by a full `.sort()` and `.slice()` is highly inefficient (`O(N log N)`).
 **Action:** Replace the spread and sort with sequential imperative loops that push directly into a target array, using early `break` statements to truncate exactly at the required limit (`O(N)`).
+
+## 2026-05-04 - [Performance Insight: Avoid intermediate array allocation for counting elements]
+**Learning:** Using `.filter(...).length` in Svelte `$derived` blocks on large arrays (like `vault.allEntities`) allocates a completely unnecessary intermediate array in memory, creating excess garbage collection pressure on every reactivity tick. While a verbose imperative loop is extremely efficient, a declarative `.reduce((count, item) => count + (condition ? 1 : 0), 0)` is slightly slower than a `for` loop but completely avoids array allocation and is far more readable.
+**Action:** Use `.reduce()` instead of `.filter(...).length` when counting matching items in reactive blocks to eliminate intermediate array memory allocation without sacrificing code readability.

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -29,8 +29,12 @@
   }
 
   let explorerTab = $state<"all" | "review">("all");
+  // ⚡ Bolt Optimization: Replace .filter().length with .reduce() to avoid intermediate array allocation
   let draftCount = $derived(
-    vault.allEntities.filter((e) => e.status === "draft").length,
+    vault.allEntities.reduce(
+      (count, e) => count + (e.status === "draft" ? 1 : 0),
+      0,
+    ),
   );
 
   const actioningIds = $state(new Set<string>());

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -29,11 +29,12 @@
   );
   const hasSelectedToken = $derived(Boolean(mapSession.selectedToken));
   const VTT_ENTITY_TYPES = ["character", "creature", "item"];
-  const vttEntityCount = $derived.by(
-    () =>
-      vault.allEntities.filter((entity) =>
-        VTT_ENTITY_TYPES.includes(entity.type),
-      ).length,
+  // ⚡ Bolt Optimization: Replace .filter().length with .reduce() to avoid intermediate array allocation
+  const vttEntityCount = $derived(
+    vault.allEntities.reduce(
+      (count, e) => count + (VTT_ENTITY_TYPES.includes(e.type) ? 1 : 0),
+      0,
+    ),
   );
 
   let showUpload = $state(false);


### PR DESCRIPTION
💡 What: Replaced `.filter(...).length` with a memory-efficient `.reduce()` pattern for derived counts.
🎯 Why: `.filter(...).length` eagerly allocates an intermediate array of all matching items just to count them, increasing garbage collection pressure when `$derived` blocks re-evaluate over large collections like `vault.allEntities`.
📊 Impact: Reduces array allocations (`O(N)` memory to `O(1)` memory) while maintaining declarative readability.
🔬 Measurement: Verify tests run properly, and memory profiles show reduced array allocations during state changes affecting `vttEntityCount` and `draftCount`.

---
*PR created automatically by Jules for task [9099462106816331814](https://jules.google.com/task/9099462106816331814) started by @eserlan*