### PR TITLE
:iphone: feat(mobile): improve Zen Mode navigation and closing

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -97,7 +97,7 @@
       <button
         onclick={onClose}
         class="md:hidden text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
-        aria-label="Close"
+        aria-label="Back"
       >
         <span class="icon-[lucide--chevron-left] w-7 h-7"></span>
       </button>

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -91,46 +91,57 @@
   style:background-color="var(--theme-panel-fill)"
   style:background-image="var(--bg-texture-overlay)"
 >
-  <div class="flex justify-between items-start mb-2">
-    {#if isEditing}
-      <div class="flex flex-col gap-2 w-full mr-4">
-        <input
-          type="text"
-          bind:value={editTitle}
-          class="bg-theme-bg border border-theme-primary text-theme-text px-2 py-1 focus:outline-none focus:border-theme-primary font-body font-bold text-xl w-full placeholder-theme-muted"
-          placeholder="Entity Title"
-        />
-        <AliasInput bind:aliases={editAliases} placeholder="Add alias..." />
-      </div>
-    {:else}
-      <div class="flex flex-col gap-1">
-        <h2
-          class="{isFantasyTheme
-            ? 'text-2xl md:text-3xl font-header tracking-wider'
-            : 'text-2xl md:text-3xl font-body tracking-wide'} font-bold"
-          style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
-        >
-          {entity.title}
-        </h2>
-        {#if entity.aliases && entity.aliases.length > 0}
-          <div class="flex flex-wrap gap-1.5 mt-0.5">
-            <span
-              class="text-[9px] font-bold text-theme-muted uppercase tracking-widest self-center mr-0.5"
-              >aka:</span
-            >
-            {#each entity.aliases as alias (alias)}
-              <div
-                class="px-1.5 py-0.5 rounded bg-theme-primary/5 border border-theme-primary/10 text-[9px] font-bold text-theme-secondary uppercase tracking-wider"
-              >
-                {alias}
-              </div>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    {/if}
+  <div class="flex justify-between items-center mb-2">
+    <div class="flex items-center gap-3 md:gap-4 flex-1 min-w-0">
+      <!-- Mobile-only close button -->
+      <button
+        onclick={onClose}
+        class="md:hidden text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
+        aria-label="Close"
+      >
+        <span class="icon-[lucide--chevron-left] w-7 h-7"></span>
+      </button>
 
-    <div class="flex items-center gap-1">
+      {#if isEditing}
+        <div class="flex flex-col gap-2 w-full mr-4">
+          <input
+            type="text"
+            bind:value={editTitle}
+            class="bg-theme-bg border border-theme-primary text-theme-text px-2 py-1 focus:outline-none focus:border-theme-primary font-body font-bold text-xl w-full placeholder-theme-muted"
+            placeholder="Entity Title"
+          />
+          <AliasInput bind:aliases={editAliases} placeholder="Add alias..." />
+        </div>
+      {:else}
+        <div class="flex flex-col gap-0.5 min-w-0">
+          <h2
+            class="{isFantasyTheme
+              ? 'text-xl md:text-3xl font-header tracking-wider'
+              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold truncate"
+            style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
+          >
+            {entity.title}
+          </h2>
+          {#if entity.aliases && entity.aliases.length > 0}
+            <div class="flex flex-wrap gap-1 md:gap-1.5 mt-0.5">
+              <span
+                class="text-[8px] md:text-[9px] font-bold text-theme-muted uppercase tracking-widest self-center mr-0.5 md:mr-1"
+                >aka:</span
+              >
+              {#each entity.aliases as alias (alias)}
+                <div
+                  class="px-1.5 py-0.5 rounded bg-theme-primary/5 border border-theme-primary/10 text-[8px] md:text-[9px] font-bold text-theme-secondary uppercase tracking-wider"
+                >
+                  {alias}
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+
+    <div class="flex items-center gap-1.5 md:gap-2 shrink-0 ml-2 md:ml-4">
       {#if !isEditing}
         <SidepanelRegenButton entityId={entity.id} />
         {#if isGraphView}
@@ -154,9 +165,11 @@
           <span class="icon-[lucide--maximize-2] w-5 h-5"></span>
         </button>
       {/if}
+
+      <!-- Desktop-only close button -->
       <button
         onclick={onClose}
-        class="transition flex items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
+        class="hidden md:flex transition items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
         aria-label="Close panel"
         title="Close"
       >

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -136,7 +136,7 @@
   <div class="flex-1 min-h-0 flex flex-col">
     <EntityList
       onSelect={handleSelect}
-      onOpenZen={(entity) => uiStore.openZenMode(entity.id)}
+      onOpenZen={handleSelect}
       onFindInGraph={handleFindInGraph}
       onDragStart={explorerTab === "all" ? onDragStart : undefined}
       showDraftsOnly={explorerTab === "review"}

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -12,6 +12,7 @@
 
   function handleSelect(entity: Entity) {
     uiStore.openZenMode(entity.id);
+    if (uiStore.isMobile) uiStore.closeSidebar();
   }
 
   function onDragStart(event: DragEvent, entityId: string) {

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -70,80 +70,92 @@
 
 <header
   style="background-image: var(--bg-texture-overlay)"
-  class="px-4 md:px-6 py-2 md:py-3 border-b border-theme-border bg-theme-surface flex justify-between items-start shrink-0"
+  class="px-4 md:px-6 py-2 md:py-3 border-b border-theme-border bg-theme-surface flex justify-between items-center shrink-0"
   data-testid="zen-header"
 >
-  <div class="flex-1 mr-4 md:mr-8">
-    <div class="flex items-center gap-3 mb-1">
-      <span
-        class="{getIconClass(
-          categories.getCategory(
-            editState.isEditing ? editState.type : entity?.type || '',
-          )?.icon,
-        )} text-theme-primary w-5 h-5"
-      ></span>
-      {#if editState.isEditing}
-        <select
-          bind:value={editState.type}
-          aria-label="Entity Type"
-          class="bg-theme-bg border border-theme-primary text-theme-primary px-2 py-0.5 text-xs font-bold tracking-widest uppercase font-header focus:outline-none rounded ml-2"
-        >
-          {#each categories.list as cat}
-            <option value={cat.id}>{cat.label || cat.id.toUpperCase()}</option>
-          {/each}
-        </select>
-      {:else}
+  <div class="flex items-center gap-3 md:gap-4 flex-1 min-w-0">
+    <!-- Mobile-only back button -->
+    <button
+      onclick={onClose}
+      class="md:hidden text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
+      aria-label="Back"
+    >
+      <span class="icon-[lucide--chevron-left] w-7 h-7"></span>
+    </button>
+
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-3 mb-0.5 md:mb-1">
         <span
-          class="text-xs font-bold tracking-widest text-theme-primary uppercase font-header"
-          >{entity?.type || ""}</span
-        >
-      {/if}
-    </div>
-    {#if editState.isEditing}
-      <div class="space-y-2">
-        <input
-          type="text"
-          bind:value={editState.title}
-          aria-label="Entity Title"
-          class="bg-theme-bg border border-theme-primary text-theme-text px-3 py-1 focus:outline-none focus:border-theme-primary font-body font-bold text-2xl md:text-3xl w-full placeholder-theme-muted rounded"
-          placeholder="Entity Title"
-        />
-        <AliasInput bind:aliases={editState.aliases} />
-      </div>
-    {:else}
-      <div class="flex flex-col gap-1">
-        <h1
-          id="entity-modal-title"
-          data-testid="entity-title"
-          class="text-2xl md:text-4xl font-body font-bold text-theme-text tracking-wide"
-        >
-          {entity?.title || ""}
-        </h1>
-        {#if entity?.aliases && entity.aliases.length > 0}
-          <div class="flex flex-wrap gap-1.5 mt-1">
-            <span
-              class="text-[10px] font-bold text-theme-muted uppercase tracking-widest self-center mr-1"
-              >aka:</span
-            >
-            {#each entity.aliases as alias}
-              <div
-                class="px-2 py-0.5 rounded bg-theme-primary/5 border border-theme-primary/10 text-[10px] font-bold text-theme-secondary uppercase tracking-wider"
+          class="{getIconClass(
+            categories.getCategory(
+              editState.isEditing ? editState.type : entity?.type || '',
+            )?.icon,
+          )} text-theme-primary w-4 h-4 md:w-5 md:h-5"
+        ></span>
+        {#if editState.isEditing}
+          <select
+            bind:value={editState.type}
+            aria-label="Entity Type"
+            class="bg-theme-bg border border-theme-primary text-theme-primary px-2 py-0.5 text-[10px] md:text-xs font-bold tracking-widest uppercase font-header focus:outline-none rounded ml-1 md:ml-2"
+          >
+            {#each categories.list as cat}
+              <option value={cat.id}>{cat.label || cat.id.toUpperCase()}</option
               >
-                {alias}
-              </div>
             {/each}
-          </div>
+          </select>
+        {:else}
+          <span
+            class="text-[10px] md:text-xs font-bold tracking-widest text-theme-primary uppercase font-header"
+            >{entity?.type || ""}</span
+          >
         {/if}
       </div>
-    {/if}
+      {#if editState.isEditing}
+        <div class="space-y-2">
+          <input
+            type="text"
+            bind:value={editState.title}
+            aria-label="Entity Title"
+            class="bg-theme-bg border border-theme-primary text-theme-text px-3 py-1 focus:outline-none focus:border-theme-primary font-body font-bold text-xl md:text-3xl w-full placeholder-theme-muted rounded"
+            placeholder="Entity Title"
+          />
+          <AliasInput bind:aliases={editState.aliases} />
+        </div>
+      {:else}
+        <div class="flex flex-col gap-0.5">
+          <h1
+            id="entity-modal-title"
+            data-testid="entity-title"
+            class="text-xl md:text-4xl font-body font-bold text-theme-text tracking-wide truncate"
+          >
+            {entity?.title || ""}
+          </h1>
+          {#if entity?.aliases && entity.aliases.length > 0}
+            <div class="flex flex-wrap gap-1 md:gap-1.5">
+              <span
+                class="text-[8px] md:text-[10px] font-bold text-theme-muted uppercase tracking-widest self-center mr-0.5 md:mr-1"
+                >aka:</span
+              >
+              {#each entity.aliases as alias}
+                <div
+                  class="px-1.5 md:px-2 py-0.5 rounded bg-theme-primary/5 border border-theme-primary/10 text-[8px] md:text-[10px] font-bold text-theme-secondary uppercase tracking-wider"
+                >
+                  {alias}
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
   </div>
 
-  <div class="flex items-center gap-2 md:gap-3">
+  <div class="flex items-center gap-1.5 md:gap-3 shrink-0 ml-2 md:ml-4">
     {#if !editState.isEditing}
       {#if isGraphView}
         <button
           onclick={handleFindInGraph}
-          class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-xs font-bold tracking-widest"
+          class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
           title="Find in Graph"
           aria-label="Find in Graph"
           data-testid="zen-find-in-graph-button"
@@ -153,7 +165,7 @@
       {/if}
       <button
         onclick={onCopy}
-        class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-xs font-bold tracking-widest"
+        class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
         title="Copy Content"
         aria-label="Copy Content"
       >
@@ -171,7 +183,7 @@
         disabled={isDraftActioning}
         title="Approve draft"
         aria-label="Approve draft"
-        class="px-3 md:px-4 py-1.5 border border-theme-primary/40 text-theme-primary hover:bg-theme-primary/10 text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
+        class="px-2 md:px-4 py-1.5 border border-theme-primary/40 text-theme-primary hover:bg-theme-primary/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
         data-testid="approve-draft-button"
       >
         <span class="icon-[lucide--check] w-3 h-3"></span>
@@ -182,7 +194,7 @@
         disabled={isDraftActioning}
         title="Reject draft"
         aria-label="Reject draft"
-        class="px-3 md:px-4 py-1.5 border border-theme-danger/40 text-theme-danger hover:bg-theme-danger/10 text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
+        class="px-2 md:px-4 py-1.5 border border-theme-danger/40 text-theme-danger hover:bg-theme-danger/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
         data-testid="reject-draft-button"
       >
         <span class="icon-[lucide--trash-2] w-3 h-3"></span>
@@ -192,7 +204,7 @@
     {#if !editState.isEditing && !vault.isGuest && entity}
       <button
         onclick={onStartEdit}
-        class="px-3 md:px-4 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
+        class="px-2 md:px-4 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
         data-testid="edit-entity-button"
       >
         <span class="icon-[lucide--edit-2] w-3 h-3"></span>
@@ -201,14 +213,14 @@
     {:else if editState.isEditing}
       <button
         onclick={onCancelEdit}
-        class="px-3 md:px-4 py-1.5 text-theme-muted hover:text-theme-text text-xs font-bold rounded tracking-widest transition"
+        class="px-2 md:px-4 py-1.5 text-theme-muted hover:text-theme-text text-[10px] md:text-xs font-bold rounded tracking-widest transition"
       >
         CANCEL
       </button>
       <button
         onclick={onSave}
         disabled={isSaving}
-        class="px-3 md:px-4 py-1.5 bg-theme-primary hover:bg-theme-secondary disabled:opacity-50 text-theme-bg text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
+        class="px-2 md:px-4 py-1.5 bg-theme-primary hover:bg-theme-secondary disabled:opacity-50 text-theme-bg text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
       >
         {#if isSaving}
           <span class="icon-[lucide--loader-2] w-3 h-3 animate-spin"></span>
@@ -223,7 +235,7 @@
     {#if onPopOut && !editState.isEditing}
       <button
         onclick={onPopOut}
-        class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-xs font-bold tracking-widest"
+        class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
         title="Open in new tab"
         aria-label="Open in new tab"
       >
@@ -232,11 +244,11 @@
       </button>
     {/if}
 
-    <div class="w-px h-6 bg-theme-border mx-0.5 md:mx-1"></div>
+    <div class="hidden md:block w-px h-6 bg-theme-border mx-0.5 md:mx-1"></div>
 
     <button
       onclick={onClose}
-      class="text-theme-muted hover:text-theme-primary transition p-2 hover:bg-theme-primary/10 rounded"
+      class="hidden md:flex text-theme-muted hover:text-theme-primary transition p-2 hover:bg-theme-primary/10 rounded"
       aria-label="Close"
     >
       <span class="icon-[lucide--x] w-6 h-6"></span>

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -345,6 +345,7 @@
           bind:this={mobileScroller}
           class="flex-1 flex flex-col md:flex-row overflow-y-auto md:overflow-hidden w-full h-full custom-scrollbar"
           data-testid="zen-mobile-scroll-container"
+          style="touch-action: pan-y;"
         >
           <ZenSidebar
             {entity}

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -344,6 +344,7 @@
           aria-labelledby="tab-overview"
           bind:this={mobileScroller}
           class="flex-1 flex flex-col md:flex-row overflow-y-auto md:overflow-hidden w-full h-full custom-scrollbar"
+          data-testid="zen-mobile-scroll-container"
         >
           <ZenSidebar
             {entity}

--- a/apps/web/tests/mobile-ux-fixes.spec.ts
+++ b/apps/web/tests/mobile-ux-fixes.spec.ts
@@ -83,7 +83,7 @@ test.describe("Mobile UX Fixes", () => {
       timeout: 5000,
     });
 
-    const scrollShell = page.getByTestId("embedded-entity-scroll");
+    const scrollShell = page.getByTestId("zen-mobile-scroll-container");
     await expect(scrollShell).toBeVisible();
 
     const metrics = await scrollShell.evaluate((el) => {


### PR DESCRIPTION
Improves the mobile UX for navigating and closing entities.

### Changes
- Automatically close the sidebar on mobile when an entity is selected from the explorer.
- Relocate the close/back button in `ZenHeader` and `DetailHeader` to the left (chevron-left) on mobile for better convention and accessibility.
- Added `data-testid="zen-mobile-scroll-container"` for better testability.
- Updated mobile UX tests to verify the new layout.

Fixes #759