### PR TITLE
fix(explorer): prevent many labels from hiding entity name

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -343,7 +343,7 @@
         </button>
 
         {#if entity.labels && entity.labels.length > 0}
-          <div class="flex gap-1 shrink-0 px-2 flex-wrap justify-end">
+          <div class="flex gap-1 px-2 flex-wrap justify-end max-w-[50%]">
             {#each entity.labels as label}
               <button
                 type="button"


### PR DESCRIPTION
This PR fixes a UI issue in the Entity Explorer where an entity's name would be completely hidden or severely truncated if it had many labels.

### Changes
- Removed `shrink-0` from the labels container in `EntityList.svelte`.
- Added `max-w-[50%]` to the labels container to ensure the name always has at least 50% of the available horizontal space.
- Labels will now wrap to a new line if they exceed the 50% width limit, preserving the visibility and readability of the entity title.

### Verification
- Verified with unit tests in `apps/web/src/lib/components/explorer/EntityList.test.ts`.
- Manually checked the layout logic against the provided screenshot.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>