### PR TITLE
fix(explorer): use compact labels with counter to prevent overflow

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -343,7 +343,7 @@
         </button>
 
         {#if entity.labels && entity.labels.length > 0}
-          <div class="flex gap-1 shrink-0 px-2 flex-wrap justify-end">
+          <div class="flex gap-1 px-2 flex-wrap justify-end max-w-[50%]">
             {#each entity.labels as label}
               <button
                 type="button"

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -343,8 +343,10 @@
         </button>
 
         {#if entity.labels && entity.labels.length > 0}
-          <div class="flex gap-1 px-2 flex-wrap justify-end max-w-[50%]">
-            {#each entity.labels as label}
+          <div
+            class="flex gap-1 px-2 flex-nowrap justify-end max-w-[45%] shrink-0"
+          >
+            {#each entity.labels.slice(0, 2) as label}
               <button
                 type="button"
                 onclick={(e) => {
@@ -360,6 +362,13 @@
                 {label}
               </button>
             {/each}
+            {#if entity.labels.length > 2}
+              <div
+                class="text-[7px] text-theme-muted font-mono flex items-center"
+              >
+                +{entity.labels.length - 2}
+              </div>
+            {/if}
           </div>
         {/if}
 


### PR DESCRIPTION
This PR refines the Entity Explorer UI to handle entities with many labels more gracefully.

### Improvements
- **Compact Layout**: Switched from wrapping labels (which increased row height and pushed the name) to a single-line approach.
- **Label Counter**: Shows only the first 2 labels and a count for additional ones (e.g., `+3`).
- **Prioritize Name**: Reserved space for the entity title and ensured it remains visible even with multiple labels.
- **Branch Naming**: Renamed branch to `762-fix-label-overflow` to align with the issue number.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>