### PR TITLE
Fix E2E test failures caused by 404 in SvelteKit prerendering

### DIFF
--- a/apps/web/src/lib/content/blog/gdrive-cloud-sync.md
+++ b/apps/web/src/lib/content/blog/gdrive-cloud-sync.md
@@ -60,6 +60,6 @@ The first join uses a slightly broader Drive scope so Codex can read a folder it
 
 Head to **Settings → Cloud Sync** and click **Connect Google Drive**. The first time you connect you'll go through a standard Google OAuth flow — takes about thirty seconds.
 
-If you run into anything, the [help article](/help/gdrive-cloud-sync) has a step-by-step walkthrough.
+If you run into anything, the [help article](/help#help/gdrive-cloud-sync) has a step-by-step walkthrough.
 
 Happy world-building.

--- a/apps/web/static/llms-full.txt
+++ b/apps/web/static/llms-full.txt
@@ -584,6 +584,49 @@ When you open Codex on a new device:
 
 ---
 
+### GOOGLE DRIVE CLOUD SYNC
+
+Codex Cryptica can back up your vault to your personal Google Drive and restore it from any device. Your files go straight from your browser to your Drive — our servers never see them.
+
+## Connect Your Vault
+
+1. Open **Settings → Cloud Sync**.
+2. Click **Connect Google Drive** and sign in when Google prompts you.
+3. Codex creates a `CodexCryptica/` folder on your Drive (if it doesn't exist) and a subfolder named after your vault inside it. The folder ID is saved locally so future syncs know where to go.
+
+Once connected you'll see two buttons:
+
+- **Save to Drive** — pushes your local vault up to the cloud.
+- **Load from Drive** — pulls the cloud version back down. Only files that are newer than your local copy are downloaded, so a full re-pull stays fast.
+
+> [!NOTE]
+> Sync is always manual. Codex never uploads in the background without you clicking a button, so you stay in control of what leaves your device.
+
+## Import a Vault from Drive
+
+If you have vaults already stored in your `CodexCryptica/` Drive folder (from another device), you can load them without setting them up from scratch:
+
+1. In **Settings → Cloud Sync**, click **Browse Drive**.
+2. Codex lists every vault subfolder it finds under `CodexCryptica/`.
+3. Click **Load** next to any vault. Codex creates a local vault (or finds the existing one), then pulls only the files that are newer than what you have locally.
+
+## Join a Shared Vault (Co-GM Flow)
+
+If your GM has shared their Drive vault folder with you, you can connect to it directly:
+
+1. Ask your GM to share the Drive folder and copy the share link (it looks like `https://drive.google.com/drive/folders/…`).
+2. In **Settings → Cloud Sync**, paste the link into the **Join a Shared Vault** field and click **Join**.
+3. Google will ask you to grant read access to the shared folder. Once approved, Codex imports the vault locally and you can pull updates any time with **Load from Drive**.
+
+> [!NOTE]
+> The first join asks for broader Drive access so Codex can read folders you don't own. Normal push/pull to your own vaults uses the narrower `drive.file` scope and only accesses files Codex itself created.
+
+## Disconnect
+
+Click **Disconnect** in the connected state to remove the Drive link from this vault. Your local vault and the files on Drive are both preserved — only the sync mapping is removed.
+
+---
+
 ### VAULT STRUCTURE
 
 Codex Cryptica uses standard Markdown files. You can even open your vault folder in other apps like Obsidian or VS Code.

--- a/apps/web/static/sitemap.xml
+++ b/apps/web/static/sitemap.xml
@@ -37,6 +37,12 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://codexcryptica.com/blog/gdrive-cloud-sync</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <lastmod>2026-04-30T10:00:00.000Z</lastmod>
+  </url>
+  <url>
     <loc>https://codexcryptica.com/blog/vtt-introduction</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## Tests Failed
- The E2E tests failed because `npm run build` failed. The build failed with a 404 error during prerendering: `Error: 404 /help/gdrive-cloud-sync (linked from /blog/gdrive-cloud-sync)`.

## Root Cause
- The `gdrive-cloud-sync.md` blog post included a link to `[help article](/help/gdrive-cloud-sync)`. SvelteKit's static prerenderer (`adapter-static`) attempted to crawl this link but the actual application handles help articles via hash routing (`/#help/article-id` or `/help#help/article-id`), meaning `/help/gdrive-cloud-sync` is not a valid route.

## Steps Taken
- Identified the source of the 404 in `apps/web/src/lib/content/blog/gdrive-cloud-sync.md`.
- Updated the link to `/help#help/gdrive-cloud-sync`.
- Verified the build succeeds with no 404s.
- Ran the full test suite (`pnpm run test:e2e --reporter=list`) and linter (`pnpm run lint`) to confirm all checks pass.

---
*PR created automatically by Jules for task [151031927126760455](https://jules.google.com/task/151031927126760455) started by @eserlan*