### PR TITLE
🎨 Palette: Make hover tooltip visible on keyboard focus in DetailImage

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -164,7 +164,7 @@
           class="w-full h-auto max-h-48 md:max-h-80 object-contain opacity-90 group-hover:opacity-100 transition mx-auto"
         />
         <div
-          class="absolute bottom-2 right-2 bg-theme-surface text-theme-primary text-[9px] px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 transition"
+          class="absolute bottom-2 right-2 bg-theme-surface text-theme-primary text-[9px] px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition"
         >
           Click to enlarge
         </div>


### PR DESCRIPTION
Added `group-focus:opacity-100` to the image lightbox hint tooltip in `DetailImage.svelte`. Previously, the 'Click to enlarge' text only appeared on `group-hover:opacity-100`, which made it completely invisible to keyboard users when they tabbed to the parent button. This change ensures screen reader and keyboard-only users also see the helpful text indicating what action the button performs.

---
*PR created automatically by Jules for task [2280463337680731077](https://jules.google.com/task/2280463337680731077) started by @eserlan*