### PR TITLE
fix(oracle): smart apply reconciliation + removeMessage crash

### DIFF
--- a/apps/web/src/lib/components/oracle/chat-message.actions.test.ts
+++ b/apps/web/src/lib/components/oracle/chat-message.actions.test.ts
@@ -28,6 +28,10 @@ describe("ChatMessageActions", () => {
       pushUndoAction: vi.fn(),
       updateMessageEntity: vi.fn(),
       undo: vi.fn().mockResolvedValue(undefined),
+      reconcileSmartApply: vi.fn().mockResolvedValue({
+        content: "new chronicle",
+        lore: "new lore",
+      }),
     };
     graph = {
       requestFit: vi.fn(),
@@ -64,12 +68,8 @@ describe("ChatMessageActions", () => {
     expect(oracle.pushUndoAction).toHaveBeenCalled();
   });
 
-  it("snapshots the entity before cloning during undo capture", async () => {
+  it("captures a deep copy of the entity state for undo", async () => {
     const setSaved = vi.fn();
-    const entityRef = vault.entities.target;
-    const structuredCloneSpy = vi
-      .spyOn(globalThis, "structuredClone")
-      .mockImplementation((value) => value as any);
 
     await actions.copyToChronicle({
       message: {
@@ -80,8 +80,13 @@ describe("ChatMessageActions", () => {
       setSaved,
     });
 
-    expect(structuredCloneSpy).toHaveBeenCalledTimes(1);
-    expect(structuredCloneSpy.mock.calls[0][0]).not.toBe(entityRef);
+    const undo = oracle.pushUndoAction.mock.calls.at(-1)?.[1];
+    vault.entities.target.content = "mutated after capture";
+    await undo?.();
+
+    expect(vault.updateEntity).toHaveBeenCalledWith("target", {
+      content: "old chronicle",
+    });
   });
 
   it("creates a node from parsed chat content", async () => {

--- a/apps/web/src/lib/components/oracle/chat-message.actions.ts
+++ b/apps/web/src/lib/components/oracle/chat-message.actions.ts
@@ -59,17 +59,7 @@ export class ChatMessageActions {
   private captureState(entityId: string) {
     const entity = this.vault.entities[entityId] as EntityLike | undefined;
     if (!entity) return null;
-    const snapshot = { ...entity } as EntityLike;
-
-    try {
-      return structuredClone(snapshot) as EntityLike;
-    } catch (error) {
-      console.warn(
-        "Failed to structuredClone entity, falling back to JSON parse/stringify",
-        error,
-      );
-      return JSON.parse(JSON.stringify(snapshot)) as EntityLike;
-    }
+    return JSON.parse(JSON.stringify(entity)) as EntityLike;
   }
 
   private async updateWithUndo(
@@ -124,20 +114,21 @@ export class ChatMessageActions {
       return;
     }
 
-    const updates: Partial<EntityLike> = {};
-    if (params.parsed.chronicle) {
-      updates.content = params.parsed.chronicle;
-    }
-    if (params.parsed.lore) {
-      updates.lore = params.parsed.lore;
-    }
+    const incoming: { chronicle?: string; lore?: string } = {};
+    if (params.parsed.chronicle) incoming.chronicle = params.parsed.chronicle;
+    if (params.parsed.lore) incoming.lore = params.parsed.lore;
 
-    console.log("[Oracle] Smart Apply updates:", updates);
-
-    if (Object.keys(updates).length === 0) {
+    if (Object.keys(incoming).length === 0) {
       console.warn("[Oracle] Smart Apply aborted: No updates extracted");
       return;
     }
+
+    const updates = await this.oracle.reconcileSmartApply(
+      finalTargetId,
+      incoming,
+    );
+
+    console.log("[Oracle] Smart Apply reconciled updates:", updates);
 
     await this.updateWithUndo(
       finalTargetId,

--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -574,6 +574,7 @@ describe("OracleStore", () => {
       // Chat history methods
       expect(typeof context.chatHistory.addMessage).toBe("function");
       expect(typeof context.chatHistory.setMessages).toBe("function");
+      expect(typeof context.chatHistory.removeMessage).toBe("function");
 
       // Context retrieval methods (Regressed in previous version)
       expect(context.contextRetrieval).toBeDefined();
@@ -711,6 +712,102 @@ describe("OracleStore", () => {
 
       expect(result.content).toBe("C");
       expect(result.lore).toBe("L\n\nmore");
+    });
+
+    describe("reconcileSmartApply", () => {
+      beforeEach(() => {
+        (mockVault as any).entities = {
+          target: {
+            id: "target",
+            title: "Zariel",
+            type: "npc",
+            content: "Old chronicle",
+            lore: "Old lore",
+            connections: [],
+          },
+        };
+      });
+
+      it("calls reconcileEntityUpdate with snapshotted args and returns selective fields", async () => {
+        (oracle as any).textGeneration.reconcileEntityUpdate = vi
+          .fn()
+          .mockResolvedValue({
+            content: "Merged chronicle",
+            lore: "Merged lore",
+          });
+
+        const result = await oracle.reconcileSmartApply("target", {
+          chronicle: "New chronicle",
+          lore: "New lore",
+        });
+
+        expect(
+          (oracle as any).textGeneration.reconcileEntityUpdate,
+        ).toHaveBeenCalledWith(
+          "test-key",
+          "test-model",
+          expect.objectContaining({ id: "target" }),
+          { chronicle: "New chronicle", lore: "New lore" },
+          expect.any(Array),
+        );
+        expect(result).toEqual({
+          content: "Merged chronicle",
+          lore: "Merged lore",
+        });
+      });
+
+      it("omits fields not present in incoming when returning reconciled result", async () => {
+        (oracle as any).textGeneration.reconcileEntityUpdate = vi
+          .fn()
+          .mockResolvedValue({
+            content: "Merged chronicle",
+            lore: "Merged lore",
+          });
+
+        const result = await oracle.reconcileSmartApply("target", {
+          chronicle: "New chronicle",
+        });
+
+        expect(result.content).toBe("Merged chronicle");
+        expect(result.lore).toBeUndefined();
+      });
+
+      it("falls back to local append when AI is disabled", async () => {
+        (mockUiStore as any).aiDisabled = true;
+        (oracle as any).textGeneration.reconcileEntityUpdate = vi.fn();
+
+        const result = await oracle.reconcileSmartApply("target", {
+          chronicle: "Appended",
+          lore: "New lore",
+        });
+
+        expect(result).toEqual({
+          content: "Old chronicle\n\nAppended",
+          lore: "Old lore\n\nNew lore",
+        });
+        expect(
+          (oracle as any).textGeneration.reconcileEntityUpdate,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("falls back to local append when reconcileEntityUpdate throws", async () => {
+        (oracle as any).textGeneration.reconcileEntityUpdate = vi
+          .fn()
+          .mockRejectedValue(new Error("AI error"));
+
+        const result = await oracle.reconcileSmartApply("target", {
+          lore: "Extra lore",
+        });
+
+        expect(result).toEqual({ lore: "Old lore\n\nExtra lore" });
+      });
+
+      it("throws when entity is not found", async () => {
+        (mockVault as any).entities = {};
+        await expect(
+          oracle.reconcileSmartApply("missing", { chronicle: "x" }),
+        ).rejects.toThrow("Entity missing not found.");
+      });
     });
 
     it("should reset the store", () => {

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -32,7 +32,7 @@ import {
 } from "dice-engine";
 import { diceHistory as defaultDiceHistory } from "./dice-history.svelte";
 import { categories as defaultCategories } from "./categories.svelte";
-import type { TextGenerationService } from "schema";
+import type { Entity, TextGenerationService } from "schema";
 
 export type { ChatMessage, UndoableAction };
 

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -351,6 +351,9 @@ export class OracleStore {
         clearMessages: wrap(
           this.chatHistoryService.clearMessages?.bind(this.chatHistoryService),
         ),
+        removeMessage: wrap(
+          this.chatHistoryService.removeMessage?.bind(this.chatHistoryService),
+        ),
         addProposal: wrap(
           this.chatHistoryService.addProposal?.bind(this.chatHistoryService),
         ),
@@ -568,6 +571,66 @@ export class OracleStore {
 
   async removeMessage(id: string) {
     await this.chatHistoryService.removeMessage(id);
+  }
+
+  async reconcileSmartApply(
+    entityId: string,
+    incoming: { chronicle?: string; lore?: string },
+  ): Promise<{ content?: string; lore?: string }> {
+    const existing = this.vault.entities[entityId];
+    if (!existing) throw new Error(`Entity ${entityId} not found.`);
+
+    const fallback = () => ({
+      content: incoming.chronicle
+        ? existing.content
+          ? existing.content + "\n\n" + incoming.chronicle
+          : incoming.chronicle
+        : undefined,
+      lore: incoming.lore
+        ? existing.lore
+          ? existing.lore + "\n\n" + incoming.lore
+          : incoming.lore
+        : undefined,
+    });
+
+    if (this.uiStore.aiDisabled || !this.textGeneration.reconcileEntityUpdate) {
+      return fallback();
+    }
+
+    try {
+      const snapExisting = $state.snapshot(existing);
+      const snapIncoming = $state.snapshot({
+        chronicle: incoming.chronicle || "",
+        lore: incoming.lore || "",
+      });
+      const snapContext = $state.snapshot(
+        buildRelatedEntityContext({
+          entity: existing,
+          incoming: {
+            chronicle: incoming.chronicle || "",
+            lore: incoming.lore || "",
+          },
+          vault: this.vault,
+          getConsolidatedContext: (related) =>
+            this.contextRetrieval.getConsolidatedContext(related),
+        }),
+      );
+
+      const reconciled = await this.textGeneration.reconcileEntityUpdate(
+        this.effectiveApiKey || "",
+        this.modelName,
+        snapExisting,
+        snapIncoming,
+        snapContext,
+      );
+
+      return {
+        content: incoming.chronicle ? reconciled.content : undefined,
+        lore: incoming.lore ? reconciled.lore : undefined,
+      };
+    } catch {
+      return fallback();
+    }
   }
 
   async reconcileDiscoveryProposal(proposal: DiscoveryProposal) {

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -573,6 +573,33 @@ export class OracleStore {
     await this.chatHistoryService.removeMessage(id);
   }
 
+  private async reconcileEntityFields(
+    existing: Entity,
+    incoming: { chronicle: string; lore: string },
+  ): Promise<{ content: string; lore: string }> {
+    if (!this.textGeneration.reconcileEntityUpdate) {
+      throw new Error("reconcileEntityUpdate not available");
+    }
+    const snapExisting = $state.snapshot(existing);
+    const snapIncoming = $state.snapshot(incoming);
+    const snapContext = $state.snapshot(
+      buildRelatedEntityContext({
+        entity: existing,
+        incoming,
+        vault: this.vault,
+        getConsolidatedContext: (related) =>
+          this.contextRetrieval.getConsolidatedContext(related),
+      }),
+    );
+    return this.textGeneration.reconcileEntityUpdate(
+      this.effectiveApiKey || "",
+      this.modelName,
+      snapExisting,
+      snapIncoming,
+      snapContext,
+    );
+  }
+
   async reconcileSmartApply(
     entityId: string,
     incoming: { chronicle?: string; lore?: string },
@@ -580,7 +607,7 @@ export class OracleStore {
     const existing = this.vault.entities[entityId];
     if (!existing) throw new Error(`Entity ${entityId} not found.`);
 
-    const fallback = () => ({
+    const fallback = (): { content?: string; lore?: string } => ({
       content: incoming.chronicle
         ? existing.content
           ? existing.content + "\n\n" + incoming.chronicle
@@ -598,32 +625,10 @@ export class OracleStore {
     }
 
     try {
-      const snapExisting = $state.snapshot(existing);
-      const snapIncoming = $state.snapshot({
+      const reconciled = await this.reconcileEntityFields(existing, {
         chronicle: incoming.chronicle || "",
         lore: incoming.lore || "",
       });
-      const snapContext = $state.snapshot(
-        buildRelatedEntityContext({
-          entity: existing,
-          incoming: {
-            chronicle: incoming.chronicle || "",
-            lore: incoming.lore || "",
-          },
-          vault: this.vault,
-          getConsolidatedContext: (related) =>
-            this.contextRetrieval.getConsolidatedContext(related),
-        }),
-      );
-
-      const reconciled = await this.textGeneration.reconcileEntityUpdate(
-        this.effectiveApiKey || "",
-        this.modelName,
-        snapExisting,
-        snapIncoming,
-        snapContext,
-      );
-
       return {
         content: incoming.chronicle ? reconciled.content : undefined,
         lore: incoming.lore ? reconciled.lore : undefined,
@@ -651,32 +656,10 @@ export class OracleStore {
     }
 
     try {
-      // We MUST snapshot reactive state before sending to a worker (PR Fix)
-      const snapExisting = $state.snapshot(existing);
-      const snapIncoming = $state.snapshot({
+      return await this.reconcileEntityFields(existing, {
         chronicle: proposal.draft.chronicle,
         lore: proposal.draft.lore,
       });
-      const snapContext = $state.snapshot(
-        buildRelatedEntityContext({
-          entity: existing,
-          incoming: {
-            chronicle: proposal.draft.chronicle,
-            lore: proposal.draft.lore,
-          },
-          vault: this.vault,
-          getConsolidatedContext: (related) =>
-            this.contextRetrieval.getConsolidatedContext(related),
-        }),
-      );
-
-      return await this.textGeneration.reconcileEntityUpdate(
-        this.effectiveApiKey || "",
-        this.modelName,
-        snapExisting,
-        snapIncoming,
-        snapContext,
-      );
     } catch {
       return {
         content: existing.content || proposal.draft.chronicle,


### PR DESCRIPTION
## Summary

- **Smart Apply was overwriting entity content** instead of merging it — calls to `applySmart` now route through a new `oracle.reconcileSmartApply()` method that uses the same AI reconciliation prompt as auto-archive, with a simple append fallback when AI is disabled.
- **`removeMessage is not a function` crash** — `removeMessage` was missing from the chatHistory context object wired into the oracle executor; added the binding alongside the other `ChatHistoryService` methods.
- **`structuredClone DataCloneError` warning** — `captureState` was calling `structuredClone` on Svelte 5 reactive proxies, which can't be serialized that way; replaced with `JSON.parse(JSON.stringify())`.

## Test plan

- [ ] Chat with oracle, write content about an existing entity, hit Smart Apply — confirm existing fields are merged, not replaced
- [ ] Confirm Smart Apply undo restores the pre-apply state correctly
- [ ] Confirm Copy to Chronicle and Copy to Lore still work with undo
- [ ] Confirm no `structuredClone` DataCloneError in console
- [ ] Confirm no `removeMessage is not a function` error when using oracle chat
- [ ] All 1085 unit tests pass (verified in pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)