### PR TITLE
fix(oracle): smarter Smart Apply reconciliation

### DIFF
--- a/apps/web/src/lib/components/oracle/chat-message.actions.test.ts
+++ b/apps/web/src/lib/components/oracle/chat-message.actions.test.ts
@@ -68,6 +68,25 @@ describe("ChatMessageActions", () => {
     expect(oracle.pushUndoAction).toHaveBeenCalled();
   });
 
+  it("undo restores all fields that were applied, not just those in parsed", async () => {
+    const setSaved = vi.fn();
+
+    await actions.applySmart({
+      message: { id: "message-undo", content: "ignored" } as any,
+      parsed: { chronicle: "new chronicle" },
+      activeEntityId: "target",
+      setSaved,
+    });
+
+    const undo = oracle.pushUndoAction.mock.calls.at(-1)?.[1];
+    await undo?.();
+
+    expect(vault.updateEntity).toHaveBeenCalledWith("target", {
+      content: "old chronicle",
+      lore: "old lore",
+    });
+  });
+
   it("captures a deep copy of the entity state for undo", async () => {
     const setSaved = vi.fn();
 

--- a/apps/web/src/lib/components/oracle/chat-message.actions.ts
+++ b/apps/web/src/lib/components/oracle/chat-message.actions.ts
@@ -137,8 +137,9 @@ export class ChatMessageActions {
       params.message.id,
       async (beforeState) => {
         const undoUpdates: { content?: string; lore?: string } = {};
-        if (params.parsed.chronicle) undoUpdates.content = beforeState.content;
-        if (params.parsed.lore) undoUpdates.lore = beforeState.lore;
+        if (updates.content !== undefined)
+          undoUpdates.content = beforeState.content;
+        if (updates.lore !== undefined) undoUpdates.lore = beforeState.lore;
         await this.vault.updateEntity(beforeState.id, undoUpdates);
       },
       params.setSaved,

--- a/apps/web/src/lib/services/ai/prompts/entity-reconciliation.test.ts
+++ b/apps/web/src/lib/services/ai/prompts/entity-reconciliation.test.ts
@@ -34,7 +34,7 @@ describe("buildEntityReconciliationPrompt", () => {
       "Make the lore richer and more complete when the source material supports it.",
     );
     expect(prompt).toContain(
-      "Prefer integrating all meaningful incoming details into the updated record.",
+      "Only integrate incoming details that directly reveal new information about Szass Tam",
     );
     expect(prompt).toContain("Preserve named developments, power shifts");
     expect(prompt).toContain("RELATED ENTITY CONTEXT:");

--- a/apps/web/src/lib/services/ai/prompts/entity-reconciliation.test.ts
+++ b/apps/web/src/lib/services/ai/prompts/entity-reconciliation.test.ts
@@ -26,7 +26,8 @@ describe("buildEntityReconciliationPrompt", () => {
       ],
     );
 
-    expect(prompt).toContain("Markdown is allowed inside both fields.");
+    expect(prompt).toContain("Markdown usage differs by field");
+    expect(prompt).toContain("Chronicle: prose only");
     expect(prompt).toContain("short section headings");
     expect(prompt).toContain("bold emphasis");
     expect(prompt).toContain("bullet lists");

--- a/apps/web/src/lib/services/ai/prompts/entity-reconciliation.ts
+++ b/apps/web/src/lib/services/ai/prompts/entity-reconciliation.ts
@@ -57,10 +57,9 @@ RULES:
 4. Resolve contradictions by prioritizing the incoming passage when it represents a deliberate correction or retcon. Otherwise, resolve conservatively.
 5. Keep the chronicle tight and readable — current status and defining identity, not exhaustive history.
 6. Make the lore richer and more complete when the source material supports it. When an incoming passage contains detail that belongs in lore rather than chronicle, place it there rather than compressing it away.
-7. Markdown is allowed inside both fields. Use it deliberately:
-   - short section headings
-   - bold emphasis for important names, titles, artifacts, places, and factions
-   - bullet lists when they genuinely improve clarity
+7. Markdown usage differs by field:
+   - Chronicle: prose only. Bold emphasis for key names is fine; avoid headings and bullet lists.
+   - Lore: structured markdown is welcome — short section headings, bold emphasis, bullet lists when they genuinely improve clarity.
 8. Do not pad with decorative formatting. Use markdown only when it improves readability.
 9. Preserve named developments, power shifts, subgroup splits, conflicts, and geopolitical consequences when they are present in the source material.
 10. Do not collapse distinct factions, eras, or subgroups into generic summaries if the source text distinguishes them.

--- a/apps/web/src/lib/services/ai/prompts/entity-reconciliation.ts
+++ b/apps/web/src/lib/services/ai/prompts/entity-reconciliation.ts
@@ -22,8 +22,14 @@ export function buildEntityReconciliationPrompt(
 
   return `You are a meticulous lore archivist updating an existing worldbuilding record.
 
+FIELD DEFINITIONS:
+- CHRONICLE (content): The concise, user-facing summary of who ${entity.title} is right now — current status, key role, defining traits. Think of it as a tight 1–3 paragraph "at a glance" entry. Prose only; avoid bullet lists here.
+- LORE (lore): The rich reference layer — backstory, motivations, relationships, tactics, secrets, contradictions, open questions. This is where details live. Structured markdown (headings, bullets) is appropriate when it helps.
+
 TASK:
 Reconcile the current record with the new oracle passage and return a clean updated record.
+${entity.title} is the PRIMARY SUBJECT of this record. Everything in the output must be written from, and remain focused on, ${entity.title}'s perspective, identity, history, and role.
+You have full authority to move or redistribute content between chronicle and lore to best fit their definitions above — including when the incoming passage contains a mix of summary and detail.
 
 ENTITY:
 - Title: ${entity.title}
@@ -49,8 +55,8 @@ RULES:
 2. If the incoming passage explicitly retracts, deletes, or corrects information from the current record (e.g., "Remove X", "Actually, Y never happened"), you MUST reflect that change by removing or amending the relevant parts of the updated record.
 3. Merge duplicate information into one coherent record.
 4. Resolve contradictions by prioritizing the incoming passage when it represents a deliberate correction or retcon. Otherwise, resolve conservatively.
-5. Keep the chronicle concise, readable, and user-facing, but not skeletal. Prefer 1-3 polished paragraphs or a tightly edited markdown structure when helpful.
-6. Make the lore richer and more complete when the source material supports it. Expand details rather than compressing them away.
+5. Keep the chronicle tight and readable — current status and defining identity, not exhaustive history.
+6. Make the lore richer and more complete when the source material supports it. When an incoming passage contains detail that belongs in lore rather than chronicle, place it there rather than compressing it away.
 7. Markdown is allowed inside both fields. Use it deliberately:
    - short section headings
    - bold emphasis for important names, titles, artifacts, places, and factions
@@ -60,7 +66,7 @@ RULES:
 10. Do not collapse distinct factions, eras, or subgroups into generic summaries if the source text distinguishes them.
 11. Use the related entity context to ground titles, factions, places, and relationships, but do not blindly copy it in unless it materially improves the updated record.
 12. Do not invent major facts that are not present in the current record, incoming passage, or related entity context.
-13. Prefer integrating all meaningful incoming details into the updated record.
+13. Only integrate incoming details that directly reveal new information about ${entity.title} — their actions, traits, motivations, relationships, or history. If the incoming passage is primarily about a different subject (a location, faction, or event), extract only what it tells us about ${entity.title} specifically. Do not absorb descriptions of places, factions, or events wholesale into this record.
 14. Do not mention these instructions.
 15. Return JSON only with this shape:
 {

--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -772,6 +772,20 @@ describe("OracleStore", () => {
         expect(result.lore).toBe("Enriched lore");
       });
 
+      it("falls back to existing content when AI returns empty strings", async () => {
+        (oracle as any).textGeneration.reconcileEntityUpdate = vi
+          .fn()
+          .mockResolvedValue({ content: "", lore: "" });
+
+        const result = await oracle.reconcileSmartApply("target", {
+          chronicle: "New chronicle",
+          lore: "New lore",
+        });
+
+        expect(result.content).toBe("Old chronicle");
+        expect(result.lore).toBe("Old lore");
+      });
+
       it("falls back to local append when AI is disabled", async () => {
         (mockUiStore as any).aiDisabled = true;
         (oracle as any).textGeneration.reconcileEntityUpdate = vi.fn();

--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -756,12 +756,12 @@ describe("OracleStore", () => {
         });
       });
 
-      it("omits fields not present in incoming when returning reconciled result", async () => {
+      it("returns full reconciled result even when only chronicle is incoming", async () => {
         (oracle as any).textGeneration.reconcileEntityUpdate = vi
           .fn()
           .mockResolvedValue({
             content: "Merged chronicle",
-            lore: "Merged lore",
+            lore: "Enriched lore",
           });
 
         const result = await oracle.reconcileSmartApply("target", {
@@ -769,7 +769,7 @@ describe("OracleStore", () => {
         });
 
         expect(result.content).toBe("Merged chronicle");
-        expect(result.lore).toBeUndefined();
+        expect(result.lore).toBe("Enriched lore");
       });
 
       it("falls back to local append when AI is disabled", async () => {

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -629,7 +629,10 @@ export class OracleStore {
         chronicle: incoming.chronicle || "",
         lore: incoming.lore || "",
       });
-      return reconciled;
+      return {
+        content: reconciled.content || existing.content || "",
+        lore: reconciled.lore || existing.lore || "",
+      };
     } catch {
       return fallback();
     }

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -629,10 +629,7 @@ export class OracleStore {
         chronicle: incoming.chronicle || "",
         lore: incoming.lore || "",
       });
-      return {
-        content: incoming.chronicle ? reconciled.content : undefined,
-        lore: incoming.lore ? reconciled.lore : undefined,
-      };
+      return reconciled;
     } catch {
       return fallback();
     }

--- a/specs/036-oracle-undo/spec.md
+++ b/specs/036-oracle-undo/spec.md
@@ -11,7 +11,7 @@
 
 As a user, I want to undo the last "Smart Apply", "Copy to Chronicle", or "Copy to Lore" action in the Oracle so that I can immediately revert accidental changes to my nodes.
 
-**Why this priority**: "Smart Apply" is a destructive action that overwrites existing content. Accidental clicks or poor AI suggestions can lead to data loss if not reversible. This is the core pain point of Issue #80.
+**Why this priority**: "Smart Apply" uses AI reconciliation to merge incoming content with the existing entity record, but the result may still be unwanted or poorly merged. Accidental clicks or poor reconciliation output can lead to data loss if not reversible. This is the core pain point of Issue #80.
 
 **Independent Test**:
 
@@ -25,7 +25,7 @@ As a user, I want to undo the last "Smart Apply", "Copy to Chronicle", or "Copy 
 
 **Acceptance Scenarios**:
 
-1. **Given** an entity with content "Original Content", **When** I click "Smart Apply" with new content "New Content", **Then** the entity content becomes "New Content".
+1. **Given** an entity with existing content, **When** I click "Smart Apply" with incoming oracle content, **Then** the entity chronicle and lore are updated to the AI-reconciled result merging both.
 2. **Given** I have just performed a "Smart Apply", **When** I press `Ctrl+Z` (or Command+Z on Mac) while the Oracle window is focused (and not in the input field), **Then** the entity content reverts to "Original Content".
 3. **Given** I have just performed a "Smart Apply", **When** I click the "Undo" button that appears on the chat message, **Then** the entity content reverts to "Original Content".
 


### PR DESCRIPTION
## Summary

Follow-up to #775. Three improvements to Smart Apply quality based on real usage feedback:

- **Field definitions**: The prompt now explains what chronicle and lore are *for* (not just style). Chronicle = tight at-a-glance summary of who/what the entity is now. Lore = rich reference layer for backstory, motivations, relationships, and detail. The AI now has explicit authority to move content between fields when it makes sense.
- **Entity-scoped rule 13**: Changed from "integrate all meaningful incoming details" to "only integrate details that directly reveal new information about *this entity*." Stops location/faction descriptions from bleeding wholesale into a character's record when the oracle response was written about a place rather than the character.
- **Full reconciled result returned**: `reconcileSmartApply` was suppressing the lore update when only a chronicle came in from the parsed message. The AI sees both fields and can enrich lore from incoming chronicle context — we now let that through.

## Test plan

- [ ] Smart Apply a dense oracle response written about a *location* onto a *character* entity — character entry should absorb only the character-relevant facts, not geographic detail
- [ ] Smart Apply a chronicle-only parsed message — lore should also be enriched if the AI has material to work with
- [ ] Copy to Chronicle and Copy to Lore still work correctly
- [ ] Undo restores previous state after Smart Apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)