### PR TITLE
✨ feat(mobile): open graph nodes in Zen Mode directly on tap

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -344,6 +344,12 @@
                   ui.toggleConnectMode();
                 }
               } else {
+                if (ui.isMobile) {
+                  ui.openZenMode(id);
+                  selectedId = null;
+                  node.unselect();
+                  return;
+                }
                 clearNodeSelectTimer();
                 nodeSelectTimer = window.setTimeout(() => {
                   selectedId = id;
@@ -351,10 +357,11 @@
                 }, NODE_SELECT_DELAY_MS);
               }
             },
-            onNodeDoubleTap: (id) => {
+            onNodeDoubleTap: (id, node) => {
               clearNodeSelectTimer();
               ui.openZenMode(id);
               selectedId = null;
+              node.unselect();
             },
             onEdgeTap: (data) => {
               editingEdge = {

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -345,6 +345,7 @@
                 }
               } else {
                 if (ui.isMobile) {
+                  clearNodeSelectTimer();
                   ui.openZenMode(id);
                   selectedId = null;
                   node.unselect();

--- a/apps/web/tests/mobile-graph-zen.spec.ts
+++ b/apps/web/tests/mobile-graph-zen.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Mobile Graph Zen Mode", () => {
+  test.beforeEach(async ({ page }) => {
+    // Set viewport to mobile size
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+    });
+
+    await page.goto("/");
+    await expect(page.getByTestId("graph-canvas")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Ensure uiStore knows it's mobile (might need a short wait for matchMedia to fire)
+    await page.waitForFunction(
+      () => (window as any).uiStore?.isMobile === true,
+      { timeout: 5000 },
+    );
+
+    await page.evaluate(() => {
+      const ui = (window as any).uiStore;
+      if (ui) {
+        ui.dismissedWorldPage = true;
+        ui.dismissedLandingPage = true;
+      }
+    });
+  });
+
+  test("should open Zen mode directly from a graph node single tap on mobile", async ({
+    page,
+  }) => {
+    // Create an entity directly via evaluate to ensure it exists for the graph
+    await page.evaluate(async () => {
+      const vault = (window as any).vault;
+      vault.isInitialized = true;
+      vault.rootHandle = {};
+      return await vault.createEntity("npc", "Mobile Tap Node", {
+        content: "Mobile Content",
+      });
+    });
+
+    const nodeIdHandle = await page.waitForFunction(
+      () => {
+        const vault = (window as any).vault;
+        const entity = Object.values(vault?.entities || {}).find(
+          (item: any) => item.title === "Mobile Tap Node",
+        );
+        return entity ? (entity as any).id : null;
+      },
+      { timeout: 10000 },
+    );
+    const nodeId = (await nodeIdHandle.jsonValue()) as string;
+
+    // Wait for node to appear in graph
+    await page.waitForFunction(
+      (id) => {
+        const cy = (window as any).cy;
+        return cy && cy.$id(id).length > 0;
+      },
+      nodeId,
+      { timeout: 10000 },
+    );
+
+    const canvasBox = await page.getByTestId("graph-canvas").boundingBox();
+    const nodePosition = await page.evaluate((id) => {
+      const cy = (window as any).cy;
+      return cy.$id(id).renderedPosition();
+    }, nodeId);
+
+    expect(canvasBox).not.toBeNull();
+    if (!canvasBox) return;
+
+    // Single click/tap
+    await page.mouse.click(
+      canvasBox.x + nodePosition.x,
+      canvasBox.y + nodePosition.y,
+    );
+
+    // Zen Mode modal should appear
+    const modal = page.getByTestId("zen-mode-modal");
+    await expect(modal).toBeVisible({ timeout: 10000 });
+
+    // Check title in Zen mode
+    const titleElement = modal.getByTestId("entity-title");
+    await expect(titleElement).toHaveText("Mobile Tap Node");
+  });
+});

--- a/apps/web/tests/mobile-graph-zen.spec.ts
+++ b/apps/web/tests/mobile-graph-zen.spec.ts
@@ -88,5 +88,17 @@ test.describe("Mobile Graph Zen Mode", () => {
     // Check title in Zen mode
     const titleElement = modal.getByTestId("entity-title");
     await expect(titleElement).toHaveText("Mobile Tap Node");
+
+    // Close Zen Mode
+    await modal.getByRole("button", { name: "Close" }).click();
+    await expect(modal).toBeHidden();
+
+    // Verify node is not selected in Cytoscape
+    const isSelected = await page.evaluate((id) => {
+      const cy = (window as any).cy;
+      return cy.$id(id).selected();
+    }, nodeId);
+
+    expect(isSelected).toBe(false);
   });
 });

--- a/specs/009-mobile-ux-sync-feedback/spec.md
+++ b/specs/009-mobile-ux-sync-feedback/spec.md
@@ -121,6 +121,21 @@ As a mobile user, I want to access graph controls through a single toggle button
 1. **Given** a mobile device, **When** I tap the graph control toggle, **Then** the full set of controls (zoom, fit, filters) appears in an overlaid menu.
 2. **Given** the mobile control menu is open, **When** I trigger a "Fit to Screen" action, **Then** the action executes and the control menu automatically closes.
 
+---
+
+### User Story 9 - Direct Zen Mode Access from Graph (Priority: P2)
+
+As a mobile user, I want tapping a node in the graph to immediately open its full details in Zen Mode, so that I can quickly read and edit my lore without the extra step of a selection delay or double-tap.
+
+**Why this priority**: Streamlines the primary mobile workflow where Zen Mode is the standard viewing context.
+
+**Independent Test**: On a mobile-sized viewport, tap a graph node once and verify Zen Mode opens immediately.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mobile device, **When** I tap a node in the graph, **Then** the Zen Mode modal opens for that entity immediately.
+2. **Given** Zen Mode is opened via a single tap, **When** I close Zen Mode, **Then** the node should not remain visually selected in the graph.
+
 ## Requirements
 
 ### Functional Requirements
@@ -140,6 +155,7 @@ As a mobile user, I want to access graph controls through a single toggle button
 - **FR-013**: Clicking a connected entity in the embedded connections view MUST update the main content area while preserving sidebar state (Oracle, Explorer).
 - **FR-014**: Connections section MUST show an appropriate empty state when no connections exist for an entity.
 - **FR-015**: Graph controls MUST collapse into a single floating toggle button on mobile viewports, revealing a compact overlaid menu when activated.
+- **FR-016**: Tapping a node in the graph on mobile viewports MUST immediately trigger `openZenMode` and clear active graph selection.
 
 ### User Story 4 - Reliable Sync Consistency (Priority: P0)
 


### PR DESCRIPTION
Implements a mobile-specific UX improvement where tapping a node in the graph immediately opens it in Zen Mode. This bypasses the standard selection delay and double-tap requirement, which is more intuitive on mobile devices. Also ensures nodes are unselected in Cytoscape to avoid lingering selection rings.