### PR TITLE
:sparkles: feat(oracle): add entity selection and high-confidence auto-linking to chat #786

### DIFF
--- a/apps/web/src/lib/components/oracle/ChatMessage.svelte
+++ b/apps/web/src/lib/components/oracle/ChatMessage.svelte
@@ -426,11 +426,36 @@
 
               <button
                 onclick={() => (isSelectingEntity = !isSelectingEntity)}
-                class="flex items-center gap-1.5 px-2 py-1 rounded text-[10px] font-bold tracking-widest transition-all bg-theme-surface border border-theme-border text-theme-muted hover:bg-theme-primary hover:text-black hover:border-theme-primary"
-                title="Link this message to an entity"
+                class="flex items-center gap-1.5 px-2 py-1 rounded text-[10px] font-bold tracking-widest transition-all bg-theme-surface border border-theme-border text-theme-muted hover:bg-theme-primary hover:text-black hover:border-theme-primary group/link relative"
+                title={message.entityId
+                  ? `Linked to ${vault.entities[message.entityId]?.title || "Entity"}`
+                  : "Link this message to an entity"}
               >
-                <span class="icon-[lucide--link] w-3 h-3 shrink-0"></span>
-                <span class="font-header">LINK ENTITY</span>
+                <span
+                  class={message.entityId
+                    ? "icon-[lucide--link-2] w-3 h-3 text-theme-primary"
+                    : "icon-[lucide--link] w-3 h-3 shrink-0"}
+                ></span>
+                <span class="font-header truncate max-w-[120px]">
+                  {message.entityId
+                    ? (
+                        vault.entities[message.entityId]?.title || "LINKED"
+                      ).toUpperCase()
+                    : "LINK ENTITY"}
+                </span>
+
+                {#if message.entityId}
+                  <button
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      oracle.updateMessageEntity(message.id, null);
+                    }}
+                    class="ml-1 p-0.5 hover:text-red-400 transition-colors"
+                    title="Clear link"
+                  >
+                    <span class="icon-[lucide--x] w-2.5 h-2.5"></span>
+                  </button>
+                {/if}
               </button>
 
               {#if targetEntity || activeEntity}

--- a/apps/web/src/lib/components/oracle/ChatMessage.svelte
+++ b/apps/web/src/lib/components/oracle/ChatMessage.svelte
@@ -29,6 +29,7 @@
   import { appEventBus } from "@codex/events";
   import { ORACLE_EVENTS } from "@codex/oracle-engine";
   import { regenerationService } from "$lib/services/RegenerationService.svelte";
+  import Autocomplete from "../ui/Autocomplete.svelte";
 
   let { message = $bindable() }: { message: ChatMessage } = $props();
   const chatMessageActions = new ChatMessageActions({
@@ -55,6 +56,8 @@
   );
   let isCopied = $state(false);
   let showDiscoveryChips = $state(false);
+  let isSelectingEntity = $state(false);
+  let selectedEntityId = $state<string | null>(null);
   let htmlCache = $state("");
   let lastParsedContent = "";
 
@@ -67,6 +70,14 @@
         isSaved = false;
       }
     });
+  });
+
+  $effect(() => {
+    if (selectedEntityId) {
+      oracle.updateMessageEntity(message.id, selectedEntityId);
+      isSelectingEntity = false;
+      selectedEntityId = null;
+    }
   });
 
   let isLastAction = $derived(
@@ -327,6 +338,21 @@
               class="mt-3 pt-3 border-t border-theme-border flex flex-wrap gap-2 justify-end"
               transition:fade
             >
+              {#if isSelectingEntity}
+                <div class="w-full mb-2" transition:fade>
+                  <Autocomplete
+                    bind:selectedId={selectedEntityId}
+                    placeholder="Search for an entity..."
+                  />
+                  <button
+                    onclick={() => (isSelectingEntity = false)}
+                    class="mt-1 text-[9px] text-theme-muted hover:text-theme-primary font-bold uppercase tracking-widest font-header"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              {/if}
+
               {#if message.hasDrawAction}
                 <button
                   onclick={() => oracle.drawMessage(message.id)}
@@ -397,6 +423,15 @@
                   </div>
                 </button>
               {/if}
+
+              <button
+                onclick={() => (isSelectingEntity = !isSelectingEntity)}
+                class="flex items-center gap-1.5 px-2 py-1 rounded text-[10px] font-bold tracking-widest transition-all bg-theme-surface border border-theme-border text-theme-muted hover:bg-theme-primary hover:text-black hover:border-theme-primary"
+                title="Link this message to an entity"
+              >
+                <span class="icon-[lucide--link] w-3 h-3 shrink-0"></span>
+                <span class="font-header">LINK ENTITY</span>
+              </button>
 
               {#if targetEntity || activeEntity}
                 {#if canOverride}

--- a/packages/oracle-engine/src/oracle-executor.test.ts
+++ b/packages/oracle-engine/src/oracle-executor.test.ts
@@ -617,6 +617,46 @@ describe("OracleActionExecutor - Detailed", () => {
       expect(mockContext.chatHistory.setMessages).toHaveBeenCalled();
     });
 
+    it("should auto-link high confidence entity matches if no entityId is set", async () => {
+      mockContext.uiStore.entityDiscoveryMode = "suggest";
+      mockGenerator.generateChatResponse.mockImplementation(
+        async (
+          _query: string,
+          _context: any,
+          onPartial: (partial: string) => void,
+        ) => {
+          onPartial("The Red Hand is a cult.");
+          // Simulating a response where no primaryEntityId is yet determined by context retrieval
+          return { primaryEntityId: undefined, sourceIds: [] };
+        },
+      );
+
+      mockContext.draftingEngine = {
+        propose: vi.fn().mockResolvedValue([
+          {
+            entityId: "e_redhand",
+            title: "Red Hand",
+            type: "group",
+            draft: { chronicle: "A cult.", lore: "" },
+            confidence: 0.9, // High confidence > 0.8
+          },
+        ]),
+      };
+
+      await executor.execute(
+        { type: "chat", query: "Who are the Red Hand?", isAIIntent: true },
+        mockContext,
+      );
+
+      const finalMessages =
+        mockContext.chatHistory.setMessages.mock.calls[0][0];
+      const assistantMessage = finalMessages.find(
+        (m: any) => m.role === "assistant",
+      );
+
+      expect(assistantMessage.entityId).toBe("e_redhand");
+    });
+
     it("should reconcile existing entity updates during auto-archive", async () => {
       mockContext.uiStore.entityDiscoveryMode = "auto-create";
       mockContext.vault.entities = {

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -838,6 +838,17 @@ The Lore Oracle supports several slash commands to help you manage your vault:
               ...newProposals,
             ];
 
+            // Auto-link high confidence existing entities if no entity is linked yet
+            if (!finalMsgs[assistantMsgIndex].entityId) {
+              const highConfidenceMatch = proposals.find(
+                (p: DiscoveryProposal) => p.entityId && p.confidence > 0.8,
+              );
+              if (highConfidenceMatch) {
+                finalMsgs[assistantMsgIndex].entityId =
+                  highConfidenceMatch.entityId;
+              }
+            }
+
             for (const p of newProposals) {
               await context.logActivity?.({
                 type: "discovery",

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -840,9 +840,12 @@ The Lore Oracle supports several slash commands to help you manage your vault:
 
             // Auto-link high confidence existing entities if no entity is linked yet
             if (!finalMsgs[assistantMsgIndex].entityId) {
-              const highConfidenceMatch = proposals.find(
-                (p: DiscoveryProposal) => p.entityId && p.confidence > 0.8,
-              );
+              const highConfidenceMatch = [...proposals]
+                .filter(
+                  (p: DiscoveryProposal) => p.entityId && p.confidence > 0.8,
+                )
+                .sort((a, b) => b.confidence - a.confidence)[0];
+
               if (highConfidenceMatch) {
                 finalMsgs[assistantMsgIndex].entityId =
                   highConfidenceMatch.entityId;


### PR DESCRIPTION
This PR addresses issue #786 by improving the entity linking workflow in the Oracle chat. Manual selection via Autocomplete and AI auto-linking for high-confidence matches (>80%). Closes #786