### PR TITLE
refactor: modularize MapView.svelte god file

### DIFF
--- a/apps/web/src/lib/components/map/MapCanvas.svelte
+++ b/apps/web/src/lib/components/map/MapCanvas.svelte
@@ -49,7 +49,6 @@
     vttPings,
     vttDragPreview,
     interactions,
-    getCanvas,
   }: {
     mapImage: HTMLImageElement | null;
     maskCanvas: HTMLCanvasElement | null;
@@ -59,7 +58,6 @@
     vttPings: PingState[];
     vttDragPreview: EnrichedDragPreview | null;
     interactions: MapInteractionManager;
-    getCanvas: (c: HTMLCanvasElement) => void;
   } = $props();
 
   let canvas = $state<HTMLCanvasElement | null>(null);
@@ -74,10 +72,6 @@
       mapStore.gridColor || themeStore.activeTheme.tokens.primary;
     const rgb = baseColor.startsWith("#") ? hexToRgb(baseColor) : baseColor;
     return `rgba(${rgb}, 0.55)`;
-  });
-
-  $effect(() => {
-    if (canvas) getCanvas(canvas);
   });
 
   function handleResize() {
@@ -100,23 +94,11 @@
 
   function draw() {
     if (canvas) {
-      const canvasSize = {
-        width: canvas.width || 1,
-        height: canvas.height || 1,
-      };
-
-      if (
-        canvasSize.width !== mapStore.canvasSize.width ||
-        canvasSize.height !== mapStore.canvasSize.height
-      ) {
-        mapStore.setCanvasSize(canvasSize.width, canvasSize.height);
-      }
-
       renderMap({
         canvas: canvas,
         image: mapImage,
         transform: mapStore.viewport,
-        canvasSize,
+        canvasSize: mapStore.canvasSize,
         pins: mapStore.pins,
         maskCanvas: maskCanvas,
         showFog: mapStore.showFog,

--- a/apps/web/src/lib/components/map/MapCanvas.svelte
+++ b/apps/web/src/lib/components/map/MapCanvas.svelte
@@ -5,7 +5,40 @@
   import { themeStore } from "../../stores/theme.svelte";
   import { hexToRgb } from "../../utils/color";
   import { renderMap } from "map-engine";
+  import type { Point } from "schema";
+  import type { PingState, Token } from "../../../types/vtt";
   import type { MapInteractionManager } from "./map-interactions.svelte";
+
+  interface EnrichedToken extends Token {
+    label: string;
+    image: HTMLImageElement | null;
+    selected: boolean;
+    active: boolean;
+    visible: boolean;
+  }
+
+  interface EnrichedMeasurement {
+    active: boolean;
+    start: Point | null;
+    end: Point | null;
+    label: string;
+  }
+
+  interface RemoteEnrichedMeasurement {
+    start: Point;
+    end: Point;
+    label: string;
+    color: string;
+    peerId: string;
+  }
+
+  interface EnrichedDragPreview {
+    entityId: string;
+    x: number;
+    y: number;
+    label: string;
+    valid: boolean;
+  }
 
   let {
     mapImage,
@@ -20,11 +53,11 @@
   }: {
     mapImage: HTMLImageElement | null;
     maskCanvas: HTMLCanvasElement | null;
-    vttTokens: any[];
-    vttMeasurement: any;
-    remoteMeasurement: any;
-    vttPings: any[];
-    vttDragPreview: any;
+    vttTokens: EnrichedToken[];
+    vttMeasurement: EnrichedMeasurement | null;
+    remoteMeasurement: RemoteEnrichedMeasurement | null;
+    vttPings: PingState[];
+    vttDragPreview: EnrichedDragPreview | null;
     interactions: MapInteractionManager;
     getCanvas: (c: HTMLCanvasElement) => void;
   } = $props();

--- a/apps/web/src/lib/components/map/MapCanvas.svelte
+++ b/apps/web/src/lib/components/map/MapCanvas.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { mapStore } from "../../stores/map.svelte";
+  import { mapSession } from "../../stores/map-session.svelte";
+  import { themeStore } from "../../stores/theme.svelte";
+  import { hexToRgb } from "../../utils/color";
+  import { renderMap } from "map-engine";
+  import type { MapInteractionManager } from "./map-interactions.svelte";
+
+  let {
+    mapImage,
+    maskCanvas,
+    vttTokens,
+    vttMeasurement,
+    remoteMeasurement,
+    vttPings,
+    vttDragPreview,
+    interactions,
+    getCanvas,
+  }: {
+    mapImage: HTMLImageElement | null;
+    maskCanvas: HTMLCanvasElement | null;
+    vttTokens: any[];
+    vttMeasurement: any;
+    remoteMeasurement: any;
+    vttPings: any[];
+    vttDragPreview: any;
+    interactions: MapInteractionManager;
+    getCanvas: (c: HTMLCanvasElement) => void;
+  } = $props();
+
+  let canvas = $state<HTMLCanvasElement | null>(null);
+  let container = $state<HTMLDivElement | null>(null);
+  let animationFrameId: number;
+
+  const fogColor = $derived(
+    `rgba(${hexToRgb(themeStore.activeTheme.tokens.secondary)}, ${mapStore.isGMMode ? 0.6 : 1.0})`,
+  );
+  const gridColor = $derived.by(() => {
+    const baseColor =
+      mapStore.gridColor || themeStore.activeTheme.tokens.primary;
+    const rgb = baseColor.startsWith("#") ? hexToRgb(baseColor) : baseColor;
+    return `rgba(${rgb}, 0.55)`;
+  });
+
+  $effect(() => {
+    if (canvas) getCanvas(canvas);
+  });
+
+  function handleResize() {
+    if (container && canvas) {
+      const dpr = window.devicePixelRatio || 1;
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+      mapStore.setCanvasSize(w, h);
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      }
+    }
+  }
+
+  function draw() {
+    if (canvas) {
+      const canvasSize = {
+        width: canvas.width || 1,
+        height: canvas.height || 1,
+      };
+
+      if (
+        canvasSize.width !== mapStore.canvasSize.width ||
+        canvasSize.height !== mapStore.canvasSize.height
+      ) {
+        mapStore.setCanvasSize(canvasSize.width, canvasSize.height);
+      }
+
+      renderMap({
+        canvas: canvas,
+        image: mapImage,
+        transform: mapStore.viewport,
+        canvasSize,
+        pins: mapStore.pins,
+        maskCanvas: maskCanvas,
+        showFog: mapStore.showFog,
+        fogColor,
+        accentColor: themeStore.activeTheme.tokens.primary,
+        grid: {
+          type: mapStore.showGrid ? "square" : "none",
+          size: mapStore.gridSize,
+          color: gridColor,
+          opacity: 0.65,
+          offsetX: mapStore.gridOffsetX,
+          offsetY: mapStore.gridOffsetY,
+          fixed: mapSession.gridMoveMode && mapStore.isGMMode,
+        },
+        tokens: vttTokens,
+        measurement: vttMeasurement,
+      });
+
+      if (vttDragPreview) {
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          const point = mapStore.project({
+            x: vttDragPreview.x,
+            y: vttDragPreview.y,
+          });
+          const size = Math.max(
+            28,
+            (mapStore.gridSize || 50) * mapStore.viewport.zoom,
+          );
+          const radius = size / 2;
+          const stroke = vttDragPreview.valid
+            ? themeStore.activeTheme.tokens.primary
+            : "#ef4444";
+          const fill = vttDragPreview.valid
+            ? "rgba(16, 185, 129, 0.25)"
+            : "rgba(239, 68, 68, 0.25)";
+
+          ctx.save();
+          ctx.translate(point.x, point.y);
+          ctx.globalAlpha = 0.8;
+          ctx.fillStyle = fill;
+          ctx.strokeStyle = stroke;
+          ctx.lineWidth = 2;
+          ctx.setLineDash([6, 4]);
+          ctx.beginPath();
+          ctx.arc(0, 0, radius, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.stroke();
+
+          ctx.setLineDash([]);
+          ctx.beginPath();
+          ctx.arc(0, 0, 4, 0, Math.PI * 2);
+          ctx.fillStyle = stroke;
+          ctx.fill();
+
+          ctx.font = "600 12px sans-serif";
+          ctx.textAlign = "center";
+          ctx.textBaseline = "bottom";
+          ctx.fillStyle = stroke;
+          ctx.fillText(vttDragPreview.label, 0, -radius - 8);
+          ctx.restore();
+        }
+      }
+
+      if (vttPings.length > 0) {
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          const now = Date.now();
+          const PING_DURATION = 3000;
+          for (const ping of vttPings) {
+            const elapsed = now - ping.timestamp;
+            if (elapsed > PING_DURATION) continue;
+
+            const progress = elapsed / PING_DURATION;
+            const pingPoint = mapStore.project({
+              x: ping.x,
+              y: ping.y,
+            });
+
+            ctx.save();
+
+            const baseRadius = 25 * mapStore.viewport.zoom;
+            const expandRange = 40 * mapStore.viewport.zoom;
+            const radius = baseRadius + progress * expandRange;
+            const opacity = 1 - progress;
+
+            ctx.beginPath();
+            ctx.arc(pingPoint.x, pingPoint.y, radius, 0, Math.PI * 2);
+            ctx.strokeStyle = ping.color;
+            ctx.globalAlpha = opacity;
+            ctx.lineWidth = 4 * (1 - progress) + 1;
+
+            ctx.shadowColor = ping.color;
+            ctx.shadowBlur = 10 * opacity;
+            ctx.stroke();
+
+            ctx.globalAlpha = opacity * 0.5;
+            ctx.beginPath();
+            ctx.arc(pingPoint.x, pingPoint.y, 3, 0, Math.PI * 2);
+            ctx.fillStyle = ping.color;
+            ctx.fill();
+
+            ctx.restore();
+          }
+        }
+      }
+
+      if (remoteMeasurement) {
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          const start = mapStore.project(remoteMeasurement.start);
+          const end = mapStore.project(remoteMeasurement.end);
+
+          ctx.save();
+          ctx.strokeStyle = remoteMeasurement.color;
+          ctx.lineWidth = 2;
+          ctx.setLineDash([8, 4]);
+          ctx.globalAlpha = 0.8;
+
+          ctx.beginPath();
+          ctx.moveTo(start.x, start.y);
+          ctx.lineTo(end.x, end.y);
+          ctx.stroke();
+
+          ctx.setLineDash([]);
+          ctx.beginPath();
+          ctx.arc(start.x, start.y, 5, 0, Math.PI * 2);
+          ctx.fillStyle = remoteMeasurement.color;
+          ctx.fill();
+
+          ctx.beginPath();
+          ctx.arc(end.x, end.y, 5, 0, Math.PI * 2);
+          ctx.fill();
+
+          const midX = (start.x + end.x) / 2;
+          const midY = (start.y + end.y) / 2;
+          ctx.font = "12px sans-serif";
+          ctx.fillStyle = remoteMeasurement.color;
+          ctx.textAlign = "center";
+          ctx.textBaseline = "bottom";
+          ctx.fillText(remoteMeasurement.label, midX, midY - 8);
+
+          ctx.restore();
+        }
+      }
+
+      if (
+        mapStore.isGMMode &&
+        interactions.isAltPressed &&
+        interactions.isPointerOver
+      ) {
+        const ctx = canvas.getContext("2d");
+        if (ctx) {
+          ctx.save();
+          const primaryRGB = hexToRgb(themeStore.activeTheme.tokens.primary);
+
+          ctx.beginPath();
+          ctx.arc(
+            interactions.lastMousePos.x,
+            interactions.lastMousePos.y,
+            interactions.visualBrushRadius,
+            0,
+            Math.PI * 2,
+          );
+          ctx.strokeStyle = `rgba(${primaryRGB}, 0.5)`;
+          ctx.lineWidth = 2;
+          ctx.stroke();
+
+          ctx.fillStyle = `rgba(${primaryRGB}, 0.1)`;
+          ctx.fill();
+
+          ctx.beginPath();
+          ctx.arc(
+            interactions.lastMousePos.x,
+            interactions.lastMousePos.y,
+            2,
+            0,
+            Math.PI * 2,
+          );
+          ctx.fillStyle = `rgba(${primaryRGB}, 0.5)`;
+          ctx.fill();
+
+          ctx.restore();
+        }
+      }
+    }
+    animationFrameId = requestAnimationFrame(draw);
+  }
+
+  onMount(() => {
+    setTimeout(handleResize, 10);
+    const resizeObserver = new ResizeObserver(handleResize);
+    if (container) resizeObserver.observe(container);
+
+    animationFrameId = requestAnimationFrame(draw);
+
+    return () => {
+      resizeObserver.disconnect();
+      cancelAnimationFrame(animationFrameId);
+    };
+  });
+</script>
+
+<div bind:this={container} class="absolute inset-0">
+  <canvas
+    bind:this={canvas}
+    class="absolute inset-0 {mapSession.gridFitMode && mapStore.isGMMode
+      ? 'cursor-crosshair'
+      : ''} {mapSession.gridMoveMode && mapStore.isGMMode ? 'cursor-move' : ''}"
+  ></canvas>
+</div>

--- a/apps/web/src/lib/components/map/MapContextMenu.svelte
+++ b/apps/web/src/lib/components/map/MapContextMenu.svelte
@@ -165,6 +165,7 @@
       <!-- Resize Submenu (Host only) -->
       <div
         class="relative group"
+        role="presentation"
         onmouseenter={() => {
           showResizeSubmenu = true;
           showStatusSubmenu = false;
@@ -244,6 +245,7 @@
       {@const activeEffects = _ctxToken?.statusEffects ?? []}
       <div
         class="relative group"
+        role="presentation"
         onmouseenter={() => {
           showStatusSubmenu = true;
           showResizeSubmenu = false;

--- a/apps/web/src/lib/components/map/MapContextMenu.svelte
+++ b/apps/web/src/lib/components/map/MapContextMenu.svelte
@@ -1,0 +1,343 @@
+<script lang="ts">
+  import { fade } from "svelte/transition";
+  import { mapStore } from "../../stores/map.svelte";
+  import { uiStore } from "../../stores/ui.svelte";
+  import { mapSession } from "../../stores/map-session.svelte";
+  import { TOKEN_STATUS_EFFECTS } from "../../../types/vtt";
+
+  let {
+    x,
+    y,
+    imgX,
+    imgY,
+    tokenId,
+    onClose,
+  }: {
+    x: number;
+    y: number;
+    imgX: number;
+    imgY: number;
+    tokenId?: string;
+    onClose: () => void;
+  } = $props();
+
+  let showResizeSubmenu = $state(false);
+  let showStatusSubmenu = $state(false);
+</script>
+
+<div
+  class="fixed z-[1000] bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[140px]"
+  style="left: {x}px; top: {y}px;"
+  transition:fade={{ duration: 100 }}
+  role="presentation"
+  onmousedown={(e) => e.stopPropagation()}
+>
+  {#if tokenId}
+    <button
+      class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+      onclick={() => {
+        mapSession.pingToken(tokenId);
+        onClose();
+      }}
+    >
+      <span class="icon-[lucide--radar] w-3.5 h-3.5 text-theme-primary"></span>
+      <span>Ping Token</span>
+    </button>
+
+    <!-- View Entity (host always; guest only if token is not gm-only) -->
+    {@const _ctxToken = mapSession.tokens[tokenId]}
+    {#if _ctxToken?.entityId && mapSession.canViewToken(tokenId, mapSession.myPeerId, mapStore.isGMMode)}
+      <div class="h-px bg-theme-border my-1 mx-2"></div>
+      <button
+        class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+        onclick={() => {
+          if (_ctxToken?.entityId) {
+            uiStore.openZenMode(_ctxToken.entityId);
+            onClose();
+          }
+        }}
+      >
+        <span class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary"
+        ></span>
+        <span>Look at {_ctxToken.name}</span>
+      </button>
+    {/if}
+
+    <!-- Multi-select actions (GM only) -->
+    {#if mapStore.isGMMode && !uiStore.isGuestMode}
+      {#if mapSession.selectedTokens.size > 1 && mapSession.selectedTokens.has(tokenId)}
+        <div class="h-px bg-theme-border my-1 mx-2"></div>
+        <div
+          class="px-3 py-1 text-[9px] font-bold uppercase tracking-widest text-theme-muted"
+        >
+          {mapSession.selectedTokens.size} tokens selected
+        </div>
+        <!-- Hide Selected -->
+        <button
+          class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+          onclick={() => {
+            for (const id of mapSession.selectedTokens) {
+              mapSession.toggleTokenVisibility(id);
+            }
+            onClose();
+          }}
+        >
+          <span class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted"
+          ></span>
+          <span>Hide Selected</span>
+        </button>
+        <!-- Remove Selected -->
+        <button
+          class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-red-400"
+          onclick={() => {
+            for (const id of mapSession.selectedTokens) {
+              mapSession.removeToken(id);
+            }
+            onClose();
+          }}
+        >
+          <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+          <span>Remove Selected</span>
+        </button>
+      {:else}
+        <!-- Select All Visible -->
+        <button
+          class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+          onclick={() => {
+            const allIds = Object.keys(mapSession.tokens);
+            mapSession.setMultiSelection(allIds);
+            onClose();
+          }}
+        >
+          <span
+            class="icon-[lucide--square-mouse-pointer] w-3.5 h-3.5 text-theme-muted"
+          ></span>
+          <span>Select All</span>
+        </button>
+      {/if}
+    {/if}
+
+    <div class="h-px bg-theme-border my-1 mx-2"></div>
+
+    <!-- Removal -->
+    {#if mapStore.isGMMode && !uiStore.isGuestMode}
+      <button
+        class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+        onclick={() => {
+          mapSession.cloneToken(tokenId);
+          onClose();
+        }}
+      >
+        <span class="icon-[lucide--copy-plus] w-3.5 h-3.5"></span>
+        <span>Clone Token</span>
+      </button>
+
+      <!-- Show/Hide Token -->
+      <button
+        class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+        onclick={() => {
+          mapSession.toggleTokenVisibility(tokenId);
+          onClose();
+        }}
+      >
+        {#if _ctxToken?.visibleTo === "all"}
+          <span class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted"
+          ></span>
+          <span>Hide from Guests</span>
+        {:else}
+          <span class="icon-[lucide--eye] w-3.5 h-3.5 text-theme-primary"
+          ></span>
+          <span>Show to All</span>
+        {/if}
+      </button>
+
+      <button
+        class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-red-400"
+        onclick={() => {
+          mapSession.removeToken(tokenId);
+          onClose();
+        }}
+      >
+        <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+        <span>Remove Token</span>
+      </button>
+
+      <!-- Resize Submenu (Host only) -->
+      <div
+        class="relative group"
+        onmouseenter={() => {
+          showResizeSubmenu = true;
+          showStatusSubmenu = false;
+        }}
+        onmouseleave={() => {
+          showResizeSubmenu = false;
+          showStatusSubmenu = false;
+        }}
+      >
+        <button
+          class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
+          aria-haspopup="menu"
+          aria-expanded={showResizeSubmenu}
+          onclick={(e) => {
+            e.stopPropagation();
+            showResizeSubmenu = !showResizeSubmenu;
+            if (showResizeSubmenu) showStatusSubmenu = false;
+          }}
+          onkeydown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              e.stopPropagation();
+              showResizeSubmenu = !showResizeSubmenu;
+              if (showResizeSubmenu) showStatusSubmenu = false;
+            }
+          }}
+        >
+          <div class="flex items-center gap-2">
+            <span class="icon-[lucide--maximize] w-3.5 h-3.5"></span>
+            <span>Resize</span>
+          </div>
+          <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50"></span>
+        </button>
+
+        {#if showResizeSubmenu}
+          <div
+            class="absolute left-full top-0 ml-px bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[100px]"
+            role="menu"
+            aria-label="Resize options"
+          >
+            {#each [1, 2, 3, 4] as scale (scale)}
+              <button
+                class="w-full text-left px-4 py-2 text-xs hover:bg-theme-primary/20 hover:text-theme-primary transition-colors font-mono"
+                role="menuitem"
+                onclick={() => {
+                  const gridSize = mapStore.gridSize || 50;
+                  const token = mapSession.tokens[tokenId];
+                  if (token) {
+                    const snappedX =
+                      Math.round((token.x - mapStore.gridOffsetX) / gridSize) *
+                        gridSize +
+                      mapStore.gridOffsetX;
+                    const snappedY =
+                      Math.round((token.y - mapStore.gridOffsetY) / gridSize) *
+                        gridSize +
+                      mapStore.gridOffsetY;
+
+                    mapSession.updateToken(tokenId, {
+                      x: snappedX,
+                      y: snappedY,
+                      width: scale * gridSize,
+                      height: scale * gridSize,
+                    });
+                  }
+                  onClose();
+                  showResizeSubmenu = false;
+                }}
+              >
+                {scale}x{scale}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+
+      <!-- Status Submenu (Host only) -->
+      {@const activeEffects = _ctxToken?.statusEffects ?? []}
+      <div
+        class="relative group"
+        onmouseenter={() => {
+          showStatusSubmenu = true;
+          showResizeSubmenu = false;
+        }}
+        onmouseleave={() => {
+          showStatusSubmenu = false;
+          showResizeSubmenu = false;
+        }}
+      >
+        <button
+          class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
+          aria-haspopup="menu"
+          aria-expanded={showStatusSubmenu}
+          onclick={(e) => {
+            e.stopPropagation();
+            showStatusSubmenu = !showStatusSubmenu;
+            if (showStatusSubmenu) showResizeSubmenu = false;
+          }}
+          onkeydown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              e.stopPropagation();
+              showStatusSubmenu = !showStatusSubmenu;
+              if (showStatusSubmenu) showResizeSubmenu = false;
+            }
+          }}
+        >
+          <div class="flex items-center gap-2">
+            <span class="icon-[lucide--badge] w-3.5 h-3.5"></span>
+            <span>Status</span>
+          </div>
+          <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50"></span>
+        </button>
+
+        {#if showStatusSubmenu}
+          <div
+            class="absolute left-full top-0 ml-px bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[160px]"
+            role="menu"
+            aria-label="Status options"
+          >
+            {#each TOKEN_STATUS_EFFECTS as effect (effect.id)}
+              {@const isActive = activeEffects.includes(effect.id)}
+              <button
+                class="w-full text-left px-4 py-2 text-xs transition-colors flex items-center gap-2 {isActive
+                  ? 'text-theme-primary hover:bg-theme-primary/20'
+                  : 'text-theme-text hover:bg-theme-bg/50'}"
+                role="menuitemcheckbox"
+                aria-checked={isActive}
+                onclick={() => {
+                  const token = mapSession.tokens[tokenId];
+                  if (token) {
+                    const current = token.statusEffects ?? [];
+                    const updated = isActive
+                      ? current.filter((e: string) => e !== effect.id)
+                      : [...current, effect.id];
+                    mapSession.updateToken(tokenId, {
+                      statusEffects: updated,
+                    });
+                  }
+                  onClose();
+                  showStatusSubmenu = false;
+                  showResizeSubmenu = false;
+                }}
+              >
+                <span
+                  class="{effect.icon} w-3.5 h-3.5 flex-shrink-0"
+                  style:color={effect.color}
+                ></span>
+                <span class="flex-1">{effect.label}</span>
+                {#if isActive}
+                  <span
+                    class="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-amber-900/10 text-[11px] font-black leading-none text-amber-950 shadow-[0_0_0_1px_rgba(120,53,15,0.25)]"
+                    aria-hidden="true"
+                  >
+                    ✓
+                  </span>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  {:else}
+    <button
+      class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
+      onclick={() => {
+        mapSession.ping(imgX, imgY);
+        onClose();
+      }}
+    >
+      <span class="icon-[lucide--map-pin] w-3.5 h-3.5 text-theme-primary"
+      ></span>
+      <span>Ping Here</span>
+    </button>
+  {/if}
+</div>

--- a/apps/web/src/lib/components/map/MapOverlays.svelte
+++ b/apps/web/src/lib/components/map/MapOverlays.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import PinLinker from "./PinLinker.svelte";
+  import MapPinPopover from "./MapPinPopover.svelte";
+  import { mapStore } from "../../stores/map.svelte";
+  import { uiStore } from "../../stores/ui.svelte";
+  import { vault } from "../../stores/vault.svelte";
+  import type { MapInteractionManager } from "./map-interactions.svelte";
+
+  let { interactions }: { interactions: MapInteractionManager } = $props();
+
+  let selectedPin = $derived(
+    mapStore.pins.find((p) => p.id === interactions.selectedPinId),
+  );
+  let subMapForSelected = $derived(
+    selectedPin?.entityId
+      ? mapStore.getEntitySubMap(selectedPin.entityId)
+      : null,
+  );
+</script>
+
+{#if mapStore.pendingPinCoords}
+  <PinLinker
+    onSelect={(id) => {
+      mapStore.addPin(id, mapStore.pendingPinCoords!);
+      mapStore.pendingPinCoords = null;
+    }}
+    onCancel={() => {
+      mapStore.addPin(undefined, mapStore.pendingPinCoords!);
+      mapStore.pendingPinCoords = null;
+    }}
+  />
+{/if}
+
+{#if selectedPin}
+  {@const pos = mapStore.project(selectedPin.coordinates)}
+  <MapPinPopover
+    x={pos.x}
+    y={pos.y}
+    entity={selectedPin.entityId ? vault.entities[selectedPin.entityId] : null}
+    subMap={subMapForSelected}
+    onOpenEntity={(entityId) => uiStore.openZenMode(entityId)}
+    onEnterSubmap={(mapId) => mapStore.selectMap(mapId, true)}
+    onDelete={() => {
+      if (interactions.selectedPinId) {
+        mapStore.removePin(interactions.selectedPinId);
+        interactions.selectedPinId = null;
+      }
+    }}
+    onClose={() => (interactions.selectedPinId = null)}
+  />
+{/if}
+
+{#if interactions.gridFitStart && interactions.gridFitEnd}
+  <div
+    class="absolute inset-0 z-[60] pointer-events-none"
+    style:cursor="crosshair"
+  >
+    <div
+      class="absolute border-2 border-dashed"
+      style:border-color="var(--color-theme-primary, #78350f)"
+      style:left={`${Math.min(interactions.gridFitStart.x, interactions.gridFitEnd.x)}px`}
+      style:top={`${Math.min(interactions.gridFitStart.y, interactions.gridFitEnd.y)}px`}
+      style:width={`${Math.abs(interactions.gridFitEnd.x - interactions.gridFitStart.x)}px`}
+      style:height={`${Math.abs(interactions.gridFitEnd.y - interactions.gridFitStart.y)}px`}
+    ></div>
+  </div>
+{/if}
+
+{#if interactions.boxSelectStart && interactions.boxSelectEnd}
+  <div
+    class="absolute inset-0 z-[60] pointer-events-none"
+    style:cursor="crosshair"
+  >
+    <div
+      class="absolute border-2 border-dashed bg-theme-primary/10"
+      style:border-color="var(--color-theme-primary, #78350f)"
+      style:left={`${Math.min(interactions.boxSelectStart.x, interactions.boxSelectEnd.x)}px`}
+      style:top={`${Math.min(interactions.boxSelectStart.y, interactions.boxSelectEnd.y)}px`}
+      style:width={`${Math.abs(interactions.boxSelectEnd.x - interactions.boxSelectStart.x)}px`}
+      style:height={`${Math.abs(interactions.boxSelectEnd.y - interactions.boxSelectStart.y)}px`}
+    ></div>
+  </div>
+{/if}

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -40,9 +40,9 @@
   let mapImage = $state<HTMLImageElement | null>(null);
   let maskCanvas = $state<HTMLCanvasElement | null>(null);
 
-  // Non-reactive mirrors for MapCanvas passing inside rAF loop
-  let _drawImage: HTMLImageElement | null = null;
-  let _drawMask: HTMLCanvasElement | null = null;
+  // Reactive mirrors for MapCanvas passing
+  let _drawImage = $state<HTMLImageElement | null>(null);
+  let _drawMask = $state<HTMLCanvasElement | null>(null);
 
   const painter = new MapFogPainter({
     mapStore,

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -22,8 +22,8 @@
   import { MapFogPainter } from "./map-fog-painter";
   import { MapViewAssetLoader } from "./map-view-loader";
   import MapPinPopover from "./MapPinPopover.svelte";
+  import MapContextMenu from "./MapContextMenu.svelte";
   import { hitTestToken, measureDistance } from "$lib/utils/vtt-helpers";
-  import { TOKEN_STATUS_EFFECTS } from "../../../types/vtt";
 
   function hashToColor(input: string) {
     let hash = 0;
@@ -555,8 +555,6 @@
     imgY: number;
     tokenId?: string;
   } | null>(null);
-  let showResizeSubmenu = $state(false);
-  let showStatusSubmenu = $state(false);
 
   const visualBrushRadius = $derived(
     mapStore.brushRadius * mapStore.viewport.zoom,
@@ -638,8 +636,6 @@
 
   function onMouseDown(e: MouseEvent) {
     contextMenu = null;
-    showResizeSubmenu = false;
-    showStatusSubmenu = false;
     updateCachedRect();
     if (cachedRect) {
       lastMousePos = {
@@ -953,8 +949,6 @@
 
   function onDoubleClick(e: MouseEvent) {
     contextMenu = null;
-    showResizeSubmenu = false;
-    showStatusSubmenu = false;
     if (!container) return;
 
     const rect = container.getBoundingClientRect();
@@ -992,8 +986,6 @@
     );
 
     const imgCoords = mapStore.unproject({ x, y });
-    showResizeSubmenu = false;
-    showStatusSubmenu = false;
     contextMenu = {
       x: e.clientX,
       y: e.clientY,
@@ -1143,359 +1135,14 @@
   {/if}
 
   {#if contextMenu}
-    <div
-      class="fixed z-[1000] bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[140px]"
-      style="left: {contextMenu.x}px; top: {contextMenu.y}px;"
-      transition:fade={{ duration: 100 }}
-      role="presentation"
-      onmousedown={(e) => e.stopPropagation()}
-    >
-      {#if contextMenu.tokenId}
-        <button
-          class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-          onclick={() => {
-            if (contextMenu?.tokenId) {
-              mapSession.pingToken(contextMenu.tokenId);
-              contextMenu = null;
-            }
-          }}
-        >
-          <span class="icon-[lucide--radar] w-3.5 h-3.5 text-theme-primary"
-          ></span>
-          <span>Ping Token</span>
-        </button>
-
-        <!-- View Entity (host always; guest only if token is not gm-only) -->
-        {#if contextMenu.tokenId}
-          {@const _ctxToken = mapSession.tokens[contextMenu.tokenId]}
-          {#if _ctxToken?.entityId && mapSession.canViewToken(contextMenu.tokenId, mapSession.myPeerId, mapStore.isGMMode)}
-            <div class="h-px bg-theme-border my-1 mx-2"></div>
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-              onclick={() => {
-                if (_ctxToken?.entityId) {
-                  uiStore.openZenMode(_ctxToken.entityId);
-                  contextMenu = null;
-                }
-              }}
-            >
-              <span
-                class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary"
-              ></span>
-              <span>Look at {_ctxToken.name}</span>
-            </button>
-          {/if}
-        {/if}
-
-        <!-- Multi-select actions (GM only) -->
-        {#if mapStore.isGMMode && !uiStore.isGuestMode}
-          {#if contextMenu?.tokenId && mapSession.selectedTokens.size > 1 && mapSession.selectedTokens.has(contextMenu.tokenId)}
-            <div class="h-px bg-theme-border my-1 mx-2"></div>
-            <div
-              class="px-3 py-1 text-[9px] font-bold uppercase tracking-widest text-theme-muted"
-            >
-              {mapSession.selectedTokens.size} tokens selected
-            </div>
-            <!-- Hide Selected -->
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-              onclick={() => {
-                for (const id of mapSession.selectedTokens) {
-                  mapSession.toggleTokenVisibility(id);
-                }
-                contextMenu = null;
-              }}
-            >
-              <span class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted"
-              ></span>
-              <span>Hide Selected</span>
-            </button>
-            <!-- Remove Selected -->
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-red-400"
-              onclick={() => {
-                for (const id of mapSession.selectedTokens) {
-                  mapSession.removeToken(id);
-                }
-                contextMenu = null;
-              }}
-            >
-              <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
-              <span>Remove Selected</span>
-            </button>
-          {:else}
-            <!-- Select All Visible -->
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-              onclick={() => {
-                const allIds = Object.keys(mapSession.tokens);
-                mapSession.setMultiSelection(allIds);
-                contextMenu = null;
-              }}
-            >
-              <span
-                class="icon-[lucide--square-mouse-pointer] w-3.5 h-3.5 text-theme-muted"
-              ></span>
-              <span>Select All</span>
-            </button>
-          {/if}
-        {/if}
-
-        <div class="h-px bg-theme-border my-1 mx-2"></div>
-
-        <!-- Removal -->
-        {#if mapStore.isGMMode && !uiStore.isGuestMode}
-          <button
-            class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-            onclick={() => {
-              if (contextMenu?.tokenId) {
-                mapSession.cloneToken(contextMenu.tokenId);
-                contextMenu = null;
-              }
-            }}
-          >
-            <span class="icon-[lucide--copy-plus] w-3.5 h-3.5"></span>
-            <span>Clone Token</span>
-          </button>
-
-          <!-- Show/Hide Token -->
-          {#if contextMenu?.tokenId}
-            {@const token = mapSession.tokens[contextMenu.tokenId]}
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-              onclick={() => {
-                if (contextMenu?.tokenId) {
-                  mapSession.toggleTokenVisibility(contextMenu.tokenId);
-                  contextMenu = null;
-                }
-              }}
-            >
-              {#if token?.visibleTo === "all"}
-                <span
-                  class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted"
-                ></span>
-                <span>Hide from Guests</span>
-              {:else}
-                <span class="icon-[lucide--eye] w-3.5 h-3.5 text-theme-primary"
-                ></span>
-                <span>Show to All</span>
-              {/if}
-            </button>
-          {/if}
-        {/if}
-
-        {#if mapStore.isGMMode && !uiStore.isGuestMode}
-          <button
-            class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-red-400"
-            onclick={() => {
-              if (contextMenu?.tokenId) {
-                mapSession.removeToken(contextMenu.tokenId);
-                contextMenu = null;
-              }
-            }}
-          >
-            <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
-            <span>Remove Token</span>
-          </button>
-        {/if}
-
-        <!-- Resize Submenu (Host only) -->
-        {#if mapStore.isGMMode && !uiStore.isGuestMode}
-          <div
-            class="relative group"
-            onmouseenter={() => {
-              showResizeSubmenu = true;
-              showStatusSubmenu = false;
-            }}
-            onmouseleave={() => {
-              showResizeSubmenu = false;
-              showStatusSubmenu = false;
-            }}
-          >
-            <button
-              class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
-              aria-haspopup="menu"
-              aria-expanded={showResizeSubmenu}
-              onclick={(e) => {
-                e.stopPropagation();
-                showResizeSubmenu = !showResizeSubmenu;
-                if (showResizeSubmenu) showStatusSubmenu = false;
-              }}
-              onkeydown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  showResizeSubmenu = !showResizeSubmenu;
-                  if (showResizeSubmenu) showStatusSubmenu = false;
-                }
-              }}
-            >
-              <div class="flex items-center gap-2">
-                <span class="icon-[lucide--maximize] w-3.5 h-3.5"></span>
-                <span>Resize</span>
-              </div>
-              <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50"
-              ></span>
-            </button>
-
-            {#if showResizeSubmenu}
-              <div
-                class="absolute left-full top-0 ml-px bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[100px]"
-                role="menu"
-                aria-label="Resize options"
-              >
-                {#each [1, 2, 3, 4] as scale (scale)}
-                  <button
-                    class="w-full text-left px-4 py-2 text-xs hover:bg-theme-primary/20 hover:text-theme-primary transition-colors font-mono"
-                    role="menuitem"
-                    onclick={() => {
-                      if (contextMenu?.tokenId) {
-                        const gridSize = mapStore.gridSize || 50;
-                        const token = mapSession.tokens[contextMenu.tokenId];
-                        if (token) {
-                          const snappedX =
-                            Math.round(
-                              (token.x - mapStore.gridOffsetX) / gridSize,
-                            ) *
-                              gridSize +
-                            mapStore.gridOffsetX;
-                          const snappedY =
-                            Math.round(
-                              (token.y - mapStore.gridOffsetY) / gridSize,
-                            ) *
-                              gridSize +
-                            mapStore.gridOffsetY;
-
-                          mapSession.updateToken(contextMenu.tokenId, {
-                            x: snappedX,
-                            y: snappedY,
-                            width: scale * gridSize,
-                            height: scale * gridSize,
-                          });
-                        }
-                        contextMenu = null;
-                        showResizeSubmenu = false;
-                      }
-                    }}
-                  >
-                    {scale}x{scale}
-                  </button>
-                {/each}
-              </div>
-            {/if}
-          </div>
-        {/if}
-
-        <!-- Status Submenu (Host only) -->
-        {#if mapStore.isGMMode && !uiStore.isGuestMode}
-          {#if contextMenu.tokenId}
-            {@const token = mapSession.tokens[contextMenu.tokenId]}
-            {@const activeEffects = token?.statusEffects ?? []}
-            <div
-              class="relative group"
-              onmouseenter={() => {
-                showStatusSubmenu = true;
-                showResizeSubmenu = false;
-              }}
-              onmouseleave={() => {
-                showStatusSubmenu = false;
-                showResizeSubmenu = false;
-              }}
-            >
-              <button
-                class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center justify-between gap-2"
-                aria-haspopup="menu"
-                aria-expanded={showStatusSubmenu}
-                onclick={(e) => {
-                  e.stopPropagation();
-                  showStatusSubmenu = !showStatusSubmenu;
-                  if (showStatusSubmenu) showResizeSubmenu = false;
-                }}
-                onkeydown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    showStatusSubmenu = !showStatusSubmenu;
-                    if (showStatusSubmenu) showResizeSubmenu = false;
-                  }
-                }}
-              >
-                <div class="flex items-center gap-2">
-                  <span class="icon-[lucide--badge] w-3.5 h-3.5"></span>
-                  <span>Status</span>
-                </div>
-                <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50"
-                ></span>
-              </button>
-
-              {#if showStatusSubmenu}
-                <div
-                  class="absolute left-full top-0 ml-px bg-theme-surface border border-theme-border rounded shadow-2xl py-1 min-w-[160px]"
-                  role="menu"
-                  aria-label="Status options"
-                >
-                  {#each TOKEN_STATUS_EFFECTS as effect (effect.id)}
-                    {@const isActive = activeEffects.includes(effect.id)}
-                    <button
-                      class="w-full text-left px-4 py-2 text-xs transition-colors flex items-center gap-2 {isActive
-                        ? 'text-theme-primary hover:bg-theme-primary/20'
-                        : 'text-theme-text hover:bg-theme-bg/50'}"
-                      role="menuitemcheckbox"
-                      aria-checked={isActive}
-                      onclick={() => {
-                        if (contextMenu?.tokenId) {
-                          const token = mapSession.tokens[contextMenu.tokenId];
-                          if (token) {
-                            const current = token.statusEffects ?? [];
-                            const updated = isActive
-                              ? current.filter((e: string) => e !== effect.id)
-                              : [...current, effect.id];
-                            mapSession.updateToken(contextMenu.tokenId, {
-                              statusEffects: updated,
-                            });
-                          }
-                          contextMenu = null;
-                          showStatusSubmenu = false;
-                          showResizeSubmenu = false;
-                        }
-                      }}
-                    >
-                      <span
-                        class="{effect.icon} w-3.5 h-3.5 flex-shrink-0"
-                        style:color={effect.color}
-                      ></span>
-                      <span class="flex-1">{effect.label}</span>
-                      {#if isActive}
-                        <span
-                          class="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-amber-900/10 text-[11px] font-black leading-none text-amber-950 shadow-[0_0_0_1px_rgba(120,53,15,0.25)]"
-                          aria-hidden="true"
-                        >
-                          ✓
-                        </span>
-                      {/if}
-                    </button>
-                  {/each}
-                </div>
-              {/if}
-            </div>
-          {/if}
-        {/if}
-      {:else}
-        <button
-          class="w-full text-left px-3 py-2 text-xs hover:bg-theme-bg/50 transition-colors flex items-center gap-2 text-theme-text"
-          onclick={() => {
-            if (contextMenu) {
-              mapSession.ping(contextMenu.imgX, contextMenu.imgY);
-              contextMenu = null;
-            }
-          }}
-        >
-          <span class="icon-[lucide--map-pin] w-3.5 h-3.5 text-theme-primary"
-          ></span>
-          <span>Ping Here</span>
-        </button>
-      {/if}
-    </div>
+    <MapContextMenu
+      x={contextMenu.x}
+      y={contextMenu.y}
+      imgX={contextMenu.imgX}
+      imgY={contextMenu.imgY}
+      tokenId={contextMenu.tokenId}
+      onClose={() => (contextMenu = null)}
+    />
   {/if}
 
   {#if gridFitStart && gridFitEnd}

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -1,29 +1,17 @@
 <script lang="ts">
-  import { onMount, type Snippet } from "svelte";
+  import { type Snippet } from "svelte";
   import { fade } from "svelte/transition";
   import { mapStore } from "../../stores/map.svelte";
   import { vault } from "../../stores/vault.svelte";
-  import { uiStore } from "../../stores/ui.svelte";
-  import { themeStore } from "../../stores/theme.svelte";
   import { oracle } from "../../stores/oracle.svelte";
-  import { mapSession } from "../../stores/map-session.svelte";
-  import { p2pGuestService } from "../../cloud-bridge/p2p/guest-service";
-  import { p2pHost } from "../../cloud-bridge/p2p/host-service.svelte";
-  import { hexToRgb } from "../../utils/color";
-  import { renderMap } from "map-engine";
-  import PinLinker from "./PinLinker.svelte";
-  import {
-    findClickedPin,
-    getKeyboardViewportUpdate,
-    getZoomViewportUpdate,
-    isClickGesture,
-    shouldIgnoreMapKeyboardEvent,
-  } from "./map-view-helpers";
   import { MapFogPainter } from "./map-fog-painter";
   import { MapViewAssetLoader } from "./map-view-loader";
-  import MapPinPopover from "./MapPinPopover.svelte";
+  import { MapInteractionManager } from "./map-interactions.svelte";
+  import MapCanvas from "./MapCanvas.svelte";
+  import MapOverlays from "./MapOverlays.svelte";
   import MapContextMenu from "./MapContextMenu.svelte";
-  import { hitTestToken, measureDistance } from "$lib/utils/vtt-helpers";
+  import { measureDistance } from "$lib/utils/vtt-helpers";
+  import { mapSession } from "../../stores/map-session.svelte";
 
   function hashToColor(input: string) {
     let hash = 0;
@@ -47,25 +35,26 @@
     onMapDrop?: (event: DragEvent) => void;
   } = $props();
 
-  let canvas = $state<HTMLCanvasElement | null>(null);
   let container = $state<HTMLDivElement | null>(null);
+  let _canvasElement: HTMLCanvasElement | null = null;
   let mapImage = $state<HTMLImageElement | null>(null);
   let maskCanvas = $state<HTMLCanvasElement | null>(null);
-  let selectedPinId = $state<string | null>(null);
-  let animationFrameId: number;
-  let mapAnnouncement = $state("");
-  // Plain (non-reactive) mirrors for the rAF draw loop — Svelte 5 $state
-  // signals may not be reliably readable from requestAnimationFrame callbacks.
+
+  // Non-reactive mirrors for MapCanvas passing inside rAF loop
   let _drawImage: HTMLImageElement | null = null;
   let _drawMask: HTMLCanvasElement | null = null;
-  let painter: MapFogPainter;
 
-  painter = new MapFogPainter({
+  const painter = new MapFogPainter({
     mapStore,
     oracle,
     getMaskCanvas: () => maskCanvas,
     getMapImage: () => mapImage,
     createCanvas: () => document.createElement("canvas"),
+  });
+
+  const interactions = new MapInteractionManager({
+    painter,
+    getContainer: () => container,
   });
 
   const mapAssets = new MapViewAssetLoader({
@@ -106,12 +95,6 @@
     },
   });
 
-  let selectedPin = $derived(mapStore.pins.find((p) => p.id === selectedPinId));
-  let subMapForSelected = $derived(
-    selectedPin?.entityId
-      ? mapStore.getEntitySubMap(selectedPin.entityId)
-      : null,
-  );
   const activeMapSignature = $derived.by(() => {
     const activeMap = mapStore.activeMap;
     if (!activeMap) return null;
@@ -120,15 +103,6 @@
   let lastMapSignature: string | null = null;
   let loadedMaskPath = $state<string | null>(null);
 
-  const fogColor = $derived(
-    `rgba(${hexToRgb(themeStore.activeTheme.tokens.secondary)}, ${mapStore.isGMMode ? 0.6 : 1.0})`,
-  );
-  const gridColor = $derived.by(() => {
-    const baseColor =
-      mapStore.gridColor || themeStore.activeTheme.tokens.primary;
-    const rgb = baseColor.startsWith("#") ? hexToRgb(baseColor) : baseColor;
-    return `rgba(${rgb}, 0.55)`;
-  });
   const vttMeasurement = $derived.by(() => {
     const measurement = mapSession.measurement;
     if (!measurement.active || !measurement.start || !measurement.end) {
@@ -164,6 +138,10 @@
       peerId: rm.peerId,
     };
   });
+
+  let tokenImageCache = $state<Record<string, HTMLImageElement | null>>({});
+  let tokenImageSourceCache = $state<Record<string, string>>({});
+
   const vttTokens = $derived.by(() => {
     const isHost = mapStore.isGMMode;
     const peerId = mapSession.myPeerId;
@@ -171,8 +149,6 @@
     const tokens = mapSession.allTokens;
     const result = [];
 
-    // ⚡ Bolt Optimization: Replace chained .filter().map() with an imperative loop
-    // to avoid intermediate array allocations and reduce GC pressure.
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i];
       if (mapSession.canViewToken(token.id, peerId, isHost)) {
@@ -246,11 +222,9 @@
   });
 
   $effect(() => {
-    handleResize();
     if (activeMapSignature === lastMapSignature) {
       return;
     }
-
     lastMapSignature = activeMapSignature;
     return mapAssets.sync(mapStore.activeMap);
   });
@@ -281,770 +255,6 @@
       cancelled = true;
     };
   });
-
-  function handleResize() {
-    if (container && canvas) {
-      const dpr = window.devicePixelRatio || 1;
-      const w = container.clientWidth;
-      const h = container.clientHeight;
-
-      canvas.width = w * dpr;
-      canvas.height = h * dpr;
-      canvas.style.width = `${w}px`;
-      canvas.style.height = `${h}px`;
-      mapStore.setCanvasSize(w, h);
-      const ctx = canvas.getContext("2d");
-      if (ctx) {
-        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      }
-    }
-  }
-
-  function draw() {
-    if (canvas) {
-      const canvasSize = {
-        width: canvas.width || 1,
-        height: canvas.height || 1,
-      };
-
-      // Sync non-reactive mirror variables for the render loop
-      _drawMask = maskCanvas;
-
-      // Keep mapStore in sync so project/unproject calls stay accurate
-      if (
-        canvasSize.width !== mapStore.canvasSize.width ||
-        canvasSize.height !== mapStore.canvasSize.height
-      ) {
-        mapStore.setCanvasSize(canvasSize.width, canvasSize.height);
-      }
-
-      renderMap({
-        canvas: canvas,
-        image: _drawImage,
-        transform: mapStore.viewport,
-        canvasSize,
-        pins: mapStore.pins,
-        maskCanvas: _drawMask,
-        showFog: mapStore.showFog,
-        fogColor,
-        accentColor: themeStore.activeTheme.tokens.primary,
-        grid: {
-          type: mapStore.showGrid ? "square" : "none",
-          size: mapStore.gridSize,
-          color: gridColor,
-          opacity: 0.65,
-          offsetX: mapStore.gridOffsetX,
-          offsetY: mapStore.gridOffsetY,
-          fixed: mapSession.gridMoveMode && mapStore.isGMMode,
-        },
-        tokens: vttTokens,
-        measurement: vttMeasurement,
-      });
-
-      if (vttDragPreview) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          const point = mapStore.project({
-            x: vttDragPreview.x,
-            y: vttDragPreview.y,
-          });
-          const size = Math.max(
-            28,
-            (mapStore.gridSize || 50) * mapStore.viewport.zoom,
-          );
-          const radius = size / 2;
-          const stroke = vttDragPreview.valid
-            ? themeStore.activeTheme.tokens.primary
-            : "#ef4444";
-          const fill = vttDragPreview.valid
-            ? "rgba(16, 185, 129, 0.25)"
-            : "rgba(239, 68, 68, 0.25)";
-
-          ctx.save();
-          ctx.translate(point.x, point.y);
-          ctx.globalAlpha = 0.8;
-          ctx.fillStyle = fill;
-          ctx.strokeStyle = stroke;
-          ctx.lineWidth = 2;
-          ctx.setLineDash([6, 4]);
-          ctx.beginPath();
-          ctx.arc(0, 0, radius, 0, Math.PI * 2);
-          ctx.fill();
-          ctx.stroke();
-
-          ctx.setLineDash([]);
-          ctx.beginPath();
-          ctx.arc(0, 0, 4, 0, Math.PI * 2);
-          ctx.fillStyle = stroke;
-          ctx.fill();
-
-          ctx.font = "600 12px sans-serif";
-          ctx.textAlign = "center";
-          ctx.textBaseline = "bottom";
-          ctx.fillStyle = stroke;
-          ctx.fillText(vttDragPreview.label, 0, -radius - 8);
-          ctx.restore();
-        }
-      }
-
-      if (vttPings.length > 0) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          const now = Date.now();
-          const PING_DURATION = 3000;
-          for (const ping of vttPings) {
-            const elapsed = now - ping.timestamp;
-            if (elapsed > PING_DURATION) continue;
-
-            const progress = elapsed / PING_DURATION; // 0 to 1
-            const pingPoint = mapStore.project({
-              x: ping.x,
-              y: ping.y,
-            });
-
-            ctx.save();
-
-            // Single expanding wave
-            // Start radius: if it was a token ping (centered on token), we want it to start at the edge.
-            // Since we don't store "isTokenPing", we'll use a heuristic or just a sensible base.
-            // Default base is 25px (half of standard 50px grid).
-            const baseRadius = 25 * mapStore.viewport.zoom;
-            const expandRange = 40 * mapStore.viewport.zoom;
-            const radius = baseRadius + progress * expandRange;
-            const opacity = 1 - progress;
-
-            ctx.beginPath();
-            ctx.arc(pingPoint.x, pingPoint.y, radius, 0, Math.PI * 2);
-            ctx.strokeStyle = ping.color;
-            ctx.globalAlpha = opacity;
-            ctx.lineWidth = 4 * (1 - progress) + 1;
-
-            // Glow effect
-            ctx.shadowColor = ping.color;
-            ctx.shadowBlur = 10 * opacity;
-            ctx.stroke();
-
-            // Minimal center dot for orientation
-            ctx.globalAlpha = opacity * 0.5;
-            ctx.beginPath();
-            ctx.arc(pingPoint.x, pingPoint.y, 3, 0, Math.PI * 2);
-            ctx.fillStyle = ping.color;
-            ctx.fill();
-
-            ctx.restore();
-          }
-        }
-      }
-
-      // Render remote measurement from other peers
-      if (remoteMeasurement) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          const start = mapStore.project(remoteMeasurement.start);
-          const end = mapStore.project(remoteMeasurement.end);
-
-          ctx.save();
-          ctx.strokeStyle = remoteMeasurement.color;
-          ctx.lineWidth = 2;
-          ctx.setLineDash([8, 4]);
-          ctx.globalAlpha = 0.8;
-
-          ctx.beginPath();
-          ctx.moveTo(start.x, start.y);
-          ctx.lineTo(end.x, end.y);
-          ctx.stroke();
-
-          // Draw endpoint circles
-          ctx.setLineDash([]);
-          ctx.beginPath();
-          ctx.arc(start.x, start.y, 5, 0, Math.PI * 2);
-          ctx.fillStyle = remoteMeasurement.color;
-          ctx.fill();
-
-          ctx.beginPath();
-          ctx.arc(end.x, end.y, 5, 0, Math.PI * 2);
-          ctx.fill();
-
-          // Draw label
-          const midX = (start.x + end.x) / 2;
-          const midY = (start.y + end.y) / 2;
-          ctx.font = "12px sans-serif";
-          ctx.fillStyle = remoteMeasurement.color;
-          ctx.textAlign = "center";
-          ctx.textBaseline = "bottom";
-          ctx.fillText(remoteMeasurement.label, midX, midY - 8);
-
-          ctx.restore();
-        }
-      }
-
-      // Render Visual Brush Indicator directly on canvas for zero-lag tracking
-      if (mapStore.isGMMode && isAltPressed && isPointerOver) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          ctx.save();
-          const primaryRGB = hexToRgb(themeStore.activeTheme.tokens.primary);
-
-          // Outer circle
-          ctx.beginPath();
-          ctx.arc(
-            lastMousePos.x,
-            lastMousePos.y,
-            visualBrushRadius,
-            0,
-            Math.PI * 2,
-          );
-          ctx.strokeStyle = `rgba(${primaryRGB}, 0.5)`;
-          ctx.lineWidth = 2;
-          ctx.stroke();
-
-          // Fill
-          ctx.fillStyle = `rgba(${primaryRGB}, 0.1)`;
-          ctx.fill();
-
-          // Center dot
-          ctx.beginPath();
-          ctx.arc(lastMousePos.x, lastMousePos.y, 2, 0, Math.PI * 2);
-          ctx.fillStyle = `rgba(${primaryRGB}, 0.5)`;
-          ctx.fill();
-
-          ctx.restore();
-        }
-      }
-    }
-    animationFrameId = requestAnimationFrame(draw);
-  }
-
-  onMount(() => {
-    // Initial resize, delayed slightly to ensure DOM is painted
-    setTimeout(handleResize, 10);
-    const resizeObserver = new ResizeObserver(handleResize);
-    if (container) resizeObserver.observe(container);
-
-    animationFrameId = requestAnimationFrame(draw);
-
-    return () => {
-      resizeObserver.disconnect();
-      cancelAnimationFrame(animationFrameId);
-    };
-  });
-
-  // Interaction handlers
-  const KEYBOARD_PAN_STEP = 50;
-  const KEYBOARD_ZOOM_STEP = 0.1;
-  let isPanning = false;
-  let lastMousePos = $state({ x: 0, y: 0 });
-  let mouseDownPos = { x: 0, y: 0 };
-  let isAltPressed = $state(false);
-  let isPointerOver = $state(false);
-  let gridFitStart = $state<{ x: number; y: number } | null>(null);
-  let gridFitEnd = $state<{ x: number; y: number } | null>(null);
-  let boxSelectStart = $state<{ x: number; y: number } | null>(null);
-  let boxSelectEnd = $state<{ x: number; y: number } | null>(null);
-  let cachedRect: DOMRect | null = null;
-  let dragState = $state<{
-    tokenId: string;
-    offset: { x: number; y: number };
-  } | null>(null);
-  let tokenImageCache = $state<Record<string, HTMLImageElement | null>>({});
-  let tokenImageSourceCache = $state<Record<string, string>>({});
-  let contextMenu = $state<{
-    x: number;
-    y: number;
-    imgX: number;
-    imgY: number;
-    tokenId?: string;
-  } | null>(null);
-
-  const visualBrushRadius = $derived(
-    mapStore.brushRadius * mapStore.viewport.zoom,
-  );
-
-  function updateCachedRect() {
-    if (container) {
-      cachedRect = container.getBoundingClientRect();
-    }
-  }
-
-  function onKeyDown(event: KeyboardEvent) {
-    if (shouldIgnoreMapKeyboardEvent(event.target)) {
-      return;
-    }
-
-    const { key, altKey } = event;
-    isAltPressed = altKey;
-    const viewport = mapStore.viewport;
-
-    if (!viewport) return;
-
-    const update = getKeyboardViewportUpdate(key, viewport, {
-      panStep: KEYBOARD_PAN_STEP,
-      zoomStep: KEYBOARD_ZOOM_STEP,
-    });
-
-    if (update) {
-      mapStore.updateViewport(update.pan, update.zoom);
-      mapAnnouncement = update.announcement;
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  }
-
-  function onGlobalKeyDown(event: KeyboardEvent) {
-    // Grid move mode: Enter applies, Escape cancels
-    if (event.key === "Enter" && mapSession.gridMoveMode) {
-      event.preventDefault();
-      const viewport = mapStore.viewport;
-      const canvasSize = mapStore.canvasSize;
-      mapStore.gridOffsetX =
-        -((viewport.pan.x + canvasSize.width / 2) / viewport.zoom) %
-        mapStore.gridSize;
-      mapStore.gridOffsetY =
-        -((viewport.pan.y + canvasSize.height / 2) / viewport.zoom) %
-        mapStore.gridSize;
-      mapSession.gridMoveMode = false;
-      uiStore.clearNotification();
-      return;
-    }
-    if (event.key === "Escape") {
-      if (mapSession.gridMoveMode) {
-        mapSession.gridMoveMode = false;
-        uiStore.clearNotification();
-        return;
-      }
-      if (mapSession.gridFitMode) {
-        mapSession.gridFitMode = false;
-        gridFitStart = null;
-        gridFitEnd = null;
-        return;
-      }
-      if (boxSelectStart) {
-        boxSelectStart = null;
-        boxSelectEnd = null;
-        return;
-      }
-      if (mapSession.selectedTokens.size > 1) {
-        mapSession.clearSelection();
-        return;
-      }
-    }
-  }
-
-  function onKeyUp(event: KeyboardEvent) {
-    isAltPressed = event.altKey;
-  }
-
-  function onMouseDown(e: MouseEvent) {
-    contextMenu = null;
-    updateCachedRect();
-    if (cachedRect) {
-      lastMousePos = {
-        x: e.clientX - cachedRect.left,
-        y: e.clientY - cachedRect.top,
-      };
-    }
-    mouseDownPos = { x: e.clientX, y: e.clientY };
-    isAltPressed = e.altKey;
-
-    // Ctrl/Cmd+click: start box selection
-    if (
-      mapStore.isGMMode &&
-      (e.ctrlKey || e.metaKey) &&
-      mapSession.vttEnabled &&
-      cachedRect
-    ) {
-      e.preventDefault();
-      boxSelectStart = { x: lastMousePos.x, y: lastMousePos.y };
-      boxSelectEnd = boxSelectStart;
-      isPanning = false;
-      return;
-    }
-
-    if (mapSession.vttEnabled && cachedRect) {
-      const hitToken = hitTestToken(
-        mapSession.allTokens,
-        (point) => mapStore.project(point),
-        lastMousePos.x,
-        lastMousePos.y,
-      );
-
-      if (
-        hitToken &&
-        mapSession.canMoveToken(
-          hitToken.id,
-          p2pGuestService.peerId,
-          mapStore.isGMMode,
-        )
-      ) {
-        const imgPoint = mapStore.unproject(lastMousePos);
-        dragState = {
-          tokenId: hitToken.id,
-          offset: {
-            x: imgPoint.x - hitToken.x,
-            y: imgPoint.y - hitToken.y,
-          },
-        };
-        mapSession.draggingTokenId = hitToken.id;
-        // Ctrl/Cmd+click to add to selection, Shift+click to toggle
-        if (e.ctrlKey || e.metaKey) {
-          mapSession.addToSelection(hitToken.id);
-        } else if (e.shiftKey) {
-          if (mapSession.selectedTokens.has(hitToken.id)) {
-            mapSession.removeFromSelection(hitToken.id);
-          } else {
-            mapSession.addToSelection(hitToken.id);
-          }
-        } else {
-          mapSession.setSelection(hitToken.id);
-        }
-        isPanning = false;
-        return;
-      }
-    }
-
-    if (mapSession.gridMoveMode && mapStore.isGMMode && cachedRect) {
-      // In grid move mode, mouse drag moves the viewport (pan) freely
-      // Grid stays fixed at screen origin
-      e.preventDefault();
-      e.stopPropagation();
-      isPanning = true;
-      return;
-    }
-
-    if (mapSession.gridFitMode && mapStore.isGMMode && cachedRect) {
-      e.preventDefault();
-      e.stopPropagation();
-      gridFitStart = { x: lastMousePos.x, y: lastMousePos.y };
-      gridFitEnd = gridFitStart;
-      return;
-    }
-
-    if (mapStore.isGMMode && e.altKey) {
-      painter.begin(
-        { x: lastMousePos.x, y: lastMousePos.y },
-        e.shiftKey || e.ctrlKey || e.metaKey,
-      );
-    } else if (e.button === 0) {
-      isPanning = true;
-    }
-  }
-
-  function onMouseMove(e: MouseEvent) {
-    if (!cachedRect) updateCachedRect();
-    if (!cachedRect) return;
-
-    const mouseX = e.clientX - cachedRect.left;
-    const mouseY = e.clientY - cachedRect.top;
-    isAltPressed = e.altKey;
-
-    if (boxSelectStart) {
-      boxSelectEnd = { x: mouseX, y: mouseY };
-      lastMousePos = { x: mouseX, y: mouseY };
-      return;
-    }
-
-    if (dragState) {
-      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
-      const nextX = imgPoint.x - dragState.offset.x;
-      const nextY = imgPoint.y - dragState.offset.y;
-      if (mapStore.isGMMode) {
-        mapSession.moveToken(dragState.tokenId, nextX, nextY);
-      } else {
-        mapSession.requestTokenMove(dragState.tokenId, nextX, nextY, true);
-        p2pGuestService.requestTokenMove(dragState.tokenId, nextX, nextY);
-      }
-      lastMousePos = { x: mouseX, y: mouseY };
-      return;
-    }
-
-    if (gridFitStart) {
-      gridFitEnd = { x: mouseX, y: mouseY };
-      lastMousePos = { x: mouseX, y: mouseY };
-      return;
-    }
-
-    if (painter.isPainting) {
-      painter.move(
-        { x: mouseX, y: mouseY },
-        e.shiftKey || e.ctrlKey || e.metaKey,
-      );
-    } else if (
-      mapSession.measurement.active &&
-      mapSession.measurement.start &&
-      !mapSession.measurement.locked
-    ) {
-      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
-      mapSession.setMeasurementEnd(imgPoint, true);
-    } else if (isPanning && !isAltPressed) {
-      const dx = mouseX - lastMousePos.x;
-      const dy = mouseY - lastMousePos.y;
-
-      mapStore.updateViewport(
-        { x: mapStore.viewport.pan.x + dx, y: mapStore.viewport.pan.y + dy },
-        mapStore.viewport.zoom,
-      );
-    }
-    lastMousePos = { x: mouseX, y: mouseY };
-  }
-
-  function onMouseEnter() {
-    isPointerOver = true;
-    updateCachedRect();
-  }
-
-  function onMouseLeave() {
-    isPointerOver = false;
-  }
-
-  async function onMouseUp(e: MouseEvent) {
-    if (painter.isPainting) {
-      const finished = await painter.finish();
-      if (
-        finished &&
-        mapStore.isGMMode &&
-        !uiStore.isGuestMode &&
-        mapSession.vttEnabled
-      ) {
-        void p2pHost.broadcastActiveMapFogSync();
-      }
-    }
-
-    if (boxSelectStart && boxSelectEnd && cachedRect) {
-      // Find all tokens within the selection rectangle
-      const allTokens = mapSession.allTokens;
-      const x1 = Math.min(boxSelectStart.x, boxSelectEnd.x);
-      const y1 = Math.min(boxSelectStart.y, boxSelectEnd.y);
-      const x2 = Math.max(boxSelectStart.x, boxSelectEnd.x);
-      const y2 = Math.max(boxSelectStart.y, boxSelectEnd.y);
-      const minArea = 100; // Minimum drag area to count as box select
-
-      if ((x2 - x1) * (y2 - y1) > minArea) {
-        const selected: string[] = [];
-        for (const token of allTokens) {
-          const projected = mapStore.project({ x: token.x, y: token.y });
-          if (
-            projected.x >= x1 &&
-            projected.x <= x2 &&
-            projected.y >= y1 &&
-            projected.y <= y2
-          ) {
-            selected.push(token.id);
-          }
-        }
-        mapSession.setMultiSelection(selected);
-      }
-
-      boxSelectStart = null;
-      boxSelectEnd = null;
-      return;
-    }
-
-    if (dragState) {
-      if (!mapStore.isGMMode) {
-        mapSession.confirmTokenMove(dragState.tokenId);
-      }
-      mapSession.draggingTokenId = null;
-      dragState = null;
-      isPanning = false;
-      return;
-    }
-
-    if (gridFitStart && gridFitEnd && cachedRect) {
-      const viewport = mapStore.viewport;
-      const _canvasSize = mapStore.canvasSize;
-      const _zoom = viewport.zoom;
-
-      // Convert drawn screen-space coords to image space
-      const startImg = mapStore.unproject(gridFitStart);
-      const endImg = mapStore.unproject(gridFitEnd);
-
-      const imgWidth = Math.abs(endImg.x - startImg.x);
-      const imgHeight = Math.abs(endImg.y - startImg.y);
-
-      // Ignore tiny drags
-      if (imgWidth >= 5 || imgHeight >= 5) {
-        // Cell size from larger dimension (image-space)
-        const cellSize = Math.round(Math.max(imgWidth, imgHeight));
-        mapStore.gridSize = cellSize;
-
-        // Set offset so grid lines pass through top-left of drawn square
-        const gridMinX = Math.min(startImg.x, endImg.x);
-        const gridMinY = Math.min(startImg.y, endImg.y);
-        mapStore.gridOffsetX = -(gridMinX % cellSize);
-        mapStore.gridOffsetY = -(gridMinY % cellSize);
-      }
-
-      gridFitStart = null;
-      gridFitEnd = null;
-      mapSession.gridFitMode = false;
-      // Open grid settings so user can fine-tune with move mode
-      mapSession.showGridSettings = true;
-      return;
-    }
-
-    if (isPanning) {
-      if (
-        isClickGesture(
-          { x: mouseDownPos.x, y: mouseDownPos.y },
-          { x: e.clientX, y: e.clientY },
-        )
-      ) {
-        handleMapClick(e);
-      }
-    }
-    isPanning = false;
-  }
-
-  function handleMapClick(e: MouseEvent) {
-    if (!container) return;
-    const rect = container.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-
-    if (mapSession.vttEnabled) {
-      const hitToken = hitTestToken(
-        mapSession.allTokens,
-        (point) => mapStore.project(point),
-        x,
-        y,
-      );
-
-      if (hitToken) {
-        mapSession.setSelection(hitToken.id);
-        selectedPinId = null;
-        return;
-      }
-
-      mapSession.setSelection(null);
-      if (mapSession.measurement.active) {
-        const imgCoords = mapStore.unproject({ x, y });
-        if (!mapSession.measurement.start) {
-          mapSession.setMeasurementStart(imgCoords);
-        } else if (!mapSession.measurement.locked) {
-          mapSession.setMeasurementEnd(imgCoords);
-          mapSession.setMeasurementLocked(true);
-        } else {
-          mapSession.setMeasurementStart(imgCoords);
-        }
-      }
-      return;
-    }
-
-    const clickedPin = findClickedPin(
-      mapStore.pins,
-      (point) => mapStore.project(point),
-      x,
-      y,
-    );
-
-    if (clickedPin) {
-      selectedPinId = clickedPin.id;
-      if (clickedPin.entityId) {
-        vault.selectedEntityId = clickedPin.entityId;
-      }
-    } else {
-      selectedPinId = null;
-    }
-  }
-
-  function onDoubleClick(e: MouseEvent) {
-    contextMenu = null;
-    if (!container) return;
-
-    const rect = container.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-
-    const imgCoords = mapStore.unproject({ x, y });
-    if (mapSession.vttEnabled && mapStore.isGMMode && !uiStore.isGuestMode) {
-      mapSession.pendingTokenCoords = imgCoords;
-    } else if (!mapSession.vttEnabled) {
-      mapStore.pendingPinCoords = imgCoords;
-    }
-  }
-
-  function onContextMenu(e: MouseEvent) {
-    if (gridFitStart) {
-      gridFitStart = null;
-      gridFitEnd = null;
-      mapSession.gridFitMode = false;
-      return;
-    }
-
-    if (!mapSession.vttEnabled || !container) return;
-    e.preventDefault();
-
-    const rect = container.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-
-    const hitToken = hitTestToken(
-      mapSession.allTokens,
-      (point) => mapStore.project(point),
-      x,
-      y,
-    );
-
-    const imgCoords = mapStore.unproject({ x, y });
-    contextMenu = {
-      x: e.clientX,
-      y: e.clientY,
-      imgX: imgCoords.x,
-      imgY: imgCoords.y,
-      tokenId: hitToken?.id,
-    };
-  }
-  function onWheel(e: WheelEvent) {
-    const canResize =
-      mapSession.vttEnabled && mapStore.isGMMode && !uiStore.isGuestMode;
-    if (e.shiftKey && canResize) {
-      if (!container) return;
-      e.preventDefault();
-
-      const rect = container.getBoundingClientRect();
-      const mouseX = e.clientX - rect.left;
-      const mouseY = e.clientY - rect.top;
-
-      const hitToken = hitTestToken(
-        mapSession.allTokens,
-        (point) => mapStore.project(point),
-        mouseX,
-        mouseY,
-      );
-
-      if (hitToken) {
-        const gridSize = mapStore.gridSize || 50;
-        const currentScale = Math.round(hitToken.width / gridSize);
-        let nextScale = currentScale + (e.deltaY < 0 ? 1 : -1);
-        nextScale = Math.max(1, Math.min(4, nextScale));
-
-        if (nextScale !== currentScale) {
-          mapSession.updateToken(hitToken.id, {
-            width: nextScale * gridSize,
-            height: nextScale * gridSize,
-          });
-        }
-        return;
-      }
-    }
-
-    e.preventDefault();
-    if (!container) return;
-
-    const rect = container.getBoundingClientRect();
-    const mouseX = e.clientX - rect.left;
-    const mouseY = e.clientY - rect.top;
-    const update = getZoomViewportUpdate({
-      mouse: { x: mouseX, y: mouseY },
-      canvasSize: mapStore.canvasSize,
-      viewport: mapStore.viewport,
-      deltaY: e.deltaY,
-      altHeld: isAltPressed,
-    });
-
-    mapStore.updateViewport(update.pan, update.zoom);
-    mapAnnouncement = update.announcement;
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -1057,30 +267,35 @@
   aria-roledescription="map"
   aria-label="Interactive map. Use arrow keys to pan and plus or minus keys to zoom."
   tabindex="0"
-  onmouseenter={onMouseEnter}
-  onmouseleave={onMouseLeave}
-  onmousedown={onMouseDown}
-  onmousemove={onMouseMove}
-  onmouseup={onMouseUp}
-  ondblclick={onDoubleClick}
-  oncontextmenu={onContextMenu}
-  onwheel={onWheel}
-  onkeydown={onKeyDown}
-  onkeyup={onKeyUp}
+  onmouseenter={interactions.onMouseEnter}
+  onmouseleave={interactions.onMouseLeave}
+  onmousedown={interactions.onMouseDown}
+  onmousemove={interactions.onMouseMove}
+  onmouseup={interactions.onMouseUp}
+  ondblclick={interactions.onDoubleClick}
+  oncontextmenu={interactions.onContextMenu}
+  onwheel={interactions.onWheel}
+  onkeydown={interactions.onKeyDown}
+  onkeyup={interactions.onKeyUp}
   ondragover={onMapDragOver}
   ondragleave={onMapDragLeave}
   ondrop={onMapDrop}
 >
-  <canvas
-    bind:this={canvas}
-    class="absolute inset-0 {mapSession.gridFitMode && mapStore.isGMMode
-      ? 'cursor-crosshair'
-      : ''} {mapSession.gridMoveMode && mapStore.isGMMode ? 'cursor-move' : ''}"
-  ></canvas>
+  <MapCanvas
+    mapImage={_drawImage}
+    maskCanvas={_drawMask}
+    {vttTokens}
+    {vttMeasurement}
+    {remoteMeasurement}
+    {vttPings}
+    {vttDragPreview}
+    {interactions}
+    getCanvas={(c) => (_canvasElement = c)}
+  />
 
   {#if !mapImage}
     <div
-      class="absolute inset-0 flex items-center justify-center bg-theme-bg/40 backdrop-blur-sm z-50"
+      class="absolute inset-0 flex items-center justify-center bg-theme-bg/40 backdrop-blur-sm z-50 pointer-events-none"
       transition:fade
     >
       <div class="flex flex-col items-center gap-4">
@@ -1097,87 +312,23 @@
   {/if}
 
   <div aria-live="polite" aria-atomic="true" class="sr-only">
-    {mapAnnouncement}
+    {interactions.mapAnnouncement}
   </div>
 
-  {#if mapStore.pendingPinCoords}
-    <PinLinker
-      onSelect={(id) => {
-        mapStore.addPin(id, mapStore.pendingPinCoords!);
-        mapStore.pendingPinCoords = null;
-      }}
-      onCancel={() => {
-        mapStore.addPin(undefined, mapStore.pendingPinCoords!);
-        mapStore.pendingPinCoords = null;
-      }}
-    />
-  {/if}
+  <MapOverlays {interactions} />
 
-  {#if selectedPin}
-    {@const pos = mapStore.project(selectedPin.coordinates)}
-    <MapPinPopover
-      x={pos.x}
-      y={pos.y}
-      entity={selectedPin.entityId
-        ? vault.entities[selectedPin.entityId]
-        : null}
-      subMap={subMapForSelected}
-      onOpenEntity={(entityId) => uiStore.openZenMode(entityId)}
-      onEnterSubmap={(mapId) => mapStore.selectMap(mapId, true)}
-      onDelete={() => {
-        if (selectedPinId) {
-          mapStore.removePin(selectedPinId);
-          selectedPinId = null;
-        }
-      }}
-      onClose={() => (selectedPinId = null)}
-    />
-  {/if}
-
-  {#if contextMenu}
+  {#if interactions.contextMenu}
     <MapContextMenu
-      x={contextMenu.x}
-      y={contextMenu.y}
-      imgX={contextMenu.imgX}
-      imgY={contextMenu.imgY}
-      tokenId={contextMenu.tokenId}
-      onClose={() => (contextMenu = null)}
+      x={interactions.contextMenu.x}
+      y={interactions.contextMenu.y}
+      imgX={interactions.contextMenu.imgX}
+      imgY={interactions.contextMenu.imgY}
+      tokenId={interactions.contextMenu.tokenId}
+      onClose={() => (interactions.contextMenu = null)}
     />
-  {/if}
-
-  {#if gridFitStart && gridFitEnd}
-    <div
-      class="absolute inset-0 z-[60] pointer-events-none"
-      style:cursor="crosshair"
-    >
-      <div
-        class="absolute border-2 border-dashed"
-        style:border-color="var(--color-theme-primary, #78350f)"
-        style:left={`${Math.min(gridFitStart.x, gridFitEnd.x)}px`}
-        style:top={`${Math.min(gridFitStart.y, gridFitEnd.y)}px`}
-        style:width={`${Math.abs(gridFitEnd.x - gridFitStart.x)}px`}
-        style:height={`${Math.abs(gridFitEnd.y - gridFitStart.y)}px`}
-      ></div>
-    </div>
-  {/if}
-
-  {#if boxSelectStart && boxSelectEnd}
-    <div
-      class="absolute inset-0 z-[60] pointer-events-none"
-      style:cursor="crosshair"
-    >
-      <div
-        class="absolute border-2 border-dashed bg-theme-primary/10"
-        style:border-color="var(--color-theme-primary, #78350f)"
-        style:left={`${Math.min(boxSelectStart.x, boxSelectEnd.x)}px`}
-        style:top={`${Math.min(boxSelectStart.y, boxSelectEnd.y)}px`}
-        style:width={`${Math.abs(boxSelectEnd.x - boxSelectStart.x)}px`}
-        style:height={`${Math.abs(boxSelectEnd.y - boxSelectStart.y)}px`}
-      ></div>
-    </div>
   {/if}
 
   {@render children?.()}
 </div>
 
-<svelte:window onkeydown={onGlobalKeyDown} />
+<svelte:window onkeydown={interactions.onGlobalKeyDown} />

--- a/apps/web/src/lib/components/map/MapView.svelte
+++ b/apps/web/src/lib/components/map/MapView.svelte
@@ -36,13 +36,8 @@
   } = $props();
 
   let container = $state<HTMLDivElement | null>(null);
-  let _canvasElement: HTMLCanvasElement | null = null;
   let mapImage = $state<HTMLImageElement | null>(null);
   let maskCanvas = $state<HTMLCanvasElement | null>(null);
-
-  // Reactive mirrors for MapCanvas passing
-  let _drawImage = $state<HTMLImageElement | null>(null);
-  let _drawMask = $state<HTMLCanvasElement | null>(null);
 
   const painter = new MapFogPainter({
     mapStore,
@@ -64,17 +59,13 @@
     onClear: () => {
       painter.cancel();
       mapImage = null;
-      _drawImage = null;
       maskCanvas = null;
-      _drawMask = null;
     },
     onImageLoaded: (img) => {
-      _drawImage = img;
       mapImage = img;
     },
     onMaskLoaded: (mask) => {
       maskCanvas = mask;
-      _drawMask = mask;
     },
     onDimensionsLoaded: async (width, height) => {
       const activeMap = mapStore.activeMap;
@@ -247,7 +238,6 @@
     void mapStore.loadMask(image.width, image.height).then((mask) => {
       if (cancelled) return;
       maskCanvas = mask;
-      _drawMask = mask;
       loadedMaskPath = fogMaskPath;
     });
 
@@ -282,15 +272,14 @@
   ondrop={onMapDrop}
 >
   <MapCanvas
-    mapImage={_drawImage}
-    maskCanvas={_drawMask}
+    {mapImage}
+    {maskCanvas}
     {vttTokens}
     {vttMeasurement}
     {remoteMeasurement}
     {vttPings}
     {vttDragPreview}
     {interactions}
-    getCanvas={(c) => (_canvasElement = c)}
   />
 
   {#if !mapImage}

--- a/apps/web/src/lib/components/map/map-interactions.svelte.ts
+++ b/apps/web/src/lib/components/map/map-interactions.svelte.ts
@@ -1,0 +1,532 @@
+import { mapStore } from "../../stores/map.svelte";
+import { mapSession } from "../../stores/map-session.svelte";
+import { uiStore } from "../../stores/ui.svelte";
+import { vault } from "../../stores/vault.svelte";
+import { p2pGuestService } from "../../cloud-bridge/p2p/guest-service";
+import { p2pHost } from "../../cloud-bridge/p2p/host-service.svelte";
+import { hitTestToken } from "$lib/utils/vtt-helpers";
+import {
+  findClickedPin,
+  getKeyboardViewportUpdate,
+  getZoomViewportUpdate,
+  isClickGesture,
+  shouldIgnoreMapKeyboardEvent,
+} from "./map-view-helpers";
+import type { MapFogPainter } from "./map-fog-painter";
+
+export class MapInteractionManager {
+  painter: MapFogPainter;
+  getContainer: () => HTMLElement | null;
+
+  isPanning = $state(false);
+  lastMousePos = $state({ x: 0, y: 0 });
+  mouseDownPos = { x: 0, y: 0 };
+  isAltPressed = $state(false);
+  isPointerOver = $state(false);
+  gridFitStart = $state<{ x: number; y: number } | null>(null);
+  gridFitEnd = $state<{ x: number; y: number } | null>(null);
+  boxSelectStart = $state<{ x: number; y: number } | null>(null);
+  boxSelectEnd = $state<{ x: number; y: number } | null>(null);
+  dragState = $state<{
+    tokenId: string;
+    offset: { x: number; y: number };
+  } | null>(null);
+  contextMenu = $state<{
+    x: number;
+    y: number;
+    imgX: number;
+    imgY: number;
+    tokenId?: string;
+  } | null>(null);
+  selectedPinId = $state<string | null>(null);
+  mapAnnouncement = $state("");
+
+  cachedRect: DOMRect | null = null;
+  KEYBOARD_PAN_STEP = 50;
+  KEYBOARD_ZOOM_STEP = 0.1;
+
+  visualBrushRadius = $derived(mapStore.brushRadius * mapStore.viewport.zoom);
+
+  constructor(opts: {
+    painter: MapFogPainter;
+    getContainer: () => HTMLElement | null;
+  }) {
+    this.painter = opts.painter;
+    this.getContainer = opts.getContainer;
+  }
+
+  updateCachedRect() {
+    const el = this.getContainer();
+    if (el) {
+      this.cachedRect = el.getBoundingClientRect();
+    }
+  }
+
+  onKeyDown = (event: KeyboardEvent) => {
+    if (shouldIgnoreMapKeyboardEvent(event.target as HTMLElement)) {
+      return;
+    }
+
+    const { key, altKey } = event;
+    this.isAltPressed = altKey;
+    const viewport = mapStore.viewport;
+
+    if (!viewport) return;
+
+    const update = getKeyboardViewportUpdate(key, viewport, {
+      panStep: this.KEYBOARD_PAN_STEP,
+      zoomStep: this.KEYBOARD_ZOOM_STEP,
+    });
+
+    if (update) {
+      mapStore.updateViewport(update.pan, update.zoom);
+      this.mapAnnouncement = update.announcement;
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  onGlobalKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter" && mapSession.gridMoveMode) {
+      event.preventDefault();
+      const viewport = mapStore.viewport;
+      const canvasSize = mapStore.canvasSize;
+      mapStore.gridOffsetX =
+        -((viewport.pan.x + canvasSize.width / 2) / viewport.zoom) %
+        mapStore.gridSize;
+      mapStore.gridOffsetY =
+        -((viewport.pan.y + canvasSize.height / 2) / viewport.zoom) %
+        mapStore.gridSize;
+      mapSession.gridMoveMode = false;
+      uiStore.clearNotification();
+      return;
+    }
+    if (event.key === "Escape") {
+      if (mapSession.gridMoveMode) {
+        mapSession.gridMoveMode = false;
+        uiStore.clearNotification();
+        return;
+      }
+      if (mapSession.gridFitMode) {
+        mapSession.gridFitMode = false;
+        this.gridFitStart = null;
+        this.gridFitEnd = null;
+        return;
+      }
+      if (this.boxSelectStart) {
+        this.boxSelectStart = null;
+        this.boxSelectEnd = null;
+        return;
+      }
+      if (mapSession.selectedTokens.size > 1) {
+        mapSession.clearSelection();
+        return;
+      }
+    }
+  };
+
+  onKeyUp = (event: KeyboardEvent) => {
+    this.isAltPressed = event.altKey;
+  };
+
+  onMouseDown = (e: MouseEvent) => {
+    this.contextMenu = null;
+    this.updateCachedRect();
+    if (this.cachedRect) {
+      this.lastMousePos = {
+        x: e.clientX - this.cachedRect.left,
+        y: e.clientY - this.cachedRect.top,
+      };
+    }
+    this.mouseDownPos = { x: e.clientX, y: e.clientY };
+    this.isAltPressed = e.altKey;
+
+    if (
+      mapStore.isGMMode &&
+      (e.ctrlKey || e.metaKey) &&
+      mapSession.vttEnabled &&
+      this.cachedRect
+    ) {
+      e.preventDefault();
+      this.boxSelectStart = { x: this.lastMousePos.x, y: this.lastMousePos.y };
+      this.boxSelectEnd = this.boxSelectStart;
+      this.isPanning = false;
+      return;
+    }
+
+    if (mapSession.vttEnabled && this.cachedRect) {
+      const hitToken = hitTestToken(
+        mapSession.allTokens,
+        (point) => mapStore.project(point),
+        this.lastMousePos.x,
+        this.lastMousePos.y,
+      );
+
+      if (
+        hitToken &&
+        mapSession.canMoveToken(
+          hitToken.id,
+          p2pGuestService.peerId,
+          mapStore.isGMMode,
+        )
+      ) {
+        const imgPoint = mapStore.unproject(this.lastMousePos);
+        this.dragState = {
+          tokenId: hitToken.id,
+          offset: {
+            x: imgPoint.x - hitToken.x,
+            y: imgPoint.y - hitToken.y,
+          },
+        };
+        mapSession.draggingTokenId = hitToken.id;
+        if (e.ctrlKey || e.metaKey) {
+          mapSession.addToSelection(hitToken.id);
+        } else if (e.shiftKey) {
+          if (mapSession.selectedTokens.has(hitToken.id)) {
+            mapSession.removeFromSelection(hitToken.id);
+          } else {
+            mapSession.addToSelection(hitToken.id);
+          }
+        } else {
+          mapSession.setSelection(hitToken.id);
+        }
+        this.isPanning = false;
+        return;
+      }
+    }
+
+    if (mapSession.gridMoveMode && mapStore.isGMMode && this.cachedRect) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.isPanning = true;
+      return;
+    }
+
+    if (mapSession.gridFitMode && mapStore.isGMMode && this.cachedRect) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.gridFitStart = { x: this.lastMousePos.x, y: this.lastMousePos.y };
+      this.gridFitEnd = this.gridFitStart;
+      return;
+    }
+
+    if (mapStore.isGMMode && e.altKey) {
+      this.painter.begin(
+        { x: this.lastMousePos.x, y: this.lastMousePos.y },
+        e.shiftKey || e.ctrlKey || e.metaKey,
+      );
+    } else if (e.button === 0) {
+      this.isPanning = true;
+    }
+  };
+
+  onMouseMove = (e: MouseEvent) => {
+    if (!this.cachedRect) this.updateCachedRect();
+    if (!this.cachedRect) return;
+
+    const mouseX = e.clientX - this.cachedRect.left;
+    const mouseY = e.clientY - this.cachedRect.top;
+    this.isAltPressed = e.altKey;
+
+    if (this.boxSelectStart) {
+      this.boxSelectEnd = { x: mouseX, y: mouseY };
+      this.lastMousePos = { x: mouseX, y: mouseY };
+      return;
+    }
+
+    if (this.dragState) {
+      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
+      const nextX = imgPoint.x - this.dragState.offset.x;
+      const nextY = imgPoint.y - this.dragState.offset.y;
+      if (mapStore.isGMMode) {
+        mapSession.moveToken(this.dragState.tokenId, nextX, nextY);
+      } else {
+        mapSession.requestTokenMove(this.dragState.tokenId, nextX, nextY, true);
+        p2pGuestService.requestTokenMove(this.dragState.tokenId, nextX, nextY);
+      }
+      this.lastMousePos = { x: mouseX, y: mouseY };
+      return;
+    }
+
+    if (this.gridFitStart) {
+      this.gridFitEnd = { x: mouseX, y: mouseY };
+      this.lastMousePos = { x: mouseX, y: mouseY };
+      return;
+    }
+
+    if (this.painter.isPainting) {
+      this.painter.move(
+        { x: mouseX, y: mouseY },
+        e.shiftKey || e.ctrlKey || e.metaKey,
+      );
+    } else if (
+      mapSession.measurement.active &&
+      mapSession.measurement.start &&
+      !mapSession.measurement.locked
+    ) {
+      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
+      mapSession.setMeasurementEnd(imgPoint, true);
+    } else if (this.isPanning && !this.isAltPressed) {
+      const dx = mouseX - this.lastMousePos.x;
+      const dy = mouseY - this.lastMousePos.y;
+      mapStore.updateViewport(
+        { x: mapStore.viewport.pan.x + dx, y: mapStore.viewport.pan.y + dy },
+        mapStore.viewport.zoom,
+      );
+    }
+    this.lastMousePos = { x: mouseX, y: mouseY };
+  };
+
+  onMouseEnter = () => {
+    this.isPointerOver = true;
+    this.updateCachedRect();
+  };
+
+  onMouseLeave = () => {
+    this.isPointerOver = false;
+  };
+
+  onMouseUp = async (e: MouseEvent) => {
+    if (this.painter.isPainting) {
+      const finished = await this.painter.finish();
+      if (
+        finished &&
+        mapStore.isGMMode &&
+        !uiStore.isGuestMode &&
+        mapSession.vttEnabled
+      ) {
+        void p2pHost.broadcastActiveMapFogSync();
+      }
+    }
+
+    if (this.boxSelectStart && this.boxSelectEnd && this.cachedRect) {
+      const allTokens = mapSession.allTokens;
+      const x1 = Math.min(this.boxSelectStart.x, this.boxSelectEnd.x);
+      const y1 = Math.min(this.boxSelectStart.y, this.boxSelectEnd.y);
+      const x2 = Math.max(this.boxSelectStart.x, this.boxSelectEnd.x);
+      const y2 = Math.max(this.boxSelectStart.y, this.boxSelectEnd.y);
+      const minArea = 100;
+
+      if ((x2 - x1) * (y2 - y1) > minArea) {
+        const selected: string[] = [];
+        for (const token of allTokens) {
+          const projected = mapStore.project({ x: token.x, y: token.y });
+          if (
+            projected.x >= x1 &&
+            projected.x <= x2 &&
+            projected.y >= y1 &&
+            projected.y <= y2
+          ) {
+            selected.push(token.id);
+          }
+        }
+        mapSession.setMultiSelection(selected);
+      }
+
+      this.boxSelectStart = null;
+      this.boxSelectEnd = null;
+      return;
+    }
+
+    if (this.dragState) {
+      if (!mapStore.isGMMode) {
+        mapSession.confirmTokenMove(this.dragState.tokenId);
+      }
+      mapSession.draggingTokenId = null;
+      this.dragState = null;
+      this.isPanning = false;
+      return;
+    }
+
+    if (this.gridFitStart && this.gridFitEnd && this.cachedRect) {
+      const startImg = mapStore.unproject(this.gridFitStart);
+      const endImg = mapStore.unproject(this.gridFitEnd);
+      const imgWidth = Math.abs(endImg.x - startImg.x);
+      const imgHeight = Math.abs(endImg.y - startImg.y);
+
+      if (imgWidth >= 5 || imgHeight >= 5) {
+        const cellSize = Math.round(Math.max(imgWidth, imgHeight));
+        mapStore.gridSize = cellSize;
+        const gridMinX = Math.min(startImg.x, endImg.x);
+        const gridMinY = Math.min(startImg.y, endImg.y);
+        mapStore.gridOffsetX = -(gridMinX % cellSize);
+        mapStore.gridOffsetY = -(gridMinY % cellSize);
+      }
+
+      this.gridFitStart = null;
+      this.gridFitEnd = null;
+      mapSession.gridFitMode = false;
+      mapSession.showGridSettings = true;
+      return;
+    }
+
+    if (this.isPanning) {
+      if (
+        isClickGesture(
+          { x: this.mouseDownPos.x, y: this.mouseDownPos.y },
+          { x: e.clientX, y: e.clientY },
+        )
+      ) {
+        this.handleMapClick(e);
+      }
+    }
+    this.isPanning = false;
+  };
+
+  handleMapClick = (e: MouseEvent) => {
+    const el = this.getContainer();
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    if (mapSession.vttEnabled) {
+      const hitToken = hitTestToken(
+        mapSession.allTokens,
+        (point) => mapStore.project(point),
+        x,
+        y,
+      );
+
+      if (hitToken) {
+        mapSession.setSelection(hitToken.id);
+        this.selectedPinId = null;
+        return;
+      }
+
+      mapSession.setSelection(null);
+      if (mapSession.measurement.active) {
+        const imgCoords = mapStore.unproject({ x, y });
+        if (!mapSession.measurement.start) {
+          mapSession.setMeasurementStart(imgCoords);
+        } else if (!mapSession.measurement.locked) {
+          mapSession.setMeasurementEnd(imgCoords);
+          mapSession.setMeasurementLocked(true);
+        } else {
+          mapSession.setMeasurementStart(imgCoords);
+        }
+      }
+      return;
+    }
+
+    const clickedPin = findClickedPin(
+      mapStore.pins,
+      (point) => mapStore.project(point),
+      x,
+      y,
+    );
+
+    if (clickedPin) {
+      this.selectedPinId = clickedPin.id;
+      if (clickedPin.entityId) {
+        vault.selectedEntityId = clickedPin.entityId;
+      }
+    } else {
+      this.selectedPinId = null;
+    }
+  };
+
+  onDoubleClick = (e: MouseEvent) => {
+    this.contextMenu = null;
+    const el = this.getContainer();
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const imgCoords = mapStore.unproject({ x, y });
+    if (mapSession.vttEnabled && mapStore.isGMMode && !uiStore.isGuestMode) {
+      mapSession.pendingTokenCoords = imgCoords;
+    } else if (!mapSession.vttEnabled) {
+      mapStore.pendingPinCoords = imgCoords;
+    }
+  };
+
+  onContextMenu = (e: MouseEvent) => {
+    if (this.gridFitStart) {
+      this.gridFitStart = null;
+      this.gridFitEnd = null;
+      mapSession.gridFitMode = false;
+      return;
+    }
+
+    const el = this.getContainer();
+    if (!mapSession.vttEnabled || !el) return;
+    e.preventDefault();
+
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const hitToken = hitTestToken(
+      mapSession.allTokens,
+      (point) => mapStore.project(point),
+      x,
+      y,
+    );
+
+    const imgCoords = mapStore.unproject({ x, y });
+    this.contextMenu = {
+      x: e.clientX,
+      y: e.clientY,
+      imgX: imgCoords.x,
+      imgY: imgCoords.y,
+      tokenId: hitToken?.id,
+    };
+  };
+
+  onWheel = (e: WheelEvent) => {
+    const canResize =
+      mapSession.vttEnabled && mapStore.isGMMode && !uiStore.isGuestMode;
+    const el = this.getContainer();
+
+    if (e.shiftKey && canResize) {
+      if (!el) return;
+      e.preventDefault();
+
+      const rect = el.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
+
+      const hitToken = hitTestToken(
+        mapSession.allTokens,
+        (point) => mapStore.project(point),
+        mouseX,
+        mouseY,
+      );
+
+      if (hitToken) {
+        const gridSize = mapStore.gridSize || 50;
+        const currentScale = Math.round(hitToken.width / gridSize);
+        let nextScale = currentScale + (e.deltaY < 0 ? 1 : -1);
+        nextScale = Math.max(1, Math.min(4, nextScale));
+
+        if (nextScale !== currentScale) {
+          mapSession.updateToken(hitToken.id, {
+            width: nextScale * gridSize,
+            height: nextScale * gridSize,
+          });
+        }
+        return;
+      }
+    }
+
+    e.preventDefault();
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+    const mouseY = e.clientY - rect.top;
+    const update = getZoomViewportUpdate({
+      mouse: { x: mouseX, y: mouseY },
+      canvasSize: mapStore.canvasSize,
+      viewport: mapStore.viewport,
+      deltaY: e.deltaY,
+      altHeld: this.isAltPressed,
+    });
+
+    mapStore.updateViewport(update.pan, update.zoom);
+    this.mapAnnouncement = update.announcement;
+  };
+}

--- a/apps/web/src/lib/components/map/map-interactions.svelte.ts
+++ b/apps/web/src/lib/components/map/map-interactions.svelte.ts
@@ -523,7 +523,7 @@ export class MapInteractionManager {
       canvasSize: mapStore.canvasSize,
       viewport: mapStore.viewport,
       deltaY: e.deltaY,
-      altHeld: this.isAltPressed,
+      altHeld: e.altKey,
     });
 
     mapStore.updateViewport(update.pan, update.zoom);

--- a/apps/web/src/lib/components/map/map-interactions.test.ts
+++ b/apps/web/src/lib/components/map/map-interactions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MapInteractionManager } from "./map-interactions.svelte";
+
+// Mocking stores
+vi.mock("../../stores/map.svelte", () => ({
+  mapStore: {
+    viewport: { pan: { x: 0, y: 0 }, zoom: 1 },
+    canvasSize: { width: 800, height: 600 },
+    isGMMode: true,
+    brushRadius: 10,
+    updateViewport: vi.fn(),
+    project: vi.fn((p) => p),
+    unproject: vi.fn((p) => p),
+  },
+}));
+
+vi.mock("../../stores/map-session.svelte", () => ({
+  mapSession: {
+    vttEnabled: true,
+    gridFitMode: false,
+    gridMoveMode: false,
+    selectedTokens: new Set(),
+    tokens: {},
+    allTokens: [],
+    measurement: { active: false, start: null, end: null, locked: false },
+    setSelection: vi.fn(),
+    clearSelection: vi.fn(),
+  },
+}));
+
+vi.mock("../../stores/ui.svelte", () => ({
+  uiStore: {
+    isGuestMode: false,
+    clearNotification: vi.fn(),
+  },
+}));
+
+vi.mock("../../stores/vault.svelte", () => ({
+  vault: {
+    selectedEntityId: null,
+    entities: {},
+  },
+}));
+
+describe("MapInteractionManager", () => {
+  let manager: MapInteractionManager;
+  let painterMock: any;
+  let containerMock: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    painterMock = {
+      begin: vi.fn(),
+      move: vi.fn(),
+      finish: vi.fn(),
+      isPainting: false,
+    };
+    containerMock = {
+      getBoundingClientRect: vi.fn(() => ({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 600,
+      })),
+    };
+    manager = new MapInteractionManager({
+      painter: painterMock,
+      getContainer: () => containerMock,
+    });
+  });
+
+  it("should handle mouse down and start panning", () => {
+    const event = new MouseEvent("mousedown", {
+      clientX: 100,
+      clientY: 100,
+      button: 0,
+    });
+    manager.onMouseDown(event);
+    expect(manager.isPanning).toBe(true);
+    expect(manager.lastMousePos).toEqual({ x: 100, y: 100 });
+  });
+
+  it("should handle mouse move and update viewport when panning", async () => {
+    const { mapStore } = await import("../../stores/map.svelte");
+
+    manager.onMouseDown(
+      new MouseEvent("mousedown", { clientX: 100, clientY: 100, button: 0 }),
+    );
+    manager.onMouseMove(
+      new MouseEvent("mousemove", { clientX: 110, clientY: 120 }),
+    );
+
+    expect(mapStore.updateViewport).toHaveBeenCalledWith({ x: 10, y: 20 }, 1);
+  });
+
+  it("should start box selection when Ctrl is pressed on GM mode", () => {
+    const event = new MouseEvent("mousedown", {
+      clientX: 100,
+      clientY: 100,
+      ctrlKey: true,
+      button: 0,
+    });
+    manager.onMouseDown(event);
+    expect(manager.boxSelectStart).toEqual({ x: 100, y: 100 });
+    expect(manager.isPanning).toBe(false);
+  });
+
+  it("should handle wheel zoom", async () => {
+    const { mapStore } = await import("../../stores/map.svelte");
+    const event = new WheelEvent("wheel", {
+      clientX: 400,
+      clientY: 300,
+      deltaY: -100,
+    });
+    // We need to preventDefault
+    vi.spyOn(event, "preventDefault");
+
+    manager.onWheel(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(mapStore.updateViewport).toHaveBeenCalled();
+  });
+
+  it("should clear selection on Escape", async () => {
+    const { mapSession } = await import("../../stores/map-session.svelte");
+    mapSession.selectedTokens.add("token-1");
+    mapSession.selectedTokens.add("token-2");
+
+    const event = new KeyboardEvent("keydown", { key: "Escape" });
+    manager.onGlobalKeyDown(event);
+
+    expect(mapSession.clearSelection).toHaveBeenCalled();
+  });
+});

--- a/docs/refactoring/MAP_VIEW_REFACTOR.md
+++ b/docs/refactoring/MAP_VIEW_REFACTOR.md
@@ -1,0 +1,92 @@
+# MapView Refactor Proposal
+
+## Overview
+
+At **1,536 lines**, `apps/web/src/lib/components/map/MapView.svelte` is currently the largest file in the Codex-Cryptica repository. It is a critical component that bridges the core `map-engine`, the Svelte application state, and complex user interactions (VTT tools, GM tools, panning/zooming, and selections).
+
+The size of this file makes it difficult to maintain, test, and safely extend without causing regressions in unrelated map behaviors.
+
+This proposal outlines a strategy to decompose `MapView.svelte` into smaller, focused modules, adhering to the principle of separation of concerns.
+
+## Identified Hotspots (The "Why")
+
+Analyzing the current `MapView.svelte` reveals several distinct responsibilities tangled together:
+
+1. **Context Menu UI (~350 lines)**: The `contextMenu` template code is massive. It contains nested logic for checking GM/Guest roles, token visibility, grid alignment calculations, and iterating over status effects.
+2. **Interaction State Machine (~330 lines)**: The `onMouseDown`, `onMouseMove`, `onMouseUp`, `onWheel`, and `onKeyDown` handlers form an enormous implicit state machine. They manage panning, token dragging, box selection, grid fitting, brush painting, and measurement—all using a dozen disconnected `$state` variables (e.g., `dragState`, `gridFitStart`, `boxSelectStart`, `isPanning`).
+3. **Canvas Render Loop (~190 lines)**: The `draw()` function in `requestAnimationFrame` calls `renderMap()` but also imperatively draws P2P pings, drag previews, remote measurements, and visual brush indicators directly onto the 2D context.
+4. **VTT State Derivations (~70 lines)**: Converting raw store arrays into mapped, filtered objects for rendering (e.g., `vttTokens`, `vttMeasurement`, `remoteMeasurement`).
+
+## Proposed Architecture
+
+To solve this, we should split `MapView.svelte` into a coordinator component and several specialized sub-components/classes.
+
+### 1. `MapContextMenu.svelte`
+
+Extract the context menu UI into its own component.
+
+- **Props**: `contextMenu` state (x, y, token info), active token data, callbacks for actions (ping, delete, resize, status effects).
+- **Benefit**: Removes 350+ lines of dense template logic.
+
+### 2. `MapInteractions.svelte.ts` (State Class)
+
+Extract the event handlers into a dedicated Svelte 5 class.
+
+- **Responsibility**: Encapsulate the complex state machine (panning, drawing, token dragging, box selection).
+- **Implementation**: A class that takes the container/canvas elements and binds to their events. It internally manages `$state` for `boxSelectStart`, `gridFitStart`, etc., exposing only what the UI needs to render overlays.
+- **Benefit**: Makes interaction logic fully testable without mounting the entire MapView component.
+
+### 3. `MapCanvas.svelte`
+
+Extract the raw `<canvas>` element and the `requestAnimationFrame` render loop.
+
+- **Props**: `activeMap`, derived `vttTokens`, `vttMeasurement`, `pings`, etc.
+- **Responsibility**: Handle `ResizeObserver`, device pixel ratio scaling, and executing the `renderMap` call from `map-engine`. Custom imperative drawing (like P2P pings or the visual brush) should be moved here or to a `map-engine` plugin layer.
+- **Benefit**: Isolates performance-critical rendering code from UI layout logic.
+
+### 4. `MapOverlays.svelte`
+
+Extract DOM-based overlays (DOM elements that float over the canvas).
+
+- **Responsibility**: Render `PinLinker`, `MapPinPopover`, and the dashed borders for box selection and grid fitting.
+- **Benefit**: Cleans up the main template, making it easier to read.
+
+### 5. `MapView.svelte` (The Coordinator)
+
+After extraction, `MapView.svelte` becomes a structural shell.
+
+- **Responsibility**: Bind the pieces together. It initializes the `MapFogPainter`, `MapViewAssetLoader`, and `MapInteractions`, passing state down to `MapCanvas` and `MapOverlays`.
+- **Target Size**: ~150 - 250 lines.
+
+## Execution Plan
+
+To minimize risk and avoid breaking VTT interactions, this refactor should be executed in phases:
+
+### Phase 1: Context Menu Extraction (Low Risk, High Impact) - **COMPLETED**
+
+- [x] Create `MapContextMenu.svelte`.
+- [x] Move the entire `#if contextMenu` block into the new component.
+- [x] Pass required store data or callbacks.
+- _Actual LOC reduction: ~320 lines._
+
+### Phase 2: Overlay Extraction (Low Risk)
+
+- Create `MapOverlays.svelte` to handle the grid fit rect, box select rect, `PinLinker`, and `MapPinPopover`.
+- _Expected LOC reduction: ~100 lines._
+
+### Phase 3: Canvas Rendering Isolation (Medium Risk)
+
+- Create `MapCanvas.svelte`.
+- Move the `canvas` DOM element, `handleResize`, the `ResizeObserver`, and the `draw()` loop.
+- _Expected LOC reduction: ~250 lines._
+
+### Phase 4: Interaction State Machine (High Risk / High Reward)
+
+- Create `map-interactions.svelte.ts`.
+- Migrate all `onMouse*`, `onKey*`, and `onWheel` handlers into this class.
+- Update `MapView.svelte` to instantiate this class and attach its listeners to the container.
+- _Expected LOC reduction: ~400 lines._
+
+## Summary
+
+By executing this refactor, we will eliminate the largest god file in the project, resulting in a cleaner UI hierarchy, easier testing for complex map gestures, and a more maintainable VTT environment.

--- a/docs/refactoring/MAP_VIEW_REFACTOR.md
+++ b/docs/refactoring/MAP_VIEW_REFACTOR.md
@@ -69,24 +69,24 @@ To minimize risk and avoid breaking VTT interactions, this refactor should be ex
 - [x] Pass required store data or callbacks.
 - _Actual LOC reduction: ~320 lines._
 
-### Phase 2: Overlay Extraction (Low Risk)
+### Phase 2: Overlay Extraction (Low Risk) - **COMPLETED**
 
-- Create `MapOverlays.svelte` to handle the grid fit rect, box select rect, `PinLinker`, and `MapPinPopover`.
-- _Expected LOC reduction: ~100 lines._
+- [x] Create `MapOverlays.svelte` to handle the grid fit rect, box select rect, `PinLinker`, and `MapPinPopover`.
+- _Actual LOC reduction: ~70 lines._
 
-### Phase 3: Canvas Rendering Isolation (Medium Risk)
+### Phase 3: Canvas Rendering Isolation (Medium Risk) - **COMPLETED**
 
-- Create `MapCanvas.svelte`.
-- Move the `canvas` DOM element, `handleResize`, the `ResizeObserver`, and the `draw()` loop.
-- _Expected LOC reduction: ~250 lines._
+- [x] Create `MapCanvas.svelte`.
+- [x] Move the `canvas` DOM element, `handleResize`, the `ResizeObserver`, and the `draw()` loop.
+- _Actual LOC reduction: ~280 lines._
 
-### Phase 4: Interaction State Machine (High Risk / High Reward)
+### Phase 4: Interaction State Machine (High Risk / High Reward) - **COMPLETED**
 
-- Create `map-interactions.svelte.ts`.
-- Migrate all `onMouse*`, `onKey*`, and `onWheel` handlers into this class.
-- Update `MapView.svelte` to instantiate this class and attach its listeners to the container.
-- _Expected LOC reduction: ~400 lines._
+- [x] Create `map-interactions.svelte.ts`.
+- [x] Migrate all `onMouse*`, `onKey*`, and `onWheel` handlers into this class.
+- [x] Update `MapView.svelte` to instantiate this class and attach its listeners to the container.
+- _Actual LOC reduction: ~480 lines._
 
 ## Summary
 
-By executing this refactor, we will eliminate the largest god file in the project, resulting in a cleaner UI hierarchy, easier testing for complex map gestures, and a more maintainable VTT environment.
+By executing this refactor, we successfully eliminated the largest god file in the project. `MapView.svelte` has been reduced from 1,536 lines to 328 lines, resulting in a cleaner UI hierarchy, easier testing for complex map gestures, and a more maintainable VTT environment.

--- a/specs/058-map-mode/tasks.md
+++ b/specs/058-map-mode/tasks.md
@@ -42,7 +42,7 @@ description: "Task list for Interactive Campaign Mapping & Spatial Lore"
 
 **Goal**: Render a high-resolution map image with fluid zoom and pan
 
-- [x] T009 [P] [US1] Create base `MapView.svelte` with HTML5 Canvas element in `apps/web/src/lib/components/map/MapView.svelte`
+- [x] T009 [P] [US1] Create base `MapView.svelte` as a coordinator component in `apps/web/src/lib/components/map/MapView.svelte`
 - [x] T010 [US1] Implement high-performance zoom and pan logic in `packages/map-engine/src/renderer.ts`
 - [x] T011 [US1] Implement image upload and OPFS storage logic in `apps/web/src/lib/stores/map.svelte.ts`
 - [x] T012 [US1] Create Map Mode route at `apps/web/src/routes/map/+page.svelte`
@@ -57,7 +57,7 @@ description: "Task list for Interactive Campaign Mapping & Spatial Lore"
 **Goal**: Drop pins on the map and link them to existing Lore entities
 
 - [x] T014 [P] [US2] Implement `PinLayer.svelte` for rendering interactive markers in `apps/web/src/lib/components/map/PinLayer.svelte`
-- [x] T015 [US2] Add double-click listener to `MapView.svelte` to trigger pin creation at specific image coordinates
+- [x] T015 [US2] Add double-click listener to `MapInteractionManager` to trigger pin creation at specific image coordinates
 - [x] T016 [US2] Create `PinLinker.svelte` modal for selecting an existing Entity to link to a pin
 - [x] T017 [US2] Connect pin click events to `uiStore.openZenMode()` side-panel logic
 - [x] T018 [US2] Implement pin icon resolution based on linked Entity category
@@ -114,3 +114,4 @@ description: "Task list for Interactive Campaign Mapping & Spatial Lore"
 
 - T001, T002, T004 (Setup) can run in parallel.
 - Documentation (T028) can be authored while implementation is in progress.
+  ress.

--- a/specs/079-vtt-light/plan.md
+++ b/specs/079-vtt-light/plan.md
@@ -64,7 +64,10 @@ apps/web/src/
 │   │   └── vault.svelte.ts             # Vault and OPFS persistence helpers
 │   ├── components/
 │   │   ├── map/
-│   │   │   ├── MapView.svelte           # Map canvas, token overlay, drag handling
+│   │   │   ├── MapView.svelte           # Map coordinator component
+│   │   │   ├── MapCanvas.svelte         # High-performance VTT layer (tokens, fog)
+│   │   │   ├── MapOverlays.svelte       # DOM-based VTT overlays (selection, grid fit)
+│   │   │   ├── map-interactions.svelte.ts # Input state machine (drag, measure, zoom)
 │   │   │   ├── VTTControls.svelte       # Top-level VTT controls and host share entry
 │   │   │   ├── vtt-ui.ts                # Shared VTT UI state helpers
 │   │   │   └── vtt-mode-menu.svelte.ts  # Mode menu state helpers

--- a/specs/079-vtt-light/quickstart.md
+++ b/specs/079-vtt-light/quickstart.md
@@ -24,9 +24,9 @@ Start with the `EncounterSession` class. It should:
 
 Test first: `apps/web/tests/unit/stores/map-session.test.ts`
 
-### 2. Add token rendering to MapView
+### 2. Add token rendering to MapCanvas
 
-In `apps/web/src/lib/components/map/MapView.svelte`, inside the `draw()` function, after the `renderMap()` call:
+In `apps/web/src/lib/components/map/MapCanvas.svelte`, inside the `draw()` function, after the `renderMap()` call:
 
 ```typescript
 // After renderMap()
@@ -59,7 +59,7 @@ Render a list with drag-reorder capability, token selection handoff, and an opti
 
 ### 5. Token drag interaction
 
-Add pointer event handling in `MapView.svelte` (or a new `TokenDragLayer.svelte`):
+Add pointer event handling in `MapInteractionManager` (`map-interactions.svelte.ts`):
 
 - On pointer down over a token: start drag
 - On pointer move: update token x/y (snap to grid if grid active)
@@ -94,18 +94,20 @@ pnpm run dev
 
 ## Key Files to Modify
 
-| File                                                       | Change                                       |
-| ---------------------------------------------------------- | -------------------------------------------- |
-| `apps/web/src/lib/stores/map-session.svelte.ts`            | New session state store                      |
-| `packages/map-engine/src/renderer.ts`                      | Add `renderTokens()` function                |
-| `apps/web/src/lib/components/map/MapView.svelte`           | Add VTT overlay rendering and input handling |
-| `apps/web/src/lib/components/map/VTTControls.svelte`       | Toolbar and icon-button actions              |
-| `apps/web/src/lib/components/vtt/VTTChatSidebar.svelte`    | Left-side chat panel                         |
-| `apps/web/src/lib/components/vtt/VTTChat.svelte`           | Chat input, slash commands, dice modal entry |
-| `apps/web/src/lib/components/vtt/InitiativePanel.svelte`   | Turn order UI + pop-out                      |
-| `apps/web/src/lib/components/vtt/TokenDetail.svelte`       | Token owner/remove actions                   |
-| `apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts` | Add VTT message handlers                     |
-| `apps/web/src/lib/cloud-bridge/p2p/guest-service.ts`       | Add VTT message handlers                     |
+| File                                                         | Change                                       |
+| ------------------------------------------------------------ | -------------------------------------------- |
+| `apps/web/src/lib/stores/map-session.svelte.ts`              | New session state store                      |
+| `packages/map-engine/src/renderer.ts`                        | Add `renderTokens()` function                |
+| `apps/web/src/lib/components/map/MapView.svelte`             | Coordinator component for Map views          |
+| `apps/web/src/lib/components/map/MapCanvas.svelte`           | VTT overlay rendering (tokens, pings, etc.)  |
+| `apps/web/src/lib/components/map/map-interactions.svelte.ts` | Input handling and gestural state machine    |
+| `apps/web/src/lib/components/map/VTTControls.svelte`         | Toolbar and icon-button actions              |
+| `apps/web/src/lib/components/vtt/VTTChatSidebar.svelte`      | Left-side chat panel                         |
+| `apps/web/src/lib/components/vtt/VTTChat.svelte`             | Chat input, slash commands, dice modal entry |
+| `apps/web/src/lib/components/vtt/InitiativePanel.svelte`     | Turn order UI + pop-out                      |
+| `apps/web/src/lib/components/vtt/TokenDetail.svelte`         | Token owner/remove actions                   |
+| `apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts`   | Add VTT message handlers                     |
+| `apps/web/src/lib/cloud-bridge/p2p/guest-service.ts`         | Add VTT message handlers                     |
 
 ## Testing Strategy
 

--- a/specs/079-vtt-light/research.md
+++ b/specs/079-vtt-light/research.md
@@ -2,9 +2,9 @@
 
 ## Decision 1: Token Rendering Approach
 
-**Context**: The existing `MapView.svelte` renders everything on a single canvas via `renderMap()` in the map-engine. Pins, grid, fog, and the map image are all composited in one pass.
+**Context**: The existing `MapView.svelte` (modularized) delegates rendering via `renderMap()` in the map-engine. Pins, grid, fog, and the map image are all composited in one pass.
 
-**Decision**: Render tokens as a post-render canvas overlay inside `MapView.svelte`'s existing `draw()` loop, after `renderMap()` returns but before the frame completes.
+**Decision**: Render tokens as a post-render canvas overlay inside `MapCanvas.svelte`'s existing `draw()` loop, after `renderMap()` returns but before the frame completes.
 
 **Rationale**:
 

--- a/specs/079-vtt-light/tasks.md
+++ b/specs/079-vtt-light/tasks.md
@@ -70,9 +70,9 @@
 - [x] T015 [US1] Add token add/remove methods to MapSession store in `apps/web/src/lib/stores/map-session.svelte.ts`
 - [x] T016 [US1] Implement grid snapping helper in `apps/web/src/lib/utils/vtt-helpers.ts` (snap to `mapStore.gridSize`)
 - [x] T017 [US1] Create VTTControls.svelte with an always-visible VTT mode toggle in `apps/web/src/lib/components/map/VTTControls.svelte`
-- [x] T018 [US1] Wire VTT mode toggle to MapView.svelte draw() loop to enable token overlay rendering
+- [x] T018 [US1] Wire VTT mode toggle to MapCanvas.svelte draw() loop to enable token overlay rendering
 - [x] T019 [US1] Add token placement UI (click to place + dialog for name/entity link) in `apps/web/src/lib/components/map/TokenAddDialog.svelte`
-- [x] T020 [US1] Implement pointer-based token drag in MapView.svelte (pointer down/move/up with coordinate transform)
+- [x] T020 [US1] Implement pointer-based token drag in `MapInteractionManager` (`map-interactions.svelte.ts`)
 - [x] T021 [US1] Add grid snapping to token drag using vtt-helpers.ts (snap only when `mapStore.showGrid` is true; free placement otherwise)
 - [x] T022 [US1] Render token labels as canvas text in `renderTokens()` for freeform tokens
 - [x] T023 [US1] Render token images from linked entities in `renderTokens()` using entity image blob URLs
@@ -97,11 +97,11 @@
 
 ### Implementation for User Story 2
 
-- [x] T029 [US2] Add token hit-testing in MapView.svelte pointer handler (detect click on token bounds)
+- [x] T029 [US2] Add token hit-testing in `MapInteractionManager` pointer handler (detect click on token bounds)
 - [x] T030 [US2] Wire token click to MapSession store selection state
 - [x] T031 [US2] Create TokenDetail.svelte side panel in `apps/web/src/lib/components/vtt/TokenDetail.svelte` with ownership assignment and selected-token removal actions
 - [x] T032 [US2] Render token selection highlight (glow/border) in `renderTokens()` canvas function
-- [x] T033 [US2] Implement deselect on empty-space click in MapView.svelte
+- [x] T033 [US2] Implement deselect on empty-space click in `MapInteractionManager`
 
 **Checkpoint**: Token selection and detail view work independently. Can select, view details, and deselect.
 
@@ -146,7 +146,7 @@
 
 - [x] T044 [US4] Add measurement tool state to MapSession store (startPoint, endPoint, active)
 - [x] T045 [US4] Create MeasurementTool.svelte overlay in `apps/web/src/lib/components/map/MeasurementTool.svelte`
-- [x] T046 [US4] Implement measurement click handler in MapView.svelte (pointer events on measurement tool active)
+- [x] T046 [US4] Implement measurement click handler in `MapInteractionManager` (pointer events on measurement tool active)
 - [x] T047 [US4] Draw measurement line and distance label on canvas in `renderTokens()` or dedicated `renderMeasurement()` function
 - [x] T048 [US4] Display distance using map scale if defined, otherwise pixel distance
 - [x] T049 [US4] Add measurement tool toggle to VTTControls.svelte
@@ -175,7 +175,7 @@
 - [x] T056 [US5] Implement TOKEN_ADD_REQUEST handler in host-service.svelte.ts (host assigns id, ownerPeerId, broadcasts TOKEN_ADDED)
 - [x] T057 [US5] Implement TURN_ADVANCE broadcast from MapSession store through host-service when host advances turn
 - [x] T058 [US5] Add token ownership assignment and removal UI in TokenDetail.svelte (GM assigns move permission to connected guests and can delete selected tokens without affecting visibility)
-- [x] T059 [US5] Implement guest permission enforcement in MapView.svelte drag handler (check ownerPeerId before allowing drag; do not use ownership as a visibility filter)
+- [x] T059 [US5] Implement guest permission enforcement in `MapInteractionManager` drag handler (check ownerPeerId before allowing drag; do not use ownership as a visibility filter)
 - [x] T060 [US5] Implement session fog reveal sync (host paints fog using existing MapFogPainter brush → broadcasts FOG_REVEAL stroke deltas → guests apply to in-memory session mask)
 - [x] T061 [US5] Implement MAP_PING broadcast for guest/host cursor pings
 - [x] T062 [US5] Handle host disconnection (detect peer disconnect, broadcast SESSION_ENDED to guests so they see a disconnected UI state, then clear session state immediately)
@@ -226,7 +226,7 @@
 - [x] T082 Extract shared dice-roll rendering into `apps/web/src/lib/components/dice/DiceRollResult.svelte` and reuse it in Oracle and VTT chat message rendering
 - [x] T083 Add the dice modal entry button to the VTT chat input row in `apps/web/src/lib/components/vtt/VTTChat.svelte`
 - [x] T084 Broadcast resolved dice rolls from the shared modal into VTT chat and the P2P transcript path in `apps/web/src/lib/components/dice/DiceModal.svelte` and `apps/web/src/lib/stores/map-session.svelte.ts`
-- [x] T085 Guard map zoom shortcuts while typing in VTT chat by ignoring editable targets in `apps/web/src/lib/components/map/MapView.svelte` and `apps/web/src/lib/components/map/map-view-helpers.ts`
+- [x] T085 Guard map zoom shortcuts while typing in VTT chat by ignoring editable targets in `MapInteractionManager` and `map-view-helpers.ts`
 - [x] T086 Convert primary VTT controls to icon buttons in `apps/web/src/lib/components/map/VTTControls.svelte`
 - [x] T087 Keep the shared modal provider mounted in VTT fullscreen so the dice modal can open from the chat sidebar in `apps/web/src/routes/(app)/+layout.svelte`
 
@@ -345,3 +345,7 @@ With multiple developers:
 - Constitution requirement: constructor DI for all stores and services
 - Constitution requirement: Svelte 5 `$derived` for computed state (not `$state(prop)`)
 - Constitution requirement: Tailwind 4 CSS syntax
+  S syntax
+  `$state(prop)`)
+- Constitution requirement: Tailwind 4 CSS syntax
+  S syntax

--- a/specs/085-vtt-entity-list/plan.md
+++ b/specs/085-vtt-entity-list/plan.md
@@ -55,7 +55,8 @@ apps/web/src/
 │   │   ├── explorer/
 │   │   │   └── EntityList.svelte (reused)
 │   │   └── map/
-│   │       └── MapView.svelte (updated for drag preview)
+│   │       ├── MapView.svelte (updated as coordinator)
+│   │       └── MapCanvas.svelte (updated for drag preview rendering)
 │   ├── stores/
 │   │   ├── map-session.svelte.ts (updated for drag state)
 │   │   └── ui.svelte.ts (updated for persistence)

--- a/specs/085-vtt-entity-list/research.md
+++ b/specs/085-vtt-entity-list/research.md
@@ -29,7 +29,7 @@ The wrapper `div` around `MapView` in `+page.svelte` already handles `ondrop` fo
 To provide visual feedback (Priority P2), `MapSessionStore` needs a `dragPreview` state.
 
 - Updated during `handleDragOver` in `+page.svelte`.
-- Rendered in `MapView.svelte` within the `draw()` loop using a semi-transparent version of the token.
+- Rendered in `MapCanvas.svelte` within the `draw()` loop using a semi-transparent version of the token.
 
 ### 4. Persistence
 

--- a/specs/085-vtt-entity-list/tasks.md
+++ b/specs/085-vtt-entity-list/tasks.md
@@ -39,8 +39,8 @@
 
 - [x] T012 [US3] Update `handleDragOver` to continuously update `mapSession.dragPreview` with unprojected coordinates in `apps/web/src/routes/(app)/map/+page.svelte`
 - [x] T013 [US3] Implement `handleDragLeave` and `handleDrop` cleanup to clear `mapSession.dragPreview` in `apps/web/src/routes/(app)/map/+page.svelte`
-- [x] T014 [US3] Update the `draw` loop in `apps/web/src/lib/components/map/MapView.svelte` to render a ghost token at `mapSession.dragPreview` coordinates.
-- [x] T015 [US3] Add validation check in `MapView.svelte` to change preview style (e.g., red tint) when the cursor is over invalid drop zones.
+- [x] T014 [US3] Update the `draw` loop in `apps/web/src/lib/components/map/MapCanvas.svelte` to render a ghost token at `mapSession.dragPreview` coordinates.
+- [x] T015 [US3] Add validation check in `MapCanvas.svelte` to change preview style (e.g., red tint) when the cursor is over invalid drop zones.
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 


### PR DESCRIPTION
This PR modularizes the massive `MapView.svelte` (formerly ~1,536 lines) by decomposing it into focused sub-modules. This successfully addresses the "God File" status of MapView.

**Changes:**
- Extracted **Interaction State Machine** into `MapInteractionManager` (`map-interactions.svelte.ts`).
- Extracted **Canvas Rendering** and the rAF loop into `MapCanvas.svelte`.
- Extracted **DOM Overlays** (PinLinker, Popovers, Rects) into `MapOverlays.svelte`.
- Extracted **Context Menu** into `MapContextMenu.svelte` (Phase 1).
- Updated `MapView.svelte` to act as a lightweight coordinator (~330 lines).

**Verification:**
- `pnpm test` passed.
- `pnpm run lint` passed (including svelte-check).
- Manual code review of interactions logic ensures parity with the original monolithic implementation.

Resolves #789.