### PR TITLE
🎨 Palette: [UX improvement] Add accessible spinner to DetailFooter save button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,6 +37,7 @@
 
 **Learning:** When creating or updating custom modal/dialog components (e.g., those using floating backdrops like `fixed inset-0`), strictly ensure screen reader accessibility by applying `role="dialog"`, `aria-modal="true"`, and an explicit `aria-label` or `aria-labelledby` directly to the main inner container element.
 **Action:** Add ARIA dialog roles, aria-modal, and appropriate labels to VTTGridSettings, CategorySettings icon picker sub-modal, and ZenModeModal.
+
 ## 2026-05-07 - Focus vs Focus-Visible Accessibility
 
 **Learning:** When making components keyboard accessible, using standard `focus:` styles often results in ugly outlines appearing for mouse users after they click a button. This discourages developers from adding focus states at all.
@@ -46,7 +47,13 @@
 
 **Learning:** Non-submit buttons in Svelte components can accidentally submit forms if they are ever wrapped in a `<form>` context and don't explicitly have a type.
 **Action:** Always explicitly define `type="button"` on generic buttons to prevent unexpected form submission behavior.
+
 ## 2026-05-11 - Toggle Button State
 
 **Learning:** Found custom toggle buttons (like the VTT mode switchers) that change visual state via classes but don't communicate their "pressed" status to screen readers, making it impossible for non-visual users to know which mode is active.
 **Action:** Always add `aria-pressed={isActive}` to button elements that function as state toggles, ensuring their programmatic state matches their visual state.
+
+## 2026-05-15 - DetailFooter Accessible Loading State
+
+**Learning:** Found the Save button in `DetailFooter.svelte` was relying on an inaccessible text-only `animate-pulse` class ("SAVING...") without a visual spinner and lacking an `aria-busy` state, making the loading state less obvious and invisible to assistive technology.
+**Action:** Replaced text-only pulse with the standard SVG spinner (`icon-[lucide--loader-2] animate-spin`) next to static "SAVING..." text, and explicitly bound `aria-busy={isSaving}` on the parent button.

--- a/apps/web/src/lib/components/entity-detail/DetailFooter.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailFooter.svelte
@@ -39,9 +39,11 @@
         style:border-color="var(--theme-selected-border)"
         style:color="var(--theme-action-text)"
         disabled={isSaving}
+        aria-busy={isSaving}
       >
         {#if isSaving}
-          <span class="animate-pulse">SAVING...</span>
+          <span class="icon-[lucide--loader-2] w-4 h-4 animate-spin" aria-hidden="true"></span>
+          <span>SAVING...</span>
         {:else}
           {themeStore.jargon.save.toUpperCase()} CHANGES
         {/if}

--- a/apps/web/src/lib/components/entity-detail/DetailFooter.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailFooter.svelte
@@ -33,6 +33,7 @@
         CANCEL
       </button>
       <button
+        type="button"
         onclick={onSave}
         class="text-xs font-bold px-6 py-2 rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed border"
         style:background-color="var(--theme-action-bg)"
@@ -42,7 +43,10 @@
         aria-busy={isSaving}
       >
         {#if isSaving}
-          <span class="icon-[lucide--loader-2] w-4 h-4 animate-spin" aria-hidden="true"></span>
+          <span
+            class="icon-[lucide--loader-2] w-4 h-4 animate-spin"
+            aria-hidden="true"
+          ></span>
           <span>SAVING...</span>
         {:else}
           {themeStore.jargon.save.toUpperCase()} CHANGES


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add accessible spinner to DetailFooter save button

💡 **What:**
Replaced the text-only `animate-pulse` loading text on the `DetailFooter` save button with the standard application SVG spinner (`lucide--loader-2`) and added the `aria-busy` attribute.

🎯 **Why:**
The previous loading state ("SAVING...") only used CSS pulse animation which is less obvious than a spinner, and completely lacked programmatic `aria-busy` states for screen readers during an important asynchronous save operation.

♿ **Accessibility:**
Added `aria-busy={isSaving}` to the button so assistive technology is explicitly aware of the loading state while changes are being saved to the vault. Included `aria-hidden="true"` on the visual spinner icon.

---
*PR created automatically by Jules for task [3602683872426439655](https://jules.google.com/task/3602683872426439655) started by @eserlan*