### PR TITLE
fix: prevent art style from being explicitly mentioned in descriptions #801

### DIFF
--- a/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
@@ -59,6 +59,7 @@ describe("ContextRetrievalService", () => {
     };
 
     mockSearchService.search
+      .mockResolvedValueOnce([]) // Style search
       .mockResolvedValueOnce([]) // Main search
       .mockResolvedValueOnce([]); // Keyword search
 
@@ -68,7 +69,7 @@ describe("ContextRetrievalService", () => {
       mockVault,
     );
 
-    expect(mockSearchService.search).toHaveBeenCalledTimes(2);
+    expect(mockSearchService.search).toHaveBeenCalledTimes(3);
     expect(mockSearchService.search).toHaveBeenLastCalledWith(
       expect.any(String),
       expect.objectContaining({ includeDrafts: true }),
@@ -184,6 +185,34 @@ describe("ContextRetrievalService", () => {
       expect.anything(),
     );
     expect(result.content).toContain("Neon aesthetic");
+  });
+
+  it("should exclude art style entity from regular subject context", async () => {
+    const mockVault: any = {
+      entities: {
+        s1: { id: "s1", title: "Art Style: Neon", content: "Neon vibes" },
+        e1: { id: "e1", title: "Neo-Tokyo", content: "The city" },
+      },
+      selectedEntityId: null,
+      inboundConnections: {},
+    };
+
+    // Style search finds s1
+    mockSearchService.search
+      .mockResolvedValueOnce([{ id: "s1", score: 0.9 }]) // Style search
+      .mockResolvedValueOnce([{ id: "e1", score: 0.9 }]); // Main search
+
+    const result = await service.retrieveContext("test", new Set(), mockVault);
+
+    // Should be in global style block
+    expect(result.content).toContain("--- GLOBAL ART STYLE ---");
+    expect(result.content).toContain("Neon vibes");
+
+    // But should NOT be in a regular file block (which would cause the AI to mention it)
+    expect(result.content).not.toContain("--- File: Art Style: Neon ---");
+
+    // Regular entity should still be there
+    expect(result.content).toContain("--- File: Neo-Tokyo ---");
   });
 
   it("should handle truncation of large context", async () => {

--- a/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
@@ -200,7 +200,10 @@ describe("ContextRetrievalService", () => {
     // Style search finds s1
     mockSearchService.search
       .mockResolvedValueOnce([{ id: "s1", score: 0.9 }]) // Style search
-      .mockResolvedValueOnce([{ id: "e1", score: 0.9 }]); // Main search
+      .mockResolvedValueOnce([
+        { id: "e1", score: 0.9 },
+        { id: "s1", score: 0.9 },
+      ]); // Main search
 
     const result = await service.retrieveContext("test", new Set(), mockVault);
 

--- a/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
@@ -218,6 +218,36 @@ describe("ContextRetrievalService", () => {
     expect(result.content).toContain("--- File: Neo-Tokyo ---");
   });
 
+  it("should still show 'Available Records' fallback when art style is found but query has no other matches", async () => {
+    const mockVault: any = {
+      entities: {
+        s1: { id: "s1", title: "Art Style: Neon", content: "Neon vibes" },
+        e1: { id: "e1", title: "Alpha", content: "Content" },
+      },
+      selectedEntityId: null,
+      inboundConnections: {},
+    };
+
+    // Style search finds s1, main search finds nothing
+    mockSearchService.search
+      .mockResolvedValueOnce([{ id: "s1", score: 0.9 }]) // Style search
+      .mockResolvedValueOnce([]); // Main search
+
+    const result = await service.retrieveContext(
+      "unknown",
+      new Set(),
+      mockVault,
+    );
+
+    // Style should be there
+    expect(result.content).toContain("--- GLOBAL ART STYLE ---");
+    // Fallback should trigger and list available records
+    expect(result.content).toContain("--- Available Records ---");
+    expect(result.content).toContain("Alpha");
+    // But art style should NOT be in the available records list (natural exclusion)
+    expect(result.content).not.toContain("Alpha, Art Style: Neon");
+  });
+
   it("should handle truncation of large context", async () => {
     const longContent = "A".repeat(11000);
     const mockVault: any = {

--- a/apps/web/src/lib/services/ai/context-retrieval.service.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.ts
@@ -4,6 +4,7 @@ import type { ContextRetrievalService } from "schema";
 export class DefaultContextRetrievalService implements ContextRetrievalService {
   private styleCache: string | null = null;
   private styleTitleCache: string | null = null;
+  private cachedVaultId: string | null = null;
 
   constructor(private searchService = defaultSearchService) {}
 
@@ -80,6 +81,12 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
   }> {
     let styleContext = "";
     let activeStyleTitle: string | undefined;
+
+    const currentVaultId = vault.activeVaultId || vault.id || "default";
+    if (this.cachedVaultId !== currentVaultId) {
+      this.clearStyleCache();
+      this.cachedVaultId = currentVaultId;
+    }
 
     // 1. Retrieve Global Art Style (Influences tone/description)
     if (this.styleCache !== null) {
@@ -343,6 +350,7 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
   clearStyleCache() {
     this.styleCache = null;
     this.styleTitleCache = null;
+    this.cachedVaultId = null;
   }
 }
 

--- a/apps/web/src/lib/services/ai/context-retrieval.service.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.ts
@@ -71,7 +71,7 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
     excludeTitles: Set<string>,
     vault: any,
     lastEntityId?: string,
-    isImage: boolean = false,
+    _isImage: boolean = false,
   ): Promise<{
     content: string;
     primaryEntityId?: string;
@@ -81,51 +81,54 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
     let styleContext = "";
     let activeStyleTitle: string | undefined;
 
-    if (isImage) {
-      if (this.styleCache !== null) {
-        styleContext = this.styleCache;
-        activeStyleTitle = this.styleTitleCache || undefined;
-      } else {
-        const styleResults = await this.searchService.search(
-          "art style direction visual aesthetic style guide",
-          { limit: 3, includeDrafts: true },
-        );
-        const styleKeywords = [
-          "art style",
-          "visual aesthetic",
-          "style guide",
-          "art direction",
-          "visual direction",
-        ];
-        let bestStyleId: string | undefined;
+    // 1. Retrieve Global Art Style (Influences tone/description)
+    if (this.styleCache !== null) {
+      styleContext = this.styleCache;
+      activeStyleTitle = this.styleTitleCache || undefined;
+    } else {
+      const styleResults = await this.searchService.search(
+        "art style direction visual aesthetic style guide",
+        { limit: 3, includeDrafts: true },
+      );
+      const styleKeywords = [
+        "art style",
+        "visual aesthetic",
+        "style guide",
+        "art direction",
+        "visual direction",
+      ];
+      let bestStyleId: string | undefined;
 
-        for (const res of styleResults) {
-          if (res.score > 0.4) {
-            const ent = vault.entities[res.id];
-            const title = ent?.title?.toLowerCase() || "";
-            if (styleKeywords.some((kw) => title.includes(kw))) {
-              bestStyleId = res.id;
-              break;
-            }
+      for (const res of styleResults) {
+        if (res.score > 0.4) {
+          const ent = vault.entities[res.id];
+          const title = ent?.title?.toLowerCase() || "";
+          if (styleKeywords.some((kw) => title.includes(kw))) {
+            bestStyleId = res.id;
+            break;
           }
-        }
-
-        if (bestStyleId) {
-          const styleId = bestStyleId;
-          // Ensure content is loaded from Dexie before reading context.
-          await vault.loadEntityContent?.(styleId);
-          const styleEntity = vault.entities[styleId];
-          if (styleEntity) {
-            styleContext = `--- GLOBAL ART STYLE ---\n${this.getConsolidatedContext(styleEntity)}\n\n`;
-            activeStyleTitle = styleEntity.title;
-            this.styleCache = styleContext;
-            this.styleTitleCache = activeStyleTitle || "";
-          }
-        } else {
-          this.styleCache = "";
-          this.styleTitleCache = "";
         }
       }
+
+      if (bestStyleId) {
+        const styleId = bestStyleId;
+        await vault.loadEntityContent?.(styleId);
+        const styleEntity = vault.entities[styleId];
+        if (styleEntity) {
+          styleContext = `--- GLOBAL ART STYLE ---\n${this.getConsolidatedContext(styleEntity)}\n\n`;
+          activeStyleTitle = styleEntity.title;
+          this.styleCache = styleContext;
+          this.styleTitleCache = activeStyleTitle || "";
+        }
+      } else {
+        this.styleCache = "";
+        this.styleTitleCache = "";
+      }
+    }
+
+    // Ensure the style entity itself isn't treated as a subject in the prose
+    if (activeStyleTitle) {
+      excludeTitles.add(activeStyleTitle);
     }
 
     let results = await this.searchService.search(query, {

--- a/apps/web/src/lib/services/ai/context-retrieval.service.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.ts
@@ -127,15 +127,15 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
           this.styleCache = styleContext;
           this.styleTitleCache = activeStyleTitle || "";
         }
-      } else {
-        this.styleCache = "";
-        this.styleTitleCache = "";
       }
     }
 
-    // Ensure the style entity itself isn't treated as a subject in the prose
+    // Ensure the style entity itself isn't treated as a subject in the prose.
+    // We use a local set to avoid polluting the caller's excludeTitles,
+    // which would suppress the "Available Records" fallback logic below.
+    const internalExclusions = new Set(excludeTitles);
     if (activeStyleTitle) {
-      excludeTitles.add(activeStyleTitle);
+      internalExclusions.add(activeStyleTitle);
     }
 
     let results = await this.searchService.search(query, {
@@ -225,7 +225,7 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
     const addEntityToContext = (id: string, isEnrichment: boolean = false) => {
       if (contextMap.has(id)) return;
       const entity = vault.entities[id];
-      if (!entity || excludeTitles.has(entity.title)) return;
+      if (!entity || internalExclusions.has(entity.title)) return;
 
       const mainContent = isEnrichment
         ? (entity.content || "").trim()
@@ -326,7 +326,7 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
       let first = true;
       for (let i = 0; i < count; i++) {
         const title = allEntities[i].title;
-        if (title) {
+        if (title && !internalExclusions.has(title)) {
           if (!first) {
             allTitles += ", ";
           }

--- a/apps/web/src/lib/services/ai/prompts/system-instructions.ts
+++ b/apps/web/src/lib/services/ai/prompts/system-instructions.ts
@@ -123,6 +123,13 @@ Do NOT append artificial labels in prose such as:
 - "(Location)"
 Keep prose natural and readable.
 
+Artistic & Stylistic Influence:
+When a "GLOBAL ART STYLE" or "STYLISTIC INFLUENCE" is provided in the context:
+- use it to inform the sensory details, mood, lighting, and aesthetic of your descriptions.
+- do NOT mention the art style entity by name (e.g., do not say "according to the Cyberpunk style").
+- do NOT cite it as a source of information.
+- integrate the style seamlessly into your prose so it feels like a natural part of the world's atmosphere.
+
 Formatting
 Markdown is encouraged when it improves readability.
 Use:

--- a/specs/008-lore-oracle/spec.md
+++ b/specs/008-lore-oracle/spec.md
@@ -31,6 +31,7 @@ Users desire a natural language interface to query their vault ("Who is the king
 - System MUST support multi-turn history even when using the system-provided proxy (no custom API key mode).
 - System MUST implement a **Sliding Window** (default: 10 messages) for conversation history to prevent excessive token usage and payload size.
 - System MUST optimize prompt structure for **Implicit Caching** by maintaining prefix stability (System -> History -> Lore Context -> Query).
+- System MUST automatically retrieve and apply the global "Art Style" to inform tone and sensory details, but MUST explicitly instruct the AI NOT to mention the style by name or cite it as a source in the generated prose.
 
 ### FR-003: Integrated Chat UI
 


### PR DESCRIPTION
This PR resolves #801 by refining how the Oracle utilizes "Art Style" records.

Previously, if a global art style entity was detected, it was injected as a regular file in the context. This sometimes caused the AI to break the fourth wall and mention the art style as a factual subject (e.g., "The tavern looks like this because of your Grimdark style").

**Changes:**
1. **Context Separation:** `retrieveContext` now always resolves the global art style and adds it to a dedicated `--- GLOBAL ART STYLE ---` header block. It then explicitly adds the style's title to the `excludeTitles` set to prevent it from being injected a second time as a standard file subject.
2. **System Instruction Update:** The Oracle's prompt instructions have been updated to explicitly instruct the AI on how to handle "GLOBAL ART STYLE" context. It is now directed to use the style to inform mood, lighting, and sensory details, but is strictly forbidden from mentioning the style entity by name or citing it as a source.
3. **Test Coverage:** Updated existing `retrieveContext` tests to account for the new search pattern and added a new test specifically verifying that the art style entity is excluded from the regular file context.

Fixes #801