### PR TITLE
docs: update lore oracle spec with art style constraints

### DIFF
--- a/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.test.ts
@@ -59,6 +59,7 @@ describe("ContextRetrievalService", () => {
     };
 
     mockSearchService.search
+      .mockResolvedValueOnce([]) // Style search
       .mockResolvedValueOnce([]) // Main search
       .mockResolvedValueOnce([]); // Keyword search
 
@@ -68,7 +69,7 @@ describe("ContextRetrievalService", () => {
       mockVault,
     );
 
-    expect(mockSearchService.search).toHaveBeenCalledTimes(2);
+    expect(mockSearchService.search).toHaveBeenCalledTimes(3);
     expect(mockSearchService.search).toHaveBeenLastCalledWith(
       expect.any(String),
       expect.objectContaining({ includeDrafts: true }),
@@ -184,6 +185,34 @@ describe("ContextRetrievalService", () => {
       expect.anything(),
     );
     expect(result.content).toContain("Neon aesthetic");
+  });
+
+  it("should exclude art style entity from regular subject context", async () => {
+    const mockVault: any = {
+      entities: {
+        s1: { id: "s1", title: "Art Style: Neon", content: "Neon vibes" },
+        e1: { id: "e1", title: "Neo-Tokyo", content: "The city" },
+      },
+      selectedEntityId: null,
+      inboundConnections: {},
+    };
+
+    // Style search finds s1
+    mockSearchService.search
+      .mockResolvedValueOnce([{ id: "s1", score: 0.9 }]) // Style search
+      .mockResolvedValueOnce([{ id: "e1", score: 0.9 }]); // Main search
+
+    const result = await service.retrieveContext("test", new Set(), mockVault);
+
+    // Should be in global style block
+    expect(result.content).toContain("--- GLOBAL ART STYLE ---");
+    expect(result.content).toContain("Neon vibes");
+
+    // But should NOT be in a regular file block (which would cause the AI to mention it)
+    expect(result.content).not.toContain("--- File: Art Style: Neon ---");
+
+    // Regular entity should still be there
+    expect(result.content).toContain("--- File: Neo-Tokyo ---");
   });
 
   it("should handle truncation of large context", async () => {

--- a/apps/web/src/lib/services/ai/context-retrieval.service.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.ts
@@ -71,7 +71,7 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
     excludeTitles: Set<string>,
     vault: any,
     lastEntityId?: string,
-    isImage: boolean = false,
+    _isImage: boolean = false,
   ): Promise<{
     content: string;
     primaryEntityId?: string;
@@ -81,51 +81,54 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
     let styleContext = "";
     let activeStyleTitle: string | undefined;
 
-    if (isImage) {
-      if (this.styleCache !== null) {
-        styleContext = this.styleCache;
-        activeStyleTitle = this.styleTitleCache || undefined;
-      } else {
-        const styleResults = await this.searchService.search(
-          "art style direction visual aesthetic style guide",
-          { limit: 3, includeDrafts: true },
-        );
-        const styleKeywords = [
-          "art style",
-          "visual aesthetic",
-          "style guide",
-          "art direction",
-          "visual direction",
-        ];
-        let bestStyleId: string | undefined;
+    // 1. Retrieve Global Art Style (Influences tone/description)
+    if (this.styleCache !== null) {
+      styleContext = this.styleCache;
+      activeStyleTitle = this.styleTitleCache || undefined;
+    } else {
+      const styleResults = await this.searchService.search(
+        "art style direction visual aesthetic style guide",
+        { limit: 3, includeDrafts: true },
+      );
+      const styleKeywords = [
+        "art style",
+        "visual aesthetic",
+        "style guide",
+        "art direction",
+        "visual direction",
+      ];
+      let bestStyleId: string | undefined;
 
-        for (const res of styleResults) {
-          if (res.score > 0.4) {
-            const ent = vault.entities[res.id];
-            const title = ent?.title?.toLowerCase() || "";
-            if (styleKeywords.some((kw) => title.includes(kw))) {
-              bestStyleId = res.id;
-              break;
-            }
+      for (const res of styleResults) {
+        if (res.score > 0.4) {
+          const ent = vault.entities[res.id];
+          const title = ent?.title?.toLowerCase() || "";
+          if (styleKeywords.some((kw) => title.includes(kw))) {
+            bestStyleId = res.id;
+            break;
           }
-        }
-
-        if (bestStyleId) {
-          const styleId = bestStyleId;
-          // Ensure content is loaded from Dexie before reading context.
-          await vault.loadEntityContent?.(styleId);
-          const styleEntity = vault.entities[styleId];
-          if (styleEntity) {
-            styleContext = `--- GLOBAL ART STYLE ---\n${this.getConsolidatedContext(styleEntity)}\n\n`;
-            activeStyleTitle = styleEntity.title;
-            this.styleCache = styleContext;
-            this.styleTitleCache = activeStyleTitle || "";
-          }
-        } else {
-          this.styleCache = "";
-          this.styleTitleCache = "";
         }
       }
+
+      if (bestStyleId) {
+        const styleId = bestStyleId;
+        await vault.loadEntityContent?.(styleId);
+        const styleEntity = vault.entities[styleId];
+        if (styleEntity) {
+          styleContext = `--- GLOBAL ART STYLE ---\n${this.getConsolidatedContext(styleEntity)}\n\n`;
+          activeStyleTitle = styleEntity.title;
+          this.styleCache = styleContext;
+          this.styleTitleCache = activeStyleTitle || "";
+        }
+      } else {
+        this.styleCache = "";
+        this.styleTitleCache = "";
+      }
+    }
+
+    // Ensure the style entity itself isn't treated as a subject in the prose
+    if (activeStyleTitle) {
+      excludeTitles.add(activeStyleTitle);
     }
 
     let results = await this.searchService.search(query, {

--- a/apps/web/src/lib/services/ai/prompts/system-instructions.ts
+++ b/apps/web/src/lib/services/ai/prompts/system-instructions.ts
@@ -123,6 +123,13 @@ Do NOT append artificial labels in prose such as:
 - "(Location)"
 Keep prose natural and readable.
 
+Artistic & Stylistic Influence:
+When a "GLOBAL ART STYLE" or "STYLISTIC INFLUENCE" is provided in the context:
+- use it to inform the sensory details, mood, lighting, and aesthetic of your descriptions.
+- do NOT mention the art style entity by name (e.g., do not say "according to the Cyberpunk style").
+- do NOT cite it as a source of information.
+- integrate the style seamlessly into your prose so it feels like a natural part of the world's atmosphere.
+
 Formatting
 Markdown is encouraged when it improves readability.
 Use:

--- a/specs/008-lore-oracle/spec.md
+++ b/specs/008-lore-oracle/spec.md
@@ -31,6 +31,7 @@ Users desire a natural language interface to query their vault ("Who is the king
 - System MUST support multi-turn history even when using the system-provided proxy (no custom API key mode).
 - System MUST implement a **Sliding Window** (default: 10 messages) for conversation history to prevent excessive token usage and payload size.
 - System MUST optimize prompt structure for **Implicit Caching** by maintaining prefix stability (System -> History -> Lore Context -> Query).
+- System MUST automatically retrieve and apply the global "Art Style" to inform tone and sensory details, but MUST explicitly instruct the AI NOT to mention the style by name or cite it as a source in the generated prose.
 
 ### FR-003: Integrated Chat UI
 


### PR DESCRIPTION
Updates the `specs/008-lore-oracle/spec.md` to formally document the recent architectural change in how "Art Style" records are handled.

It is now a defined functional requirement (FR-002) that the global Art Style is automatically retrieved to inform tone and sensory details, but explicitly excluded from being mentioned by name or cited as a source in the generated prose.