### PR TITLE
🎨 Palette: [UX improvement] Add focus-visible styles to map UI buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,6 @@
 
 **Learning:** Found the Save button in `DetailFooter.svelte` was relying on an inaccessible text-only `animate-pulse` class ("SAVING...") without a visual spinner and lacking an `aria-busy` state, making the loading state less obvious and invisible to assistive technology.
 **Action:** Replaced text-only pulse with the standard SVG spinner (`icon-[lucide--loader-2] animate-spin`) next to static "SAVING..." text, and explicitly bound `aria-busy={isSaving}` on the parent button.
+## 2026-05-16 - Focus Visible for VTT Grid Settings
+**Learning:** Interactive buttons within modals and menus often miss explicit keyboard focus indicators if they only use mouse-centric hover classes.
+**Action:** Add Tailwind focus-visible utilities to ensure accessibility without degrading the mouse user experience.

--- a/apps/web/src/lib/components/map/VTTGridColorMenu.svelte
+++ b/apps/web/src/lib/components/map/VTTGridColorMenu.svelte
@@ -71,6 +71,7 @@
     <div class="grid grid-cols-2 gap-2">
       {#each gridColors as color (color.value)}
         <button
+          type="button"
           role="menuitem"
           class="flex items-center gap-2 rounded-md border border-theme-border bg-theme-bg/60 px-2.5 py-2 text-left text-xs text-theme-text transition-all hover:border-theme-primary hover:bg-theme-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
           onclick={() => setGridColor(color.value)}
@@ -87,6 +88,7 @@
 
     <div class="mt-3 pt-3 border-t border-theme-border/50">
       <button
+        type="button"
         role="menuitem"
         class="w-full rounded-md border border-theme-border bg-theme-bg/60 px-3 py-2 text-left text-xs font-bold uppercase tracking-wider text-theme-muted transition-all hover:text-theme-primary hover:border-theme-primary hover:bg-theme-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
         onclick={() => setGridColor(null)}

--- a/apps/web/src/lib/components/map/VTTGridColorMenu.svelte
+++ b/apps/web/src/lib/components/map/VTTGridColorMenu.svelte
@@ -72,7 +72,7 @@
       {#each gridColors as color (color.value)}
         <button
           role="menuitem"
-          class="flex items-center gap-2 rounded-md border border-theme-border bg-theme-bg/60 px-2.5 py-2 text-left text-xs text-theme-text transition-all hover:border-theme-primary hover:bg-theme-primary/10"
+          class="flex items-center gap-2 rounded-md border border-theme-border bg-theme-bg/60 px-2.5 py-2 text-left text-xs text-theme-text transition-all hover:border-theme-primary hover:bg-theme-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
           onclick={() => setGridColor(color.value)}
           aria-label={`Set grid color to ${color.label}`}
         >
@@ -88,7 +88,7 @@
     <div class="mt-3 pt-3 border-t border-theme-border/50">
       <button
         role="menuitem"
-        class="w-full rounded-md border border-theme-border bg-theme-bg/60 px-3 py-2 text-left text-xs font-bold uppercase tracking-wider text-theme-muted transition-all hover:text-theme-primary hover:border-theme-primary hover:bg-theme-primary/10"
+        class="w-full rounded-md border border-theme-border bg-theme-bg/60 px-3 py-2 text-left text-xs font-bold uppercase tracking-wider text-theme-muted transition-all hover:text-theme-primary hover:border-theme-primary hover:bg-theme-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
         onclick={() => setGridColor(null)}
       >
         Theme Default

--- a/apps/web/src/lib/components/map/VTTGridSettings.svelte
+++ b/apps/web/src/lib/components/map/VTTGridSettings.svelte
@@ -124,7 +124,7 @@
               Draw a square around a map grid cell
             </p>
             <button
-              class="w-full px-4 py-2 rounded-md border border-theme-border text-theme-muted rounded-md hover:bg-theme-bg transition-all uppercase text-[10px] font-bold tracking-wider"
+              class="w-full px-4 py-2 rounded-md border border-theme-border text-theme-muted hover:bg-theme-bg transition-all uppercase text-[10px] font-bold tracking-wider focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
               onclick={() => {
                 mapSession.gridFitMode = false;
               }}
@@ -134,7 +134,7 @@
           </div>
         {:else}
           <button
-            class="w-full px-4 py-2.5 rounded-md border border-dashed border-theme-border text-theme-muted text-[10px] font-bold uppercase tracking-wider transition-all hover:border-theme-primary hover:text-theme-primary hover:bg-theme-primary/5 flex items-center justify-center gap-2"
+            class="w-full px-4 py-2.5 rounded-md border border-dashed border-theme-border text-theme-muted text-[10px] font-bold uppercase tracking-wider transition-all hover:border-theme-primary hover:text-theme-primary hover:bg-theme-primary/5 flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
             onclick={() => {
               mapSession.gridFitMode = true;
               close();
@@ -149,7 +149,7 @@
 
           {#if mapStore.gridSize > 0}
             <button
-              class="w-full px-4 py-2.5 rounded-md border border-dashed border-theme-border text-theme-muted text-[10px] font-bold uppercase tracking-wider transition-all hover:border-theme-primary hover:text-theme-primary hover:bg-theme-primary/5 flex items-center justify-center gap-2"
+              class="w-full px-4 py-2.5 rounded-md border border-dashed border-theme-border text-theme-muted text-[10px] font-bold uppercase tracking-wider transition-all hover:border-theme-primary hover:text-theme-primary hover:bg-theme-primary/5 flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
               onclick={() => {
                 mapSession.gridMoveMode = true;
                 close();
@@ -172,13 +172,13 @@
 
       <div class="pt-2 flex gap-3">
         <button
-          class="flex-1 px-4 py-2 border border-theme-border text-theme-muted rounded-md hover:bg-theme-bg transition-all uppercase text-[10px] font-bold tracking-wider"
+          class="flex-1 px-4 py-2 border border-theme-border text-theme-muted rounded-md hover:bg-theme-bg transition-all uppercase text-[10px] font-bold tracking-wider focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
           onclick={close}
         >
           Close
         </button>
         <button
-          class="flex-1 px-4 py-2 bg-theme-primary text-theme-bg rounded-md font-bold uppercase tracking-wider hover:bg-theme-primary/90 transition-all"
+          class="flex-1 px-4 py-2 bg-theme-primary text-theme-bg rounded-md font-bold uppercase tracking-wider hover:bg-theme-primary/90 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-2 focus-visible:ring-offset-theme-surface"
           onclick={save}
         >
           Apply to All

--- a/apps/web/src/lib/components/map/VTTGridSettings.svelte
+++ b/apps/web/src/lib/components/map/VTTGridSettings.svelte
@@ -124,6 +124,7 @@
               Draw a square around a map grid cell
             </p>
             <button
+              type="button"
               class="w-full px-4 py-2 rounded-md border border-theme-border text-theme-muted hover:bg-theme-bg transition-all uppercase text-[10px] font-bold tracking-wider focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
               onclick={() => {
                 mapSession.gridFitMode = false;
@@ -134,6 +135,7 @@
           </div>
         {:else}
           <button
+            type="button"
             class="w-full px-4 py-2.5 rounded-md border border-dashed border-theme-border text-theme-muted text-[10px] font-bold uppercase tracking-wider transition-all hover:border-theme-primary hover:text-theme-primary hover:bg-theme-primary/5 flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
             onclick={() => {
               mapSession.gridFitMode = true;
@@ -149,6 +151,7 @@
 
           {#if mapStore.gridSize > 0}
             <button
+              type="button"
               class="w-full px-4 py-2.5 rounded-md border border-dashed border-theme-border text-theme-muted text-[10px] font-bold uppercase tracking-wider transition-all hover:border-theme-primary hover:text-theme-primary hover:bg-theme-primary/5 flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
               onclick={() => {
                 mapSession.gridMoveMode = true;
@@ -172,12 +175,14 @@
 
       <div class="pt-2 flex gap-3">
         <button
+          type="button"
           class="flex-1 px-4 py-2 border border-theme-border text-theme-muted rounded-md hover:bg-theme-bg transition-all uppercase text-[10px] font-bold tracking-wider focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary"
           onclick={close}
         >
           Close
         </button>
         <button
+          type="button"
           class="flex-1 px-4 py-2 bg-theme-primary text-theme-bg rounded-md font-bold uppercase tracking-wider hover:bg-theme-primary/90 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-2 focus-visible:ring-offset-theme-surface"
           onclick={save}
         >


### PR DESCRIPTION
💡 What: Added `focus-visible:outline-none`, `focus-visible:ring-2`, and `focus-visible:ring-theme-primary` to all `<button>` elements in `VTTGridSettings.svelte` and `VTTGridColorMenu.svelte`.

🎯 Why: These buttons previously lacked any visual indicator when navigated via keyboard. This small change ensures users relying on keyboard navigation can clearly see which interactive element has focus, while keeping standard mouse interactions unchanged.

♿ Accessibility: Greatly improves keyboard navigation mapping for users with visual or motor impairments who rely on a clear focus ring, satisfying standard WCAG focus visibility guidelines.

---
*PR created automatically by Jules for task [5075272814054532432](https://jules.google.com/task/5075272814054532432) started by @eserlan*