### PR TITLE
:bug: fix: robust wrapping for mobile entity titles #804

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
           name: dist
           path: apps/web/build/
           include-hidden-files: true
-          retention-days: 7
+          retention-days: 1
 
       - name: Upload staging artifact for promotion
         if: github.ref_name == 'staging'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
           name: dist
           path: apps/web/build/
           include-hidden-files: true
-          retention-days: 1
+          retention-days: 7
 
       - name: Upload staging artifact for promotion
         if: github.ref_name == 'staging'

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -86,22 +86,53 @@
   </div>
 {/if}
 
+{#snippet headerActions()}
+  {#if !isEditing}
+    <SidepanelRegenButton entityId={entity.id} />
+    {#if isGraphView}
+      <button
+        onclick={handleFindInGraph}
+        class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
+        aria-label="Find in Graph"
+        title="Find in Graph"
+        data-testid="find-in-graph-button"
+      >
+        <span class="icon-[lucide--target] w-5 h-5"></span>
+      </button>
+    {/if}
+    <button
+      onclick={() => ui.openZenMode(entity.id)}
+      class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
+      aria-label="Enter Zen Mode"
+      title="Zen Mode (Full Screen)"
+      data-testid="enter-zen-mode-button"
+    >
+      <span class="icon-[lucide--maximize-2] w-5 h-5"></span>
+    </button>
+  {/if}
+{/snippet}
+
 <div
   class="p-4 md:p-6 border-b border-theme-border bg-theme-surface"
   style:background-color="var(--theme-panel-fill)"
   style:background-image="var(--bg-texture-overlay)"
 >
+  <!-- Mobile-only top bar -->
+  <div class="flex md:hidden justify-between items-center mb-4">
+    <button
+      onclick={onClose}
+      class="text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
+      aria-label="Back"
+    >
+      <span class="icon-[lucide--chevron-left] w-7 h-7"></span>
+    </button>
+    <div class="flex items-center gap-1.5">
+      {@render headerActions()}
+    </div>
+  </div>
+
   <div class="flex justify-between items-center mb-2">
     <div class="flex items-center gap-3 md:gap-4 flex-1 min-w-0">
-      <!-- Mobile-only close button -->
-      <button
-        onclick={onClose}
-        class="md:hidden text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
-        aria-label="Back"
-      >
-        <span class="icon-[lucide--chevron-left] w-7 h-7"></span>
-      </button>
-
       {#if isEditing}
         <div class="flex flex-col gap-2 w-full mr-4">
           <input
@@ -117,7 +148,7 @@
           <h2
             class="{isFantasyTheme
               ? 'text-xl md:text-3xl font-header tracking-wider'
-              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold truncate"
+              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold md:truncate"
             style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
           >
             {entity.title}
@@ -141,35 +172,15 @@
       {/if}
     </div>
 
-    <div class="flex items-center gap-1.5 md:gap-2 shrink-0 ml-2 md:ml-4">
-      {#if !isEditing}
-        <SidepanelRegenButton entityId={entity.id} />
-        {#if isGraphView}
-          <button
-            onclick={handleFindInGraph}
-            class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
-            aria-label="Find in Graph"
-            title="Find in Graph"
-            data-testid="find-in-graph-button"
-          >
-            <span class="icon-[lucide--target] w-5 h-5"></span>
-          </button>
-        {/if}
-        <button
-          onclick={() => ui.openZenMode(entity.id)}
-          class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
-          aria-label="Enter Zen Mode"
-          title="Zen Mode (Full Screen)"
-          data-testid="enter-zen-mode-button"
-        >
-          <span class="icon-[lucide--maximize-2] w-5 h-5"></span>
-        </button>
-      {/if}
+    <div
+      class="hidden md:flex items-center gap-1.5 md:gap-2 shrink-0 ml-2 md:ml-4"
+    >
+      {@render headerActions()}
 
       <!-- Desktop-only close button -->
       <button
         onclick={onClose}
-        class="hidden md:flex transition items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
+        class="transition items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
         aria-label="Close panel"
         title="Close"
       >

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -131,8 +131,8 @@
     </div>
   </div>
 
-  <div class="flex justify-between items-center mb-2">
-    <div class="flex items-center gap-3 md:gap-4 flex-1 min-w-0">
+  <div class="flex justify-between items-start md:items-center mb-2">
+    <div class="flex items-start md:items-center gap-3 md:gap-4 flex-1 min-w-0">
       {#if isEditing}
         <div class="flex flex-col gap-2 w-full mr-4">
           <input
@@ -148,7 +148,7 @@
           <h2
             class="{isFantasyTheme
               ? 'text-xl md:text-3xl font-header tracking-wider'
-              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold md:truncate"
+              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold whitespace-normal md:truncate"
             style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
           >
             {entity.title}

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -91,6 +91,7 @@
     <SidepanelRegenButton entityId={entity.id} />
     {#if isGraphView}
       <button
+        type="button"
         onclick={handleFindInGraph}
         class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
         aria-label="Find in Graph"
@@ -101,6 +102,7 @@
       </button>
     {/if}
     <button
+      type="button"
       onclick={() => ui.openZenMode(entity.id)}
       class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
       aria-label="Enter Zen Mode"
@@ -120,6 +122,7 @@
   <!-- Mobile-only top bar -->
   <div class="flex md:hidden justify-between items-center mb-4">
     <button
+      type="button"
       onclick={onClose}
       class="text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
       aria-label="Back"
@@ -179,8 +182,9 @@
 
       <!-- Desktop-only close button -->
       <button
+        type="button"
         onclick={onClose}
-        class="transition items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
+        class="flex transition items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
         aria-label="Close panel"
         title="Close"
       >


### PR DESCRIPTION
## Description
This PR provides a more robust fix for the entity title truncation on mobile (Issue #804).

## Changes
- **Explicit Wrapping:** Added `whitespace-normal` to the entity title on mobile to ensure it always wraps even if parent styles attempt to force single-line behavior.
- **Improved Alignment:** Changed vertical alignment from `items-center` to `items-start` on mobile. This ensures that multi-line titles are top-aligned, which is the standard UI pattern for wrapping headers.
- **Breakpoint Logic:** Maintained the single-line `truncate` behavior for `md` screens and above to keep the desktop view clean.

## Verification
- Verified with unit tests in `DetailHeader.test.ts`.
- Manual verification of class application across breakpoints.

Fixes #804