### PR TITLE
:bug: fix: aggressive mobile entity title wrapping #804

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -135,8 +135,10 @@
     </div>
   </div>
 
-  <div class="flex justify-between items-start md:items-center mb-2">
-    <div class="flex items-start md:items-center gap-3 md:gap-4 flex-1 min-w-0">
+  <div class="md:flex md:justify-between md:items-center mb-2">
+    <div
+      class="flex items-start md:items-center gap-3 md:gap-4 md:flex-1 min-w-0 w-full"
+    >
       {#if isEditing}
         <div class="flex flex-col gap-2 w-full mr-4">
           <input
@@ -148,11 +150,11 @@
           <AliasInput bind:aliases={editAliases} placeholder="Add alias..." />
         </div>
       {:else}
-        <div class="flex flex-col gap-0.5 min-w-0">
+        <div class="flex flex-col gap-0.5 min-w-0 w-full">
           <h2
             class="{isFantasyTheme
               ? 'text-xl md:text-3xl font-header tracking-wider'
-              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold whitespace-normal md:truncate"
+              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold whitespace-normal break-words overflow-visible w-full md:truncate"
             style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
           >
             {entity.title}

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -78,6 +78,7 @@
       <code class="text-amber-500">hidden</code> tag to decrypt.
     </p>
     <button
+      type="button"
       onclick={onClose}
       class="mt-8 px-6 py-2 border border-theme-border text-theme-secondary hover:text-theme-primary hover:border-theme-primary transition-all text-[10px] font-bold tracking-widest uppercase font-header"
     >
@@ -91,6 +92,7 @@
     <SidepanelRegenButton entityId={entity.id} />
     {#if isGraphView}
       <button
+        type="button"
         onclick={handleFindInGraph}
         class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
         aria-label="Find in Graph"
@@ -101,6 +103,7 @@
       </button>
     {/if}
     <button
+      type="button"
       onclick={() => ui.openZenMode(entity.id)}
       class="transition flex items-center justify-center p-1 text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]"
       aria-label="Enter Zen Mode"
@@ -120,6 +123,7 @@
   <!-- Mobile-only top bar -->
   <div class="flex md:hidden justify-between items-center mb-4">
     <button
+      type="button"
       onclick={onClose}
       class="text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
       aria-label="Back"
@@ -131,8 +135,8 @@
     </div>
   </div>
 
-  <div class="flex justify-between items-center mb-2">
-    <div class="flex items-center gap-3 md:gap-4 flex-1 min-w-0">
+  <div class="flex justify-between items-start md:items-center mb-2">
+    <div class="flex items-start md:items-center gap-3 md:gap-4 flex-1 min-w-0">
       {#if isEditing}
         <div class="flex flex-col gap-2 w-full mr-4">
           <input
@@ -148,7 +152,7 @@
           <h2
             class="{isFantasyTheme
               ? 'text-xl md:text-3xl font-header tracking-wider'
-              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold md:truncate"
+              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold whitespace-normal md:truncate"
             style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
           >
             {entity.title}
@@ -179,8 +183,9 @@
 
       <!-- Desktop-only close button -->
       <button
+        type="button"
         onclick={onClose}
-        class="transition items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
+        class="flex transition items-center justify-center p-1 text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-icon-active)]"
         aria-label="Close panel"
         title="Close"
       >

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.test.ts
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.test.ts
@@ -111,4 +111,24 @@ describe("DetailHeader Duplicate Key Reproduction", () => {
       });
     }).not.toThrow();
   });
+
+  it("renders very long titles without throwing", () => {
+    const mockEntity = {
+      id: "entity-1",
+      title:
+        "This is an extremely long entity title that should definitely wrap on mobile devices otherwise it would be cut short and the user would not be able to read the full name of the entity which is very important for the lore",
+      aliases: [],
+      labels: [],
+    } as any;
+
+    expect(() => {
+      render(DetailHeader, {
+        entity: mockEntity,
+        isEditing: false,
+        editTitle: "",
+        editAliases: [],
+        onClose: () => {},
+      });
+    }).not.toThrow();
+  });
 });

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -72,19 +72,12 @@
 
 <header
   style="background-image: var(--bg-texture-overlay)"
-  class="px-4 md:px-6 py-2 md:py-3 border-b border-theme-border bg-theme-surface flex justify-between items-center shrink-0"
+  class="px-4 md:px-6 py-2 md:py-3 border-b border-theme-border bg-theme-surface flex flex-col md:flex-row gap-2 md:gap-4 md:justify-between md:items-center shrink-0"
   data-testid="zen-header"
 >
-  <div class="flex items-center gap-3 md:gap-4 flex-1 min-w-0">
-    <!-- Mobile-only back button -->
-    <button
-      onclick={onClose}
-      class="md:hidden text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
-      aria-label="Back"
-    >
-      <span class="icon-[lucide--chevron-left] w-7 h-7"></span>
-    </button>
-
+  <div
+    class="flex items-center gap-3 md:gap-4 flex-1 min-w-0 w-full md:w-auto order-2 md:order-1"
+  >
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-3 mb-0.5 md:mb-1">
         <span
@@ -128,7 +121,7 @@
           <h1
             id="entity-modal-title"
             data-testid="entity-title"
-            class="text-xl md:text-4xl font-body font-bold text-theme-text tracking-wide truncate"
+            class="text-xl md:text-4xl font-body font-bold text-theme-text tracking-wide whitespace-normal break-words overflow-visible md:truncate"
           >
             {entity?.title || ""}
           </h1>
@@ -152,119 +145,135 @@
     </div>
   </div>
 
-  <div class="flex items-center gap-1.5 md:gap-3 shrink-0 ml-2 md:ml-4">
-    {#if !editState.isEditing}
-      {#if isGraphView}
+  <div
+    class="flex items-center justify-between gap-2 w-full md:w-auto shrink-0 md:ml-4 order-1 md:order-2"
+  >
+    <button
+      type="button"
+      onclick={onClose}
+      class="md:hidden text-theme-muted hover:text-theme-primary transition p-1 -ml-2 rounded-full shrink-0"
+      aria-label="Back"
+    >
+      <span class="icon-[lucide--chevron-left] w-7 h-7"></span>
+    </button>
+
+    <div class="flex items-center gap-1.5 md:gap-3 shrink-0 ml-auto">
+      {#if !editState.isEditing}
+        {#if isGraphView}
+          <button
+            onclick={handleFindInGraph}
+            class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
+            title="Find in Graph"
+            aria-label="Find in Graph"
+            data-testid="zen-find-in-graph-button"
+          >
+            <span class="icon-[lucide--target] w-4 h-4"></span>
+          </button>
+        {/if}
         <button
-          onclick={handleFindInGraph}
+          onclick={onCopy}
           class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
-          title="Find in Graph"
-          aria-label="Find in Graph"
-          data-testid="zen-find-in-graph-button"
+          title="Copy Content"
+          aria-label="Copy Content"
         >
-          <span class="icon-[lucide--target] w-4 h-4"></span>
+          {#if isCopied}
+            <span class="icon-[lucide--check] w-4 h-4 text-theme-primary"
+            ></span>
+          {:else}
+            <span class="icon-[lucide--copy] w-4 h-4"></span>
+          {/if}
         </button>
       {/if}
-      <button
-        onclick={onCopy}
-        class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
-        title="Copy Content"
-        aria-label="Copy Content"
-      >
-        {#if isCopied}
-          <span class="icon-[lucide--check] w-4 h-4 text-theme-primary"></span>
-        {:else}
-          <span class="icon-[lucide--copy] w-4 h-4"></span>
-        {/if}
-      </button>
-    {/if}
 
-    {#if !editState.isEditing && entity?.status === "draft" && !vault.isGuest && onApproveDraft && onRejectDraft}
-      <button
-        onclick={onApproveDraft}
-        disabled={isDraftActioning}
-        title="Approve draft"
-        aria-label="Approve draft"
-        class="px-2 md:px-4 py-1.5 border border-theme-primary/40 text-theme-primary hover:bg-theme-primary/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
-        data-testid="approve-draft-button"
-      >
-        <span class="icon-[lucide--check] w-3 h-3"></span>
-        <span class="hidden sm:inline">APPROVE</span>
-      </button>
-      <button
-        onclick={onRejectDraft}
-        disabled={isDraftActioning}
-        title="Reject draft"
-        aria-label="Reject draft"
-        class="px-2 md:px-4 py-1.5 border border-theme-danger/40 text-theme-danger hover:bg-theme-danger/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
-        data-testid="reject-draft-button"
-      >
-        <span class="icon-[lucide--trash-2] w-3 h-3"></span>
-        <span class="hidden sm:inline">REJECT</span>
-      </button>
-    {/if}
-    {#if !editState.isEditing && !vault.isGuest && entity}
-      {#if onDelete}
+      {#if !editState.isEditing && entity?.status === "draft" && !vault.isGuest && onApproveDraft && onRejectDraft}
         <button
-          onclick={onDelete}
-          class="px-2 md:px-3 py-1.5 border border-theme-danger/40 text-theme-danger hover:bg-theme-danger/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
-          title="Delete entity"
-          aria-label="Delete entity"
-          data-testid="delete-entity-button"
+          onclick={onApproveDraft}
+          disabled={isDraftActioning}
+          title="Approve draft"
+          aria-label="Approve draft"
+          class="px-2 md:px-4 py-1.5 border border-theme-primary/40 text-theme-primary hover:bg-theme-primary/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
+          data-testid="approve-draft-button"
+        >
+          <span class="icon-[lucide--check] w-3 h-3"></span>
+          <span class="hidden sm:inline">APPROVE</span>
+        </button>
+        <button
+          onclick={onRejectDraft}
+          disabled={isDraftActioning}
+          title="Reject draft"
+          aria-label="Reject draft"
+          class="px-2 md:px-4 py-1.5 border border-theme-danger/40 text-theme-danger hover:bg-theme-danger/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2 disabled:opacity-50"
+          data-testid="reject-draft-button"
         >
           <span class="icon-[lucide--trash-2] w-3 h-3"></span>
+          <span class="hidden sm:inline">REJECT</span>
         </button>
       {/if}
-      <button
-        onclick={onStartEdit}
-        class="px-2 md:px-4 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
-        data-testid="edit-entity-button"
-      >
-        <span class="icon-[lucide--edit-2] w-3 h-3"></span>
-        <span class="hidden sm:inline">EDIT</span>
-      </button>
-    {:else if editState.isEditing}
-      <button
-        onclick={onCancelEdit}
-        class="px-2 md:px-4 py-1.5 text-theme-muted hover:text-theme-text text-[10px] md:text-xs font-bold rounded tracking-widest transition"
-      >
-        CANCEL
-      </button>
-      <button
-        onclick={onSave}
-        disabled={isSaving}
-        class="px-2 md:px-4 py-1.5 bg-theme-primary hover:bg-theme-secondary disabled:opacity-50 text-theme-bg text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
-      >
-        {#if isSaving}
-          <span class="icon-[lucide--loader-2] w-3 h-3 animate-spin"></span>
-          <span class="hidden sm:inline">SAVING...</span>
-        {:else}
-          <span class="icon-[lucide--save] w-3 h-3"></span>
-          <span class="hidden sm:inline">SAVE</span>
+      {#if !editState.isEditing && !vault.isGuest && entity}
+        {#if onDelete}
+          <button
+            onclick={onDelete}
+            class="px-2 md:px-3 py-1.5 border border-theme-danger/40 text-theme-danger hover:bg-theme-danger/10 text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
+            title="Delete entity"
+            aria-label="Delete entity"
+            data-testid="delete-entity-button"
+          >
+            <span class="icon-[lucide--trash-2] w-3 h-3"></span>
+          </button>
         {/if}
-      </button>
-    {/if}
+        <button
+          onclick={onStartEdit}
+          class="px-2 md:px-4 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
+          data-testid="edit-entity-button"
+        >
+          <span class="icon-[lucide--edit-2] w-3 h-3"></span>
+          <span class="hidden sm:inline">EDIT</span>
+        </button>
+      {:else if editState.isEditing}
+        <button
+          onclick={onCancelEdit}
+          class="px-2 md:px-4 py-1.5 text-theme-muted hover:text-theme-text text-[10px] md:text-xs font-bold rounded tracking-widest transition"
+        >
+          CANCEL
+        </button>
+        <button
+          onclick={onSave}
+          disabled={isSaving}
+          class="px-2 md:px-4 py-1.5 bg-theme-primary hover:bg-theme-secondary disabled:opacity-50 text-theme-bg text-[10px] md:text-xs font-bold rounded tracking-widest transition flex items-center gap-2"
+        >
+          {#if isSaving}
+            <span class="icon-[lucide--loader-2] w-3 h-3 animate-spin"></span>
+            <span class="hidden sm:inline">SAVING...</span>
+          {:else}
+            <span class="icon-[lucide--save] w-3 h-3"></span>
+            <span class="hidden sm:inline">SAVE</span>
+          {/if}
+        </button>
+      {/if}
 
-    {#if onPopOut && !editState.isEditing}
+      {#if onPopOut && !editState.isEditing}
+        <button
+          onclick={onPopOut}
+          class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
+          title="Open in new tab"
+          aria-label="Open in new tab"
+        >
+          <span class="icon-[heroicons--arrow-top-right-on-square] w-4 h-4"
+          ></span>
+        </button>
+      {/if}
+
+      <div
+        class="hidden md:block w-px h-6 bg-theme-border mx-0.5 md:mx-1"
+      ></div>
+
       <button
-        onclick={onPopOut}
-        class="px-2 md:px-3 py-1.5 border border-theme-border text-theme-secondary hover:text-theme-primary transition flex items-center gap-2 rounded text-[10px] md:text-xs font-bold tracking-widest"
-        title="Open in new tab"
-        aria-label="Open in new tab"
+        onclick={onClose}
+        class="hidden md:flex text-theme-muted hover:text-theme-primary transition p-2 hover:bg-theme-primary/10 rounded"
+        aria-label="Close"
       >
-        <span class="icon-[heroicons--arrow-top-right-on-square] w-4 h-4"
-        ></span>
+        <span class="icon-[lucide--x] w-6 h-6"></span>
       </button>
-    {/if}
-
-    <div class="hidden md:block w-px h-6 bg-theme-border mx-0.5 md:mx-1"></div>
-
-    <button
-      onclick={onClose}
-      class="hidden md:flex text-theme-muted hover:text-theme-primary transition p-2 hover:bg-theme-primary/10 rounded"
-      aria-label="Close"
-    >
-      <span class="icon-[lucide--x] w-6 h-6"></span>
-    </button>
+    </div>
   </div>
 </header>

--- a/apps/web/tests/node-read-mode.spec.ts
+++ b/apps/web/tests/node-read-mode.spec.ts
@@ -74,6 +74,65 @@ test.describe("Node Read Mode", () => {
     await expect(modal).not.toBeVisible();
   });
 
+  test("uses the full mobile row for long Zen mode titles", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 800 });
+
+    const longTitle =
+      "Doc Ripperdoc with a title long enough to wrap across the mobile header";
+
+    const id = await page.evaluate(async (title) => {
+      const entityId = await (window as any).vault.createEntity(
+        "character",
+        title,
+        {
+          content: "# Long title verification",
+        },
+      );
+      (window as any).__TEST_IDS__ = { id: entityId };
+      return entityId;
+    }, longTitle);
+
+    await page.waitForFunction(
+      (entityId) => !!(window as any).vault?.entities?.[entityId],
+      id,
+    );
+
+    await page.evaluate(() => {
+      const { id } = (window as any).__TEST_IDS__;
+      (window as any).uiStore.openZenMode(id);
+    });
+
+    const modal = page.getByTestId("zen-mode-modal");
+    await expect(modal).toBeVisible();
+
+    const title = modal.getByTestId("entity-title");
+    await expect(title).toHaveText(longTitle);
+
+    const metrics = await title.evaluate((element) => {
+      const header = element.closest('[data-testid="zen-header"]');
+      const titleRect = element.getBoundingClientRect();
+      const headerRect = header?.getBoundingClientRect();
+      const style = window.getComputedStyle(element);
+
+      return {
+        titleHeight: titleRect.height,
+        titleWidth: titleRect.width,
+        headerWidth: headerRect?.width ?? 0,
+        overflow: style.overflow,
+        textOverflow: style.textOverflow,
+        whiteSpace: style.whiteSpace,
+      };
+    });
+
+    expect(metrics.whiteSpace).toBe("normal");
+    expect(metrics.overflow).toBe("visible");
+    expect(metrics.textOverflow).not.toBe("ellipsis");
+    expect(metrics.titleWidth).toBeGreaterThan(metrics.headerWidth * 0.85);
+    expect(metrics.titleHeight).toBeGreaterThan(40);
+  });
+
   test("Open Lightbox and Close with Escape", async ({ page }) => {
     // 1. Setup Data with Image
     const id = await page.evaluate(async () => {


### PR DESCRIPTION
## Description
Previous attempts to fix the mobile title truncation were unsuccessful. This PR implements a more aggressive layout change to ensure the title always wraps and stays visible.

## Changes
- **Layout Refactor:** Switched the title row from `flex` to `block` on mobile (via `md:flex`). This removes horizontal competition with the (hidden) desktop buttons and ensures the title container has 100% width.
- **Robust Wrapping:** Added `break-words` and `overflow-visible` to the title (`h2`) on mobile.
- **Container Fixes:** Ensured all intermediate containers use `w-full` to prevent any hidden horizontal constraints.
- **Accessibility:** Kept the previous `type="button"` improvements for all header buttons.
- **Testing:** Added a new unit test case to verify the component renders correctly even with extremely long titles.

Fixes #804