### PR TITLE
:bug: Fix AI-refined category assignment for new discoveries

### DIFF
--- a/ENTITY_CREATION_FLOW.md
+++ b/ENTITY_CREATION_FLOW.md
@@ -1,0 +1,76 @@
+# Entity Creation & Reconciliation Flow
+
+This document describes how entities are created and reconciled in Codex Cryptica, specifically focusing on how categories (types) are determined.
+
+## Logic Overview
+
+When the Oracle suggests a new entity (Discovery), it provides a title and a type guess. When the user "commits" this discovery, the following flow occurs:
+
+### ASCII Flow Diagram
+
+```text
++-----------------------+
+|  Discovery Proposal   | (title, type guess, draft)
++-----------+-----------+
+            |
+            v
++-----------+-----------+
+| reconcileNewEntityDraft| (OracleStore)
++-----------+-----------+
+            |
+            v
++-----------+-----------+
+| reconcileEntityFields | (Calls AI with "shell" entity)
++-----------+-----------+
+            |
+            | AI Prompt (entity-reconciliation.ts):
+            | "Choose the single best categoryId from ALLOWED CATEGORIES
+            |  based on the final reconciled chronicle and lore.
+            |  Prefer the final record over the earlier type guess."
+            v
++-----------+-----------+
+|  AI Response (JSON)   | (content, lore, categoryId)
++-----------+-----------+
+            |
+            v
++-----------+-----------+
+| reconcileEntityUpdate | (TextGenerationService)
++-----------+-----------+
+            |
+            | Returns { content, lore, categoryId }
+            v
++-----------+-----------+
+| reconcileEntityFields | (OracleStore)
++-----------+-----------+
+            |
+            | [Fixed] Returns:
+            | { content, lore, categoryId }
+            v
++-----------+-----------+
+| reconcileNewEntityDraft| (OracleStore)
++-----------+-----------+
+            |
+            | [Fixed] Returns:
+            | { content, lore, categoryId }
+            v
++-----------+-----------+
+|    DiscoveryChip      | (UI Component)
++-----------+-----------+
+            |
+            | [Fixed] Logic:
+            | Calls vault.createEntity((reconciled.categoryId || proposal.type), ...)
+            | Now uses AI-refined category if available.
+            v
++-----------+-----------+
+|     Vault Store       |
++-----------+-----------+
+```
+
+## Observations
+
+1.  **AI Involvement**: The reconciliation prompt _is_ instructed to refined the category (`categoryId`) based on the full draft.
+2.  **Connected Pipeline**: The refined `categoryId` is now correctly propagated through `OracleStore` and used by `DiscoveryChip`.
+
+## Conclusion
+
+The entity creation pipeline now ensures that the most accurate category (determined by the AI during reconciliation) is used when a new record is added to the vault.

--- a/ENTITY_CREATION_FLOW.md
+++ b/ENTITY_CREATION_FLOW.md
@@ -68,7 +68,7 @@ When the Oracle suggests a new entity (Discovery), it provides a title and a typ
 
 ## Observations
 
-1.  **AI Involvement**: The reconciliation prompt _is_ instructed to refined the category (`categoryId`) based on the full draft.
+1.  **AI Involvement**: The reconciliation prompt _is_ instructed to refine the category (`categoryId`) based on the full draft.
 2.  **Connected Pipeline**: The refined `categoryId` is now correctly propagated through `OracleStore` and used by `DiscoveryChip`.
 
 ## Conclusion

--- a/apps/web/src/lib/components/oracle/DiscoveryChip.svelte
+++ b/apps/web/src/lib/components/oracle/DiscoveryChip.svelte
@@ -46,7 +46,7 @@
           proposal.draft,
         );
         const entityId = await vault.createEntity(
-          proposal.type as any,
+          (reconciled.categoryId || proposal.type) as any,
           proposal.title,
           {
             content: reconciled.content,

--- a/apps/web/src/lib/components/oracle/DiscoveryChip.test.ts
+++ b/apps/web/src/lib/components/oracle/DiscoveryChip.test.ts
@@ -184,4 +184,37 @@ describe("DiscoveryChip", () => {
       );
     });
   });
+
+  it("overrides the initial type guess with the AI-refined categoryId when provided", async () => {
+    mockOracle.reconcileNewEntityDraft.mockResolvedValue({
+      content: "refined content",
+      lore: "refined lore",
+      categoryId: "location", // Refined from 'npc'
+    });
+
+    render(DiscoveryChip, {
+      proposal: {
+        title: "The Iron Keep",
+        type: "npc", // Initial guess
+        draft: {
+          chronicle: "a scary place",
+          lore: "full of knights",
+        },
+        confidence: 0.8,
+      },
+    });
+
+    await fireEvent.click(screen.getByLabelText("Create The Iron Keep"));
+
+    await waitFor(() => {
+      expect(mockVault.createEntity).toHaveBeenCalledWith(
+        "location",
+        "The Iron Keep",
+        {
+          content: "refined content",
+          lore: "refined lore",
+        },
+      );
+    });
+  });
 });

--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -443,6 +443,7 @@ describe("OracleStore", () => {
             type: "npc",
           }),
         ],
+        expect.any(Array),
       );
     });
 
@@ -758,10 +759,12 @@ describe("OracleStore", () => {
           expect.objectContaining({ id: "target" }),
           { chronicle: "New chronicle", lore: "New lore" },
           expect.any(Array),
+          expect.any(Array),
         );
         expect(result).toEqual({
           content: "Merged chronicle",
           lore: "Merged lore",
+          categoryId: undefined,
         });
       });
 

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -620,7 +620,7 @@ export class OracleStore {
   private async reconcileEntityFields(
     existing: Entity,
     incoming: { chronicle: string; lore: string },
-  ): Promise<{ content: string; lore: string }> {
+  ): Promise<{ content: string; lore: string; categoryId?: string }> {
     if (!this.textGeneration.reconcileEntityUpdate) {
       throw new Error("reconcileEntityUpdate not available");
     }
@@ -635,23 +635,34 @@ export class OracleStore {
           this.contextRetrieval.getConsolidatedContext(related),
       }),
     );
+    const snapCategories = $state.snapshot(this.categories.list).map((c) => ({
+      id: c.id,
+      label: c.label,
+      description: c.description,
+    }));
+
     return this.textGeneration.reconcileEntityUpdate(
       this.effectiveApiKey || "",
       this.modelName,
       snapExisting,
       snapIncoming,
       snapContext,
+      snapCategories,
     );
   }
 
   async reconcileSmartApply(
     entityId: string,
     incoming: { chronicle?: string; lore?: string },
-  ): Promise<{ content?: string; lore?: string }> {
+  ): Promise<{ content?: string; lore?: string; categoryId?: string }> {
     const existing = this.vault.entities[entityId];
     if (!existing) throw new Error(`Entity ${entityId} not found.`);
 
-    const fallback = (): { content?: string; lore?: string } => ({
+    const fallback = (): {
+      content?: string;
+      lore?: string;
+      categoryId?: string;
+    } => ({
       content: incoming.chronicle
         ? existing.content
           ? existing.content + "\n\n" + incoming.chronicle
@@ -676,6 +687,7 @@ export class OracleStore {
       return {
         content: reconciled.content || existing.content || "",
         lore: reconciled.lore || existing.lore || "",
+        categoryId: reconciled.categoryId,
       };
     } catch {
       return fallback();
@@ -716,7 +728,7 @@ export class OracleStore {
     title: string,
     type: string,
     draft: { chronicle: string; lore: string },
-  ): Promise<{ content: string; lore: string }> {
+  ): Promise<{ content: string; lore: string; categoryId?: string }> {
     if (this.uiStore.aiDisabled || !this.textGeneration.reconcileEntityUpdate) {
       return { content: draft.chronicle, lore: draft.lore };
     }
@@ -734,6 +746,7 @@ export class OracleStore {
       return {
         content: reconciled.content || draft.chronicle,
         lore: reconciled.lore || draft.lore,
+        categoryId: reconciled.categoryId,
       };
     } catch {
       return { content: draft.chronicle, lore: draft.lore };

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -638,7 +638,6 @@ export class OracleStore {
     const snapCategories = $state.snapshot(this.categories.list).map((c) => ({
       id: c.id,
       label: c.label,
-      description: c.description,
     }));
 
     return this.textGeneration.reconcileEntityUpdate(

--- a/apps/web/src/lib/workers/oracle.worker.ts
+++ b/apps/web/src/lib/workers/oracle.worker.ts
@@ -61,6 +61,7 @@ class OracleWorker {
     entity: any,
     incoming: { chronicle: string; lore: string },
     relatedEntities: any[] = [],
+    categories: any[] = [],
   ): Promise<any> {
     return this.textGeneration.reconcileEntityUpdate(
       apiKey,
@@ -68,6 +69,7 @@ class OracleWorker {
       entity,
       incoming,
       relatedEntities,
+      categories,
     );
   }
 


### PR DESCRIPTION
## Description
This PR addresses an issue where the Oracle's AI-refined category suggestion was being ignored during the creation of new entities from Discovery chips. 

## Changes
- **OracleStore**: Updated reconciliation methods to correctly propagate the categoryId returned by the AI text generation service.
- **DiscoveryChip**: Updated to use the AI-refined category when calling vault.createEntity, falling back to the initial guess only if a refined category isn't provided.
- Added ENTITY_CREATION_FLOW.md diagram mapping this flow.

These changes ensure new entities take full advantage of the AI's contextual analysis for proper categorization.