### PR TITLE
⚡ Bolt: [Performance Insight: Array allocation in context retrieval]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,8 @@
 
 **Learning:** Replaced `Object.values()` when iterating over the large `entities` record in `VaultLifecycleManager` with an imperative loop over keys (`for (const id in entities) { const entity = entities[id]; ... }`). Also replaced `...Object.values(entity.metadata || {}).flat()` with direct array push logic. This prevents creation of large intermediate arrays, reducing garbage collection pauses in hot paths like vault persistence and data loading.
 **Action:** When iterating over a large object or assembling a large sequence of items, prefer an imperative iteration (`for...in`) over `Object.values()`, and direct array insertions over spread operators and `.flat()`, to eliminate intermediate allocations and garbage collection overhead.
+
+## 2026-05-18 - [Performance Insight: Avoid array returning reduce]
+
+**Learning:** Using `.reduce((acc, item) => { acc.push(item); return acc; }, [])` creates a closure and adds overhead compared to simply pushing to an array in an imperative `for...of` loop. In hot paths like context retrieval which occurs frequently, this can cause unnecessary GC overhead.
+**Action:** Replace `.reduce()` that initializes and returns an array with an imperative `for...of` loop and a standard array `push`.

--- a/apps/web/src/lib/services/ai/context-retrieval.service.ts
+++ b/apps/web/src/lib/services/ai/context-retrieval.service.ts
@@ -316,45 +316,44 @@ export class DefaultContextRetrievalService implements ContextRetrievalService {
       const prefix = isActive ? "[ACTIVE FILE] " : "";
 
       let connectionContext = "";
-      const outbound = (entity.connections || []).reduce(
-        (acc: string[], c: any) => {
-          const targetEntity = vault.entities[c.target];
-          if (
-            targetEntity &&
-            (!vault.isGuest ||
-              isEntityVisible(targetEntity, {
-                sharedMode: true,
-                defaultVisibility: vault.defaultVisibility,
-              }))
-          ) {
-            acc.push(
-              `- ${entity.title} → ${c.label || c.type} → ${targetEntity.title}`,
-            );
-          }
-          return acc;
-        },
-        [],
-      );
 
-      const inbound = (vault.inboundConnections[id] || []).reduce(
-        (acc: string[], item: any) => {
-          const sourceEntity = vault.entities[item.sourceId];
-          if (
-            sourceEntity &&
-            (!vault.isGuest ||
-              isEntityVisible(sourceEntity, {
-                sharedMode: true,
-                defaultVisibility: vault.defaultVisibility,
-              }))
-          ) {
-            acc.push(
-              `- ${sourceEntity.title} → ${item.connection.label || item.connection.type} → ${entity.title}`,
-            );
-          }
-          return acc;
-        },
-        [],
-      );
+      // ⚡ Bolt Optimization: Replace .reduce() that returns an array with an imperative loop to eliminate closure allocation overhead.
+      const outbound: string[] = [];
+      const connections = entity.connections || [];
+      for (const c of connections) {
+        const targetEntity = vault.entities[c.target];
+        if (
+          targetEntity &&
+          (!vault.isGuest ||
+            isEntityVisible(targetEntity, {
+              sharedMode: true,
+              defaultVisibility: vault.defaultVisibility,
+            }))
+        ) {
+          outbound.push(
+            `- ${entity.title} → ${c.label || c.type} → ${targetEntity.title}`,
+          );
+        }
+      }
+
+      // ⚡ Bolt Optimization: Replace .reduce() that returns an array with an imperative loop to eliminate closure allocation overhead.
+      const inbound: string[] = [];
+      const inboundConn = vault.inboundConnections[id] || [];
+      for (const item of inboundConn) {
+        const sourceEntity = vault.entities[item.sourceId];
+        if (
+          sourceEntity &&
+          (!vault.isGuest ||
+            isEntityVisible(sourceEntity, {
+              sharedMode: true,
+              defaultVisibility: vault.defaultVisibility,
+            }))
+        ) {
+          inbound.push(
+            `- ${sourceEntity.title} → ${item.connection.label || item.connection.type} → ${entity.title}`,
+          );
+        }
+      }
 
       if (outbound.length > 0 || inbound.length > 0) {
         connectionContext =


### PR DESCRIPTION
💡 **What**: Replaced `.reduce()` calls in `context-retrieval.service.ts` that were returning arrays with imperative `for...of` loops and standard array `push` calls. 
🎯 **Why**: In hot paths like context retrieval, returning an array from `.reduce()` creates closures and adds an unnecessary overhead compared to simply pushing elements into an array in a classic loop.
📊 **Impact**: Reduces GC allocations slightly during context retrieval.
🔬 **Measurement**: Looked at memory usage around context retrieval logic before/after via code inspection. Code changes verified logically correct and identical in behavior.

---
*PR created automatically by Jules for task [11458966735743743769](https://jules.google.com/task/11458966735743743769) started by @eserlan*