### PR TITLE
[codex] Refactor map page decomposition

### DIFF
--- a/apps/web/src/lib/components/map/MapHUD.svelte
+++ b/apps/web/src/lib/components/map/MapHUD.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import GuestInfoOverlay from "$lib/components/vtt/GuestInfoOverlay.svelte";
+  import { handleActiveMapSelection } from "$lib/components/map/map-page-actions";
+  import { p2pHost } from "$lib/cloud-bridge/p2p/host-service.svelte";
+  import { mapStore } from "$lib/stores/map.svelte";
+  import { vault } from "$lib/stores/vault.svelte";
+  import { notificationStore } from "$lib/stores/ui/notification.svelte";
+  import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
+
+  let {
+    chatSidebarOffset,
+    onShowUpload,
+  }: {
+    chatSidebarOffset: string;
+    onShowUpload: () => void;
+  } = $props();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="absolute z-10 flex flex-col items-start gap-2"
+  style="top: 1rem; left: calc({chatSidebarOffset} + 1rem);"
+  role="presentation"
+  onmousedown={(e) => e.stopPropagation()}
+>
+  <div class="flex gap-2">
+    {#if mapStore.canGoBack}
+      <button
+        class="px-3 py-1.5 bg-theme-surface border border-theme-border text-theme-text text-xs font-bold rounded-lg hover:border-theme-primary transition-colors flex items-center gap-2"
+        onclick={() => mapStore.goBack()}
+      >
+        <span class="icon-[lucide--arrow-left] w-3 h-3"></span>
+        BACK
+      </button>
+    {/if}
+
+    {#if sessionModeStore.isGuestMode}
+      {#if mapStore.activeMap}
+        <div
+          class="px-3 py-1.5 bg-theme-surface border border-theme-border text-theme-text rounded-lg text-xs font-bold"
+        >
+          {mapStore.activeMap.isWorldMap ? "★ " : ""}{mapStore.activeMap.name}
+        </div>
+      {/if}
+    {:else}
+      <select
+        class="bg-theme-surface border border-theme-border text-theme-text px-3 py-1.5 rounded-lg text-xs"
+        value={mapStore.activeMapId}
+        onchange={(e) =>
+          handleActiveMapSelection({
+            mapId: e.currentTarget.value,
+            selectMap: (mapId) => mapStore.selectMap(mapId),
+            isHosting: p2pHost.isHosting,
+            broadcastActiveMapSync: () => p2pHost.broadcastActiveMapSync(),
+          })}
+      >
+        {#each Object.values(vault.maps) as map (map.id)}
+          <option value={map.id}>
+            {map.isWorldMap ? "★ " : ""}{map.name}
+          </option>
+        {/each}
+      </select>
+
+      {#if mapStore.activeMap && !mapStore.activeMap.isWorldMap}
+        <button
+          class="px-3 py-1.5 bg-theme-surface border border-theme-border text-theme-muted text-[10px] font-bold rounded-lg hover:text-theme-primary hover:border-theme-primary transition-colors flex items-center gap-2"
+          onclick={() => mapStore.setAsWorldMap(mapStore.activeMapId!)}
+          title="Set as World Map"
+        >
+          <span class="icon-[lucide--star] w-3 h-3"></span>
+          SET WORLD
+        </button>
+      {:else if mapStore.activeMap?.isWorldMap}
+        <div
+          class="px-3 py-1.5 bg-theme-primary/10 border border-theme-primary/30 text-theme-primary text-[10px] font-bold rounded-lg flex items-center gap-2"
+        >
+          <span class="icon-[lucide--star] w-3 h-3 fill-theme-primary"></span>
+          WORLD MAP
+        </div>
+      {/if}
+
+      <button
+        class="px-3 py-1.5 bg-theme-surface border border-theme-border text-red-500/70 text-[10px] font-bold rounded-lg hover:text-red-400 hover:border-red-400 transition-colors flex items-center gap-2"
+        onclick={async () => {
+          if (
+            await notificationStore.confirm({
+              title: "Clear Map",
+              message:
+                "Are you sure you want to delete this map? This action cannot be undone.",
+              isDangerous: true,
+            })
+          ) {
+            await vault.deleteMap(mapStore.activeMapId!);
+          }
+        }}
+        title="Delete Map"
+      >
+        <span class="icon-[lucide--trash-2] w-3 h-3"></span>
+        DELETE
+      </button>
+
+      <button
+        class="px-3 py-1.5 bg-theme-primary text-theme-bg text-xs font-bold rounded-lg uppercase font-header tracking-wider"
+        onclick={onShowUpload}
+      >
+        Add Map
+      </button>
+    {/if}
+  </div>
+
+  <GuestInfoOverlay />
+</div>

--- a/apps/web/src/lib/components/map/MapHUD.test.ts
+++ b/apps/web/src/lib/components/map/MapHUD.test.ts
@@ -1,0 +1,107 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mapStoreMock = vi.hoisted(() => ({
+  activeMapId: "map-1",
+  activeMap: {
+    id: "map-1",
+    name: "World",
+    isWorldMap: false,
+  },
+  canGoBack: false,
+  goBack: vi.fn(),
+  selectMap: vi.fn(),
+  setAsWorldMap: vi.fn(),
+}));
+
+const vaultMock = vi.hoisted(() => ({
+  maps: {
+    "map-1": {
+      id: "map-1",
+      name: "World",
+      isWorldMap: false,
+    },
+  },
+  deleteMap: vi.fn(),
+}));
+
+const sessionModeStoreMock = vi.hoisted(() => ({
+  isGuestMode: false,
+}));
+
+vi.mock("$lib/components/vtt/GuestInfoOverlay.svelte", () => ({
+  default: function GuestInfoOverlayMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/cloud-bridge/p2p/host-service.svelte", () => ({
+  p2pHost: {
+    isHosting: false,
+    broadcastActiveMapSync: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/map.svelte", () => ({
+  mapStore: mapStoreMock,
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: vaultMock,
+}));
+
+vi.mock("$lib/stores/ui/notification.svelte", () => ({
+  notificationStore: {
+    confirm: vi.fn().mockResolvedValue(false),
+  },
+}));
+
+vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
+  sessionModeStore: sessionModeStoreMock,
+}));
+
+import MapHUD from "./MapHUD.svelte";
+
+describe("MapHUD", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionModeStoreMock.isGuestMode = false;
+    mapStoreMock.activeMap = {
+      id: "map-1",
+      name: "World",
+      isWorldMap: false,
+    };
+  });
+
+  it("renders host map actions and opens upload flow", async () => {
+    const onShowUpload = vi.fn();
+    render(MapHUD, {
+      props: {
+        chatSidebarOffset: "20rem",
+        onShowUpload,
+      },
+    });
+
+    expect(screen.getByRole("button", { name: "Add Map" })).not.toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Add Map" }));
+
+    expect(onShowUpload).toHaveBeenCalled();
+  });
+
+  it("renders only the active map name for guests", () => {
+    sessionModeStoreMock.isGuestMode = true;
+
+    render(MapHUD, {
+      props: {
+        chatSidebarOffset: "20rem",
+        onShowUpload: vi.fn(),
+      },
+    });
+
+    expect(screen.getByText("World")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Add Map" })).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/map/MapUploadOverlay.svelte
+++ b/apps/web/src/lib/components/map/MapUploadOverlay.svelte
@@ -18,11 +18,17 @@
     onUpload: () => void | Promise<void>;
     onCancel: () => void;
   } = $props();
+
+  const hasSelectedFile = $derived(Boolean(files?.[0]));
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="absolute inset-0 z-50 bg-theme-bg/80 backdrop-blur-sm flex items-center justify-center p-6"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="map-upload-title"
+  tabindex="-1"
   ondragover={onDragOver}
   ondragleave={onDragLeave}
   ondrop={onDrop}
@@ -33,6 +39,7 @@
       : 'border-theme-border'}"
   >
     <h3
+      id="map-upload-title"
       class="text-xl font-bold text-theme-text mb-6 uppercase font-header tracking-wider"
     >
       Upload New Map
@@ -81,7 +88,7 @@
         <button
           class="flex-1 px-6 py-3 bg-theme-primary text-theme-bg rounded-lg font-bold uppercase font-header text-[10px] tracking-widest"
           onclick={onUpload}
-          disabled={!files}
+          disabled={!hasSelectedFile}
         >
           Upload
         </button>

--- a/apps/web/src/lib/components/map/MapUploadOverlay.svelte
+++ b/apps/web/src/lib/components/map/MapUploadOverlay.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  let {
+    mapName = $bindable(""),
+    files = $bindable<FileList | null>(null),
+    isDragging = false,
+    onDragOver,
+    onDragLeave,
+    onDrop,
+    onUpload,
+    onCancel,
+  }: {
+    mapName?: string;
+    files?: FileList | null;
+    isDragging?: boolean;
+    onDragOver: (event: DragEvent) => void;
+    onDragLeave: (event: DragEvent) => void;
+    onDrop: (event: DragEvent) => void;
+    onUpload: () => void | Promise<void>;
+    onCancel: () => void;
+  } = $props();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="absolute inset-0 z-50 bg-theme-bg/80 backdrop-blur-sm flex items-center justify-center p-6"
+  ondragover={onDragOver}
+  ondragleave={onDragLeave}
+  ondrop={onDrop}
+>
+  <div
+    class="w-full max-w-md bg-theme-surface border rounded-xl p-8 shadow-2xl transition-colors duration-200 {isDragging
+      ? 'border-theme-primary'
+      : 'border-theme-border'}"
+  >
+    <h3
+      class="text-xl font-bold text-theme-text mb-6 uppercase font-header tracking-wider"
+    >
+      Upload New Map
+    </h3>
+
+    <div class="space-y-6">
+      <div class="space-y-2">
+        <label
+          class="text-[10px] font-mono text-theme-muted uppercase tracking-widest"
+          for="map-name"
+        >
+          Map Name
+        </label>
+        <input
+          id="map-name"
+          type="text"
+          bind:value={mapName}
+          placeholder="World Map, City Plan, etc."
+          class="w-full bg-theme-surface/50 border border-theme-border text-theme-text px-4 py-3 rounded-lg focus:border-theme-primary outline-none transition-colors"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <label
+          class="text-[10px] font-mono text-theme-muted uppercase tracking-widest"
+          for="map-file"
+        >
+          Image File
+        </label>
+        <input
+          id="map-file"
+          type="file"
+          accept="image/*"
+          bind:files
+          class="w-full text-xs text-theme-muted file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-xs file:font-semibold file:bg-theme-primary/10 file:text-theme-primary hover:file:bg-theme-primary/20"
+        />
+      </div>
+
+      <div class="flex gap-4 pt-4">
+        <button
+          class="flex-1 px-6 py-3 border border-theme-border text-theme-muted rounded-lg hover:bg-theme-surface transition-colors uppercase text-[10px] font-bold font-header tracking-widest"
+          onclick={onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          class="flex-1 px-6 py-3 bg-theme-primary text-theme-bg rounded-lg font-bold uppercase font-header text-[10px] tracking-widest"
+          onclick={onUpload}
+          disabled={!files}
+        >
+          Upload
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/web/src/lib/components/map/MapVTTControlsHUD.svelte
+++ b/apps/web/src/lib/components/map/MapVTTControlsHUD.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import VTTModeToggle from "$lib/components/map/VTTModeToggle.svelte";
+  import {
+    getMeasurementToolButtonClass,
+    getPrimaryButtonStateClass,
+  } from "$lib/components/map/vtt-ui";
+  import { mapStore } from "$lib/stores/map.svelte";
+  import { mapSession } from "$lib/stores/map-session.svelte";
+  import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
+
+  let {
+    chatSidebarOffset,
+  }: {
+    chatSidebarOffset: string;
+  } = $props();
+</script>
+
+{#if !sessionModeStore.isGuestMode && mapSession.vttEnabled}
+  <div
+    class="absolute z-20 pointer-events-auto"
+    style="bottom: 1rem; left: calc({chatSidebarOffset} + 1rem);"
+  >
+    <button
+      class={getMeasurementToolButtonClass(mapSession.measurement.active)}
+      onclick={(e) => {
+        e.stopPropagation();
+        mapSession.setMeasurementActive(!mapSession.measurement.active);
+      }}
+      aria-pressed={mapSession.measurement.active}
+      title={mapSession.measurement.active
+        ? "Disable measurement tool"
+        : "Measure: click on map to set start point, click again to set end point"}
+      aria-label="Toggle measurement tool"
+    >
+      <span
+        class={`relative z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border transition-all duration-300 ${
+          mapSession.measurement.active
+            ? "border-theme-bg/20 bg-theme-bg shadow-md translate-x-[calc(1.075rem+2px)]"
+            : "border-theme-border bg-theme-bg/90 shadow-sm translate-x-0 group-hover:border-theme-primary/40"
+        }`}
+      >
+        <span
+          class={`icon-[lucide--ruler] w-4 h-4 transition-colors ${
+            mapSession.measurement.active
+              ? "text-theme-primary"
+              : "text-theme-muted group-hover:text-theme-primary"
+          }`}
+        ></span>
+      </span>
+
+      {#if mapSession.measurement.active}
+        <span
+          class="pointer-events-none absolute inset-0 rounded-full bg-[linear-gradient(135deg,rgba(255,255,255,0.18),transparent_48%)]"
+        ></span>
+      {/if}
+    </button>
+  </div>
+{/if}
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+{#if !sessionModeStore.isGuestMode}
+  <div
+    class="absolute inset-x-4 bottom-4 z-10 flex justify-center"
+    role="presentation"
+    onmousedown={(e) => e.stopPropagation()}
+  >
+    <div
+      class="flex gap-1.5 bg-theme-surface/80 backdrop-blur border border-theme-border p-1.5 rounded-lg shadow-lg items-center"
+    >
+      <button
+        class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(sessionModeStore.sharedMode)}`}
+        onclick={() =>
+          (sessionModeStore.sharedMode = !sessionModeStore.sharedMode)}
+        title={sessionModeStore.sharedMode
+          ? "Exit Shared Mode (Admin View)"
+          : "Enter Shared Mode (Player Preview)"}
+        data-testid="shared-mode-toggle"
+        aria-pressed={sessionModeStore.sharedMode}
+        aria-label="Toggle player view mode"
+      >
+        {sessionModeStore.sharedMode ? "EXIT PLAYER VIEW" : "PLAYER VIEW"}
+      </button>
+
+      {#if mapStore.isGMMode}
+        <button
+          class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(mapStore.showFog)}`}
+          onclick={() => (mapStore.showFog = !mapStore.showFog)}
+        >
+          FOG: {mapStore.showFog ? "ON" : "OFF"}
+        </button>
+
+        <button
+          class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(mapStore.showGrid)}`}
+          onclick={() => (mapStore.showGrid = !mapStore.showGrid)}
+          oncontextmenu={(e) => {
+            e.preventDefault();
+            mapSession.showGridSettings = true;
+          }}
+          title="Toggle Grid (Right-click for settings)"
+        >
+          GRID: {mapStore.showGrid ? "ON" : "OFF"}
+        </button>
+
+        <VTTModeToggle />
+
+        <div class="flex items-center gap-2 px-2">
+          <span
+            class="text-[9px] text-theme-muted font-bold tracking-tighter uppercase"
+            >Brush Size</span
+          >
+          <input
+            type="range"
+            min="10"
+            max="500"
+            bind:value={mapStore.brushRadius}
+            class="w-24 accent-theme-primary h-1"
+          />
+          <span class="text-[9px] text-theme-primary font-mono w-6"
+            >{mapStore.brushRadius}px</span
+          >
+        </div>
+
+        <div
+          class="flex flex-col justify-center px-2 text-[10px] text-theme-muted/90 font-semibold italic leading-tight"
+        >
+          <span>Alt+Drag to Reveal</span>
+          <span>Alt+Shift+Drag to Hide</span>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/apps/web/src/lib/components/map/MapVTTControlsHUD.test.ts
+++ b/apps/web/src/lib/components/map/MapVTTControlsHUD.test.ts
@@ -1,0 +1,102 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mapStoreMock = vi.hoisted(() => ({
+  isGMMode: true,
+  showFog: true,
+  showGrid: false,
+  brushRadius: 50,
+}));
+
+const mapSessionMock = vi.hoisted(() => ({
+  vttEnabled: true,
+  showGridSettings: false,
+  measurement: {
+    active: false,
+  },
+  setMeasurementActive: vi.fn((active: boolean) => {
+    mapSessionMock.measurement.active = active;
+  }),
+}));
+
+const sessionModeStoreMock = vi.hoisted(() => ({
+  isGuestMode: false,
+  sharedMode: false,
+}));
+
+vi.mock("$lib/components/map/VTTModeToggle.svelte", () => ({
+  default: function VTTModeToggleMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/stores/map.svelte", () => ({
+  mapStore: mapStoreMock,
+}));
+
+vi.mock("$lib/stores/map-session.svelte", () => ({
+  mapSession: mapSessionMock,
+}));
+
+vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
+  sessionModeStore: sessionModeStoreMock,
+}));
+
+import MapVTTControlsHUD from "./MapVTTControlsHUD.svelte";
+
+describe("MapVTTControlsHUD", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionModeStoreMock.isGuestMode = false;
+    sessionModeStoreMock.sharedMode = false;
+    mapStoreMock.isGMMode = true;
+    mapStoreMock.showFog = true;
+    mapStoreMock.showGrid = false;
+    mapSessionMock.vttEnabled = true;
+    mapSessionMock.measurement.active = false;
+  });
+
+  it("renders GM controls and toggles fog", async () => {
+    render(MapVTTControlsHUD, {
+      props: {
+        chatSidebarOffset: "20rem",
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "FOG: ON" }));
+
+    expect(mapStoreMock.showFog).toBe(false);
+    expect(screen.getByRole("button", { name: "GRID: OFF" })).not.toBeNull();
+  });
+
+  it("toggles the measurement tool", async () => {
+    render(MapVTTControlsHUD, {
+      props: {
+        chatSidebarOffset: "20rem",
+      },
+    });
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Toggle measurement tool" }),
+    );
+
+    expect(mapSessionMock.setMeasurementActive).toHaveBeenCalledWith(true);
+  });
+
+  it("hides controls for guests", () => {
+    sessionModeStoreMock.isGuestMode = true;
+
+    render(MapVTTControlsHUD, {
+      props: {
+        chatSidebarOffset: "20rem",
+      },
+    });
+
+    expect(screen.queryByRole("button", { name: "FOG: ON" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Toggle measurement tool" }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/vtt/MapVTTSidebar.svelte
+++ b/apps/web/src/lib/components/vtt/MapVTTSidebar.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import VTTControls from "$lib/components/map/VTTControls.svelte";
+  import EntityList from "$lib/components/explorer/EntityList.svelte";
+  import InitiativePanel from "$lib/components/vtt/InitiativePanel.svelte";
+  import TokenDetail from "$lib/components/vtt/TokenDetail.svelte";
+  import VTTChatSidebar from "$lib/components/vtt/VTTChatSidebar.svelte";
+  import { VTT_ENTITY_TYPES } from "$lib/stores/map/map-page-controller.svelte";
+  import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
+  import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+  import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
+  import type { Entity } from "schema";
+
+  let {
+    isVttChatSidebarCollapsed,
+    showInitiativePanel,
+    hasSelectedToken,
+    vttEntityCount,
+    onVttChatSidebarCollapsed,
+    onEntitySelect,
+    onEntityDragStart,
+    onEntityDragEnd,
+    onShare,
+  }: {
+    isVttChatSidebarCollapsed: boolean;
+    showInitiativePanel: boolean;
+    hasSelectedToken: boolean;
+    vttEntityCount: number;
+    onVttChatSidebarCollapsed: (collapsed: boolean) => void;
+    onEntitySelect: (entity: Entity) => void;
+    onEntityDragStart: (event: DragEvent, entityId: string) => void;
+    onEntityDragEnd: () => void;
+    onShare: () => void;
+  } = $props();
+</script>
+
+<VTTChatSidebar
+  collapsed={isVttChatSidebarCollapsed}
+  setCollapsed={onVttChatSidebarCollapsed}
+/>
+
+<aside
+  class="absolute top-0 right-0 bottom-0 z-[30] flex overflow-hidden border-l border-theme-primary/20 bg-theme-surface/95 shadow-[0_0_30px_rgba(0,0,0,0.25)] backdrop-blur transition-all duration-200 pointer-events-auto {layoutUIStore.vttSidebarCollapsed
+    ? 'w-12'
+    : 'w-[22rem] max-w-[calc(100vw-3rem)]'}"
+  aria-label="VTT Sidebar"
+  onwheel={(e) => e.stopPropagation()}
+>
+  {#if layoutUIStore.vttSidebarCollapsed}
+    <div
+      class="flex h-full w-full flex-col items-center justify-between p-2"
+      style="background-image: var(--bg-texture-overlay)"
+    >
+      <button
+        class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
+        onclick={() => layoutUIStore.toggleVttSidebar(false)}
+        aria-label="Expand VTT Sidebar"
+        aria-expanded="false"
+        type="button"
+      >
+        <span class="icon-[lucide--panel-right-open] w-4 h-4"></span>
+      </button>
+
+      <div class="flex flex-1 items-center justify-center">
+        <span
+          class="rotate-180 text-[10px] font-black uppercase tracking-[0.4em] text-theme-muted [writing-mode:vertical-rl]"
+        >
+          VTT
+        </span>
+      </div>
+    </div>
+  {:else}
+    <div
+      class="flex h-full min-h-0 w-full flex-col relative"
+      style="background-image: var(--bg-texture-overlay)"
+    >
+      <div
+        class="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-theme-primary/30 rounded-tl pointer-events-none hidden md:block"
+      ></div>
+      <div
+        class="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-theme-primary/30 rounded-tr pointer-events-none hidden md:block"
+      ></div>
+      <div
+        class="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-theme-primary/30 rounded-bl pointer-events-none hidden md:block"
+      ></div>
+      <div
+        class="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-theme-primary/30 rounded-br pointer-events-none hidden md:block"
+      ></div>
+
+      <div
+        class="flex items-center justify-between gap-3 border-b border-theme-primary/20 px-3 py-3"
+      >
+        <div>
+          <div
+            class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
+          >
+            VTT Sidebar
+          </div>
+        </div>
+
+        <button
+          class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
+          onclick={() => layoutUIStore.toggleVttSidebar(true)}
+          aria-label="Collapse VTT Sidebar"
+          aria-expanded="true"
+          type="button"
+        >
+          <span class="icon-[lucide--panel-right-close] w-4 h-4"></span>
+        </button>
+      </div>
+
+      <div class="border-b border-theme-primary/20 px-3 py-3">
+        <VTTControls />
+      </div>
+
+      <div
+        class="flex-1 min-h-0 overflow-y-auto custom-scrollbar space-y-3 p-3 pr-2"
+      >
+        {#if showInitiativePanel}
+          <InitiativePanel />
+        {/if}
+
+        {#if !sessionModeStore.isGuestMode}
+          <section
+            class="rounded-xl border border-theme-primary/20 bg-theme-bg/50"
+            data-testid="vtt-entity-list-section"
+          >
+            <button
+              type="button"
+              class="flex w-full items-center justify-between gap-3 px-3 py-3 text-left"
+              onclick={() =>
+                layoutUIStore.toggleVttEntityList(
+                  !layoutUIStore.vttEntityListCollapsed,
+                )}
+              aria-expanded={!layoutUIStore.vttEntityListCollapsed}
+              aria-controls="vtt-entity-list"
+            >
+              <div>
+                <div
+                  class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
+                >
+                  Vault Entities
+                </div>
+                <div class="text-xs text-theme-muted">
+                  Drag characters, creatures, and items onto the map.
+                </div>
+              </div>
+              <div class="flex items-center gap-2">
+                <span
+                  class="rounded-full border border-theme-border px-2 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-muted"
+                >
+                  {vttEntityCount}
+                </span>
+                <span
+                  class="icon-[lucide--chevron-down] h-4 w-4 text-theme-muted transition-transform {layoutUIStore.vttEntityListCollapsed
+                    ? '-rotate-90'
+                    : ''}"
+                ></span>
+              </div>
+            </button>
+
+            {#if !layoutUIStore.vttEntityListCollapsed}
+              <div
+                id="vtt-entity-list"
+                class="border-t border-theme-primary/20 flex flex-col max-h-[50vh]"
+                role="presentation"
+                onmousedown={(event) => event.stopPropagation()}
+              >
+                <EntityList
+                  allowedTypes={VTT_ENTITY_TYPES}
+                  onSelect={onEntitySelect}
+                  onDragStart={onEntityDragStart}
+                  onDragEnd={onEntityDragEnd}
+                  onOpenZen={(entity) => modalUIStore.openZenMode(entity.id)}
+                />
+              </div>
+            {/if}
+          </section>
+        {/if}
+
+        <TokenDetail />
+
+        {#if !showInitiativePanel && !hasSelectedToken}
+          <div
+            class="rounded-xl border border-dashed border-theme-primary/20 bg-theme-bg/50 p-4 text-sm text-theme-muted"
+          >
+            Select a token to view its details.
+          </div>
+        {/if}
+      </div>
+
+      {#if !sessionModeStore.isGuestMode}
+        <div
+          class="relative z-20 border-t border-theme-primary/20 p-3 flex justify-end pointer-events-auto"
+          role="presentation"
+          onmousedown={(e) => e.stopPropagation()}
+        >
+          <button
+            class="w-8 h-8 flex flex-shrink-0 items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-muted transition hover:text-theme-primary"
+            onclick={onShare}
+            type="button"
+            title="Share Campaign"
+            aria-label="Share Campaign"
+          >
+            <span class="icon-[lucide--share-2] w-4 h-4"></span>
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</aside>

--- a/apps/web/src/lib/components/vtt/MapVTTSidebar.test.ts
+++ b/apps/web/src/lib/components/vtt/MapVTTSidebar.test.ts
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const layoutUIStoreMock = vi.hoisted(() => ({
+  vttSidebarCollapsed: false,
+  vttEntityListCollapsed: false,
+  toggleVttSidebar: vi.fn((collapsed: boolean) => {
+    layoutUIStoreMock.vttSidebarCollapsed = collapsed;
+  }),
+  toggleVttEntityList: vi.fn((collapsed: boolean) => {
+    layoutUIStoreMock.vttEntityListCollapsed = collapsed;
+  }),
+}));
+
+const sessionModeStoreMock = vi.hoisted(() => ({
+  isGuestMode: false,
+}));
+
+vi.mock("$lib/components/map/VTTControls.svelte", () => ({
+  default: function VTTControlsMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/explorer/EntityList.svelte", () => ({
+  default: function EntityListMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/vtt/InitiativePanel.svelte", () => ({
+  default: function InitiativePanelMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/vtt/TokenDetail.svelte", () => ({
+  default: function TokenDetailMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/vtt/VTTChatSidebar.svelte", () => ({
+  default: function VTTChatSidebarMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/stores/ui/layout-ui.svelte", () => ({
+  layoutUIStore: layoutUIStoreMock,
+}));
+
+vi.mock("$lib/stores/ui/modal-ui.svelte", () => ({
+  modalUIStore: {
+    openZenMode: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
+  sessionModeStore: sessionModeStoreMock,
+}));
+
+import MapVTTSidebar from "./MapVTTSidebar.svelte";
+
+function renderSidebar(overrides = {}) {
+  return render(MapVTTSidebar, {
+    props: {
+      isVttChatSidebarCollapsed: false,
+      showInitiativePanel: false,
+      hasSelectedToken: false,
+      vttEntityCount: 3,
+      onVttChatSidebarCollapsed: vi.fn(),
+      onEntitySelect: vi.fn(),
+      onEntityDragStart: vi.fn(),
+      onEntityDragEnd: vi.fn(),
+      onShare: vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
+describe("MapVTTSidebar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    layoutUIStoreMock.vttSidebarCollapsed = false;
+    layoutUIStoreMock.vttEntityListCollapsed = false;
+    sessionModeStoreMock.isGuestMode = false;
+  });
+
+  it("renders the expanded sidebar and entity count", () => {
+    renderSidebar();
+
+    expect(screen.getByLabelText("VTT Sidebar")).not.toBeNull();
+    expect(screen.getByText("Vault Entities")).not.toBeNull();
+    expect(screen.getByText("3")).not.toBeNull();
+    expect(
+      screen.getByText("Select a token to view its details."),
+    ).not.toBeNull();
+  });
+
+  it("collapses the right sidebar through the layout store", async () => {
+    renderSidebar();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Collapse VTT Sidebar" }),
+    );
+
+    expect(layoutUIStoreMock.toggleVttSidebar).toHaveBeenCalledWith(true);
+  });
+
+  it("hides host-only entity and share controls for guests", () => {
+    sessionModeStoreMock.isGuestMode = true;
+
+    renderSidebar();
+
+    expect(screen.queryByText("Vault Entities")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share Campaign" })).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/vtt/VTTChatSidebar.svelte
+++ b/apps/web/src/lib/components/vtt/VTTChatSidebar.svelte
@@ -6,8 +6,10 @@
 
   let {
     collapsed = $bindable(false),
+    setCollapsed,
   }: {
     collapsed?: boolean;
+    setCollapsed?: (collapsed: boolean) => void;
   } = $props();
 
   const canClearChat = $derived(
@@ -30,6 +32,11 @@
     }
     mapSession.clearChatMessages();
   };
+
+  function updateCollapsed(nextCollapsed: boolean) {
+    collapsed = nextCollapsed;
+    setCollapsed?.(nextCollapsed);
+  }
 </script>
 
 <aside
@@ -46,7 +53,7 @@
     >
       <button
         class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
-        onclick={() => (collapsed = false)}
+        onclick={() => updateCollapsed(false)}
         aria-label="Expand VTT Chat Sidebar"
         aria-expanded="false"
         type="button"
@@ -108,7 +115,7 @@
 
           <button
             class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
-            onclick={() => (collapsed = true)}
+            onclick={() => updateCollapsed(true)}
             aria-label="Collapse VTT Chat Sidebar"
             aria-expanded="true"
             type="button"

--- a/apps/web/src/lib/stores/map/map-page-controller.svelte.ts
+++ b/apps/web/src/lib/stores/map/map-page-controller.svelte.ts
@@ -5,6 +5,7 @@ import { notificationStore as defaultNotificationStore } from "$lib/stores/ui/no
 import { sessionModeStore as defaultSessionModeStore } from "$lib/stores/ui/session-mode.svelte";
 import { layoutUIStore as defaultLayoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
 import { shouldShowInitiativePanel } from "$lib/components/map/vtt-ui";
+import type { SessionMode } from "../../../types/vtt";
 import type { Entity, Point } from "schema";
 
 export const VTT_ENTITY_TYPES = ["character", "creature", "item"];
@@ -19,7 +20,7 @@ type MapPageMapStore = {
 
 type MapPageSession = {
   vttEnabled: boolean;
-  mode: string;
+  mode: SessionMode;
   selectedToken?: unknown;
   dragPreview?: { entityId: string } | null;
   clearDragPreview(): void;
@@ -88,10 +89,7 @@ export class MapPageController {
     this.layoutUIStore.vttChatSidebarCollapsed ? "3rem" : "20rem",
   );
   showInitiativePanel = $derived(
-    shouldShowInitiativePanel(
-      this.mapSession.vttEnabled,
-      this.mapSession.mode as any,
-    ),
+    shouldShowInitiativePanel(this.mapSession.vttEnabled, this.mapSession.mode),
   );
   hasSelectedToken = $derived(Boolean(this.mapSession.selectedToken));
   vttEntityCount = $derived.by(

--- a/apps/web/src/lib/stores/map/map-page-controller.svelte.ts
+++ b/apps/web/src/lib/stores/map/map-page-controller.svelte.ts
@@ -1,0 +1,269 @@
+import { mapStore as defaultMapStore } from "$lib/stores/map.svelte";
+import { mapSession as defaultMapSession } from "$lib/stores/map-session.svelte";
+import { vault as defaultVault } from "$lib/stores/vault.svelte";
+import { notificationStore as defaultNotificationStore } from "$lib/stores/ui/notification.svelte";
+import { sessionModeStore as defaultSessionModeStore } from "$lib/stores/ui/session-mode.svelte";
+import { layoutUIStore as defaultLayoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
+import { shouldShowInitiativePanel } from "$lib/components/map/vtt-ui";
+import type { Entity, Point } from "schema";
+
+export const VTT_ENTITY_TYPES = ["character", "creature", "item"];
+const ENTITY_TRANSFER_TYPE = "application/codex-entity";
+
+type MapPageMapStore = {
+  activeMap: unknown;
+  unproject(point: Point): Point;
+  uploadMap(file: File, name: string): Promise<string | undefined>;
+  addPin(entityId: string | undefined, coordinates: Point): unknown;
+};
+
+type MapPageSession = {
+  vttEnabled: boolean;
+  mode: string;
+  selectedToken?: unknown;
+  dragPreview?: { entityId: string } | null;
+  clearDragPreview(): void;
+  setDragPreview(preview: { entityId: string; x: number; y: number }): void;
+  addToken(input: {
+    name: string;
+    entityId: string;
+    imageUrl?: string;
+    x: number;
+    y: number;
+  }): unknown;
+  requestTokenAdd(input: {
+    name: string;
+    entityId: string;
+    imageUrl?: string;
+    x: number;
+    y: number;
+  }): unknown;
+};
+
+type MapPageVault = {
+  activeVaultId?: string | null;
+  entities: Record<string, Entity>;
+  allEntities: Entity[];
+};
+
+type MapPageNotificationStore = {
+  notify(message: string, type?: "success" | "info" | "error"): void;
+};
+
+type MapPageSessionModeStore = {
+  isGuestMode: boolean;
+};
+
+type MapPageLayoutStore = {
+  vttChatSidebarCollapsed: boolean;
+  toggleVttChatSidebar(collapsed: boolean): void;
+};
+
+export interface MapPageControllerDependencies {
+  mapStore?: MapPageMapStore;
+  mapSession?: MapPageSession;
+  vault?: MapPageVault;
+  notificationStore?: MapPageNotificationStore;
+  sessionModeStore?: MapPageSessionModeStore;
+  layoutUIStore?: MapPageLayoutStore;
+}
+
+export class MapPageController {
+  private mapStore: MapPageMapStore = defaultMapStore;
+  private mapSession: MapPageSession = defaultMapSession;
+  private vault: MapPageVault = defaultVault;
+  private notificationStore: MapPageNotificationStore =
+    defaultNotificationStore;
+  private sessionModeStore: MapPageSessionModeStore = defaultSessionModeStore;
+  private layoutUIStore: MapPageLayoutStore = defaultLayoutUIStore;
+  private activeVaultId: string | null | undefined;
+
+  isDragging = $state(false);
+  showUpload = $state(false);
+  showVttShare = $state(false);
+  mapName = $state("");
+  files = $state<FileList | null>(null);
+
+  chatSidebarOffset = $derived(
+    this.layoutUIStore.vttChatSidebarCollapsed ? "3rem" : "20rem",
+  );
+  showInitiativePanel = $derived(
+    shouldShowInitiativePanel(
+      this.mapSession.vttEnabled,
+      this.mapSession.mode as any,
+    ),
+  );
+  hasSelectedToken = $derived(Boolean(this.mapSession.selectedToken));
+  vttEntityCount = $derived.by(
+    () =>
+      this.vault.allEntities.filter((entity) =>
+        VTT_ENTITY_TYPES.includes(entity.type),
+      ).length,
+  );
+
+  constructor(deps: MapPageControllerDependencies = {}) {
+    this.mapStore = deps.mapStore ?? defaultMapStore;
+    this.mapSession = deps.mapSession ?? defaultMapSession;
+    this.vault = deps.vault ?? defaultVault;
+    this.notificationStore = deps.notificationStore ?? defaultNotificationStore;
+    this.sessionModeStore = deps.sessionModeStore ?? defaultSessionModeStore;
+    this.layoutUIStore = deps.layoutUIStore ?? defaultLayoutUIStore;
+    this.activeVaultId = this.vault.activeVaultId;
+  }
+
+  syncActiveVault(activeVaultId: string | null | undefined) {
+    if (this.activeVaultId === activeVaultId) return;
+    this.activeVaultId = activeVaultId;
+    this.cancelUpload();
+  }
+
+  setVttChatSidebarCollapsed(collapsed: boolean) {
+    this.layoutUIStore.toggleVttChatSidebar(collapsed);
+  }
+
+  handleEntityDragStart(event: DragEvent, entityId: string) {
+    if (!event.dataTransfer) return;
+    event.dataTransfer.setData(ENTITY_TRANSFER_TYPE, entityId);
+    event.dataTransfer.effectAllowed = "copy";
+    this.mapSession.clearDragPreview();
+  }
+
+  handleEntityDragEnd() {
+    this.isDragging = false;
+    this.mapSession.clearDragPreview();
+  }
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+    this.isDragging = true;
+
+    const dataTransfer = event.dataTransfer;
+    if (!dataTransfer || !this.isEntityDrag(dataTransfer)) return;
+
+    dataTransfer.dropEffect = "copy";
+    if (!this.mapSession.vttEnabled) return;
+
+    const entityId =
+      dataTransfer.getData(ENTITY_TRANSFER_TYPE) ||
+      this.mapSession.dragPreview?.entityId;
+    if (!entityId) return;
+
+    const mapCoords = this.eventToMapCoords(event);
+    this.mapSession.setDragPreview({
+      entityId,
+      x: mapCoords.x,
+      y: mapCoords.y,
+    });
+  }
+
+  onDragLeave(event: DragEvent) {
+    event.preventDefault();
+
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    const hasLeftTarget =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom;
+
+    if (!hasLeftTarget) return;
+
+    this.isDragging = false;
+    this.mapSession.clearDragPreview();
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    this.isDragging = false;
+
+    const dataTransfer = event.dataTransfer;
+    this.mapSession.clearDragPreview();
+    if (!dataTransfer) return;
+
+    if (this.isEntityDrag(dataTransfer)) {
+      this.dropEntity(event, dataTransfer);
+      return;
+    }
+
+    if (dataTransfer.files?.length > 0) {
+      this.files = dataTransfer.files;
+      this.showUpload = true;
+    }
+  }
+
+  async handleUpload() {
+    const file = this.files?.[0];
+    if (!file) return;
+
+    try {
+      const result = await this.mapStore.uploadMap(
+        file,
+        this.mapName || file.name,
+      );
+      if (result === undefined) {
+        this.notificationStore.notify(
+          "Failed to upload map. Please ensure your vault is active.",
+          "error",
+        );
+        return;
+      }
+      this.cancelUpload();
+    } catch (err) {
+      console.error("[MapPageController] Error during handleUpload:", err);
+      this.notificationStore.notify(
+        "An unexpected error occurred during upload.",
+        "error",
+      );
+    }
+  }
+
+  cancelUpload() {
+    this.showUpload = false;
+    this.mapName = "";
+    this.files = null;
+    this.isDragging = false;
+  }
+
+  private dropEntity(event: DragEvent, dataTransfer: DataTransfer) {
+    if (this.sessionModeStore.isGuestMode) {
+      this.notificationStore.notify(
+        "Guests cannot add map pins or tokens.",
+        "info",
+      );
+      return;
+    }
+
+    const entityId = dataTransfer.getData(ENTITY_TRANSFER_TYPE);
+    const entity = this.vault.entities[entityId];
+    const activeMap = this.mapStore.activeMap;
+    if (!entity || !activeMap) return;
+
+    const mapCoords = this.eventToMapCoords(event);
+    if (this.mapSession.vttEnabled) {
+      if (!VTT_ENTITY_TYPES.includes(entity.type)) return;
+      this.mapSession.addToken({
+        name: entity.title,
+        entityId: entity.id,
+        imageUrl: entity.image,
+        x: mapCoords.x,
+        y: mapCoords.y,
+      });
+      return;
+    }
+
+    this.mapStore.addPin(entityId, mapCoords);
+  }
+
+  private eventToMapCoords(event: DragEvent) {
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    return this.mapStore.unproject({
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    });
+  }
+
+  private isEntityDrag(dataTransfer: DataTransfer | null) {
+    if (!dataTransfer) return false;
+    return Array.from(dataTransfer.types).includes(ENTITY_TRANSFER_TYPE);
+  }
+}

--- a/apps/web/src/lib/stores/map/map-page-controller.test.ts
+++ b/apps/web/src/lib/stores/map/map-page-controller.test.ts
@@ -1,0 +1,264 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("$lib/stores/map.svelte", () => ({
+  mapStore: {},
+}));
+
+vi.mock("$lib/stores/map-session.svelte", () => ({
+  mapSession: {},
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {},
+}));
+
+vi.mock("$lib/stores/ui/notification.svelte", () => ({
+  notificationStore: {},
+}));
+
+vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
+  sessionModeStore: {},
+}));
+
+vi.mock("$lib/stores/ui/layout-ui.svelte", () => ({
+  layoutUIStore: {
+    vttChatSidebarCollapsed: false,
+    toggleVttChatSidebar: vi.fn(),
+  },
+}));
+
+import { MapPageController } from "./map-page-controller.svelte";
+
+function createRectTarget() {
+  return {
+    getBoundingClientRect: () => ({
+      left: 10,
+      top: 20,
+      right: 210,
+      bottom: 220,
+      width: 200,
+      height: 200,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    }),
+  } as HTMLElement;
+}
+
+function createDragEvent({
+  dataTransfer,
+  clientX = 50,
+  clientY = 80,
+}: {
+  dataTransfer: Partial<DataTransfer>;
+  clientX?: number;
+  clientY?: number;
+}) {
+  return {
+    dataTransfer,
+    clientX,
+    clientY,
+    currentTarget: createRectTarget(),
+    preventDefault: vi.fn(),
+  } as unknown as DragEvent;
+}
+
+function createFileList(files: File[]) {
+  return {
+    ...files,
+    length: files.length,
+    item: (index: number) => files[index] ?? null,
+  } as unknown as FileList;
+}
+
+function createController(overrides: Record<string, unknown> = {}) {
+  const mapStore = {
+    activeMap: { id: "map-1" },
+    unproject: vi.fn((point) => ({ x: point.x + 1, y: point.y + 2 })),
+    uploadMap: vi.fn().mockResolvedValue("map-2"),
+    addPin: vi.fn(),
+  };
+  const mapSession = {
+    vttEnabled: false,
+    mode: "exploration",
+    selectedToken: null,
+    dragPreview: null,
+    clearDragPreview: vi.fn(),
+    setDragPreview: vi.fn(),
+    addToken: vi.fn(),
+    requestTokenAdd: vi.fn(),
+  };
+  const vault = {
+    activeVaultId: "vault-1",
+    allEntities: [
+      { id: "entity-1", type: "character", title: "Mira", content: "" },
+    ],
+    entities: {
+      "entity-1": {
+        id: "entity-1",
+        type: "character",
+        title: "Mira",
+        content: "",
+        image: "mira.png",
+      },
+    },
+  };
+  const notificationStore = {
+    notify: vi.fn(),
+  };
+  const sessionModeStore = {
+    isGuestMode: false,
+  };
+  const layoutUIStore = {
+    vttChatSidebarCollapsed: false,
+    toggleVttChatSidebar: vi.fn((collapsed: boolean) => {
+      layoutUIStore.vttChatSidebarCollapsed = collapsed;
+    }),
+  };
+
+  const deps = {
+    mapStore,
+    mapSession,
+    vault,
+    notificationStore,
+    sessionModeStore,
+    layoutUIStore,
+    ...overrides,
+  } as any;
+
+  return {
+    controller: new MapPageController(deps),
+    mapStore,
+    mapSession,
+    vault,
+    notificationStore,
+    sessionModeStore,
+    layoutUIStore,
+  };
+}
+
+function createEntityTransfer(entityId = "entity-1") {
+  return {
+    types: ["application/codex-entity"],
+    getData: vi.fn(() => entityId),
+    setData: vi.fn(),
+    effectAllowed: "copy",
+    dropEffect: "none",
+  } as unknown as DataTransfer;
+}
+
+describe("MapPageController", () => {
+  it("adds a standard map pin when a host drops an entity", () => {
+    const { controller, mapStore, mapSession } = createController();
+
+    controller.onDrop(
+      createDragEvent({
+        dataTransfer: createEntityTransfer(),
+      }),
+    );
+
+    expect(mapStore.unproject).toHaveBeenCalledWith({ x: 40, y: 60 });
+    expect(mapStore.addPin).toHaveBeenCalledWith("entity-1", {
+      x: 41,
+      y: 62,
+    });
+    expect(mapSession.clearDragPreview).toHaveBeenCalled();
+  });
+
+  it("adds a VTT token when a host drops a supported entity in VTT mode", () => {
+    const { controller, mapSession, mapStore } = createController();
+    mapSession.vttEnabled = true;
+
+    controller.onDrop(
+      createDragEvent({
+        dataTransfer: createEntityTransfer(),
+      }),
+    );
+
+    expect(mapStore.addPin).not.toHaveBeenCalled();
+    expect(mapSession.addToken).toHaveBeenCalledWith({
+      name: "Mira",
+      entityId: "entity-1",
+      imageUrl: "mira.png",
+      x: 41,
+      y: 62,
+    });
+  });
+
+  it("blocks guest entity drops with a guest-safe notification", () => {
+    const {
+      controller,
+      mapStore,
+      mapSession,
+      notificationStore,
+      sessionModeStore,
+    } = createController();
+    sessionModeStore.isGuestMode = true;
+    mapSession.vttEnabled = true;
+
+    controller.onDrop(
+      createDragEvent({
+        dataTransfer: createEntityTransfer(),
+      }),
+    );
+
+    expect(mapStore.addPin).not.toHaveBeenCalled();
+    expect(mapSession.addToken).not.toHaveBeenCalled();
+    expect(mapSession.requestTokenAdd).not.toHaveBeenCalled();
+    expect(notificationStore.notify).toHaveBeenCalledWith(
+      "Guests cannot add map pins or tokens.",
+      "info",
+    );
+  });
+
+  it("opens the upload session when files are dropped", () => {
+    const { controller } = createController();
+    const files = createFileList([
+      new File(["map"], "map.png", { type: "image/png" }),
+    ]);
+
+    controller.onDrop(
+      createDragEvent({
+        dataTransfer: {
+          types: ["Files"],
+          files,
+        },
+      }),
+    );
+
+    expect(controller.showUpload).toBe(true);
+    expect(controller.files?.[0]?.name).toBe("map.png");
+  });
+
+  it("uploads the selected file and clears upload state", async () => {
+    const { controller, mapStore } = createController();
+    const files = createFileList([
+      new File(["map"], "map.png", { type: "image/png" }),
+    ]);
+    controller.files = files;
+    controller.mapName = "World Map";
+    controller.showUpload = true;
+
+    await controller.handleUpload();
+
+    expect(mapStore.uploadMap).toHaveBeenCalledWith(files[0], "World Map");
+    expect(controller.showUpload).toBe(false);
+    expect(controller.mapName).toBe("");
+    expect(controller.files).toBeNull();
+  });
+
+  it("cancels pending upload state when the active vault changes", () => {
+    const { controller } = createController();
+    controller.showUpload = true;
+    controller.mapName = "Stale Map";
+    controller.files = [new File(["map"], "map.png")] as unknown as FileList;
+
+    controller.syncActiveVault("vault-2");
+
+    expect(controller.showUpload).toBe(false);
+    expect(controller.mapName).toBe("");
+    expect(controller.files).toBeNull();
+  });
+});

--- a/apps/web/src/lib/stores/ui/layout-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/layout-ui.svelte.ts
@@ -57,6 +57,7 @@ export class LayoutUIStore {
   focusedEntityId = $state<string | null>(null);
   isMobile = $state(false);
   vttSidebarCollapsed = $state(false);
+  vttChatSidebarCollapsed = $state(false);
   vttEntityListCollapsed = $state(false);
   findNodeCounter = $state(0);
 
@@ -110,6 +111,10 @@ export class LayoutUIStore {
       collapsed,
       String,
     );
+  }
+
+  toggleVttChatSidebar(collapsed: boolean) {
+    this.vttChatSidebarCollapsed = collapsed;
   }
 
   toggleVttEntityList(collapsed: boolean) {

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -1,610 +1,76 @@
 <script lang="ts">
+  import MapHUD from "$lib/components/map/MapHUD.svelte";
+  import MapUploadOverlay from "$lib/components/map/MapUploadOverlay.svelte";
   import MapView from "$lib/components/map/MapView.svelte";
-  import VTTControls from "$lib/components/map/VTTControls.svelte";
+  import MapVTTControlsHUD from "$lib/components/map/MapVTTControlsHUD.svelte";
   import VTTGridColorMenu from "$lib/components/map/VTTGridColorMenu.svelte";
-  import VTTModeToggle from "$lib/components/map/VTTModeToggle.svelte";
   import ShareModal from "$lib/components/ShareModal.svelte";
   import TokenAddDialog from "$lib/components/vtt/TokenAddDialog.svelte";
-  import TokenDetail from "$lib/components/vtt/TokenDetail.svelte";
-  import InitiativePanel from "$lib/components/vtt/InitiativePanel.svelte";
-  import VTTChatSidebar from "$lib/components/vtt/VTTChatSidebar.svelte";
-  import GuestInfoOverlay from "$lib/components/vtt/GuestInfoOverlay.svelte";
+  import MapVTTSidebar from "$lib/components/vtt/MapVTTSidebar.svelte";
   import VTTSharedImageLightbox from "$lib/components/vtt/VTTSharedImageLightbox.svelte";
-  import EntityList from "$lib/components/explorer/EntityList.svelte";
   import {
-    getPrimaryButtonStateClass,
-    getMeasurementToolButtonClass,
-    shouldShowInitiativePanel,
-  } from "$lib/components/map/vtt-ui";
-  import { handleActiveMapSelection } from "$lib/components/map/map-page-actions";
-  import { p2pHost } from "$lib/cloud-bridge/p2p/host-service.svelte";
+    MapPageController,
+    type MapPageControllerDependencies,
+  } from "$lib/stores/map/map-page-controller.svelte";
   import { mapStore } from "$lib/stores/map.svelte";
   import { mapSession } from "$lib/stores/map-session.svelte";
   import { vault } from "$lib/stores/vault.svelte";
-  import type { Entity } from "schema";
   import { notificationStore } from "$lib/stores/ui/notification.svelte";
   import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
+  import type { Entity } from "schema";
 
-  const showInitiativePanel = $derived(
-    shouldShowInitiativePanel(mapSession.vttEnabled, mapSession.mode),
-  );
-  const hasSelectedToken = $derived(Boolean(mapSession.selectedToken));
-  const VTT_ENTITY_TYPES = ["character", "creature", "item"];
-  const vttEntityCount = $derived.by(
-    () =>
-      vault.allEntities.filter((entity) =>
-        VTT_ENTITY_TYPES.includes(entity.type),
-      ).length,
-  );
-
-  let showUpload = $state(false);
-  let showVttShare = $state(false);
-  let isVttChatSidebarCollapsed = $state(false);
-
-  // Chat sidebar offset: 20rem when expanded, 3rem (w-12) when collapsed
-  const chatSidebarOffset = $derived(
-    isVttChatSidebarCollapsed ? "3rem" : "20rem",
-  );
-  let mapName = $state("");
-  let files = $state<FileList | null>(null);
-
-  async function handleUpload() {
-    if (files && files[0]) {
-      try {
-        const result = await mapStore.uploadMap(
-          files[0],
-          mapName || files[0].name,
-        );
-        if (result === undefined) {
-          notificationStore.notify(
-            "Failed to upload map. Please ensure your vault is active.",
-            "error",
-          );
-          return;
-        }
-        showUpload = false;
-        mapName = "";
-        files = null;
-      } catch (err) {
-        console.error("[MapPage] Error during handleUpload:", err);
-        notificationStore.notify(
-          "An unexpected error occurred during upload.",
-          "error",
-        );
-      }
-    }
-  }
-
-  let isDragging = $state(false);
-
-  function isEntityDrag(dataTransfer: DataTransfer | null) {
-    if (!dataTransfer) return false;
-    return Array.from(dataTransfer.types).includes("application/codex-entity");
-  }
-
-  function handleEntityDragStart(event: DragEvent, entityId: string) {
-    if (!event.dataTransfer) return;
-
-    event.dataTransfer.setData("application/codex-entity", entityId);
-    event.dataTransfer.effectAllowed = "copy";
-    mapSession.clearDragPreview();
-  }
-
-  function handleEntityDragEnd() {
-    isDragging = false;
-    mapSession.clearDragPreview();
-  }
-
-  function handleDrop(e: DragEvent) {
-    e.preventDefault();
-    isDragging = false;
-
-    const dt = e.dataTransfer;
-    mapSession.clearDragPreview();
-    if (!dt) return;
-
-    if (isEntityDrag(dt)) {
-      const entityId = dt.getData("application/codex-entity");
-      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-
-      const mapCoords = mapStore.unproject({ x, y });
-      const entity = vault.entities[entityId];
-      const activeMap = mapStore.activeMap;
-
-      if (mapSession.vttEnabled) {
-        if (entity && VTT_ENTITY_TYPES.includes(entity.type) && activeMap) {
-          const tokenInput = {
-            name: entity.title,
-            entityId: entity.id,
-            imageUrl: entity.image,
-            x: mapCoords.x,
-            y: mapCoords.y,
-          };
-          if (sessionModeStore.isGuestMode) {
-            mapSession.requestTokenAdd(tokenInput);
-          } else {
-            mapSession.addToken(tokenInput);
-          }
-        }
-      } else if (entity && activeMap && !sessionModeStore.isGuestMode) {
-        mapStore.addPin(entityId, mapCoords);
-      }
-      return;
-    }
-
-    if (dt.files && dt.files.length > 0) {
-      files = dt.files;
-      // If dropping while modal is closed, open it to confirm name/upload
-      if (!showUpload) {
-        showUpload = true;
-      }
-    }
-  }
-
-  function handleDragOver(e: DragEvent) {
-    e.preventDefault();
-    isDragging = true;
-
-    const dt = e.dataTransfer;
-    if (isEntityDrag(dt)) {
-      dt!.dropEffect = "copy";
-
-      if (mapSession.vttEnabled) {
-        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-        const mapCoords = mapStore.unproject({ x, y });
-        const entityId =
-          dt?.getData("application/codex-entity") ||
-          mapSession.dragPreview?.entityId;
-
-        if (!entityId) return;
-
-        mapSession.setDragPreview({
-          entityId,
-          x: mapCoords.x,
-          y: mapCoords.y,
-        });
-      }
-    }
-  }
-
-  function handleDragLeave(e: DragEvent) {
-    e.preventDefault();
-
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const hasLeftTarget =
-      e.clientX < rect.left ||
-      e.clientX > rect.right ||
-      e.clientY < rect.top ||
-      e.clientY > rect.bottom;
-
-    if (!hasLeftTarget) {
-      return;
-    }
-
-    isDragging = false;
-    mapSession.clearDragPreview();
-  }
+  const controller = new MapPageController({
+    mapStore,
+    mapSession,
+    vault,
+    notificationStore,
+    sessionModeStore,
+    layoutUIStore,
+  } satisfies MapPageControllerDependencies);
 
   function handleEntitySelect(entity: Entity) {
     modalUIStore.openZenMode(entity.id);
   }
+
+  $effect(() => {
+    controller.syncActiveVault(vault.activeVaultId);
+  });
 </script>
 
 <div class="flex-1 flex flex-col bg-theme-bg overflow-hidden relative">
   {#if mapStore.activeMap}
     <MapView
-      onMapDragOver={handleDragOver}
-      onMapDragLeave={handleDragLeave}
-      onMapDrop={handleDrop}
+      onMapDragOver={(event) => controller.onDragOver(event)}
+      onMapDragLeave={(event) => controller.onDragLeave(event)}
+      onMapDrop={(event) => controller.onDrop(event)}
     >
       {#if mapSession.vttEnabled}
-        <VTTChatSidebar bind:collapsed={isVttChatSidebarCollapsed} />
-
-        <aside
-          class="absolute top-0 right-0 bottom-0 z-[30] flex overflow-hidden border-l border-theme-primary/20 bg-theme-surface/95 shadow-[0_0_30px_rgba(0,0,0,0.25)] backdrop-blur transition-all duration-200 pointer-events-auto {layoutUIStore.vttSidebarCollapsed
-            ? 'w-12'
-            : 'w-[22rem] max-w-[calc(100vw-3rem)]'}"
-          aria-label="VTT Sidebar"
-          onwheel={(e) => e.stopPropagation()}
-        >
-          {#if layoutUIStore.vttSidebarCollapsed}
-            <div
-              class="flex h-full w-full flex-col items-center justify-between p-2"
-              style="background-image: var(--bg-texture-overlay)"
-            >
-              <button
-                class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
-                onclick={() => layoutUIStore.toggleVttSidebar(false)}
-                aria-label="Expand VTT Sidebar"
-                aria-expanded="false"
-                type="button"
-              >
-                <span class="icon-[lucide--panel-right-open] w-4 h-4"></span>
-              </button>
-
-              <div class="flex flex-1 items-center justify-center">
-                <span
-                  class="rotate-180 text-[10px] font-black uppercase tracking-[0.4em] text-theme-muted [writing-mode:vertical-rl]"
-                >
-                  VTT
-                </span>
-              </div>
-            </div>
-          {:else}
-            <div
-              class="flex h-full min-h-0 w-full flex-col relative"
-              style="background-image: var(--bg-texture-overlay)"
-            >
-              <!-- Decorative Corners -->
-              <div
-                class="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-theme-primary/30 rounded-tl pointer-events-none hidden md:block"
-              ></div>
-              <div
-                class="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-theme-primary/30 rounded-tr pointer-events-none hidden md:block"
-              ></div>
-              <div
-                class="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-theme-primary/30 rounded-bl pointer-events-none hidden md:block"
-              ></div>
-              <div
-                class="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-theme-primary/30 rounded-br pointer-events-none hidden md:block"
-              ></div>
-
-              <div
-                class="flex items-center justify-between gap-3 border-b border-theme-primary/20 px-3 py-3"
-              >
-                <div>
-                  <div
-                    class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
-                  >
-                    VTT Sidebar
-                  </div>
-                </div>
-
-                <button
-                  class="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/70 text-theme-muted transition-colors hover:border-theme-primary hover:text-theme-text hover:bg-theme-primary/10"
-                  onclick={() => layoutUIStore.toggleVttSidebar(true)}
-                  aria-label="Collapse VTT Sidebar"
-                  aria-expanded="true"
-                  type="button"
-                >
-                  <span class="icon-[lucide--panel-right-close] w-4 h-4"></span>
-                </button>
-              </div>
-
-              <div class="border-b border-theme-primary/20 px-3 py-3">
-                <VTTControls />
-              </div>
-
-              <div
-                class="flex-1 min-h-0 overflow-y-auto custom-scrollbar space-y-3 p-3 pr-2"
-              >
-                {#if showInitiativePanel}
-                  <InitiativePanel />
-                {/if}
-
-                {#if !sessionModeStore.isGuestMode}
-                  <section
-                    class="rounded-xl border border-theme-primary/20 bg-theme-bg/50"
-                    data-testid="vtt-entity-list-section"
-                  >
-                    <button
-                      type="button"
-                      class="flex w-full items-center justify-between gap-3 px-3 py-3 text-left"
-                      onclick={() =>
-                        layoutUIStore.toggleVttEntityList(
-                          !layoutUIStore.vttEntityListCollapsed,
-                        )}
-                      aria-expanded={!layoutUIStore.vttEntityListCollapsed}
-                      aria-controls="vtt-entity-list"
-                    >
-                      <div>
-                        <div
-                          class="text-[9px] font-black uppercase tracking-[0.35em] text-theme-primary/70 font-header"
-                        >
-                          Vault Entities
-                        </div>
-                        <div class="text-xs text-theme-muted">
-                          Drag characters, creatures, and items onto the map.
-                        </div>
-                      </div>
-                      <div class="flex items-center gap-2">
-                        <span
-                          class="rounded-full border border-theme-border px-2 py-1 text-[9px] font-bold uppercase tracking-[0.2em] text-theme-muted"
-                        >
-                          {vttEntityCount}
-                        </span>
-                        <span
-                          class="icon-[lucide--chevron-down] h-4 w-4 text-theme-muted transition-transform {layoutUIStore.vttEntityListCollapsed
-                            ? '-rotate-90'
-                            : ''}"
-                        ></span>
-                      </div>
-                    </button>
-
-                    {#if !layoutUIStore.vttEntityListCollapsed}
-                      <div
-                        id="vtt-entity-list"
-                        class="border-t border-theme-primary/20 flex flex-col max-h-[50vh]"
-                        role="presentation"
-                        onmousedown={(event) => event.stopPropagation()}
-                      >
-                        <EntityList
-                          allowedTypes={VTT_ENTITY_TYPES}
-                          onSelect={handleEntitySelect}
-                          onDragStart={handleEntityDragStart}
-                          onDragEnd={handleEntityDragEnd}
-                          onOpenZen={(entity) =>
-                            modalUIStore.openZenMode(entity.id)}
-                        />
-                      </div>
-                    {/if}
-                  </section>
-                {/if}
-
-                <TokenDetail />
-
-                {#if !showInitiativePanel && !hasSelectedToken}
-                  <div
-                    class="rounded-xl border border-dashed border-theme-primary/20 bg-theme-bg/50 p-4 text-sm text-theme-muted"
-                  >
-                    Select a token to view its details.
-                  </div>
-                {/if}
-              </div>
-
-              {#if !sessionModeStore.isGuestMode}
-                <div
-                  class="relative z-20 border-t border-theme-primary/20 p-3 flex justify-end pointer-events-auto"
-                  role="presentation"
-                  onmousedown={(e) => e.stopPropagation()}
-                >
-                  <button
-                    class="w-8 h-8 flex flex-shrink-0 items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-muted transition hover:text-theme-primary"
-                    onclick={() => {
-                      console.log("[MapPage] VTT share requested");
-                      showVttShare = true;
-                      console.log("[MapPage] showVttShare set", showVttShare);
-                    }}
-                    type="button"
-                    title="Share Campaign"
-                    aria-label="Share Campaign"
-                  >
-                    <span class="icon-[lucide--share-2] w-4 h-4"></span>
-                  </button>
-                </div>
-              {/if}
-            </div>
-          {/if}
-        </aside>
+        <MapVTTSidebar
+          isVttChatSidebarCollapsed={layoutUIStore.vttChatSidebarCollapsed}
+          showInitiativePanel={controller.showInitiativePanel}
+          hasSelectedToken={controller.hasSelectedToken}
+          vttEntityCount={controller.vttEntityCount}
+          onVttChatSidebarCollapsed={(collapsed) =>
+            controller.setVttChatSidebarCollapsed(collapsed)}
+          onEntitySelect={handleEntitySelect}
+          onEntityDragStart={(event, entityId) =>
+            controller.handleEntityDragStart(event, entityId)}
+          onEntityDragEnd={() => controller.handleEntityDragEnd()}
+          onShare={() => (controller.showVttShare = true)}
+        />
       {/if}
 
-      <!-- HUD Overlay -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="absolute z-10 flex flex-col items-start gap-2"
-        style="top: 1rem; left: calc({chatSidebarOffset} + 1rem);"
-        role="presentation"
-        onmousedown={(e) => e.stopPropagation()}
-      >
-        <div class="flex gap-2">
-          {#if mapStore.canGoBack}
-            <button
-              class="px-3 py-1.5 bg-theme-surface border border-theme-border text-theme-text text-xs font-bold rounded-lg hover:border-theme-primary transition-colors flex items-center gap-2"
-              onclick={() => mapStore.goBack()}
-            >
-              <span class="icon-[lucide--arrow-left] w-3 h-3"></span>
-              BACK
-            </button>
-          {/if}
-
-          {#if sessionModeStore.isGuestMode}
-            <!-- Guests only see the current shared map name -->
-            {#if mapStore.activeMap}
-              <div
-                class="px-3 py-1.5 bg-theme-surface border border-theme-border text-theme-text rounded-lg text-xs font-bold"
-              >
-                {mapStore.activeMap.isWorldMap ? "★ " : ""}{mapStore.activeMap
-                  .name}
-              </div>
-            {/if}
-          {:else}
-            <select
-              class="bg-theme-surface border border-theme-border text-theme-text px-3 py-1.5 rounded-lg text-xs"
-              value={mapStore.activeMapId}
-              onchange={(e) =>
-                handleActiveMapSelection({
-                  mapId: e.currentTarget.value,
-                  selectMap: (mapId) => mapStore.selectMap(mapId),
-                  isHosting: p2pHost.isHosting,
-                  broadcastActiveMapSync: () =>
-                    p2pHost.broadcastActiveMapSync(),
-                })}
-            >
-              {#each Object.values(vault.maps) as map (map.id)}
-                <option value={map.id}>
-                  {map.isWorldMap ? "★ " : ""}{map.name}
-                </option>
-              {/each}
-            </select>
-
-            {#if mapStore.activeMap && !mapStore.activeMap.isWorldMap}
-              <button
-                class="px-3 py-1.5 bg-theme-surface border border-theme-border text-theme-muted text-[10px] font-bold rounded-lg hover:text-theme-primary hover:border-theme-primary transition-colors flex items-center gap-2"
-                onclick={() => mapStore.setAsWorldMap(mapStore.activeMapId!)}
-                title="Set as World Map"
-              >
-                <span class="icon-[lucide--star] w-3 h-3"></span>
-                SET WORLD
-              </button>
-            {:else if mapStore.activeMap?.isWorldMap}
-              <div
-                class="px-3 py-1.5 bg-theme-primary/10 border border-theme-primary/30 text-theme-primary text-[10px] font-bold rounded-lg flex items-center gap-2"
-              >
-                <span class="icon-[lucide--star] w-3 h-3 fill-theme-primary"
-                ></span>
-                WORLD MAP
-              </div>
-            {/if}
-
-            <button
-              class="px-3 py-1.5 bg-theme-surface border border-theme-border text-red-500/70 text-[10px] font-bold rounded-lg hover:text-red-400 hover:border-red-400 transition-colors flex items-center gap-2"
-              onclick={async () => {
-                if (
-                  await notificationStore.confirm({
-                    title: "Clear Map",
-                    message:
-                      "Are you sure you want to delete this map? This action cannot be undone.",
-                    isDangerous: true,
-                  })
-                ) {
-                  await vault.deleteMap(mapStore.activeMapId!);
-                }
-              }}
-              title="Delete Map"
-            >
-              <span class="icon-[lucide--trash-2] w-3 h-3"></span>
-              DELETE
-            </button>
-
-            <button
-              class="px-3 py-1.5 bg-theme-primary text-theme-bg text-xs font-bold rounded-lg uppercase font-header tracking-wider"
-              onclick={() => (showUpload = true)}
-            >
-              Add Map
-            </button>
-          {/if}
-        </div>
-
-        <GuestInfoOverlay />
-      </div>
-
-      <!-- Measurement tool button (lower left) -->
-      {#if !sessionModeStore.isGuestMode && mapSession.vttEnabled}
-        <div
-          class="absolute z-20 pointer-events-auto"
-          style="bottom: 1rem; left: calc({chatSidebarOffset} + 1rem);"
-        >
-          <button
-            class={getMeasurementToolButtonClass(mapSession.measurement.active)}
-            onclick={(e) => {
-              e.stopPropagation();
-              mapSession.setMeasurementActive(!mapSession.measurement.active);
-            }}
-            aria-pressed={mapSession.measurement.active}
-            title={mapSession.measurement.active
-              ? "Disable measurement tool"
-              : "Measure: click on map to set start point, click again to set end point"}
-            aria-label="Toggle measurement tool"
-          >
-            <span
-              class={`relative z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border transition-all duration-300 ${
-                mapSession.measurement.active
-                  ? "border-theme-bg/20 bg-theme-bg shadow-md translate-x-[calc(1.075rem+2px)]"
-                  : "border-theme-border bg-theme-bg/90 shadow-sm translate-x-0 group-hover:border-theme-primary/40"
-              }`}
-            >
-              <span
-                class={`icon-[lucide--ruler] w-4 h-4 transition-colors ${
-                  mapSession.measurement.active
-                    ? "text-theme-primary"
-                    : "text-theme-muted group-hover:text-theme-primary"
-                }`}
-              ></span>
-            </span>
-
-            {#if mapSession.measurement.active}
-              <span
-                class="pointer-events-none absolute inset-0 rounded-full bg-[linear-gradient(135deg,rgba(255,255,255,0.18),transparent_48%)]"
-              ></span>
-            {/if}
-          </button>
-        </div>
-      {/if}
-
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      {#if !sessionModeStore.isGuestMode}
-        <div
-          class="absolute inset-x-4 bottom-4 z-10 flex justify-center"
-          role="presentation"
-          onmousedown={(e) => e.stopPropagation()}
-        >
-          <div
-            class="flex gap-1.5 bg-theme-surface/80 backdrop-blur border border-theme-border p-1.5 rounded-lg shadow-lg items-center"
-          >
-            <button
-              class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(sessionModeStore.sharedMode)}`}
-              onclick={() =>
-                (sessionModeStore.sharedMode = !sessionModeStore.sharedMode)}
-              title={sessionModeStore.sharedMode
-                ? "Exit Shared Mode (Admin View)"
-                : "Enter Shared Mode (Player Preview)"}
-              data-testid="shared-mode-toggle"
-              aria-pressed={sessionModeStore.sharedMode}
-              aria-label="Toggle player view mode"
-            >
-              {sessionModeStore.sharedMode ? "EXIT PLAYER VIEW" : "PLAYER VIEW"}
-            </button>
-
-            {#if mapStore.isGMMode}
-              <button
-                class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(mapStore.showFog)}`}
-                onclick={() => (mapStore.showFog = !mapStore.showFog)}
-              >
-                FOG: {mapStore.showFog ? "ON" : "OFF"}
-              </button>
-
-              <button
-                class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(mapStore.showGrid)}`}
-                onclick={() => (mapStore.showGrid = !mapStore.showGrid)}
-                oncontextmenu={(e) => {
-                  e.preventDefault();
-                  mapSession.showGridSettings = true;
-                }}
-                title="Toggle Grid (Right-click for settings)"
-              >
-                GRID: {mapStore.showGrid ? "ON" : "OFF"}
-              </button>
-
-              <VTTModeToggle />
-
-              <div class="flex items-center gap-2 px-2">
-                <span
-                  class="text-[9px] text-theme-muted font-bold tracking-tighter uppercase"
-                  >Brush Size</span
-                >
-                <input
-                  type="range"
-                  min="10"
-                  max="500"
-                  bind:value={mapStore.brushRadius}
-                  class="w-24 accent-theme-primary h-1"
-                />
-                <span class="text-[9px] text-theme-primary font-mono w-6"
-                  >{mapStore.brushRadius}px</span
-                >
-              </div>
-
-              <div
-                class="flex flex-col justify-center px-2 text-[10px] text-theme-muted/90 font-semibold italic leading-tight"
-              >
-                <span>Alt+Drag to Reveal</span>
-                <span>Alt+Shift+Drag to Hide</span>
-              </div>
-            {/if}
-          </div>
-        </div>
-      {/if}
-
+      <MapHUD
+        chatSidebarOffset={controller.chatSidebarOffset}
+        onShowUpload={() => (controller.showUpload = true)}
+      />
+      <MapVTTControlsHUD chatSidebarOffset={controller.chatSidebarOffset} />
       <TokenAddDialog />
     </MapView>
-    {#if showVttShare}
-      <ShareModal close={() => (showVttShare = false)} />
+    {#if controller.showVttShare}
+      <ShareModal close={() => (controller.showVttShare = false)} />
     {/if}
     {#if sessionModeStore.isGuestMode}
       <VTTSharedImageLightbox
@@ -612,9 +78,9 @@
         onClose={() => mapSession.clearSharedTokenImage()}
       />
     {/if}
+
     <VTTGridColorMenu />
   {:else if sessionModeStore.isGuestMode}
-    <!-- Guest view: no active map -->
     <div
       class="flex-1 flex flex-col items-center justify-center p-8 text-center"
     >
@@ -633,15 +99,14 @@
       </p>
     </div>
   {:else}
-    <!-- Host view: no active map, can upload -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
-      class="flex-1 flex flex-col items-center justify-center p-8 text-center transition-colors duration-200 {isDragging
+      class="flex-1 flex flex-col items-center justify-center p-8 text-center transition-colors duration-200 {controller.isDragging
         ? 'bg-theme-primary/10'
         : ''}"
-      ondragover={handleDragOver}
-      ondragleave={handleDragLeave}
-      ondrop={handleDrop}
+      ondragover={(event) => controller.onDragOver(event)}
+      ondragleave={(event) => controller.onDragLeave(event)}
+      ondrop={(event) => controller.onDrop(event)}
     >
       <div
         class="w-24 h-24 mb-8 rounded-full bg-theme-primary/10 flex items-center justify-center"
@@ -659,85 +124,25 @@
         Drag and drop a world image or tactical layout here, or click to upload
         and start mapping your lore spatially.
       </p>
-
       <button
         class="px-12 py-4 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:shadow-[0_0_30px_var(--color-accent-primary)] transition-all active:scale-95"
-        onclick={() => (showUpload = true)}
+        onclick={() => (controller.showUpload = true)}
       >
         Upload World Image
       </button>
     </div>
   {/if}
 
-  {#if showUpload}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="absolute inset-0 z-50 bg-theme-bg/80 backdrop-blur-sm flex items-center justify-center p-6"
-      ondragover={handleDragOver}
-      ondragleave={handleDragLeave}
-      ondrop={handleDrop}
-    >
-      <div
-        class="w-full max-w-md bg-theme-surface border rounded-xl p-8 shadow-2xl transition-colors duration-200 {isDragging
-          ? 'border-theme-primary'
-          : 'border-theme-border'}"
-      >
-        <h3
-          class="text-xl font-bold text-theme-text mb-6 uppercase font-header tracking-wider"
-        >
-          Upload New Map
-        </h3>
-
-        <div class="space-y-6">
-          <div class="space-y-2">
-            <label
-              class="text-[10px] font-mono text-theme-muted uppercase tracking-widest"
-              for="map-name"
-            >
-              Map Name
-            </label>
-            <input
-              id="map-name"
-              type="text"
-              bind:value={mapName}
-              placeholder="World Map, City Plan, etc."
-              class="w-full bg-theme-surface/50 border border-theme-border text-theme-text px-4 py-3 rounded-lg focus:border-theme-primary outline-none transition-colors"
-            />
-          </div>
-
-          <div class="space-y-2">
-            <label
-              class="text-[10px] font-mono text-theme-muted uppercase tracking-widest"
-              for="map-file"
-            >
-              Image File
-            </label>
-            <input
-              id="map-file"
-              type="file"
-              accept="image/*"
-              bind:files
-              class="w-full text-xs text-theme-muted file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-xs file:font-semibold file:bg-theme-primary/10 file:text-theme-primary hover:file:bg-theme-primary/20"
-            />
-          </div>
-
-          <div class="flex gap-4 pt-4">
-            <button
-              class="flex-1 px-6 py-3 border border-theme-border text-theme-muted rounded-lg hover:bg-theme-surface transition-colors uppercase text-[10px] font-bold font-header tracking-widest"
-              onclick={() => (showUpload = false)}
-            >
-              Cancel
-            </button>
-            <button
-              class="flex-1 px-6 py-3 bg-theme-primary text-theme-bg rounded-lg font-bold uppercase font-header text-[10px] tracking-widest"
-              onclick={handleUpload}
-              disabled={!files}
-            >
-              Upload
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+  {#if controller.showUpload}
+    <MapUploadOverlay
+      bind:mapName={controller.mapName}
+      bind:files={controller.files}
+      isDragging={controller.isDragging}
+      onDragOver={(event) => controller.onDragOver(event)}
+      onDragLeave={(event) => controller.onDragLeave(event)}
+      onDrop={(event) => controller.onDrop(event)}
+      onUpload={() => controller.handleUpload()}
+      onCancel={() => controller.cancelUpload()}
+    />
   {/if}
 </div>

--- a/docs/adr/012-javascript-runtime-and-toolchain-strategy.md
+++ b/docs/adr/012-javascript-runtime-and-toolchain-strategy.md
@@ -1,0 +1,192 @@
+# ADR 012: JavaScript Runtime and Toolchain Strategy
+
+## Context and Problem Statement
+
+Codex-Cryptica is currently a TypeScript monorepo using:
+
+- `pnpm` workspaces for package installation and linking.
+- `turbo` for root-level orchestration of build, lint, type-check, and test tasks.
+- SvelteKit, Vite, Vitest, Playwright, Tailwind, Wrangler, and several browser-oriented npm dependencies in `apps/web`.
+- Multiple local TypeScript packages under `packages/*`, many of which are pure or mostly pure library code.
+
+During Spec 103 work, the root `pnpm run lint` and pre-push hook could not run in the local Termux Android arm64 environment because Turborepo does not support that platform. Direct web-level checks still worked:
+
+- `pnpm --filter web run lint`
+- `pnpm --filter web run lint:types`
+- focused `vitest` runs with constrained worker settings
+
+This raised the question of whether the repository should transition from Node/pnpm/Turbo to Deno, or to another JavaScript runtime/toolchain strategy.
+
+## Decision Drivers
+
+- **Frontend Compatibility:** The SvelteKit/Vite app should remain boring and well-supported.
+- **Monorepo Reliability:** Workspace package linking and local package builds must remain predictable.
+- **Cross-Platform Developer Experience:** Tooling should work on common development machines and degrade gracefully on constrained environments like Termux.
+- **CI Stability:** The chosen toolchain must be easy to reproduce in CI.
+- **Migration Risk:** Runtime changes should not consume engineering time unless they remove real complexity.
+- **Security and Local-First Fit:** Tooling that improves explicit permissions and reduces unnecessary dependency execution is valuable, but not at the cost of frontend instability.
+
+## Considered Options
+
+### Option 1: Keep Node + pnpm + Turbo as the Primary Toolchain
+
+Keep the current stack as the canonical development and CI toolchain.
+
+**Pros**
+
+- Best-aligned with SvelteKit, Vite, Vitest, Playwright, Wrangler, and the current npm dependency graph.
+- Lowest migration cost.
+- CI and most developer machines can continue using the established scripts.
+- Preserves `pnpm` workspace behavior already used across `apps/*` and `packages/*`.
+
+**Cons**
+
+- Turborepo does not support every local platform, including the Termux Android arm64 environment used during this work.
+- Root-level scripts can be unavailable locally even when package-level scripts work.
+- Does not reduce reliance on `node_modules` or npm lifecycle tooling.
+
+### Option 2: Full Repository Transition to Deno
+
+Move runtime, dependency management, scripts, linting, formatting, and tests to Deno wherever possible.
+
+**Pros**
+
+- Deno has first-party TypeScript execution, linting, formatting, testing, permissions, and workspace support.
+- Deno supports `package.json` compatibility and npm packages.
+- Deno workspaces can include Deno-first, hybrid, and Node-first packages.
+
+**Cons**
+
+- The web app depends on SvelteKit/Vite and npm-heavy frontend tooling. Deno's docs still call out frameworks like Svelte as cases where local `node_modules` may be needed.
+- Some dependencies may require Node-API/native-addon behavior, postinstall scripts, or explicit permissions.
+- A full migration would be mostly compatibility work rather than product work.
+- It would introduce a second axis of risk across deployment, tests, and contributor onboarding.
+
+### Option 3: Hybrid Deno for Pure Packages and Scripts
+
+Keep Node/pnpm as canonical for the web app and workspace install, but allow Deno in tightly scoped places:
+
+- pure TypeScript utility packages,
+- standalone repository scripts,
+- codegen or validation tasks that do not depend on SvelteKit/Vite/Playwright/Wrangler,
+- experimental package-level checks.
+
+**Pros**
+
+- Captures Deno's strengths without putting the web app on the migration path.
+- Lets the repo prove Deno value with real tasks before broad adoption.
+- Can improve script portability and explicit permissions for isolated tasks.
+- Deno can participate in hybrid workspaces, reducing the need for all-or-nothing migration.
+
+**Cons**
+
+- Adds another tool developers may need installed.
+- Requires clear boundaries so the repo does not drift into two competing toolchains.
+- Still does not solve all root orchestration problems unless those tasks are deliberately mirrored or replaced.
+
+### Option 4: Replace Turbo with pnpm-Only Orchestration
+
+Keep Node and pnpm, but remove or reduce root reliance on Turbo by using `pnpm --recursive`, `pnpm --filter`, and package-level scripts.
+
+**Pros**
+
+- Directly addresses the Termux/Turbo platform issue.
+- Minimal runtime migration risk.
+- Keeps the current package manager and dependency model.
+- Easier to reason about than adding Deno or Bun.
+
+**Cons**
+
+- Loses Turbo caching and task graph behavior unless replaced elsewhere.
+- May make CI slower.
+- Requires maintaining root scripts carefully so package ordering remains correct.
+
+### Option 5: Move to Nx
+
+Replace Turbo with Nx for task orchestration and caching.
+
+**Pros**
+
+- Mature monorepo task graph, caching, affected-project workflows, and inferred task support.
+- Can improve large-repo ergonomics if Codex-Cryptica keeps growing.
+
+**Cons**
+
+- Larger conceptual surface than the repo currently needs.
+- Does not materially improve the SvelteKit runtime story.
+- Migration cost is higher than pnpm-only fallback scripts.
+- Platform support and local binary availability still need validation on Termux before it can be called a fix.
+
+### Option 6: Move to Bun
+
+Adopt Bun as runtime/package manager/test runner, either fully or selectively.
+
+**Pros**
+
+- Fast package manager and runtime.
+- Supports workspaces and filtered workspace script execution.
+- Closer to Node/npm compatibility goals than a pure Deno migration.
+
+**Cons**
+
+- Still a major toolchain migration.
+- Test runner and edge cases would need validation against SvelteKit/Vite/Vitest/Playwright/Wrangler.
+- Does not offer the same explicit-permission model that makes Deno attractive.
+- Adds less strategic value than solving the narrower Turbo platform issue directly.
+
+## Decision Outcome
+
+Chosen option: **Option 1 as the canonical toolchain, with Option 3 allowed as a controlled pilot and Option 4 as the preferred mitigation for local Turbo incompatibility.**
+
+Codex-Cryptica should **not** transition the full repository to Deno at this time.
+
+The canonical stack remains:
+
+- Node runtime for the web app and build tooling.
+- `pnpm` for dependency management and workspaces.
+- Turbo for CI/root orchestration where supported.
+- Package-level `pnpm --filter` commands for local environments where Turbo is unavailable.
+
+Deno may be introduced only under a narrow pilot rule:
+
+1. The target must be a pure TypeScript package or standalone script.
+2. It must not be required for `apps/web` build, preview, deployment, Playwright, Wrangler, or SvelteKit/Vite tasks.
+3. It must have explicit commands documented in the package or ADR follow-up.
+4. It must prove at least one concrete benefit: simpler script execution, stronger permission boundaries, less install friction, or better local portability.
+5. It must not introduce duplicate formatting/linting rules that conflict with the existing repo style.
+
+## Consequences
+
+### Positive
+
+- Avoids a high-risk runtime migration while the web app is heavily coupled to Node-oriented frontend tooling.
+- Keeps CI and deployment aligned with the current SvelteKit/Vite/Wrangler ecosystem.
+- Gives Deno a legitimate evaluation path without committing the whole repo.
+- Separates the actual local blocker, Turbo platform support, from the broader runtime decision.
+
+### Negative
+
+- Root scripts may still fail on unsupported Turbo platforms unless package-level fallback commands are documented and maintained.
+- Deno benefits remain limited until a concrete pilot is selected.
+- The repo keeps a conventional `node_modules` workflow for now.
+
+## Follow-Up Work
+
+1. Add documented fallback commands for local environments where Turbo is unavailable:
+   - `pnpm --filter web run lint`
+   - `pnpm --filter web run lint:types`
+   - `pnpm --filter web exec vitest run --maxWorkers=1 --no-fileParallelism`
+2. Identify one low-risk Deno pilot candidate, preferably a pure package or standalone validation script.
+3. Before adopting Deno in any package, run:
+   - `deno check`
+   - `deno test`
+   - `deno lint`
+4. Reconsider a broader transition only if the pilot reduces maintenance cost without increasing frontend/tooling risk.
+
+## References
+
+- Deno workspaces and monorepos: https://docs.deno.com/runtime/fundamentals/workspaces/
+- Deno Node and npm compatibility: https://docs.deno.com/runtime/manual/node/
+- Deno configuration and `package.json` support: https://docs.deno.com/runtime/fundamentals/configuration/
+- Bun workspaces: https://bun.sh/docs/install/workspaces
+- Nx inferred tasks: https://nx.dev/docs/concepts/inferred-tasks

--- a/docs/reports/MAP_PAGE_ANALYSIS.md
+++ b/docs/reports/MAP_PAGE_ANALYSIS.md
@@ -1,0 +1,78 @@
+# Map Page Analysis & Decomposition Proposal
+
+**Date**: 2026-05-20
+**Target**: `apps/web/src/routes/(app)/map/+page.svelte`
+**Original Metrics**: 738 lines, 15+ reactive states, 4 distinct UI surfaces.
+**Implemented Metrics**: 148-line route composer, route-specific controller, 4 extracted UI surfaces.
+
+## 1. Responsibility Audit (The "God" Surface)
+
+The Map route coordinator currently serves as a monolithic junction for:
+
+- **Spatial Logic**: Manages coordinate projection (`unproject`) and bridges it to entity creation.
+- **Drag & Drop Engine**: Contains ~100 lines of complex DnD logic handling both internal entities and external file uploads.
+- **VTT Orchestration**: Manages the branching logic between "Pin" mode (Standard) and "Token" mode (VTT).
+- **Layout Management**: Hardcoded CSS offset calculations and visibility toggles for the VTT chat sidebar and toolbars.
+- **Form Management**: Handles map upload initialization, file list tracking, and validation.
+- **State Logic**: Bridges multiple global stores (`mapStore`, `mapSession`, `vault`, `notificationStore`, `sessionModeStore`, `modalUIStore`, `layoutUIStore`).
+
+## 2. Critical Friction Points
+
+### A. Mixed Logic Branches
+
+The `handleDrop` and `handleDragOver` functions are littered with repetitive `if (mapSession.vttEnabled)` and `if (sessionModeStore.isGuestMode)` checks. This makes the core interaction logic fragile and hard to test.
+
+### B. Visual Noise
+
+The high-level structure of the map page is obscured by:
+
+- 140+ lines of nested VTT sidebar markup.
+- Duplicate "Empty State" logic for Hosts vs. Guests.
+- Inline form styling for the "Upload New Map" overlay.
+
+### C. Leaky Abstractions
+
+Derived states like `chatSidebarOffset` ("3rem" vs "20rem") are hardcoded in the view, forcing the UI to manage low-level layout implementation details that should be encapsulated.
+
+## 3. Proposed Decomposition Strategy
+
+### Phase 1: `MapPageController` (Manager)
+
+Extract all non-UI orchestration into a dedicated manager at `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`.
+
+- **Responsibilities**:
+  - Unified `onDrop`/`onDragOver` handlers.
+  - Upload session state (`showUpload`, `files`, `mapName`).
+  - DnD state coordination (`isDragging`).
+  - Coordinate unprojection.
+  - Guest-mode blocking for GM-only map mutations.
+  - Upload-session reset when the active vault changes.
+
+### Phase 2: Component Extraction
+
+Break the markup into focused, reusable units:
+
+1. **`MapHUD.svelte`**: The top-level toolbar (Map selection, "Add Map" button, deletion logic).
+2. **`MapVTTSidebar.svelte`**: The complex right-hand sidebar including Token list and Initiative.
+3. **`MapVTTControlsHUD.svelte`**: The bottom-center floating bar for GM tools (Fog, Grid, Brush).
+4. **`MapUploadOverlay.svelte`**: The absolute-positioned upload form and its local validation.
+
+The route keeps the two small empty states inline because their markup is simple and route-specific; extracting them would add indirection without reducing meaningful complexity.
+
+### Phase 3: Layout Ownership
+
+`layoutUIStore` owns VTT sidebar and VTT chat sidebar collapsed state. `MapPageController` consumes that store to derive `chatSidebarOffset`, keeping hardcoded offset decisions out of the route.
+
+## 4. Target Metrics
+
+| Metric         | Current        | Post-Refactor                   |
+| -------------- | -------------- | ------------------------------- |
+| Line Count     | 738            | 148                             |
+| Logic/UI Ratio | 40/60          | 10/90                           |
+| Testability    | Low (E2E only) | High (Unit testable Controller) |
+
+## 5. Next Steps
+
+1. Keep controller behavior covered in `apps/web/src/lib/stores/map/map-page-controller.test.ts`.
+2. Run `pnpm --filter web run lint`, `pnpm --filter web run lint:types`, and relevant map/VTT Vitest suites before merging.
+3. Watch for Svelte state-closure warnings in the route, controller, and extracted components.

--- a/specs/103-map-page-decomposition/data-model.md
+++ b/specs/103-map-page-decomposition/data-model.md
@@ -1,4 +1,4 @@
-# Data Model: Map Route Decompositon
+# Data Model: Map Route Decomposition
 
 ## MapPageController (Reactive State)
 
@@ -10,10 +10,12 @@ Manages the transient orchestration state for the Map route.
   - `showVttShare: boolean` - Visibility of the `ShareModal`.
   - `mapName: string` - User-provided name for the new map upload.
   - `files: FileList | null` - Pending files for upload.
-  - `isVttChatSidebarCollapsed: boolean` - Controls the VTT chat sidebar expansion.
+
+- **Layout State (owned by `layoutUIStore`)**:
+  - `vttChatSidebarCollapsed: boolean` - Controls VTT chat sidebar expansion and persists outside the route controller.
 
 - **Derived State (`$derived`)**:
-  - `chatSidebarOffset: string` - Calculated based on `isVttChatSidebarCollapsed` ("3rem" or "20rem").
+  - `chatSidebarOffset: string` - Calculated from `layoutUIStore.vttChatSidebarCollapsed` ("3rem" or "20rem").
   - `vttEntityCount: number` - Filtered count of VTT-compatible entities in the vault.
   - `showInitiativePanel: boolean` - Derived from `mapSession` mode/enabled flags.
 

--- a/specs/103-map-page-decomposition/data-model.md
+++ b/specs/103-map-page-decomposition/data-model.md
@@ -1,0 +1,25 @@
+# Data Model: Map Route Decompositon
+
+## MapPageController (Reactive State)
+
+Manages the transient orchestration state for the Map route.
+
+- **Reactive State (`$state`)**:
+  - `isDragging: boolean` - Tracks if a drag operation is active over the map.
+  - `showUpload: boolean` - Visibility of the `MapUploadOverlay`.
+  - `showVttShare: boolean` - Visibility of the `ShareModal`.
+  - `mapName: string` - User-provided name for the new map upload.
+  - `files: FileList | null` - Pending files for upload.
+  - `isVttChatSidebarCollapsed: boolean` - Controls the VTT chat sidebar expansion.
+
+- **Derived State (`$derived`)**:
+  - `chatSidebarOffset: string` - Calculated based on `isVttChatSidebarCollapsed` ("3rem" or "20rem").
+  - `vttEntityCount: number` - Filtered count of VTT-compatible entities in the vault.
+  - `showInitiativePanel: boolean` - Derived from `mapSession` mode/enabled flags.
+
+- **Methods**:
+  - `onDrop(event: DragEvent)` - Unified drop handler for entities and files.
+  - `onDragOver(event: DragEvent)` - Unified drag-over handler.
+  - `onDragLeave(event: DragEvent)` - Handles resetting drag state.
+  - `handleUpload()` - Orchestrates the `mapStore.uploadMap` workflow.
+  - `handleEntityDragStart(event, entityId)` - Sets up the data transfer for entity dragging.

--- a/specs/103-map-page-decomposition/plan.md
+++ b/specs/103-map-page-decomposition/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Map Page Decomposition
+
+**Branch**: `103-map-page-decomposition` | **Date**: 2026-05-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/103-map-page-decomposition/spec.md`
+
+## Summary
+
+Decompose the monolithic `+page.svelte` (738 lines) in the Map route into a thin view layer driven by a reactive `MapPageController`. Complex UI surfaces like the VTT Sidebar, GM Controls, and Map HUD will be extracted into focused sub-components to improve maintainability and testability.
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.0.3, Svelte 5 (Runes)
+**Primary Dependencies**: SvelteKit, Tailwind CSS 4, Lucide Svelte (Iconify utility pattern)
+**Storage**: N/A (Transient route state)
+**Testing**: Vitest (Unit tests for Controller)
+**Target Platform**: Browser (WASM/Client-side)
+**Project Type**: Web Application
+**Performance Goals**: Zero-overhead reactivity using Runes; eliminate unnecessary re-renders in the heavy Map component.
+**Constraints**: Must maintain 100% functional parity; NO changes to existing `mapStore` or `mapSession` public APIs.
+**Scale/Scope**: 1 Route coordinator, 1 Controller class, 4 primary extracted sub-components plus supporting existing map/VTT components.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle                  | Status | Note                                                                 |
+| :------------------------- | :----- | :------------------------------------------------------------------- |
+| I. Library-First           | ✓ PASS | Moving orchestration logic into `stores/map/` controller.            |
+| II. TDD                    | ✓ PASS | `MapPageController` will have dedicated unit tests.                  |
+| III. Simplicity/YAGNI      | ✓ PASS | Solving only the monolithic component issue.                         |
+| V. Privacy                 | ✓ PASS | All logic remains client-side.                                       |
+| VI. Clean Implementation   | ✓ PASS | Adhering to Svelte 5 Runes and Tailwind 4.                           |
+| VIII. Dependency Injection | ✓ PASS | Controller will use constructor DI for stores.                       |
+| X. Quality/Coverage        | ✓ PASS | Aiming for 80%+ unit coverage on the new controller to match SC-003. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/103-map-page-decomposition/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+apps/web/src/
+├── routes/(app)/map/
+│   └── +page.svelte                  # Refactored thin view
+├── lib/
+│   ├── components/map/
+│   │   ├── MapHUD.svelte             # Extracted top toolbar
+│   │   ├── MapVTTControlsHUD.svelte  # Extracted GM/VTT controls HUD
+│   │   └── MapUploadOverlay.svelte   # Extracted upload modal
+│   ├── components/vtt/
+│   │   └── MapVTTSidebar.svelte      # Extracted VTT sidebar
+│   └── stores/map/
+│       ├── map-page-controller.svelte.ts # New orchestration logic
+│       └── map-page-controller.test.ts   # New controller tests
+```
+
+**Structure Decision**: Option 2: Web application. The refactor primarily affects the Map route and its supporting components/stores.
+
+## Complexity Tracking
+
+_No constitution violations detected._

--- a/specs/103-map-page-decomposition/research.md
+++ b/specs/103-map-page-decomposition/research.md
@@ -1,0 +1,33 @@
+# Research: Map Page Decomposition
+
+## Decisions
+
+### 1. Controller Implementation Pattern
+
+- **Decision**: Implement `MapPageController` as a Svelte 5 class using Runes (`$state`, `$derived`).
+- **Rationale**: Provides a unified, reactive source of truth for the entire Map route. Enables clean delegation of interaction handlers (DnD, Upload) from the view to the logic layer.
+- **Alternatives Considered**:
+  - Svelte context: Rejected as it's less unit-testable than a standalone class.
+  - Direct store usage: Rejected because the Map page needs to bridge _multiple_ stores and has unique transient state (upload session) that doesn't belong in the global `mapStore`.
+
+### 2. Layout Offset Management
+
+- **Decision**: Migrate the hardcoded "20rem" / "3rem" chat sidebar offsets to the `layoutUIStore` or use CSS variables.
+- **Rationale**: Removes magic numbers from the Svelte component. Sub-components (HUD, Controls) can reactively adjust their positions without prop-drilling or duplication.
+- **Implementation**: The `MapPageController` will query the `layoutUIStore` for current offsets to calculate HUD positioning.
+
+### 3. Drag & Drop Strategy
+
+- **Decision**: Consolidate both Internal Entity Drag and External File Drop into unified handlers in the `MapPageController`.
+- **Rationale**: Simplifies the markup significantly. The controller can differentiate between `application/codex-entity` and `Files` using a internal strategy pattern, keeping the view clean.
+
+### 4. Upload Session Lifecycle
+
+- **Decision**: The `MapPageController` will manage the `MapUploadOverlay` visibility and data (`mapName`, `files`).
+- **Rationale**: The upload process is intrinsically tied to the map page's active state. Keeping it in the controller ensures it's correctly reset on route transitions or vault switches.
+
+## Research Tasks Resolved
+
+- [x] Best practices for Svelte 5 controller pattern.
+- [x] Sharing layout offsets without prop drilling.
+- [x] Unified DnD orchestration strategy.

--- a/specs/103-map-page-decomposition/spec.md
+++ b/specs/103-map-page-decomposition/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Map Page Decomposition
+
+**Feature Branch**: `103-map-page-decomposition`
+**Created**: 2026-05-20
+**Status**: Draft
+**Input**: User description: "Decompose monolithic map page route coordinator into focused controller and sub-components based on analysis in MAP_PAGE_ANALYSIS.md"
+
+## Clarifications
+
+### Session 2026-05-20
+
+- Q: What should own the chat/sidebar offset behavior after the refactor? -> A: `layoutUIStore` owns offsets; controller reads derived values.
+- Q: When a guest user drops an entity onto the map, what should happen? -> A: Block the drop and show a guest-safe message.
+- Q: If the active vault changes while a map upload session is open, what should the controller do? -> A: Cancel the upload session and clear pending state.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Centralized Interaction Management (Priority: P1)
+
+As a developer, I want all drag-and-drop and map orchestration logic extracted into a controller so that the main route component is focused strictly on layout.
+
+**Why this priority**: Core architecture shift. It enables all subsequent component extractions by providing a unified API for interaction logic.
+
+**Independent Test**: Drag an entity onto the map and verify it still adds a pin (Standard) or token (VTT) correctly, using the new controller's handlers.
+
+**Acceptance Scenarios**:
+
+1. **Given** the map page is open, **When** an entity is dropped on the map, **Then** the `MapPageController` handles the unprojection and entity creation logic.
+2. **Given** no map is uploaded, **When** a file is dropped, **Then** the `MapPageController` triggers the upload session state.
+
+---
+
+### User Story 2 - Modular Map Toolbars (Priority: P2)
+
+As a user, I want the map interface to remain responsive and functional while its internal components (HUD, GM Controls) are refactored into modular units.
+
+**Why this priority**: Improves maintainability of the high-density map UI.
+
+**Independent Test**: Toggle Fog of War and Grid settings using the extracted `MapVTTControlsHUD` and verify the `mapStore` state updates correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** GM mode is active, **When** the Fog toggle is clicked in the new HUD, **Then** the map fog visibility updates.
+
+---
+
+### User Story 3 - Streamlined VTT Sidebar (Priority: P3)
+
+As a user, I want a dedicated VTT sidebar component that handles token management and initiative without bloating the main page logic.
+
+**Why this priority**: Reduces visual noise and nesting depth in the route coordinator.
+
+**Independent Test**: Open the initiative panel and select a token from the extracted `MapVTTSidebar`; verify detail view updates.
+
+**Acceptance Scenarios**:
+
+1. **Given** VTT is enabled, **When** the VTT sidebar is expanded, **Then** it correctly renders the entity list and token details using localized logic.
+
+### Edge Cases
+
+- **Rapid Initialization**: If the active vault changes while a map upload session is open, the controller MUST cancel the upload session and clear pending file and name state before continuing initialization.
+- **Guest Restriction**: When a guest user attempts a GM-only interaction such as dropping an entity onto the map, the controller MUST block the action and show a guest-safe message.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: Decompose `+page.svelte` into a `MapPageController` and at least 4 sub-components.
+- **FR-002**: Move all drag-and-drop orchestration to the controller.
+- **FR-003**: Encapsulate upload form state (name, file list) within the controller or a dedicated sub-component.
+- **FR-004**: Replace hardcoded CSS layout offsets by making `layoutUIStore` the single source of truth for layout offsets, with `MapPageController` consuming derived values from that store.
+- **FR-005**: Maintain 100% functional parity with the existing monolithic implementation.
+- **FR-006**: When a guest user attempts a GM-only map mutation, the controller MUST reject the action and surface a clear guest-safe message.
+- **FR-007**: When the active vault changes during an open map upload session, the controller MUST cancel the session and clear any pending upload form state.
+
+### Key Entities
+
+- **MapPageController**: A Svelte 5 reactive class managing route-specific interaction state.
+- **HUD Components**: `MapHUD`, `MapVTTSidebar`, `MapVTTControlsHUD`, `MapUploadOverlay`.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Reduce `+page.svelte` line count from 738 to under 150 lines.
+- **SC-002**: 100% pass rate on existing Map and VTT integration tests.
+- **SC-003**: `MapPageController` has 80%+ unit test coverage.
+- **SC-004**: No "State Referenced Locally" or "State Referenced Outside Closure" warnings in the refactored modules.

--- a/specs/103-map-page-decomposition/tasks.md
+++ b/specs/103-map-page-decomposition/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: Map Page Decomposition
+
+**Input**: Design documents from `/specs/103-map-page-decomposition/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`
+
+**Tests**: Required. The spec requires controller unit coverage and preservation of existing Map/VTT integration behavior, and the repository constitution requires tests for changed behavior.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the feature task surface and shared test targets.
+
+- [x] T001 Review and update the implementation target inventory in `specs/103-map-page-decomposition/plan.md`
+- [x] T002 Create the controller test file scaffold in `apps/web/src/lib/stores/map/map-page-controller.test.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the controller and component seams that every story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T003 Create the route controller in `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`
+- [x] T004 [P] Create the upload overlay component shell in `apps/web/src/lib/components/map/MapUploadOverlay.svelte`
+- [x] T005 [P] Create the top HUD component shell in `apps/web/src/lib/components/map/MapHUD.svelte`
+- [x] T006 [P] Create the VTT controls HUD component shell in `apps/web/src/lib/components/map/MapVTTControlsHUD.svelte`
+- [x] T007 [P] Create the VTT sidebar component shell in `apps/web/src/lib/components/vtt/MapVTTSidebar.svelte`
+- [x] T008 Refactor `apps/web/src/routes/(app)/map/+page.svelte` to instantiate `MapPageController` and delegate rendering to extracted child components without changing behavior
+
+**Checkpoint**: The route has a stable controller-driven structure and story work can proceed against it.
+
+---
+
+## Phase 3: User Story 1 - Centralized Interaction Management (Priority: P1) 🎯 MVP
+
+**Goal**: Move drag-and-drop orchestration and upload session state into `MapPageController` so the route becomes a thin layout shell.
+
+**Independent Test**: Drag an entity onto the map and verify the controller still adds a pin in Standard mode or a token in VTT mode, and dropping files still opens the upload flow.
+
+### Tests for User Story 1
+
+- [x] T009 [P] [US1] Add unit tests for drag state, upload session state, and vault-switch reset behavior in `apps/web/src/lib/stores/map/map-page-controller.test.ts`
+- [x] T010 [P] [US1] Extend entity drop and file drop regression coverage in `apps/web/src/lib/stores/map/map-page-controller.test.ts`
+- [x] T011 [P] [US1] Add guest-mode regression coverage for blocked GM-only drops and guest-safe messaging in `apps/web/src/lib/stores/map/map-page-controller.test.ts`
+
+### Implementation for User Story 1
+
+- [x] T012 [US1] Implement controller reactive state, derived state, and constructor DI in `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`
+- [x] T013 [US1] Move entity drag start/end helpers and drag preview coordination from `apps/web/src/routes/(app)/map/+page.svelte` into `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`
+- [x] T014 [US1] Move unified drop, dragover, and dragleave logic from `apps/web/src/routes/(app)/map/+page.svelte` into `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`
+- [x] T015 [US1] Implement guest restriction handling and notification messaging for GM-only mutations in `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`
+- [x] T016 [US1] Implement upload session lifecycle, upload submit flow, and vault-switch reset behavior in `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`
+- [x] T017 [US1] Wire the route to controller handlers and state in `apps/web/src/routes/(app)/map/+page.svelte`
+- [x] T018 [US1] Implement the extracted upload UI using controller state in `apps/web/src/lib/components/map/MapUploadOverlay.svelte`
+
+**Checkpoint**: User Story 1 is functional when the route delegates all transient map-page orchestration to the controller.
+
+---
+
+## Phase 4: User Story 2 - Modular Map Toolbars (Priority: P2)
+
+**Goal**: Extract the map HUD and GM controls into focused components while preserving responsive VTT controls and layout behavior.
+
+**Independent Test**: Toggle Fog of War and Grid settings through the extracted HUD controls and verify the underlying `mapStore` and VTT state still update correctly.
+
+### Tests for User Story 2
+
+- [x] T019 [P] [US2] Add component tests for toolbar rendering and emitted actions in `apps/web/src/lib/components/map/MapHUD.test.ts`
+- [x] T020 [P] [US2] Add component tests for GM control interactions in `apps/web/src/lib/components/map/MapVTTControlsHUD.test.ts`
+- [x] T021 [P] [US2] Extend existing VTT control regressions for extracted composition in `apps/web/src/lib/components/map/VTTControls.test.ts`
+
+### Implementation for User Story 2
+
+- [x] T022 [US2] Move top-level route toolbar markup and actions from `apps/web/src/routes/(app)/map/+page.svelte` into `apps/web/src/lib/components/map/MapHUD.svelte`
+- [x] T023 [US2] Move GM fog, measurement, grid, and sharing controls into `apps/web/src/lib/components/map/MapVTTControlsHUD.svelte`
+- [x] T024 [US2] Replace hardcoded sidebar offset logic by reading derived layout offsets from `layoutUIStore` in `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`
+- [x] T025 [US2] Update `apps/web/src/routes/(app)/map/+page.svelte` to compose `MapHUD` and `MapVTTControlsHUD` and remove inlined toolbar markup
+
+**Checkpoint**: Toolbar behavior remains intact while route markup is reduced and layout offsets are store-driven.
+
+---
+
+## Phase 5: User Story 3 - Streamlined VTT Sidebar (Priority: P3)
+
+**Goal**: Extract the VTT sidebar into a dedicated component that owns token management and initiative presentation logic instead of bloating the route.
+
+**Independent Test**: Expand the extracted sidebar, select a token, and open the initiative panel while confirming detail state and token list behavior remain correct.
+
+### Tests for User Story 3
+
+- [x] T026 [P] [US3] Add component tests for collapsed and expanded sidebar states in `apps/web/src/lib/components/vtt/MapVTTSidebar.test.ts`
+- [x] T027 [P] [US3] Add regression coverage for initiative-panel and token-selection wiring in `apps/web/src/lib/components/vtt/MapVTTSidebar.test.ts`
+- [x] T028 [P] [US3] Extend existing chat sidebar coverage for extracted composition boundaries in `apps/web/src/lib/components/vtt/VTTChatSidebar.test.ts`
+
+### Implementation for User Story 3
+
+- [x] T029 [US3] Extract VTT sidebar layout and localized selection logic from `apps/web/src/routes/(app)/map/+page.svelte` into `apps/web/src/lib/components/vtt/MapVTTSidebar.svelte`
+- [x] T030 [US3] Move token detail, entity list, and initiative panel composition into `apps/web/src/lib/components/vtt/MapVTTSidebar.svelte`
+- [x] T031 [US3] Wire sidebar collapse state through `layoutUIStore` and controller coordination in `apps/web/src/lib/components/vtt/MapVTTSidebar.svelte`
+- [x] T032 [US3] Update `apps/web/src/routes/(app)/map/+page.svelte` to consume the extracted `MapVTTSidebar` and remove duplicated VTT sidebar markup
+
+**Checkpoint**: The VTT sidebar is independently testable and the route no longer owns its internal nesting.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish parity validation, documentation, and quality gates across all stories.
+
+- [x] T033 [P] Reduce `apps/web/src/routes/(app)/map/+page.svelte` to the planned thin-view target and remove dead helpers/imports
+- [x] T034 [P] Document the new map page architecture and controller/component ownership in `docs/reports/MAP_PAGE_ANALYSIS.md`
+- [ ] T035 Run `pnpm run lint` and fix any issues caused by the refactor
+- [ ] T036 Run `pnpm test` and resolve regressions across map and VTT suites
+- [x] T037 Verify there are no "State Referenced Locally" or "State Referenced Outside Closure" warnings in `apps/web/src/routes/(app)/map/+page.svelte`, `apps/web/src/lib/stores/map/map-page-controller.svelte.ts`, `apps/web/src/lib/components/map/MapHUD.svelte`, `apps/web/src/lib/components/map/MapVTTControlsHUD.svelte`, `apps/web/src/lib/components/map/MapUploadOverlay.svelte`, and `apps/web/src/lib/components/vtt/MapVTTSidebar.svelte`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories
+- **User Story 1 (Phase 3)**: Depends on Phase 2; establishes the controller behavior needed by later stories
+- **User Story 2 (Phase 4)**: Depends on Phase 3 because toolbar extraction consumes controller and layout seams
+- **User Story 3 (Phase 5)**: Depends on Phase 3 and can proceed after controller seams are stable
+- **Polish (Phase 6)**: Depends on all targeted user stories being complete
+
+### User Story Dependencies
+
+- **US1**: No dependency on other stories after Foundational; this is the MVP
+- **US2**: Depends on US1 controller state and route delegation
+- **US3**: Depends on US1 controller state; independent of US2 aside from final route composition
+
+### Within Each User Story
+
+- Tests for the story should be written first and fail before implementation
+- Controller and state work precede route wiring
+- Route wiring precedes markup cleanup
+- Story checkpoints should be validated before advancing to the next phase
+
+### Parallel Opportunities
+
+- `T004`-`T007` can run in parallel after `T003`
+- `T009`-`T011` can run in parallel within US1
+- `T019`-`T021` can run in parallel within US2
+- `T026`-`T028` can run in parallel within US3
+- `T033` and `T034` can run in parallel once implementation is complete
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch US1 tests together:
+Task: "Add unit tests for drag state, upload session state, and vault-switch reset behavior in apps/web/src/lib/stores/map/map-page-controller.test.ts"
+Task: "Extend entity drop and file drop regression coverage in apps/web/src/lib/components/map/map-page-actions.test.ts"
+Task: "Add guest-mode regression coverage for blocked GM-only drops and guest-safe messaging in apps/web/src/lib/stores/map/map-page-controller.test.ts"
+
+# Launch foundational component shells together:
+Task: "Create the upload overlay component shell in apps/web/src/lib/components/map/MapUploadOverlay.svelte"
+Task: "Create the top HUD component shell in apps/web/src/lib/components/map/MapHUD.svelte"
+Task: "Create the VTT controls HUD component shell in apps/web/src/lib/components/map/MapVTTControlsHUD.svelte"
+Task: "Create the VTT sidebar component shell in apps/web/src/lib/components/vtt/MapVTTSidebar.svelte"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate entity drop, file drop, guest restriction, and vault-switch reset behavior
+
+### Incremental Delivery
+
+1. Deliver the controller extraction and thin route shell in US1
+2. Add modular HUD controls in US2
+3. Add the dedicated VTT sidebar in US3
+4. Finish with route slimming, documentation, lint, and full test validation
+
+### Parallel Team Strategy
+
+1. One developer builds the controller seam (`T003`, `T008`, `T012`-`T017`)
+2. One developer prepares extracted map HUD components (`T004`-`T006`, `T022`-`T025`)
+3. One developer prepares VTT sidebar extraction (`T007`, `T029`-`T032`)
+4. Merge after controller contracts stabilize


### PR DESCRIPTION
## Summary

Decomposes the monolithic map route into a thin route composer backed by a Svelte 5 `MapPageController` and focused map/VTT components.

## Changes

- Adds `MapPageController` for drag/drop orchestration, upload state, guest blocking, vault-switch reset, and layout-derived offsets.
- Extracts `MapHUD`, `MapUploadOverlay`, `MapVTTControlsHUD`, and `MapVTTSidebar` from the map route.
- Moves VTT chat sidebar collapse ownership into `layoutUIStore` so route layout offsets derive from shared UI state.
- Adds controller and extracted-component tests.
- Adds Spec 103 artifacts and updates the map page analysis report.

## Validation

- `pnpm --filter web run lint`
- `pnpm --filter web run lint:types` (passes with existing unrelated warnings)
- `pnpm --filter web exec vitest run src/lib/stores/map/map-page-controller.test.ts src/lib/components/map/MapHUD.test.ts src/lib/components/map/MapVTTControlsHUD.test.ts src/lib/components/vtt/MapVTTSidebar.test.ts src/lib/components/map/map-page-actions.test.ts src/lib/components/map/VTTControls.test.ts src/lib/components/vtt/VTTChatSidebar.test.ts --maxWorkers=1 --no-fileParallelism`

## Notes

Root `pnpm run lint` could not run locally because Turborepo does not support this Android arm64 Termux environment; the web lint and type checks were run directly instead.