### PR TITLE
:memo: docs: refine v0.22.0 changelog highlights to be user-facing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ This file is the Codex-facing instruction layer for this repository.
 - **Oracle Store Architecture**: The monolithic `OracleStore` is decomposed into 6 reactive managers (`ui`, `chat`, `context`, `actions`, `settingsManager`, `reconciliation`). When extending Oracle functionality, identify the correct manager in `apps/web/src/lib/stores/oracle/` instead of bloating the facade.
 - Prefer local-first and client-side solutions when the architecture allows it.
 - Keep user-facing language clear and plain.
+- **User-Facing Changelogs**: Keep all entries in the changelog (`apps/web/src/lib/content/changelog/releases.json`) strictly focused on high-impact, user-facing features. Do not list under-the-hood technical refactors, code optimization, or architectural decomposition updates in the changelog highlights.
 - Create a new branch for code changes, fixes, or refactors.
 - Prefer the GitHub app/MCP tools for structured GitHub work such as PR metadata, comments, labels, reviews, file patches, and PR edits.
 - Prefer `gh` for CI and Actions debugging, raw check/log inspection, or other terminal-native GitHub workflows.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -188,3 +188,5 @@ TypeScript: Follow standard conventions
 - 109-quicknote-scratchpad: Added Svelte 5, Svelte 5 Runes, Dexie (IndexedDB), and Cytoscape.js integration.
 
 <!-- MANUAL ADDITIONS START -->
+
+- **User-Facing Changelogs**: Keep all entries in the changelog (`apps/web/src/lib/content/changelog/releases.json`) strictly focused on high-impact, user-facing features. Do not list under-the-hood technical refactors, code optimization, or architectural decomposition updates in the changelog highlights.

--- a/apps/web/src/lib/content/changelog/releases.json
+++ b/apps/web/src/lib/content/changelog/releases.json
@@ -5,11 +5,8 @@
     "date": "2026-05-22",
     "type": "minor",
     "highlights": [
-      "QuickNote Scratchpad: A lightning-fast overlay (Ctrl+I / Cmd+I) to dump ideas instantly, fully persisted to local IndexedDB.",
-      "AI Entity Elevation: Instantly convert fleeting note scribbles into fully structured wiki entities (Characters, Locations, Items, Factions, or Events) using the Oracle AI engine.",
-      "Svelte 5 Rune Migration: Complete conversion of all reactive stores and controllers to Svelte 5 Runes for ultimate UI snappiness.",
-      "Progressive Worker Search: Background search indexing offloaded to a Web Worker, ensuring zero main-thread lag during search queries.",
-      "Decoupled Network Architecture: Fully modularized PeerJS and P2P synchronization services for robust tabletop multiplayer sessions."
+      "QuickNote Scratchpad: A lightning-fast overlay (Ctrl+I / Cmd+I) to dump ideas instantly without losing your flow.",
+      "Make Entity: Instantly convert fleeting note scraps into fully structured Codex Cryptica entities (Characters, Locations, Items, Factions, or Events) using the Oracle AI engine."
     ]
   },
   {


### PR DESCRIPTION
Refines the v0.22.0 changelog to keep it strictly user-facing, and adds guidelines to AGENTS.md and GEMINI.md to enforce this standard in the future.