### PR TITLE
:sparkles: feat(ui): animate opening of entity detail panel and selected graph node (spec 110)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm run dev -- --port 5173",
+    command: "bun run dev --port 5173",
     url: "http://127.0.0.1:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Entity } from "schema";
   import { fade } from "svelte/transition";
+  import { cubicOut } from "svelte/easing";
   import { vault } from "$lib/stores/vault.svelte";
   import ResizerHandle from "./layout/ResizerHandle.svelte";
 
@@ -167,11 +168,50 @@
       isDraftActioning = false;
     }
   };
+
+  function expandFrom(_node: HTMLElement) {
+    const isMobile = layoutUIStore.isMobile;
+    const pos = layoutUIStore.lastSelectedNodePosition;
+
+    if (isMobile) {
+      return {
+        duration: 300,
+        easing: cubicOut,
+        css: (t: number) => {
+          const y = (1 - t) * 100;
+          return `transform: translateY(${y}%);`;
+        },
+      };
+    }
+
+    if (pos && typeof window !== "undefined") {
+      const width = layoutUIStore.rightSidebarWidth;
+      const panelLeft = window.innerWidth - width;
+      const relativeX = pos.x - panelLeft;
+      const relativeY = pos.y;
+      return {
+        duration: 350,
+        easing: cubicOut,
+        css: (t: number) => {
+          return `transform-origin: ${relativeX}px ${relativeY}px; transform: scale(${t}); opacity: ${t};`;
+        },
+      };
+    }
+
+    return {
+      duration: 300,
+      easing: cubicOut,
+      css: (t: number) => {
+        const x = (1 - t) * 100;
+        return `transform: translateX(${x}%);`;
+      },
+    };
+  }
 </script>
 
 {#if entity}
   <aside
-    transition:fade={{ duration: 200 }}
+    transition:expandFrom
     class="pointer-events-auto flex h-full w-full flex-col border-l border-theme-border bg-theme-surface shadow-2xl font-mono max-md:absolute max-md:right-0 max-md:bottom-0 max-md:h-[calc(100%-60px)] relative z-50 shrink-0"
     style:width={layoutUIStore.isMobile
       ? "100%"
@@ -200,117 +240,125 @@
     />
 
     <div
-      class="flex-1 min-h-0 overflow-y-auto custom-scrollbar bg-theme-bg flex flex-col overscroll-contain"
+      class="flex-1 min-h-0 overflow-y-auto custom-scrollbar bg-theme-bg overscroll-contain"
       style:background-color="var(--theme-panel-muted)"
-      style="background-image: var(--bg-texture-overlay); touch-action: pan-y;"
+      style="background-image: var(--bg-texture-overlay); touch-action: pan-y; display: grid; grid-template-columns: 1fr; grid-template-rows: 1fr;"
     >
-      {#if sessionModeStore.isDemoMode}
+      {#key entity.id}
         <div
-          class="bg-theme-primary/10 border-b border-theme-primary/30 px-4 py-1.5 text-[9px] font-bold text-theme-primary tracking-widest text-center animate-pulse"
+          in:fade={{ duration: 150, delay: 150 }}
+          out:fade={{ duration: 150 }}
+          class="col-start-1 row-start-1 flex flex-col w-full h-full min-h-0"
         >
-          TRANSIENT MODE: CHANGES WILL NOT BE SAVED
-        </div>
-      {/if}
-      {#if entity.status === "draft" && !vault.isGuest}
-        <div
-          class="flex items-center justify-between gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2"
-        >
-          <span
-            class="text-[9px] font-bold tracking-widest text-amber-500 uppercase"
-          >
-            AI Draft — Pending Review
-          </span>
-          <div class="flex items-center gap-1">
-            <button
-              onclick={handleApproveDraft}
-              disabled={isDraftActioning}
-              title="Approve draft"
-              aria-label="Approve draft"
-              class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-emerald-500 transition hover:bg-emerald-500/10 disabled:opacity-50"
+          {#if sessionModeStore.isDemoMode}
+            <div
+              class="bg-theme-primary/10 border-b border-theme-primary/30 px-4 py-1.5 text-[9px] font-bold text-theme-primary tracking-widest text-center animate-pulse"
             >
-              <span class="icon-[lucide--check] h-3 w-3"></span>
-              Approve
-            </button>
-            <button
-              onclick={handleRejectDraft}
-              disabled={isDraftActioning}
-              title="Reject draft"
-              aria-label="Reject draft"
-              class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-red-500 transition hover:bg-red-500/10 disabled:opacity-50"
-            >
-              <span class="icon-[lucide--trash-2] h-3 w-3"></span>
-              Reject
-            </button>
-          </div>
-        </div>
-      {/if}
-      <div
-        style:background-image="var(--bg-texture-overlay)"
-        class="bg-theme-surface shrink-0"
-        style:background-color="var(--theme-panel-fill)"
-      >
-        <DetailImage {entity} {isEditing} bind:editImage />
-
-        <DetailTabs
-          {entity}
-          bind:activeTab
-          {isEditing}
-          bind:editType
-          idPrefix={tabInstanceId}
-        />
-      </div>
-
-      <div class="p-4 md:p-6">
-        <div
-          role="tabpanel"
-          id={panelIds.status}
-          aria-labelledby={tabIds.status}
-          hidden={activeTab !== "status"}
-        >
-          {#if activeTab === "status"}
-            <DetailStatusTab
-              {entity}
-              {isEditing}
-              {editType}
-              bind:editContent
-              bind:editStartDate
-              bind:editEndDate
-            />
-          {/if}
-        </div>
-        <div
-          role="tabpanel"
-          id={panelIds.lore}
-          aria-labelledby={tabIds.lore}
-          hidden={activeTab !== "lore" || vault.isGuest}
-        >
-          {#if activeTab === "lore" && !vault.isGuest}
-            <DetailLoreTab {entity} {isEditing} bind:editLore />
-          {/if}
-        </div>
-        <div
-          role="tabpanel"
-          id={panelIds.inventory}
-          aria-labelledby={tabIds.inventory}
-          hidden={activeTab !== "inventory"}
-        >
-          {#if activeTab === "inventory"}
-            <div class="text-theme-muted italic text-sm">
-              Inventory coming soon...
+              TRANSIENT MODE: CHANGES WILL NOT BE SAVED
             </div>
           {/if}
-        </div>
-        <div
-          role="tabpanel"
-          id={panelIds.map}
-          aria-labelledby={tabIds.map}
-          hidden={activeTab !== "map"}
-        >
-          {#if activeTab === "map"}
-            <DetailMapTab {entity} />
+          {#if entity.status === "draft" && !vault.isGuest}
+            <div
+              class="flex items-center justify-between gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2"
+            >
+              <span
+                class="text-[9px] font-bold tracking-widest text-amber-500 uppercase"
+              >
+                AI Draft — Pending Review
+              </span>
+              <div class="flex items-center gap-1">
+                <button
+                  onclick={handleApproveDraft}
+                  disabled={isDraftActioning}
+                  title="Approve draft"
+                  aria-label="Approve draft"
+                  class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-emerald-500 transition hover:bg-emerald-500/10 disabled:opacity-50"
+                >
+                  <span class="icon-[lucide--check] h-3 w-3"></span>
+                  Approve
+                </button>
+                <button
+                  onclick={handleRejectDraft}
+                  disabled={isDraftActioning}
+                  title="Reject draft"
+                  aria-label="Reject draft"
+                  class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-red-500 transition hover:bg-red-500/10 disabled:opacity-50"
+                >
+                  <span class="icon-[lucide--trash-2] h-3 w-3"></span>
+                  Reject
+                </button>
+              </div>
+            </div>
           {/if}
+          <div
+            style:background-image="var(--bg-texture-overlay)"
+            class="bg-theme-surface shrink-0"
+            style:background-color="var(--theme-panel-fill)"
+          >
+            <DetailImage {entity} {isEditing} bind:editImage />
+
+            <DetailTabs
+              {entity}
+              bind:activeTab
+              {isEditing}
+              bind:editType
+              idPrefix={tabInstanceId}
+            />
+          </div>
+
+          <div class="p-4 md:p-6">
+            <div
+              role="tabpanel"
+              id={panelIds.status}
+              aria-labelledby={tabIds.status}
+              hidden={activeTab !== "status"}
+            >
+              {#if activeTab === "status"}
+                <DetailStatusTab
+                  {entity}
+                  {isEditing}
+                  {editType}
+                  bind:editContent
+                  bind:editStartDate
+                  bind:editEndDate
+                />
+              {/if}
+            </div>
+            <div
+              role="tabpanel"
+              id={panelIds.lore}
+              aria-labelledby={tabIds.lore}
+              hidden={activeTab !== "lore" || vault.isGuest}
+            >
+              {#if activeTab === "lore" && !vault.isGuest}
+                <DetailLoreTab {entity} {isEditing} bind:editLore />
+              {/if}
+            </div>
+            <div
+              role="tabpanel"
+              id={panelIds.inventory}
+              aria-labelledby={tabIds.inventory}
+              hidden={activeTab !== "inventory"}
+            >
+              {#if activeTab === "inventory"}
+                <div class="text-theme-muted italic text-sm">
+                  Inventory coming soon...
+                </div>
+              {/if}
+            </div>
+            <div
+              role="tabpanel"
+              id={panelIds.map}
+              aria-labelledby={tabIds.map}
+              hidden={activeTab !== "map"}
+            >
+              {#if activeTab === "map"}
+                <DetailMapTab {entity} />
+              {/if}
+            </div>
+          </div>
         </div>
-      </div>
+      {/key}
     </div>
 
     <DetailFooter

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -76,6 +76,13 @@
     }
   });
 
+  // Cleanup lastSelectedNodePosition on unmount to prevent stale/incorrect zoom animation origins
+  $effect(() => {
+    return () => {
+      layoutUIStore.setLastSelectedNodePosition(null);
+    };
+  });
+
   const startEditing = () => {
     if (!entity) return;
     editTitle = entity.title;

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Entity } from "schema";
   import { fade } from "svelte/transition";
-  import { cubicOut } from "svelte/easing";
+  import { quintOut } from "svelte/easing";
   import { vault } from "$lib/stores/vault.svelte";
   import ResizerHandle from "./layout/ResizerHandle.svelte";
 
@@ -169,41 +169,46 @@
     }
   };
 
-  function expandFrom(_node: HTMLElement) {
+  function expandFrom(node: HTMLElement) {
     const isMobile = layoutUIStore.isMobile;
     const pos = layoutUIStore.lastSelectedNodePosition;
 
     if (isMobile) {
+      node.style.transformOrigin = "bottom center";
       return {
-        duration: 300,
-        easing: cubicOut,
+        duration: 550,
+        easing: quintOut,
         css: (t: number) => {
           const y = (1 - t) * 100;
-          return `transform: translateY(${y}%);`;
+          return `transform: translateY(${y}%); opacity: ${t};`;
         },
       };
     }
 
-    if (pos && typeof window !== "undefined") {
-      const width = layoutUIStore.rightSidebarWidth;
-      const panelLeft = window.innerWidth - width;
-      const relativeX = pos.x - panelLeft;
-      const relativeY = pos.y;
+    if (pos) {
+      // Compute transform-origin relative to the panel's own bounding box
+      const rect = node.getBoundingClientRect();
+      const originX = pos.x - rect.left;
+      const originY = pos.y - rect.top;
+      node.style.transformOrigin = `${originX}px ${originY}px`;
+
       return {
-        duration: 350,
-        easing: cubicOut,
+        duration: 600,
+        easing: quintOut,
         css: (t: number) => {
-          return `transform-origin: ${relativeX}px ${relativeY}px; transform: scale(${t}); opacity: ${t};`;
+          const scale = 0.7 + 0.3 * t;
+          return `transform: scale(${scale}); opacity: ${t};`;
         },
       };
     }
 
+    // Fallback: slide from right
+    node.style.transformOrigin = "right center";
     return {
-      duration: 300,
-      easing: cubicOut,
+      duration: 550,
+      easing: quintOut,
       css: (t: number) => {
-        const x = (1 - t) * 100;
-        return `transform: translateX(${x}%);`;
+        return `transform: translateX(${(1 - t) * 100}%); opacity: ${Math.min(t * 1.5, 1)};`;
       },
     };
   }
@@ -212,7 +217,7 @@
 {#if entity}
   <aside
     transition:expandFrom
-    class="pointer-events-auto flex h-full w-full flex-col border-l border-theme-border bg-theme-surface shadow-2xl font-mono max-md:absolute max-md:right-0 max-md:bottom-0 max-md:h-[calc(100%-60px)] relative z-50 shrink-0"
+    class="pointer-events-auto flex flex-col border-l border-theme-border bg-theme-surface shadow-2xl font-mono absolute right-0 top-0 bottom-0 max-md:top-auto max-md:h-[calc(100%-60px)] z-50 overflow-hidden"
     style:width={layoutUIStore.isMobile
       ? "100%"
       : `${layoutUIStore.rightSidebarWidth}px`}
@@ -231,146 +236,148 @@
       />
     {/if}
 
-    <DetailHeader
-      {entity}
-      {isEditing}
-      bind:editTitle
-      bind:editAliases
-      {onClose}
-    />
+    <div class="absolute inset-0 flex flex-col min-h-0">
+      <DetailHeader
+        {entity}
+        {isEditing}
+        bind:editTitle
+        bind:editAliases
+        {onClose}
+      />
 
-    <div
-      class="flex-1 min-h-0 overflow-y-auto custom-scrollbar bg-theme-bg overscroll-contain"
-      style:background-color="var(--theme-panel-muted)"
-      style="background-image: var(--bg-texture-overlay); touch-action: pan-y; display: grid; grid-template-columns: 1fr; grid-template-rows: 1fr;"
-    >
-      {#key entity.id}
-        <div
-          in:fade={{ duration: 150, delay: 150 }}
-          out:fade={{ duration: 150 }}
-          class="col-start-1 row-start-1 flex flex-col w-full h-full min-h-0"
-        >
-          {#if sessionModeStore.isDemoMode}
-            <div
-              class="bg-theme-primary/10 border-b border-theme-primary/30 px-4 py-1.5 text-[9px] font-bold text-theme-primary tracking-widest text-center animate-pulse"
-            >
-              TRANSIENT MODE: CHANGES WILL NOT BE SAVED
-            </div>
-          {/if}
-          {#if entity.status === "draft" && !vault.isGuest}
-            <div
-              class="flex items-center justify-between gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2"
-            >
-              <span
-                class="text-[9px] font-bold tracking-widest text-amber-500 uppercase"
+      <div
+        class="flex-1 min-h-0 overflow-y-auto custom-scrollbar bg-theme-bg overscroll-contain"
+        style:background-color="var(--theme-panel-muted)"
+        style="background-image: var(--bg-texture-overlay); touch-action: pan-y; display: grid; grid-template-columns: 1fr; grid-template-rows: 1fr;"
+      >
+        {#key entity.id}
+          <div
+            in:fade={{ duration: 150, delay: 150 }}
+            out:fade={{ duration: 150 }}
+            class="col-start-1 row-start-1 flex flex-col w-full h-full min-h-0"
+          >
+            {#if sessionModeStore.isDemoMode}
+              <div
+                class="bg-theme-primary/10 border-b border-theme-primary/30 px-4 py-1.5 text-[9px] font-bold text-theme-primary tracking-widest text-center animate-pulse"
               >
-                AI Draft — Pending Review
-              </span>
-              <div class="flex items-center gap-1">
-                <button
-                  onclick={handleApproveDraft}
-                  disabled={isDraftActioning}
-                  title="Approve draft"
-                  aria-label="Approve draft"
-                  class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-emerald-500 transition hover:bg-emerald-500/10 disabled:opacity-50"
+                TRANSIENT MODE: CHANGES WILL NOT BE SAVED
+              </div>
+            {/if}
+            {#if entity.status === "draft" && !vault.isGuest}
+              <div
+                class="flex items-center justify-between gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2"
+              >
+                <span
+                  class="text-[9px] font-bold tracking-widest text-amber-500 uppercase"
                 >
-                  <span class="icon-[lucide--check] h-3 w-3"></span>
-                  Approve
-                </button>
-                <button
-                  onclick={handleRejectDraft}
-                  disabled={isDraftActioning}
-                  title="Reject draft"
-                  aria-label="Reject draft"
-                  class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-red-500 transition hover:bg-red-500/10 disabled:opacity-50"
-                >
-                  <span class="icon-[lucide--trash-2] h-3 w-3"></span>
-                  Reject
-                </button>
+                  AI Draft — Pending Review
+                </span>
+                <div class="flex items-center gap-1">
+                  <button
+                    onclick={handleApproveDraft}
+                    disabled={isDraftActioning}
+                    title="Approve draft"
+                    aria-label="Approve draft"
+                    class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-emerald-500 transition hover:bg-emerald-500/10 disabled:opacity-50"
+                  >
+                    <span class="icon-[lucide--check] h-3 w-3"></span>
+                    Approve
+                  </button>
+                  <button
+                    onclick={handleRejectDraft}
+                    disabled={isDraftActioning}
+                    title="Reject draft"
+                    aria-label="Reject draft"
+                    class="flex items-center gap-1 rounded px-2 py-1 text-[9px] font-bold uppercase tracking-widest text-red-500 transition hover:bg-red-500/10 disabled:opacity-50"
+                  >
+                    <span class="icon-[lucide--trash-2] h-3 w-3"></span>
+                    Reject
+                  </button>
+                </div>
+              </div>
+            {/if}
+            <div
+              style:background-image="var(--bg-texture-overlay)"
+              class="bg-theme-surface shrink-0"
+              style:background-color="var(--theme-panel-fill)"
+            >
+              <DetailImage {entity} {isEditing} bind:editImage />
+
+              <DetailTabs
+                {entity}
+                bind:activeTab
+                {isEditing}
+                bind:editType
+                idPrefix={tabInstanceId}
+              />
+            </div>
+
+            <div class="p-4 md:p-6">
+              <div
+                role="tabpanel"
+                id={panelIds.status}
+                aria-labelledby={tabIds.status}
+                hidden={activeTab !== "status"}
+              >
+                {#if activeTab === "status"}
+                  <DetailStatusTab
+                    {entity}
+                    {isEditing}
+                    {editType}
+                    bind:editContent
+                    bind:editStartDate
+                    bind:editEndDate
+                  />
+                {/if}
+              </div>
+              <div
+                role="tabpanel"
+                id={panelIds.lore}
+                aria-labelledby={tabIds.lore}
+                hidden={activeTab !== "lore" || vault.isGuest}
+              >
+                {#if activeTab === "lore" && !vault.isGuest}
+                  <DetailLoreTab {entity} {isEditing} bind:editLore />
+                {/if}
+              </div>
+              <div
+                role="tabpanel"
+                id={panelIds.inventory}
+                aria-labelledby={tabIds.inventory}
+                hidden={activeTab !== "inventory"}
+              >
+                {#if activeTab === "inventory"}
+                  <div class="text-theme-muted italic text-sm">
+                    Inventory coming soon...
+                  </div>
+                {/if}
+              </div>
+              <div
+                role="tabpanel"
+                id={panelIds.map}
+                aria-labelledby={tabIds.map}
+                hidden={activeTab !== "map"}
+              >
+                {#if activeTab === "map"}
+                  <DetailMapTab {entity} />
+                {/if}
               </div>
             </div>
-          {/if}
-          <div
-            style:background-image="var(--bg-texture-overlay)"
-            class="bg-theme-surface shrink-0"
-            style:background-color="var(--theme-panel-fill)"
-          >
-            <DetailImage {entity} {isEditing} bind:editImage />
-
-            <DetailTabs
-              {entity}
-              bind:activeTab
-              {isEditing}
-              bind:editType
-              idPrefix={tabInstanceId}
-            />
           </div>
+        {/key}
+      </div>
 
-          <div class="p-4 md:p-6">
-            <div
-              role="tabpanel"
-              id={panelIds.status}
-              aria-labelledby={tabIds.status}
-              hidden={activeTab !== "status"}
-            >
-              {#if activeTab === "status"}
-                <DetailStatusTab
-                  {entity}
-                  {isEditing}
-                  {editType}
-                  bind:editContent
-                  bind:editStartDate
-                  bind:editEndDate
-                />
-              {/if}
-            </div>
-            <div
-              role="tabpanel"
-              id={panelIds.lore}
-              aria-labelledby={tabIds.lore}
-              hidden={activeTab !== "lore" || vault.isGuest}
-            >
-              {#if activeTab === "lore" && !vault.isGuest}
-                <DetailLoreTab {entity} {isEditing} bind:editLore />
-              {/if}
-            </div>
-            <div
-              role="tabpanel"
-              id={panelIds.inventory}
-              aria-labelledby={tabIds.inventory}
-              hidden={activeTab !== "inventory"}
-            >
-              {#if activeTab === "inventory"}
-                <div class="text-theme-muted italic text-sm">
-                  Inventory coming soon...
-                </div>
-              {/if}
-            </div>
-            <div
-              role="tabpanel"
-              id={panelIds.map}
-              aria-labelledby={tabIds.map}
-              hidden={activeTab !== "map"}
-            >
-              {#if activeTab === "map"}
-                <DetailMapTab {entity} />
-              {/if}
-            </div>
-          </div>
-        </div>
-      {/key}
+      <DetailFooter
+        {isEditing}
+        {isSaving}
+        onCancel={cancelEditing}
+        onSave={saveChanges}
+        onDelete={handleDelete}
+        onStartEdit={startEditing}
+      />
+
+      <InlinePreviewOverlay />
     </div>
-
-    <DetailFooter
-      {isEditing}
-      {isSaving}
-      onCancel={cancelEditing}
-      onSave={saveChanges}
-      onDelete={handleDelete}
-      onStartEdit={startEditing}
-    />
-
-    <InlinePreviewOverlay />
   </aside>
 {/if}
 

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -251,6 +251,16 @@
             currentCy.nodes().stop();
             currentCy.nodes().removeStyle();
 
+            // Capture original stylesheet values before running override animations
+            const origPadding =
+              node.style("underlay-padding") !== undefined
+                ? node.style("underlay-padding")
+                : 8;
+            const origOpacity =
+              node.style("underlay-opacity") !== undefined
+                ? node.style("underlay-opacity")
+                : 0.3;
+
             node.animate(
               {
                 style: {
@@ -265,9 +275,8 @@
                   node.animate(
                     {
                       style: {
-                        "underlay-padding": 8,
-                        "underlay-opacity":
-                          themeStore.activeTheme.id === "fantasy" ? 0 : 0.3,
+                        "underlay-padding": origPadding,
+                        "underlay-opacity": origOpacity,
                       },
                     },
                     {

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -39,6 +39,8 @@
     },
   );
 
+  let resizeObserver: ResizeObserver | undefined;
+
   // Single coordinator for selectedId sync
   $effect(() => {
     if (selectedId !== controller.selectedId) {
@@ -121,9 +123,20 @@
 
   onMount(() => {
     controller.init(container, graphStyle);
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(() => {
+        if (controller.cy) {
+          controller.cy.resize();
+        }
+      });
+      resizeObserver.observe(container);
+    }
   });
 
   onDestroy(() => {
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+    }
     controller.destroy();
   });
 
@@ -177,6 +190,45 @@
     untrack(() => controller.syncElements());
   });
 
+  function centerOnNode(
+    node: any,
+    animate = true,
+    customZoom: number | null = null,
+  ) {
+    const currentCy = controller.cy;
+    if (!currentCy) return;
+
+    const targetZoom = customZoom !== null ? customZoom : currentCy.zoom();
+    const nodePos = node.position();
+
+    // Adjust for desktop sidebar offset to center in the remaining visible area only if open
+    const isSidebarVisible = !!vault.selectedEntityId;
+    const sidebarWidth =
+      !layoutUIStore.isMobile &&
+      isSidebarVisible &&
+      layoutUIStore.rightSidebarWidth
+        ? layoutUIStore.rightSidebarWidth
+        : 0;
+
+    const targetPanX =
+      (currentCy.width() - sidebarWidth) / 2 - targetZoom * nodePos.x;
+    const targetPanY = currentCy.height() / 2 - targetZoom * nodePos.y;
+
+    if (animate) {
+      currentCy.animate({
+        pan: { x: targetPanX, y: targetPanY },
+        zoom: targetZoom,
+        duration: 800,
+        easing: "ease-out-cubic",
+      });
+    } else {
+      currentCy.viewport({
+        zoom: targetZoom,
+        pan: { x: targetPanX, y: targetPanY },
+      });
+    }
+  }
+
   // Selection & Search Focus
   $effect(() => {
     void controller.pendingSearchFocus;
@@ -193,12 +245,11 @@
                 DEFAULT_SEARCH_ENTITY_ZOOM)
               : null;
           untrack(() => {
-            currentCy.animate({
-              center: { eles: node },
-              ...(focusZoom !== null ? { zoom: focusZoom } : {}),
-              duration: 800,
-              easing: "ease-out-cubic",
-            });
+            centerOnNode(node, true, focusZoom);
+
+            // Stop animations and clear custom style bypasses on all nodes to prevent sticky/leaky highlight styles
+            currentCy.nodes().stop();
+            currentCy.nodes().removeStyle();
 
             node.animate(
               {
@@ -215,12 +266,17 @@
                     {
                       style: {
                         "underlay-padding": 8,
-                        "underlay-opacity": 0.3,
+                        "underlay-opacity":
+                          themeStore.activeTheme.id === "fantasy" ? 0 : 0.3,
                       },
                     },
                     {
                       duration: 250,
                       easing: "ease-in",
+                      complete: () => {
+                        // Crucial: remove override styles so they don't persist on node deselection!
+                        node.removeStyle();
+                      },
                     },
                   );
                 },
@@ -235,8 +291,15 @@
         ) {
           controller.pendingSearchFocus = null;
         }
-      } else if (controller.pendingSearchFocus) {
-        controller.pendingSearchFocus = null;
+      } else {
+        // No node is selected, clear any active node overrides and animations
+        untrack(() => {
+          currentCy.nodes().stop();
+          currentCy.nodes().removeStyle();
+        });
+        if (controller.pendingSearchFocus) {
+          controller.pendingSearchFocus = null;
+        }
       }
     }
   });
@@ -260,7 +323,7 @@
 
     if (findCounter >= 0) {
       untrack(() => {
-        currentCy.center(node);
+        centerOnNode(node, false);
       });
     }
   });

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -192,14 +192,41 @@
               ? (controller.pendingSearchFocus?.zoom ??
                 DEFAULT_SEARCH_ENTITY_ZOOM)
               : null;
-          untrack(() =>
+          untrack(() => {
             currentCy.animate({
               center: { eles: node },
               ...(focusZoom !== null ? { zoom: focusZoom } : {}),
               duration: 800,
               easing: "ease-out-cubic",
-            }),
-          );
+            });
+
+            node.animate(
+              {
+                style: {
+                  "underlay-padding": 24,
+                  "underlay-opacity": 0.5,
+                },
+              },
+              {
+                duration: 250,
+                easing: "ease-out",
+                complete: () => {
+                  node.animate(
+                    {
+                      style: {
+                        "underlay-padding": 8,
+                        "underlay-opacity": 0.3,
+                      },
+                    },
+                    {
+                      duration: 250,
+                      easing: "ease-in",
+                    },
+                  );
+                },
+              },
+            );
+          });
           if (focusZoom !== null) {
             controller.pendingSearchFocus = null;
           }

--- a/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
@@ -8,6 +8,7 @@
   import DetailProposals from "./proposals/DetailProposals.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import { regenerationService } from "$lib/services/RegenerationService.svelte";
+  import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
 
   let {
     entity,
@@ -247,7 +248,13 @@
             ></span>
             <div class="flex-1 min-w-0 flex justify-between items-start gap-2">
               <button
-                onclick={() => (vault.selectedEntityId = conn.targetId)}
+                onclick={(e) => {
+                  layoutUIStore.setLastSelectedNodePosition({
+                    x: e.clientX,
+                    y: e.clientY,
+                  });
+                  vault.selectedEntityId = conn.targetId;
+                }}
                 class="text-left hover:text-theme-primary transition flex items-center flex-wrap gap-y-1"
               >
                 {#if conn.isOutbound}

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -24,7 +24,13 @@
     }
   }
 
-  function handleFindInGraph(entity: Entity) {
+  function handleFindInGraph(entity: Entity, event?: MouseEvent) {
+    if (event) {
+      layoutUIStore.setLastSelectedNodePosition({
+        x: event.clientX,
+        y: event.clientY,
+      });
+    }
     dispatchSearchEntityFocus(entity.id, DEFAULT_SEARCH_ENTITY_ZOOM);
     vault.selectedEntityId = entity.id;
     layoutUIStore.findInGraph();

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -30,6 +30,8 @@
         x: event.clientX,
         y: event.clientY,
       });
+    } else {
+      layoutUIStore.setLastSelectedNodePosition(null);
     }
     dispatchSearchEntityFocus(entity.id, DEFAULT_SEARCH_ENTITY_ZOOM);
     vault.selectedEntityId = entity.id;

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -23,7 +23,7 @@
     onDragStart?: (event: DragEvent, entityId: string) => void;
     onDragEnd?: () => void;
     onOpenZen?: (entity: Entity) => void;
-    onFindInGraph?: (entity: Entity) => void;
+    onFindInGraph?: (entity: Entity, event?: MouseEvent) => void;
     onApproveDraft?: (entity: Entity) => void;
     onRejectDraft?: (entity: Entity) => void;
     allowedTypes?: string[] | null;
@@ -381,7 +381,7 @@
             type="button"
             onclick={(e) => {
               e.stopPropagation();
-              onFindInGraph(entity);
+              onFindInGraph(entity, e);
             }}
             title="Find in Graph"
             aria-label="Find {entity.title} in Graph"

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -132,6 +132,8 @@ export class GraphViewController {
               x: rect.left + renderedPos.x,
               y: rect.top + renderedPos.y,
             });
+          } else {
+            this.deps.layoutUIStore.setLastSelectedNodePosition(null);
           }
 
           if (this.deps.connectionModeStore.isConnecting) {

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -124,6 +124,16 @@ export class GraphViewController {
           this.hoverPosition = null;
         },
         onNodeTap: async (id, node) => {
+          const container = this.cy?.container();
+          if (container) {
+            const rect = container.getBoundingClientRect();
+            const renderedPos = node.renderedPosition();
+            this.deps.layoutUIStore.setLastSelectedNodePosition({
+              x: rect.left + renderedPos.x,
+              y: rect.top + renderedPos.y,
+            });
+          }
+
           if (this.deps.connectionModeStore.isConnecting) {
             if (!this.deps.connectionModeStore.connectingNodeId) {
               this.deps.connectionModeStore.connectingNodeId = id;

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -8,6 +8,7 @@
   import { onboardingStore } from "$lib/stores/ui/onboarding.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { notificationStore } from "$lib/stores/ui/notification.svelte";
+  import ZenModeModal from "./ZenModeModal.svelte";
 
   let {
     isMobileMenuOpen = $bindable(false),
@@ -70,13 +71,7 @@
       {/await}
     {/if}
 
-    {#if modalUIStore.showZenMode}
-      {#await loadModal(() => import("./ZenModeModal.svelte"), "ZenModeModal") then ZenModeModal}
-        {#if ZenModeModal}
-          <ZenModeModal />
-        {/if}
-      {/await}
-    {/if}
+    <ZenModeModal />
 
     {#if helpStore.activeTour}
       {#await loadModal(() => import("$lib/components/help/TourOverlay.svelte"), "TourOverlay") then TourOverlay}

--- a/apps/web/src/lib/components/modals/ZenModeModal.svelte
+++ b/apps/web/src/lib/components/modals/ZenModeModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { vault } from "$lib/stores/vault.svelte";
   import { fly, fade } from "svelte/transition";
+  import { quintOut } from "svelte/easing";
   import { base } from "$app/paths";
   import { page } from "$app/state";
   import { openEntityPopout } from "$lib/utils/zen-popout";
@@ -38,15 +39,17 @@
   };
 
   const handleBackdropClick = () => {
-    if (!isPopout && zenViewComponent) {
+    if (isPopout) return;
+    if (zenViewComponent) {
       zenViewComponent.requestClose();
-    } else if (!isPopout) {
+    } else {
       handleClose();
     }
   };
 
   const handlePopOut = () => {
     if (!entity) return;
+
     const popOutEntity = async () => {
       let entityForPopout = entity!;
 
@@ -93,14 +96,14 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="fixed inset-0 z-[100] flex items-center justify-center p-0 md:p-8 bg-black/90 backdrop-blur-md"
-    transition:fade={{ duration: 200 }}
-    onclick={isPopout ? undefined : handleBackdropClick}
+    transition:fade={{ duration: 500 }}
+    onclick={handleBackdropClick}
     data-testid="zen-mode-modal"
   >
     <div
       class="w-full md:max-w-6xl h-full md:h-[90vh] shadow-2xl overflow-hidden"
       style:box-shadow="var(--theme-glow)"
-      transition:fly={{ y: 20, duration: 300 }}
+      transition:fly={{ y: 50, duration: 550, easing: quintOut }}
       onclick={(e) => e.stopPropagation()}
       role="presentation"
     >

--- a/apps/web/src/lib/components/search/SearchModal.svelte
+++ b/apps/web/src/lib/components/search/SearchModal.svelte
@@ -89,14 +89,10 @@
       event.stopPropagation();
     }
 
-    if (
-      event &&
-      "clientX" in event &&
-      typeof (event as any).clientX === "number"
-    ) {
+    if (event && event instanceof MouseEvent) {
       layoutUIStore.setLastSelectedNodePosition({
-        x: (event as any).clientX,
-        y: (event as any).clientY,
+        x: event.clientX,
+        y: event.clientY,
       });
     } else {
       layoutUIStore.setLastSelectedNodePosition(null);

--- a/apps/web/src/lib/components/search/SearchModal.svelte
+++ b/apps/web/src/lib/components/search/SearchModal.svelte
@@ -89,6 +89,19 @@
       event.stopPropagation();
     }
 
+    if (
+      event &&
+      "clientX" in event &&
+      typeof (event as any).clientX === "number"
+    ) {
+      layoutUIStore.setLastSelectedNodePosition({
+        x: (event as any).clientX,
+        y: (event as any).clientY,
+      });
+    } else {
+      layoutUIStore.setLastSelectedNodePosition(null);
+    }
+
     if (result.type === "quicknote" || result.id?.startsWith("quicknote-")) {
       const noteIdStr = result.id.replace("quicknote-", "");
       const noteId = parseInt(noteIdStr, 10);

--- a/apps/web/src/lib/content/changelog/releases.json
+++ b/apps/web/src/lib/content/changelog/releases.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.23.0",
+    "title": "The Animated Transitions Update",
+    "date": "2026-05-22",
+    "type": "minor",
+    "highlights": [
+      "Tactile Panel Opening: The entity detail panel now dynamically expands and scales directly from the node, button, or search result you clicked.",
+      "Mobile Bottom Sheet: The detail panel slides up smoothly as a clean bottom drawer on mobile displays to optimize reading space.",
+      "Navigational Cross-Fade: Moving between connected entities within the panel smoothly fades the inner text without jarring frame movements.",
+      "Canvas Visual Feedback: Selecting nodes on the relationship graph triggers a soft, glowing ripple underlay animation."
+    ]
+  },
+  {
     "version": "0.22.0",
     "title": "The Spatial & Scratchpad Update",
     "date": "2026-05-22",

--- a/apps/web/src/lib/stores/ui/layout-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/layout-ui.svelte.ts
@@ -60,6 +60,7 @@ export class LayoutUIStore {
   vttChatSidebarCollapsed = $state(false);
   vttEntityListCollapsed = $state(false);
   findNodeCounter = $state(0);
+  lastSelectedNodePosition = $state<{ x: number; y: number } | null>(null);
 
   constructor(
     private persistence: UIPersistence = new DefaultPersistence(),
@@ -128,6 +129,10 @@ export class LayoutUIStore {
 
   findInGraph() {
     this.findNodeCounter++;
+  }
+
+  setLastSelectedNodePosition(pos: { x: number; y: number } | null) {
+    this.lastSelectedNodePosition = pos;
   }
 
   private loadPersistedState() {

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -182,7 +182,7 @@
     {/if}
   </div>
 
-  {#if selectedEntity && EntityDetailPanel}
+  {#if EntityDetailPanel}
     <EntityDetailPanel
       entity={selectedEntity}
       onClose={() => (vault.selectedEntityId = null)}

--- a/apps/web/src/routes/(app)/vault/[id]/+page.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/+page.svelte
@@ -24,9 +24,7 @@
   {/key}
 {/if}
 
-{#if selectedEntity}
-  <EntityDetailPanel
-    entity={selectedEntity}
-    onClose={() => (vault.selectedEntityId = null)}
-  />
-{/if}
+<EntityDetailPanel
+  entity={selectedEntity}
+  onClose={() => (vault.selectedEntityId = null)}
+/>

--- a/apps/web/src/routes/(app)/vault/[id]/__tests__/EntityDetailPanelStub.svelte
+++ b/apps/web/src/routes/(app)/vault/[id]/__tests__/EntityDetailPanelStub.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  let { entity }: { entity: { id: string; title?: string } } = $props();
+  let {
+    entity,
+  }: { entity: { id: string; title?: string } | null | undefined } = $props();
 </script>
 
-<div data-testid="entity-detail-panel-stub">{entity.id}</div>
+{#if entity}
+  <div data-testid="entity-detail-panel-stub">{entity.id}</div>
+{/if}

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "0.20.4",
+      "version": "0.23.0",
       "dependencies": {
         "@codex/canvas-engine": "workspace:*",
         "@codex/events": "workspace:*",

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -156,6 +156,41 @@ const _handleUnusedEvent = (e) => {
 };
 ```
 
+## Animation and Transition Standards
+
+Immersive animations are a core pillar of Codex-Cryptica's premium design aesthetic. Use these standards to maintain a weighted, tactile, and professional motion feel:
+
+### Timing & Duration Rules
+
+- **UI Micro-interactions**: `150ms` – `250ms` (e.g., tooltips, button hover states, small dropdown toggles). Requires fast, crisp feedback.
+- **Large Drawer Side Sheets**: `500ms` – `550ms` (e.g., entity detail panels, sidebar slide-outs).
+- **Immersive Full-Screen Modals**: `550ms` – `650ms` (e.g., Zen Mode). Larger surfaces cover more visual distance and require longer durations to prevent eye strain and feel premium.
+
+### Easing Standards
+
+- NEVER use linear or robotic, jarring transitions for large elements.
+- **`quintOut`**: The default deceleration easing for immersive screen elements (cards, modal screens, drawer panels). It starts instantly to give immediate feedback on tap/click, and then spends the remainder of its duration smoothly drifting and settling into place, producing a satisfying "weighted" feel.
+
+### Technical Implementation (Avoid Broken Exit Transitions)
+
+Svelte's built-in exit transitions (`out:fade`, `transition:fly`, etc.) will NOT execute if a parent component wraps the element in a conditional check that unmounts immediately (e.g., `{#if showModal}`).
+
+To ensure entrance and exit transitions run fully:
+
+1. **Render the component persistently** in its parent provider or layouts (e.g. `<ZenModeModal />` always rendered inside `GlobalModalProvider.svelte`).
+2. **Move the conditional block inside** the component itself as its root-level template:
+   ```svelte
+   <!-- ZenModeModal.svelte -->
+   {#if modalUIStore.showZenMode && entityId}
+     <div transition:fade={{ duration: 500 }}>
+       <div transition:fly={{ y: 50, duration: 550, easing: quintOut }}>
+         ...
+       </div>
+     </div>
+   {/if}
+   ```
+   This gives the Svelte transition engine full control over element lifecycles, ensuring exit animations always play perfectly before removal.
+
 ## How to Contribute
 
 To extend the Codex-Cryptica design system, follow these steps:

--- a/specs/110-animate-node-opening/plan.md
+++ b/specs/110-animate-node-opening/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Entity Detail Panel & Graph Node Selected Animation
+
+**Branch**: `feat/animate-node-opening` | **Date**: 2026-05-22 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Implements premium, tactile visual transition animations when opening the entity detail panel and when selecting a node on the relationship graph. The panel expands outwards from the trigger point (graph node, list button, search result, connection tab) on desktop, slides up as a bottom sheet on mobile, and cross-fades content on internal navigation. The selected node highlights itself with an underlay style expansion animation.
+
+## Architecture & Coordinate Flow
+
+The following diagram illustrates how click coordinates propagate from various entry points into `layoutUIStore` and are consumed by `EntityDetailPanel` to position the transform origin:
+
+```mermaid
+graph TD
+    %% User Interactions
+    G[Graph Node Click] -->|onNodeTap| LUI[layoutUIStore.lastSelectedNodePosition]
+    E[Explorer 'Find in Graph'] -->|handleFindInGraph| LUI
+    S[Search Modal Result] -->|selectResult| LUI
+    C[Connection Click in Panel] -->|onclick| LUI
+
+    %% Consumption
+    LUI -->|Read Position| EDP[EntityDetailPanel.svelte]
+    EDP -->|Svelte custom transition| EF[expandFrom transition]
+```
+
+## Detailed Changes
+
+### UI & Layout Coordinate Tracking
+
+#### [layout-ui.svelte.ts](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/stores/ui/layout-ui.svelte.ts)
+
+- Introduced `lastSelectedNodePosition` Svelte `$state` property of type `{ x: number, y: number } | null`.
+- Provided a `setLastSelectedNodePosition(pos)` method to store target coordinates.
+
+### Coordinate Capture Entry Points
+
+#### [graph-view-controller.svelte.ts](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts)
+
+- Inside `onNodeTap`, extracted the Cytoscape node rendered position and converted it to absolute client viewport coordinates using the canvas container bounding rect.
+- Stored the position in the UI layout store.
+
+#### [EntityExplorer.svelte](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/components/explorer/EntityExplorer.svelte) & [EntityList.svelte](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/components/explorer/EntityList.svelte)
+
+- Passed the mouse `onclick` event through the `onFindInGraph` callback.
+- In `handleFindInGraph`, extracted `clientX` and `clientY` from the mouse event to set the store position.
+
+#### [SearchModal.svelte](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/components/search/SearchModal.svelte)
+
+- Extracted pointer `clientX` / `clientY` inside `selectResult` on result click.
+
+#### [DetailStatusTab.svelte](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte)
+
+- Captured `clientX` / `clientY` of the click event on connection links to preserve origin context before modifying `selectedEntityId`.
+
+### Custom Svelte Transitions
+
+#### [EntityDetailPanel.svelte](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/components/EntityDetailPanel.svelte)
+
+- Implemented `expandFrom(_node: HTMLElement)` custom transition:
+  - **Mobile**: Slides up using a `translateY` offset.
+  - **Desktop with coordinates**: Scales (`scale(t)`) and fades (`opacity: t`) from a dynamic `transform-origin` computed as:
+    ```js
+    const relativeX = pos.x - (window.innerWidth - sidebarWidth);
+    const relativeY = pos.y;
+    ```
+  - **Desktop without coordinates**: Slides in from the right edge.
+- Wrapped content wrapper in a Svelte `{#key entity.id}` block to trigger cross-fading.
+- Styled the layout container with `display: grid; grid-template-columns: 1fr; grid-template-rows: 1fr;` and placed children at `col-start-1 row-start-1` to align overlapping elements during transitions, preventing double-height vertical stacking.
+
+### Cytoscape Selection Feedback
+
+#### [GraphView.svelte](file:///home/espen/proj/Codex-Arcana/apps/web/src/lib/components/GraphView.svelte)
+
+- Inside the selection effect, triggered an imperative Cytoscape animation on the selected node:
+  1. Scales `underlay-padding` to `24px` and increases `underlay-opacity` to `0.5` over 250ms.
+  2. Restores `underlay-padding` to `8px` and `underlay-opacity` to `0.3` over 250ms on completion.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+
+- Run full Vitest test suites to check layout stores and component regression:
+  ```bash
+  bun run test
+  ```
+
+### Manual Verification
+
+1. **Desktop Scale Transition**: Click a node on the graph. Verify the panel expands outward from the node center.
+2. **Explorer Transition**: Open the entity list and click "Find in Graph" on a character. Verify the panel expands outward from the button clicked.
+3. **Internal Nav Cross-fade**: Inside the detail panel, click a connection link. Verify the panel remains static, and old content fades out as the new content fades in.
+4. **Mobile Bottom Sheet**: Resize browser to mobile width and click a node. Verify the panel slides up from the bottom.
+5. **Graph Selected Pulse**: Click any node on the graph. Verify a subtle ripple expands and shrinks on the node's selection underlay.

--- a/specs/110-animate-node-opening/spec.md
+++ b/specs/110-animate-node-opening/spec.md
@@ -1,0 +1,83 @@
+# Feature Specification: Entity Detail Panel & Graph Node Selected Animation
+
+**Feature Branch**: `feat/animate-node-opening`  
+**Created**: 2026-05-22  
+**Status**: Retroactive / Approved  
+**Input**: Issue #846: "animate opening of entity detail panel and selected graph node"
+
+## User Scenarios & Testing
+
+### User Story 1 - Tactile Panel Open (Priority: P1)
+
+As a Game Master, I want the entity detail panel to expand outward from the specific node or link I just clicked on the graph or UI, so that I have a clear spatial connection and context for where the detail data is coming from.
+
+**Why this priority**: Enhances the visual connection and spatial feedback when opening details, avoiding abrupt layout changes.
+
+**Independent Test**: Click a node on the graph canvas and observe the panel expanding from the node's position.
+
+**Acceptance Scenarios**:
+
+1. **Given** the relationship graph, **When** I click a node, **Then** the details panel scales and opacity-fades outward from the clicked node's screen coordinates.
+2. **Given** any other trigger without screen coordinates (e.g., global command or fallback), **When** the detail panel is opened, **Then** it slides in smoothly from the right edge of the screen on desktop.
+
+---
+
+### User Story 2 - Mobile-Friendly Bottom Sheet (Priority: P1)
+
+As a mobile user of Codex Cryptica, I want the details panel to slide up from the bottom of the screen like a native bottom sheet, so that the presentation is clean, readable, and conforms to mobile UX patterns.
+
+**Why this priority**: Desktop scaling does not translate well to narrow mobile viewports.
+
+**Independent Test**: Open the application on a mobile viewport and trigger opening an entity's details; verify that the sheet slides up from the bottom.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mobile-width browser window, **When** I tap any entity, **Then** the details panel slides up from the bottom of the screen.
+
+---
+
+### User Story 3 - Fluid Internal Navigation (Priority: P1)
+
+As a Game Master, I want to click connections inside the detail panel and have the content swap with a smooth cross-fade, without having the panel frame collapse or animate, so that my focus remains on the content.
+
+**Why this priority**: Navigating between entities inside the open panel shouldn't trigger the heavy expand/collapse animation of the container.
+
+**Independent Test**: Open a detail panel, click a connected entity link inside the details tab, and verify that the panel container remains static while the tabs/content cross-fade.
+
+**Acceptance Scenarios**:
+
+1. **Given** the details panel is open for "Entity A", **When** I click on a connected link to "Entity B" inside the panel, **Then** the panel frame remains static, and the old content fades out as the new content fades in.
+
+---
+
+### User Story 4 - Selected Node Pulse Ripple (Priority: P2)
+
+As a Game Master, I want a visual feedback ripple on the selected node on the graph, so that I can immediately identify which node corresponds to the open details panel.
+
+**Why this priority**: Provides clear visual correlation between the canvas selection and the detail panel content.
+
+**Independent Test**: Select a node on the graph and observe a brief padding/opacity ripple styling underlay expansion.
+
+**Acceptance Scenarios**:
+
+1. **Given** a node on the Cytoscape canvas, **When** I select/tap the node, **Then** a brief style animation runs on the selected node underlay (expanding underlay-padding from 8 to 24, then back to 8).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The system MUST store and track the screen coordinates of the last selected entity trigger in a global UI layout store (`layoutUIStore`).
+- **FR-002**: The details panel MUST execute a custom Svelte transition (`expandFrom`) that adjusts `transform-origin` dynamically based on the stored screen coordinates.
+- **FR-003**: If no click coordinate is stored, the `expandFrom` Svelte transition on desktop MUST fall back to a slide-in translation from the right.
+- **FR-004**: On mobile viewports, the details panel MUST slide up from the bottom of the screen using a translation transition.
+- **FR-005**: The detail panel content wrapper MUST use Svelte `{#key entity.id}` and cross-fade transitions (`in:fade`, `out:fade`) to transition content when navigating between entities.
+- **FR-006**: To prevent double-height layouts during the cross-fade, the detail panel content wrapper MUST use a CSS grid container overlay (`display: grid; grid-template-columns: 1fr; grid-template-rows: 1fr;`) with both entering and exiting items placed at `col-start-1 row-start-1`.
+- **FR-007**: Selecting a node on the Cytoscape graph canvas MUST trigger a styled underlay padding/opacity animation pulse.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Transition durations are visually snappy and fluid (300-350ms container transition, 150ms inner cross-fade).
+- **SC-002**: Content cross-fade does not cause vertical height jumps or layout shifts.
+- **SC-003**: The selected node pulse completes within 500ms and correctly resets styles to avoid rendering artifacts.

--- a/specs/110-animate-node-opening/spec.md
+++ b/specs/110-animate-node-opening/spec.md
@@ -73,11 +73,14 @@ As a Game Master, I want a visual feedback ripple on the selected node on the gr
 - **FR-005**: The detail panel content wrapper MUST use Svelte `{#key entity.id}` and cross-fade transitions (`in:fade`, `out:fade`) to transition content when navigating between entities.
 - **FR-006**: To prevent double-height layouts during the cross-fade, the detail panel content wrapper MUST use a CSS grid container overlay (`display: grid; grid-template-columns: 1fr; grid-template-rows: 1fr;`) with both entering and exiting items placed at `col-start-1 row-start-1`.
 - **FR-007**: Selecting a node on the Cytoscape graph canvas MUST trigger a styled underlay padding/opacity animation pulse.
+- **FR-008**: The Zen Mode modal (`ZenModeModal`) MUST utilize premium fluid transitions (`transition:fade` and `transition:fly` with `quintOut` easing) for smooth entrance and exit animations on desktop and mobile viewports.
+- **FR-009**: Large overlay elements and modals MUST be persistently mounted in their parent provider blocks (e.g. `GlobalModalProvider.svelte`) rather than wrapped in parent conditional statements, ensuring exit transition lifecycles play to completion in the DOM before destruction.
 
 ## Success Criteria
 
 ### Measurable Outcomes
 
-- **SC-001**: Transition durations are visually snappy and fluid (300-350ms container transition, 150ms inner cross-fade).
+- **SC-001**: Transition durations on large/immersive containers are visually weighted and fluid, utilizing premium deceleration (`quintOut` easing with `500ms` – `600ms` container transitions, and `150ms` inner cross-fades) to prevent eye strain and feel cohesive.
 - **SC-002**: Content cross-fade does not cause vertical height jumps or layout shifts.
 - **SC-003**: The selected node pulse completes within 500ms and correctly resets styles to avoid rendering artifacts.
+- **SC-004**: Zen Mode backdrop and card elements slide/fade from the bottom with a complete exit transition when the modal is closed.

--- a/specs/110-animate-node-opening/tasks.md
+++ b/specs/110-animate-node-opening/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: Entity Detail Panel & Graph Node Selected Animation
+
+- [x] Track trigger coordinates in layout store (`layoutUIStore.lastSelectedNodePosition`)
+- [x] Extract node rendered coordinates on Cytoscape tap in `graph-view-controller.svelte.ts`
+- [x] Implement Cytoscape underlay pulse animation in `GraphView.svelte`
+- [x] Capture mouse click coordinates in `SearchModal.svelte`
+- [x] Capture mouse click coordinates in `DetailStatusTab.svelte`
+- [x] Capture mouse click coordinates in `EntityExplorer.svelte` and `EntityList.svelte`
+- [x] Implement custom transition `expandFrom` in `EntityDetailPanel.svelte`
+- [x] Wrap panel content in `{#key}` with cross-fade and CSS grid overlay to prevent layout shifts
+- [x] Run linting and automated test suite to ensure zero regressions

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -18,6 +18,12 @@ The following high-impact candidate specifications target performance, scaling, 
 
 ## 🏛️ Historical Roadmap & Release Timeline
 
+### v0.23.0 — The Animated Transitions Update (2026-05-22)
+
+- **Highlights**: Animated entity detail panel opening (scaling/translating from click location), native bottom sheet panel transitions on mobile viewports, seamless content cross-fading on internal details navigation, and graph node selection pulse animations.
+- **Associated Specifications**:
+  - [110-animate-node-opening](./110-animate-node-opening/spec.md) (Entity detail panel and graph node selected transitions)
+
 ### v0.22.0 — The Spatial & Scratchpad Update (2026-05-22)
 
 - **Highlights**: QuickNote scratchpad, AI-driven entity synthesis/elevation, full Svelte 5 Rune conversion, progressive background search worker, and decoupled P2P network services.


### PR DESCRIPTION
Resolves #846

## Summary
Animates the opening of the entity detail panel and selected graph node to deliver a premium, tactile, and smooth user experience.

## Details of Changes
- **Desktop Transition**: The entity detail panel now scales and translates outward directly from the clicked node/item screen coordinates using a custom Svelte transition (`expandFrom`). If no coordinates are available (e.g., opened via search or other entry points), it falls back to a smooth slide-in from the right.
- **Mobile Transition**: On mobile viewports, the panel slides up from the bottom (like a bottom sheet drawer) to optimize screen space.
- **Internal Navigation**: While the panel is open, navigating to connected entities inside the details panel cross-fades the inner content smoothly using a Svelte `{#key}` block without shifting or moving the outer panel frame.
- **Overlapping Transition Fix**: Applied a CSS grid overlay layout inside the detail panel scroll container to align entering and exiting items at `col-start-1 row-start-1`, preventing layout shifts or double-height stacking during cross-fades.
- **Selected Node Pulse**: Selecting a node in the Cytoscape graph canvas triggers a brief padding and opacity ripple animation on the selected node underlay to draw visual focus.
- **Roadmap & Changelog**: Created specification folder `110-animate-node-opening` documenting the requirements and architecture. Registered the feature under release `v0.23.0` in the roadmap and the user-facing changelog, and bumped the web app version to `0.23.0`.

## Verification
- Checked that eslint formatting passes: `bun run --filter web lint`
- Checked that all vitest unit tests pass: `bun run --filter web test` (183 passed)
