### PR TITLE
🔧 chore: enforce bun, remove pnpm-workspace, and update scripts/hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,3 @@
-pnpm exec commitlint --edit ${1}
+#!/usr/bin/env sh
+[ -d "$HOME/.bun/bin" ] && export PATH="$HOME/.bun/bin:$PATH"
+bunx commitlint --edit ${1}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 [ -d "$HOME/.bun/bin" ] && export PATH="$HOME/.bun/bin:$PATH"
-bunx commitlint --edit ${1}
+bunx commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
-pnpm exec lint-staged
+#!/usr/bin/env sh
+[ -d "$HOME/.bun/bin" ] && export PATH="$HOME/.bun/bin:$PATH"
+bunx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+[ -d "$HOME/.bun/bin" ] && export PATH="$HOME/.bun/bin:$PATH"
 
 skip_pattern='^(apps/web/src/lib/content/blog/|scripts/publish-blog-content\.mjs$|\.github/workflows/deploy-blog-content\.yml$|docs/BLOG_DEPLOYMENT\.md$|docs/CI_DEPLOYMENT\.md$)'
 blog_only=true

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -159,7 +159,7 @@ specs/          # Feature specifications
 
 ## Commands
 
-pnpm test; pnpm run lint
+bun run test; bun run lint
 
 ## Code Style
 
@@ -175,7 +175,7 @@ TypeScript: Follow standard conventions
 - **Style Guide Adherence**: ALWAYS read and adhere to `@docs/STYLE_GUIDE.md`. All UI components MUST use Svelte 5 Runes and Tailwind 4 semantic tokens (e.g., `text-theme-primary`).
 - **Icon Usage**: NEVER use `lucide-svelte` components. ALWAYS use the Iconify utility pattern: `class="icon-[lucide--name] h-4 w-4"`.
 - **Reactive Snapshots**: Use `$state.snapshot(obj)` when passing state to non-reactive logic or async handlers to prevent stale references.
-- **Mandatory Testing**: NEVER consider a feature or bug fix complete without corresponding unit tests. For every new logic branch or service method, you MUST add a test case. If an existing test file exists for the module, append to it; otherwise, create a new one. Verification is only complete when `pnpm test` passes with your changes.
+- **Mandatory Testing**: NEVER consider a feature or bug fix complete without corresponding unit tests. For every new logic branch or service method, you MUST add a test case. If an existing test file exists for the module, append to it; otherwise, create a new one. Verification is only complete when `bun run test` passes with your changes.
 - **Prefix Unused Vars**: Always prefix unused callback parameters or variables with an underscore (e.g., `_evt`) to satisfy strict `no-unused-vars` linting rules.
 - **Svelte 5 Reactivity**: Avoid initializing `$state` directly from props (e.g., `let x = $state(prop)`). Use `$derived` for data that should stay in sync, or ensure the intent of a local-only copy is clear to avoid `state_referenced_locally` warnings.
 - **Tailwind 4 Syntax**: Use Tailwind 4's `@reference`, `@theme`, and `@apply` rules correctly in Svelte `<style>` blocks. Ignore standard CSS linter warnings for these specific at-rules.

--- a/QWEN.md
+++ b/QWEN.md
@@ -60,7 +60,7 @@ Codex-Arcana/
 ### Prerequisites
 
 - Node.js 24+
-- pnpm (Recommended)
+- Bun (Recommended)
 
 ### Installation
 
@@ -68,19 +68,19 @@ Codex-Arcana/
 # Clone and install dependencies
 git clone <repository>
 cd Codex-Arcana
-pnpm install
+bun install
 ```
 
 ### Development
 
 ```bash
 # Start development server (all packages)
-pnpm run dev
+bun run dev
 # or
 turbo run dev
 
 # Start only the web app
-pnpm --filter web run dev
+bun run --filter web dev
 ```
 
 Open [http://localhost:5173](http://localhost:5173) to view the application.
@@ -89,7 +89,7 @@ Open [http://localhost:5173](http://localhost:5173) to view the application.
 
 ```bash
 # Build all packages
-pnpm run build
+bun run build
 # or
 turbo run build
 ```
@@ -98,26 +98,26 @@ turbo run build
 
 ```bash
 # Run all unit tests
-pnpm test
+bun run test
 
 # Run tests with coverage
-pnpm run test:coverage
+bun run test:coverage
 
 # Run E2E tests (Playwright)
-pnpm run test:e2e
+bun run test:e2e
 
 # Test specific workspace
-pnpm --filter @codex/vault-engine test
+bun run --filter @codex/vault-engine test
 ```
 
 ### Linting & Formatting
 
 ```bash
 # Lint all packages
-pnpm run lint
+bun run lint
 
 # Format code
-pnpm run format
+bun run format
 ```
 
 ## Development Conventions
@@ -135,7 +135,7 @@ All commits must start with a [gitmoji](https://gitmoji.dev/) emoji:
 🔧 Configuration change
 ```
 
-Use `pnpm exec gitmoji -c` for interactive commit with emoji selection.
+Use `bunx gitmoji -c` for interactive commit with emoji selection.
 
 ### Pre-commit Hooks
 
@@ -254,7 +254,7 @@ The application builds as a **static site** deployed to GitHub Pages. The Oracle
 
 ## Git Workflow
 
-- Before committing, run `pnpm run lint` and `pnpm run test` to catch errors early
+- Before committing, run `bun run lint` and `bun run test` to catch errors early
 - If commitlint fails, use `git reset --soft HEAD~1` to amend rather than creating new commits
 - When addressing PR comments, reference the specific comment thread in your commit message
 
@@ -284,4 +284,4 @@ The application builds as a **static site** deployed to GitHub Pages. The Oracle
 
 ## Qwen Added Memories
 
-- Always run playwright test with --last-failed --max-failures=5 --reporter=line when iterating on fixes. --last-failed only reruns previously failed tests. --max-failures=5 stops after 5 failures (fail-fast). --reporter=line gives terse output. Only applies when invoking pnpm exec playwright test directly; pnpm run test:e2e already has default flags.
+- Always run playwright test with --last-failed --max-failures=5 --reporter=line when iterating on fixes. --last-failed only reruns previously failed tests. --max-failures=5 stops after 5 failures (fail-fast). --reporter=line gives terse output. Only applies when invoking bunx playwright test directly; bun run test:e2e already has default flags.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "codex-cryptica",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.14",
   "workspaces": [
     "apps/*",
     "packages/*"
@@ -10,6 +11,7 @@
     "bun": ">=1.3.0"
   },
   "scripts": {
+    "preinstall": "node -e \"if (!/bun/.test(process.env.npm_config_user_agent || '')) { console.error('\\u001b[31mError: Please use Bun to install dependencies in this repository (run \\`bun install\\`).\\u001b[0m\\n'); process.exit(1); }\"",
     "build": "bun run --filter '*' build",
     "dev": "bun run --filter web dev",
     "lint": "bun run --filter '*' lint",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-packages:
-  - 'apps/*'
-  - 'packages/*'

--- a/scripts/blog-screenshots/README.md
+++ b/scripts/blog-screenshots/README.md
@@ -21,7 +21,7 @@ scripts/blog-screenshots/
 
 ```bash
 cd apps/web
-pnpm run test:e2e -- --grep "Blog Screenshots" --timeout=120000
+bun run test:e2e -- --grep "Blog Screenshots" --timeout=120000
 ```
 
 Screenshots are saved to `blogPics/<blog-name>/` at the project root.
@@ -160,7 +160,7 @@ Recommended approach: Use automated screenshots for deterministic commands (`/ro
 Increase the timeout:
 
 ```bash
-pnpm run test:e2e -- --grep "Blog Screenshots" --timeout=180000
+bun run test:e2e -- --grep "Blog Screenshots" --timeout=180000
 ```
 
 ### Element Not Found

--- a/scripts/blog-screenshots/playwright.config.ts
+++ b/scripts/blog-screenshots/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm run dev -- --port 5173",
+    command: "bun run dev -- --port 5173",
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/scripts/blog-screenshots/playwright.config.ts
+++ b/scripts/blog-screenshots/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "bun run dev -- --port 5173",
+    command: "bun run dev --port 5173",
     url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
   },

--- a/scripts/pr-labeler.mjs
+++ b/scripts/pr-labeler.mjs
@@ -90,6 +90,7 @@ function filesLabel(files) {
         path.endsWith("/package.json") ||
         path.endsWith("/package-lock.json") ||
         path.includes("pnpm-lock.yaml") ||
+        path.includes("bun.lock") ||
         path.includes("npm-shrinkwrap.json"),
     )
   ) {

--- a/scripts/upload-064-assets.mjs
+++ b/scripts/upload-064-assets.mjs
@@ -14,9 +14,9 @@ for (const file of files) {
   
   console.log(`Uploading ${file} to ${remotePath}...`);
   try {
-    execFileSync('pnpm', [
-        'exec',
-        'wrangler',      'r2',
+    execFileSync('bunx', [
+      'wrangler',
+      'r2',
       'object',
       'put',
       `${BUCKET}/${remotePath}`,

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -14,7 +14,7 @@ for (const file of files) {
   
   console.log(`Uploading ${file} to ${remotePath}...`);
   try {
-    execSync(`pnpm exec wrangler r2 object put ${BUCKET}/${remotePath} --file ${localPath} --remote`, { stdio: 'inherit' });
+    execSync(`bunx wrangler r2 object put ${BUCKET}/${remotePath} --file ${localPath} --remote`, { stdio: 'inherit' });
   } catch (error) {
     console.error(`Failed to upload ${file}:`, error);
   }

--- a/scripts/upload-images.mjs
+++ b/scripts/upload-images.mjs
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readdirSync } from 'fs';
 import { join } from 'path';
 
@@ -14,7 +14,16 @@ for (const file of files) {
   
   console.log(`Uploading ${file} to ${remotePath}...`);
   try {
-    execSync(`bunx wrangler r2 object put ${BUCKET}/${remotePath} --file ${localPath} --remote`, { stdio: 'inherit' });
+    execFileSync('bunx', [
+      'wrangler',
+      'r2',
+      'object',
+      'put',
+      `${BUCKET}/${remotePath}`,
+      '--file',
+      localPath,
+      '--remote'
+    ], { stdio: 'inherit' });
   } catch (error) {
     console.error(`Failed to upload ${file}:`, error);
   }


### PR DESCRIPTION
### Overview
This PR migrates the workspace fully to Bun, removing leftover pnpm references and configuration files, updating git hooks, and adding package-level checks to prevent accidental `pnpm`, `npm`, or `yarn` usage.

### Changes
- Deleted `pnpm-workspace.yaml` (workspaces are already defined in `package.json`).
- Updated `package.json` with `"packageManager": "bun@1.3.14"` and added a `preinstall` hook to warn and block other package managers.
- Updated Husky hooks (`.husky/pre-commit`, `.husky/commit-msg`, and `.husky/pre-push`) to use `bunx` / `bun` and added dynamic path exports for `~/.bun/bin` to prevent hook execution failures.
- Updated residual command references in Playwright, image uploads, and pr-labeler scripts.
- Refactored `GEMINI.md` and `QWEN.md` guidelines to recommend Bun commands to developers and AI models.