### PR TITLE
fix(p2p): ignore internal connection-level control messages in dispatcher

### DIFF
--- a/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.test.ts
@@ -122,4 +122,30 @@ describe("P2PDispatcher", () => {
     expect(handled).toBe(false);
     expect(handler.handle).not.toHaveBeenCalled();
   });
+
+  it("should silently ignore internal PeerJS connection-level messages", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const dispatcher = new P2PDispatcher();
+
+    const handler: P2PMessageHandler = {
+      canHandle: vi.fn(() => true),
+      handle: vi.fn(),
+    };
+    dispatcher.register(handler);
+
+    const internalTypes = ["handshake", "handshake_ack", "ping", "pong"];
+    for (const type of internalTypes) {
+      const handled = await dispatcher.dispatch(
+        { type } as any,
+        {} as any,
+        {} as any,
+      );
+      expect(handled).toBe(false);
+      expect(handler.canHandle).not.toHaveBeenCalled();
+      expect(handler.handle).not.toHaveBeenCalled();
+    }
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
 });

--- a/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.ts
@@ -35,6 +35,12 @@ export class P2PDispatcher<TContext = P2PHandlerContext> {
 
     const p2pMessage = message as P2PMessage;
 
+    // Filter out internal PeerJS connection-level control messages
+    const INTERNAL_TYPES = ["handshake", "handshake_ack", "ping", "pong"];
+    if (INTERNAL_TYPES.includes(p2pMessage.type)) {
+      return false;
+    }
+
     for (const handler of this.handlers) {
       try {
         if (handler.canHandle(p2pMessage)) {


### PR DESCRIPTION
Ignores internal PeerJS connection-level control messages (`handshake`, `handshake_ack`, `ping`, `pong`) in the message dispatcher on both Host and Guest sides to avoid unhandled/warning message console logs.