### PR TITLE
fix(p2p): implement host-side support for PeerJS Connection Manager handshake and heartbeats

### DIFF
--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -90,6 +90,29 @@ export class P2PHostService {
     });
 
     this.transport.on("data", async ({ conn, data }) => {
+      if (data && typeof data === "object") {
+        if (data.type === "handshake") {
+          console.log("[P2P Host] Received handshake from:", conn.peer);
+          const ack = {
+            type: "handshake_ack",
+            senderId: this.transport.id || "",
+            timestamp: Date.now(),
+            payload: null,
+          };
+          conn.send(ack);
+          return;
+        }
+        if (data.type === "ping") {
+          const pong = {
+            type: "pong",
+            senderId: this.transport.id || "",
+            timestamp: (data as any).timestamp || Date.now(),
+            payload: null,
+          };
+          conn.send(pong);
+          return;
+        }
+      }
       await this.dispatcher.dispatch(data, conn, this.getHandlerContext());
     });
 

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
@@ -587,6 +587,56 @@ describe("P2P Services", () => {
       );
     });
 
+    it("should respond to handshake with a handshake_ack message", async () => {
+      await startHostingHelper(hostService);
+      const transport = (hostService as any).transport;
+      const peerInstance = (transport as any).peer;
+
+      const mockConn = new MockConnection("guest-1");
+      peerInstance.emit("connection", mockConn);
+      mockConn.emit("open");
+
+      mockConn.emit("data", {
+        type: "handshake",
+        senderId: "guest-1",
+        timestamp: Date.now(),
+        payload: { clientPeerId: "guest-1" },
+      });
+
+      expect(mockConn.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "handshake_ack",
+          senderId: "mock-peer-id",
+        }),
+      );
+    });
+
+    it("should respond to ping with a pong message", async () => {
+      await startHostingHelper(hostService);
+      const transport = (hostService as any).transport;
+      const peerInstance = (transport as any).peer;
+
+      const mockConn = new MockConnection("guest-1");
+      peerInstance.emit("connection", mockConn);
+      mockConn.emit("open");
+
+      const pingTimestamp = 123456789;
+      mockConn.emit("data", {
+        type: "ping",
+        senderId: "guest-1",
+        timestamp: pingTimestamp,
+        payload: null,
+      });
+
+      expect(mockConn.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "pong",
+          senderId: "mock-peer-id",
+          timestamp: pingTimestamp,
+        }),
+      );
+    });
+
     it("should stop hosting and clear connections", async () => {
       await startHostingHelper(hostService);
       const transport = (hostService as any).transport;


### PR DESCRIPTION
Implements host-side protocol support for PeerJS Connection Manager handshakes and ping/pong heartbeats. When a Guest client connects using the new connection manager, the Host now correctly acknowledges the 'handshake' message and responds to 'ping' messages with 'pong'. This allows the Guest connection state to transition to 'connected' and prevents the Guest connection from timing out.