### PR TITLE
🐛 fix(p2p): unwrap PeerJSMessage envelopes and silence FILE_RESPONSE warning

### DIFF
--- a/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.test.ts
@@ -123,7 +123,7 @@ describe("P2PDispatcher", () => {
     expect(handler.handle).not.toHaveBeenCalled();
   });
 
-  it("should silently ignore internal PeerJS connection-level messages", async () => {
+  it("should silently ignore internal and silent out-of-band message types", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const dispatcher = new P2PDispatcher();
 
@@ -133,14 +133,14 @@ describe("P2PDispatcher", () => {
     };
     dispatcher.register(handler);
 
-    const internalTypes = [
+    const silentTypes = [
       "handshake",
       "handshake_ack",
       "ping",
       "pong",
       "FILE_RESPONSE",
     ];
-    for (const type of internalTypes) {
+    for (const type of silentTypes) {
       const handled = await dispatcher.dispatch(
         { type } as any,
         {} as any,

--- a/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.test.ts
@@ -133,7 +133,13 @@ describe("P2PDispatcher", () => {
     };
     dispatcher.register(handler);
 
-    const internalTypes = ["handshake", "handshake_ack", "ping", "pong"];
+    const internalTypes = [
+      "handshake",
+      "handshake_ack",
+      "ping",
+      "pong",
+      "FILE_RESPONSE",
+    ];
     for (const type of internalTypes) {
       const handled = await dispatcher.dispatch(
         { type } as any,

--- a/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.ts
@@ -35,9 +35,15 @@ export class P2PDispatcher<TContext = P2PHandlerContext> {
 
     const p2pMessage = message as P2PMessage;
 
-    // Filter out internal PeerJS connection-level control messages
-    const INTERNAL_TYPES = ["handshake", "handshake_ack", "ping", "pong"];
-    if (INTERNAL_TYPES.includes(p2pMessage.type)) {
+    // Filter out internal/silent message types that are handled out-of-band
+    const SILENT_TYPES = [
+      "handshake",
+      "handshake_ack",
+      "ping",
+      "pong",
+      "FILE_RESPONSE",
+    ];
+    if (SILENT_TYPES.includes(p2pMessage.type)) {
       return false;
     }
 

--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -113,7 +113,21 @@ export class P2PHostService {
           return;
         }
       }
-      await this.dispatcher.dispatch(data, conn, this.getHandlerContext());
+      // Unwrap PeerJSMessage envelope if present (e.g. from connection manager)
+      let messageToDispatch = data;
+      if (
+        data &&
+        typeof data === "object" &&
+        "senderId" in data &&
+        "payload" in data
+      ) {
+        messageToDispatch = (data as any).payload;
+      }
+      await this.dispatcher.dispatch(
+        messageToDispatch,
+        conn,
+        this.getHandlerContext(),
+      );
     });
 
     this.transport.on("error", (err) => {

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p.test.ts
@@ -637,6 +637,41 @@ describe("P2P Services", () => {
       );
     });
 
+    it("should unwrap a PeerJSMessage envelope before dispatching", async () => {
+      await startHostingHelper(hostService);
+      const transport = (hostService as any).transport;
+      const peerInstance = (transport as any).peer;
+
+      const mockConn = new MockConnection("guest-1");
+      peerInstance.emit("connection", mockConn);
+      mockConn.emit("open");
+
+      const dispatchSpy = vi
+        .spyOn((hostService as any).dispatcher, "dispatch")
+        .mockResolvedValue(true);
+
+      const wrappedPayload = {
+        type: "GET_FILE",
+        path: "images/test.png",
+        requestId: "req-123",
+      };
+
+      mockConn.emit("data", {
+        type: "GET_FILE",
+        senderId: "guest-1",
+        timestamp: Date.now(),
+        payload: wrappedPayload,
+      });
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        wrappedPayload,
+        expect.any(Object),
+        expect.any(Object),
+      );
+
+      dispatchSpy.mockRestore();
+    });
+
     it("should stop hosting and clear connections", async () => {
       await startHostingHelper(hostService);
       const transport = (hostService as any).transport;


### PR DESCRIPTION
This PR fixes the issue where guests cannot retrieve or sync files/images from the host (resulting in timeouts), and silences the verbose dispatcher warning 'No handler found for message type: FILE_RESPONSE'.

### Proposed Changes
1. **Unwrap Wrapped Messages on Host**: Modified `apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts` to unwrap `PeerJSMessage` envelopes prior to dispatching.
2. **Silence FILE_RESPONSE**: Added `"FILE_RESPONSE"` to the `SILENT_TYPES` list in `apps/web/src/lib/cloud-bridge/p2p/dispatcher/p2p-dispatcher.ts`.
3. **Tests**: Added a unit test verifying envelope unwrapping and dispatcher silencing. All 23 tests are green.