### PR TITLE
[codex] Default art prompts

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -273,6 +273,8 @@ The application builds as a **static site** deployed to GitHub Pages. The Oracle
 ## Active Technologies
 - TypeScript 6.x, Svelte 5, Bun 1.3.x package workflow + SvelteKit, Tailwind CSS 4 semantic tokens, Vitest, Playwright, Cytoscape, workspace `schema` and `graph-engine` packages (113-neutral-world-theming)
 - Existing browser persistence: `localStorage`, IndexedDB settings, and per-vault OPFS config. Add app-appearance preference as global browser preference; keep world theme per vault. (113-neutral-world-theming)
+- TypeScript 6.x, Svelte 5, Bun 1.3.x package workflow + SvelteKit, workspace `schema`, existing Oracle/image generation services, existing vault/entity/category stores, Vitest, Playwright (115-default-art-prompts)
+- No new settings storage. Shipped defaults live in code/shared package definitions. User-authored art direction remains ordinary vault content using existing entity/note persistence. (115-default-art-prompts)
 
 - TypeScript (as project standard) + Svelte 5 (UI), existing `map.svelte.ts` (base map), existing P2P host-service/client-adapter (sync) (079-vtt-light)
 - In-memory session state; optional vault persistence via OPFS for encounter snapshots (079-vtt-light)

--- a/apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+++ b/apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
@@ -98,6 +98,20 @@ describe("GraphContextMenuController", () => {
     expect(deps.oracle.drawEntity).toHaveBeenCalledWith("node-1");
   });
 
+  it("should keep graph image generation on the central entity draw path", async () => {
+    deps.vault.entities["node-1"] = {
+      id: "node-1",
+      title: "Glass Tower",
+      type: "location",
+    };
+    controller.selectedNodes = ["node-1"];
+
+    await controller.handleGenerateImage();
+
+    expect(deps.oracle.drawEntity).toHaveBeenCalledTimes(1);
+    expect(deps.oracle.drawEntity).toHaveBeenCalledWith("node-1");
+  });
+
   it("should handle node deletion with confirmation", async () => {
     controller.selectedNodes = ["node-1"];
     await controller.deleteNodes();

--- a/apps/web/src/lib/components/world/FrontPage.test.ts
+++ b/apps/web/src/lib/components/world/FrontPage.test.ts
@@ -335,6 +335,12 @@ describe("FrontPage", () => {
       ),
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining("Default Art Style: Moonfall"),
+    );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining("atmospheric world cover art"),
+    );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining(
         "Briefing: A broken moon hangs over the **capital**.",
       ),

--- a/apps/web/src/lib/components/world/FrontPage.test.ts
+++ b/apps/web/src/lib/components/world/FrontPage.test.ts
@@ -110,6 +110,7 @@ if (!HTMLElement.prototype.animate) {
 vi.mock("$lib/stores/theme.svelte", () => ({
   themeStore: {
     activeTheme: {
+      id: "cyberpunk",
       name: "Neon Night",
       description:
         "Cyberpunk, neon-noir, corporate control, street-level rebellion, hackers, implants, and high-tech urban danger.",
@@ -339,6 +340,9 @@ describe("FrontPage", () => {
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining("atmospheric world cover art"),
+    );
+    expect(mocks.generateCoverImage).toHaveBeenCalledWith(
+      expect.stringContaining("Theme Style: Moonfall, neon urban concept art"),
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining(

--- a/apps/web/src/lib/components/world/front-page/front-page-controller.ts
+++ b/apps/web/src/lib/components/world/front-page/front-page-controller.ts
@@ -70,7 +70,7 @@ export interface FrontPageControllerDeps {
     resolveImageUrl: (imagePath: string) => Promise<string | undefined>;
   };
   themeStore: {
-    activeTheme: { name: string; description: string };
+    activeTheme: { id?: string; name: string; description: string };
   };
 }
 
@@ -127,6 +127,7 @@ export class FrontPageController {
     const { worldStore, themeStore, vault } = this.deps;
 
     const themeName = themeStore.activeTheme.name;
+    const themeId = themeStore.activeTheme.id;
     const themeDescription = themeStore.activeTheme.description.trim();
     const briefingText =
       resolveBriefingSource(
@@ -142,6 +143,7 @@ export class FrontPageController {
       themeDescription,
       briefingText,
       retrievedWorldContext,
+      themeId,
     );
 
     try {

--- a/apps/web/src/lib/components/world/front-page/front-page-prompts.ts
+++ b/apps/web/src/lib/components/world/front-page/front-page-prompts.ts
@@ -20,6 +20,17 @@ export function createWorldCoverPrompt(
     surface: "cover",
     themeId,
   });
+  const themeArtDirection = themeId
+    ? resolveArtDirection({
+        subject: safeName,
+        surface: "chat",
+        themeId,
+      })
+    : null;
+  const themeStyleLine =
+    themeArtDirection?.source === "theme-default"
+      ? `- Theme Style: ${themeArtDirection.prompt}\n`
+      : "";
 
   return `Create atmospheric portrait cover art for "${safeName}".
 
@@ -34,7 +45,7 @@ ${safeWorldContext}
 
 Art direction:
 - Default Art Style: ${artDirection.prompt}
-- Portrait composition, vertical framing, approximately 2:3 aspect ratio.
+${themeStyleLine}- Portrait composition, vertical framing, approximately 2:3 aspect ratio.
 - Focus on the tone, mood, and symbolic atmosphere of the setting.
 - Depict the world itself more than a single action scene.
 - Emphasize place, tension, and identity through lighting, silhouette, color, and environment.

--- a/apps/web/src/lib/components/world/front-page/front-page-prompts.ts
+++ b/apps/web/src/lib/components/world/front-page/front-page-prompts.ts
@@ -1,3 +1,5 @@
+import { resolveArtDirection } from "schema";
+
 /**
  * Build an AI prompt for generating a world cover image.
  */
@@ -7,11 +9,17 @@ export function createWorldCoverPrompt(
   themeDescription: string,
   briefing: string,
   worldContext: string,
+  themeId?: string,
 ): string {
   const safeBriefing = briefing.trim() || "An unexplored setting.";
   const safeName = worldName.trim() || "this world";
   const safeWorldContext =
     worldContext.trim() || "No additional context was retrieved.";
+  const artDirection = resolveArtDirection({
+    subject: safeName,
+    surface: "cover",
+    themeId,
+  });
 
   return `Create atmospheric portrait cover art for "${safeName}".
 
@@ -25,6 +33,7 @@ World cues:
 ${safeWorldContext}
 
 Art direction:
+- Default Art Style: ${artDirection.prompt}
 - Portrait composition, vertical framing, approximately 2:3 aspect ratio.
 - Focus on the tone, mood, and symbolic atmosphere of the setting.
 - Depict the world itself more than a single action scene.

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -254,7 +254,7 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
     id: "draw-button",
     title: "Instant Visualization",
     content:
-      "For Advanced Tier users: Instantly generate visuals for your lore. Look for the 'DRAW' button on Oracle responses or in the sidepanel for entities without images. The AI respects your 'Art Style' notes.",
+      "For Advanced Tier users: Instantly generate visuals for your lore. Look for the DRAW button on Oracle responses, entity panels, Zen mode, and graph nodes. The AI uses Art Direction from normal notes or entities, then Category Defaults and the active Default Art Style.",
     icon: "icon-[lucide--brush]",
   },
   "demo-mode": {

--- a/apps/web/src/lib/content/help/chat-commands.md
+++ b/apps/web/src/lib/content/help/chat-commands.md
@@ -11,7 +11,7 @@ The Lore Oracle supports several interactive commands to help you manage your wo
 
 ### Available Commands
 
-- `/draw [subject]`: Triggers the AI to generate a visual representation of the subject.
+- `/draw [subject]`: Triggers the AI to generate a visual representation of the subject. Category words such as `character`, `location`, or `item` can guide composition when no matching entity category is available.
 - `/create [description]`: Ask the Oracle to draft a new entity record based on your description.
 - `/connect`: The primary tool for building relationships.
 - `/merge`: Combine two entities into one, synthesizing their lore and re-mapping all connections.
@@ -57,3 +57,7 @@ If you are unsure how two entities should be related or how they should be combi
 
 - `/connect oracle`: Analyzes lore to propose thematic relationship types.
 - `/merge oracle`: Opens the step-by-step consolidation wizard with content preview.
+
+## Art Direction
+
+Image generation uses Art Direction from your world before falling back to shipped Category Defaults, Default Art Style from the active theme, and the global Codex Cryptica default. To customize it, add normal notes or entity sections titled `Art Direction`, `Default Art Style`, or `Visual Direction`; no separate settings form is required.

--- a/apps/web/src/lib/services/ai/image-generation.service.test.ts
+++ b/apps/web/src/lib/services/ai/image-generation.service.test.ts
@@ -63,6 +63,20 @@ describe("DefaultImageGenerationService", () => {
       expect(result).toBe("query");
     });
 
+    it("should preserve a resolved art direction query when context is missing", async () => {
+      const resolvedPrompt =
+        "Almos, full character concept art with readable silhouette";
+
+      const result = await service.distillVisualPrompt(
+        "key",
+        resolvedPrompt,
+        "",
+        "model",
+      );
+
+      expect(result).toBe(resolvedPrompt);
+    });
+
     it("should return distilled text on success", async () => {
       mockModel.generateContent
         .mockResolvedValueOnce({

--- a/apps/web/src/lib/stores/oracle/tests/action-manager.test.ts
+++ b/apps/web/src/lib/stores/oracle/tests/action-manager.test.ts
@@ -48,4 +48,35 @@ describe("OracleActionManager", () => {
       undefined,
     );
   });
+
+  it("should draw an entity through the shared execution context", async () => {
+    const context = { uiStore: { activeThemeId: "fantasy" } };
+    mockStore.getExecutionContext.mockReturnValue(context);
+
+    await manager.drawEntity("entity-1");
+
+    expect(mockStore.ui.visualizingEntityId).toBeNull();
+    expect(mockExecutor.drawEntity).toHaveBeenCalledWith("entity-1", context);
+  });
+
+  it("should not start a duplicate entity draw while one is active", async () => {
+    mockStore.ui.visualizingEntityId = "entity-1";
+
+    await manager.drawEntity("entity-1");
+
+    expect(mockExecutor.drawEntity).not.toHaveBeenCalled();
+  });
+
+  it("should draw a message through the shared execution context", async () => {
+    const context = { uiStore: { activeThemeId: "cyberpunk" } };
+    mockStore.getExecutionContext.mockReturnValue(context);
+
+    await manager.drawMessage("message-1");
+
+    expect(mockStore.ui.visualizingMessageId).toBeNull();
+    expect(mockExecutor.drawMessage).toHaveBeenCalledWith(
+      "message-1",
+      context,
+    );
+  });
 });

--- a/apps/web/src/lib/stores/oracle/tests/context-manager.test.ts
+++ b/apps/web/src/lib/stores/oracle/tests/context-manager.test.ts
@@ -47,4 +47,23 @@ describe("OracleContextManager", () => {
     expect(context.vaultId).toBe("v1");
     expect(context.tier).toBe("advanced");
   });
+
+  it("should expose active theme id for art direction resolution", () => {
+    mockStore.themeStore.activeTheme = { id: "gothic_horror" };
+
+    const context = manager.getExecutionContext();
+
+    expect(context.uiStore.activeThemeId).toBe("gothic_horror");
+  });
+
+  it("should preserve AI gating flags in the draw execution context", () => {
+    mockStore.discoveryPolicyStore.aiDisabled = true;
+    mockStore.sessionModeStore.isDemoMode = true;
+
+    const context = manager.getExecutionContext();
+
+    expect(context.uiStore.aiDisabled).toBe(true);
+    expect(context.uiStore.isDemoMode).toBe(true);
+    expect(context.isDemoMode).toBe(true);
+  });
 });

--- a/packages/oracle-engine/src/oracle-generator.test.ts
+++ b/packages/oracle-engine/src/oracle-generator.test.ts
@@ -97,6 +97,51 @@ describe("OracleGenerator", () => {
       expect(mockContext.imageGeneration.generateImage).toHaveBeenCalled();
     });
 
+    it("should apply category and theme defaults to entity visualization prompts", async () => {
+      mockContext.vault.entities.e1 = {
+        id: "e1",
+        title: "Almos",
+        type: "character",
+        labels: [],
+      };
+      mockContext.uiStore.activeThemeId = "fantasy";
+
+      await generator.generateEntityVisualization("e1", mockContext);
+
+      expect(
+        mockContext.imageGeneration.distillVisualPrompt,
+      ).toHaveBeenCalledWith(
+        "key",
+        expect.stringContaining("full character concept art"),
+        "ctx",
+        "model",
+        false,
+      );
+    });
+
+    it("should prefer entity art direction from normal content", async () => {
+      mockContext.vault.entities.e1 = {
+        id: "e1",
+        title: "Almos",
+        type: "character",
+        labels: [],
+        content:
+          "Chronicle text\n\n## Art Direction\nink wash portrait with a silver mask\n\n## Notes\nOther text",
+      };
+
+      await generator.generateEntityVisualization("e1", mockContext);
+
+      expect(
+        mockContext.imageGeneration.distillVisualPrompt,
+      ).toHaveBeenCalledWith(
+        "key",
+        expect.stringContaining("Almos. ink wash portrait"),
+        "ctx",
+        "model",
+        false,
+      );
+    });
+
     it("should prioritize entity labels in entity visualization prompts", async () => {
       mockContext.vault.entities.e1.labels = ["necromancy", "regal", "undead"];
 
@@ -129,6 +174,67 @@ describe("OracleGenerator", () => {
         mockContext,
       );
       expect(result).toBeInstanceOf(Blob);
+    });
+
+    it("should apply chat art direction for unlinked message visualization", async () => {
+      await generator.generateMessageVisualization(
+        {
+          content:
+            "Draw the moon gate\n\n## Art Direction\nflat ink and gold leaf icon",
+        } as any,
+        mockContext,
+      );
+
+      expect(
+        mockContext.imageGeneration.distillVisualPrompt,
+      ).toHaveBeenCalledWith(
+        "key",
+        expect.stringContaining("Draw the moon gate. flat ink and gold leaf icon"),
+        "ctx",
+        "model",
+        false,
+      );
+    });
+
+    it("should use /draw category hints when no entity is linked", async () => {
+      await generator.generateMessageVisualization(
+        { content: "/draw character Almos" } as any,
+        mockContext,
+      );
+
+      expect(
+        mockContext.imageGeneration.distillVisualPrompt,
+      ).toHaveBeenCalledWith(
+        "key",
+        expect.stringContaining("Almos, full character concept art"),
+        "ctx",
+        "model",
+        false,
+      );
+    });
+
+    it("should let linked entity metadata win over /draw category hints", async () => {
+      mockContext.vault.entities.e1 = {
+        id: "e1",
+        title: "Almos",
+        type: "location",
+        labels: [],
+      };
+
+      await generator.generateMessageVisualization(
+        { content: "/draw character Almos", entityId: "e1" } as any,
+        mockContext,
+      );
+
+      expect(
+        mockContext.imageGeneration.distillVisualPrompt,
+      ).toHaveBeenCalledWith(
+        "key",
+        expect.stringContaining("Almos, establishing environment art"),
+        "ctx",
+        "model",
+        false,
+      );
     });
 
     it("should prioritize linked entity labels in message visualization prompts", async () => {

--- a/packages/oracle-engine/src/oracle-generator.ts
+++ b/packages/oracle-engine/src/oracle-generator.ts
@@ -1,18 +1,20 @@
 import type { ChatMessage, OracleExecutionContext } from "./types";
-import { resolveArtDirection } from "schema/src/art-direction";
+import { resolveArtDirection } from "schema";
+
+interface VisualEntityLike {
+  id?: string;
+  title: string;
+  type?: string;
+  categoryId?: string;
+  labels?: string[];
+  content?: string;
+  lore?: string;
+  artDirection?: string;
+}
 
 export class OracleGenerator {
   private buildEntityVisualQuery(
-    entity: {
-      id?: string;
-      title: string;
-      type?: string;
-      categoryId?: string;
-      labels?: string[];
-      content?: string;
-      lore?: string;
-      artDirection?: string;
-    },
+    entity: VisualEntityLike,
     context?: OracleExecutionContext,
   ): string {
     const artDirection = resolveArtDirection({
@@ -31,7 +33,7 @@ export class OracleGenerator {
 
   private buildMessageVisualQuery(
     message: ChatMessage,
-    entity: any,
+    entity: VisualEntityLike | null,
     context: OracleExecutionContext,
   ): string {
     if (entity) {
@@ -43,6 +45,7 @@ export class OracleGenerator {
       subject: commandSubject.subject,
       surface: "chat",
       categoryId: commandSubject.categoryId,
+      categoryIdIsHint: Boolean(commandSubject.categoryId),
       themeId: context.uiStore?.activeThemeId,
       userAuthoredArtDirection: this.extractArtDirectionFromText(
         message.content,
@@ -67,11 +70,7 @@ ${cleanLabels.map((label) => `- ${label}`).join("\n")}
 Treat these labels as strong visual direction. If they imply mood, genre, attire, symbolism, environment, or composition, prioritize them in the final image prompt.`;
   }
 
-  private extractEntityArtDirection(entity: {
-    artDirection?: string;
-    content?: string;
-    lore?: string;
-  }) {
+  private extractEntityArtDirection(entity: VisualEntityLike) {
     return (
       entity.artDirection ||
       this.extractArtDirectionFromText(entity.content) ||

--- a/packages/oracle-engine/src/oracle-generator.ts
+++ b/packages/oracle-engine/src/oracle-generator.ts
@@ -1,21 +1,118 @@
 import type { ChatMessage, OracleExecutionContext } from "./types";
+import { resolveArtDirection } from "schema/src/art-direction";
 
 export class OracleGenerator {
-  private buildEntityVisualQuery(entity: {
-    title: string;
-    labels?: string[];
-  }): string {
-    const labels = (entity.labels || []).filter(Boolean);
-    if (labels.length === 0) {
-      return `A visualization of ${entity.title}`;
+  private buildEntityVisualQuery(
+    entity: {
+      id?: string;
+      title: string;
+      type?: string;
+      categoryId?: string;
+      labels?: string[];
+      content?: string;
+      lore?: string;
+      artDirection?: string;
+    },
+    context?: OracleExecutionContext,
+  ): string {
+    const artDirection = resolveArtDirection({
+      subject: entity.title,
+      entityId: entity.id,
+      entityTitle: entity.title,
+      categoryId: entity.categoryId || entity.type,
+      categoryLabel: entity.type,
+      themeId: context?.uiStore?.activeThemeId,
+      surface: "entity",
+      entityArtDirection: this.extractEntityArtDirection(entity),
+    });
+
+    return this.appendVisualLabels(artDirection.prompt, entity.labels);
+  }
+
+  private buildMessageVisualQuery(
+    message: ChatMessage,
+    entity: any,
+    context: OracleExecutionContext,
+  ): string {
+    if (entity) {
+      return this.buildEntityVisualQuery(entity, context);
     }
 
-    return `A visualization of ${entity.title}
+    const commandSubject = this.extractDrawCommandSubject(message.content);
+    const artDirection = resolveArtDirection({
+      subject: commandSubject.subject,
+      surface: "chat",
+      categoryId: commandSubject.categoryId,
+      themeId: context.uiStore?.activeThemeId,
+      userAuthoredArtDirection: this.extractArtDirectionFromText(
+        message.content,
+      ),
+    });
+
+    return artDirection.prompt;
+  }
+
+  private appendVisualLabels(
+    basePrompt: string,
+    labels?: string[],
+  ): string {
+    const cleanLabels = (labels || []).filter(Boolean);
+    if (cleanLabels.length === 0) return basePrompt;
+
+    return `${basePrompt}
 
 HIGH-PRIORITY VISUAL LABELS:
-${labels.map((label) => `- ${label}`).join("\n")}
+${cleanLabels.map((label) => `- ${label}`).join("\n")}
 
 Treat these labels as strong visual direction. If they imply mood, genre, attire, symbolism, environment, or composition, prioritize them in the final image prompt.`;
+  }
+
+  private extractEntityArtDirection(entity: {
+    artDirection?: string;
+    content?: string;
+    lore?: string;
+  }) {
+    return (
+      entity.artDirection ||
+      this.extractArtDirectionFromText(entity.content) ||
+      this.extractArtDirectionFromText(entity.lore)
+    );
+  }
+
+  private extractArtDirectionFromText(text?: string) {
+    if (!text) return undefined;
+    const match = text.match(
+      /(?:^|\n)#{1,4}\s*(?:art direction|default art style|visual direction)\s*\n+([\s\S]*?)(?=\n#{1,4}\s|\n---|\s*$)/i,
+    );
+    return match?.[1]?.trim();
+  }
+
+  private extractMessageSubject(content: string) {
+    const firstLine = content
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    return (firstLine || content).slice(0, 180);
+  }
+
+  private extractDrawCommandSubject(content: string): {
+    subject: string;
+    categoryId?: string;
+  } {
+    const firstLine = this.extractMessageSubject(content);
+    const match = firstLine.match(/^\/(?:draw|image)\s+(.+)$/i);
+    if (!match) return { subject: firstLine };
+
+    const rawSubject = match[1].trim();
+    const categoryMatch = rawSubject.match(
+      /^(character|npc|creature|location|place|item|object|faction|event|note|concept|world|cover)\s+(.+)$/i,
+    );
+    if (!categoryMatch) return { subject: rawSubject };
+
+    return {
+      categoryId: categoryMatch[1].toLowerCase(),
+      subject: categoryMatch[2].trim(),
+    };
   }
 
   /**
@@ -213,7 +310,7 @@ Treat these labels as strong visual direction. If they imply mood, genre, attire
 
     const visualPrompt = await context.imageGeneration.distillVisualPrompt(
       apiKey,
-      this.buildEntityVisualQuery(entity),
+      this.buildEntityVisualQuery(entity, context),
       aiContext,
       context.modelName,
       context.isDemoMode,
@@ -251,7 +348,7 @@ Treat these labels as strong visual direction. If they imply mood, genre, attire
 
     const visualPrompt = await context.imageGeneration.distillVisualPrompt(
       apiKey,
-      entity ? this.buildEntityVisualQuery(entity) : message.content,
+      this.buildMessageVisualQuery(message, entity, context),
       aiContext,
       context.modelName,
       context.isDemoMode,

--- a/packages/schema/src/art-direction.test.ts
+++ b/packages/schema/src/art-direction.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  CATEGORY_ART_DIRECTION_DEFAULTS,
+  GLOBAL_ART_DIRECTION_DEFAULT,
+  THEME_ART_DIRECTION_DEFAULTS,
+  resolveArtDirection,
+} from "./art-direction";
+
+describe("art direction resolver", () => {
+  it("uses entity art direction before all other fallbacks", () => {
+    const result = resolveArtDirection({
+      subject: "Almos",
+      surface: "entity",
+      categoryId: "character",
+      themeId: "fantasy",
+      entityArtDirection: "{subject}, ink portrait with silver mask",
+      userAuthoredArtDirection: "{subject}, oil painting",
+    });
+
+    expect(result.source).toBe("entity-context");
+    expect(result.prompt).toContain("Almos, ink portrait");
+  });
+
+  it("uses user-authored art direction before shipped defaults", () => {
+    const result = resolveArtDirection({
+      subject: "The Glass Tower",
+      surface: "entity",
+      categoryId: "location",
+      themeId: "scifi",
+      entityArtDirection: "   ",
+      userAuthoredArtDirection: "{subject}, monochrome architectural plate",
+    });
+
+    expect(result.source).toBe("user-authored-context");
+    expect(result.prompt).toBe(
+      "The Glass Tower, monochrome architectural plate",
+    );
+  });
+
+  it("falls back through category, theme, and global defaults", () => {
+    expect(
+      resolveArtDirection({
+        subject: "Mara",
+        surface: "entity",
+        categoryId: "character",
+        themeId: "fantasy",
+      }).source,
+    ).toBe("category-default");
+
+    expect(
+      resolveArtDirection({
+        subject: "Mara",
+        surface: "entity",
+        themeId: "fantasy",
+      }).source,
+    ).toBe("theme-default");
+
+    expect(
+      resolveArtDirection({
+        subject: "Mara",
+        surface: "entity",
+        themeId: "missing-theme",
+      }).source,
+    ).toBe("global-default");
+  });
+
+  it("inserts the subject when the template has no placeholder", () => {
+    const result = resolveArtDirection({
+      subject: "The Ember Crown",
+      surface: "entity",
+      entityArtDirection: "Detailed prop render on a neutral background",
+    });
+
+    expect(result.prompt).toBe(
+      "The Ember Crown. Detailed prop render on a neutral background",
+    );
+  });
+
+  it("replaces repeated subject placeholders", () => {
+    const result = resolveArtDirection({
+      subject: "Aster",
+      surface: "entity",
+      entityArtDirection: "{subject} mirrored beside {subject}",
+    });
+
+    expect(result.prompt).toBe("Aster mirrored beside Aster");
+  });
+
+  it("uses cover composition for cover surface requests", () => {
+    const result = resolveArtDirection({
+      subject: "The Ninth Archive",
+      surface: "cover",
+      categoryId: "character",
+      themeId: "fantasy",
+    });
+
+    expect(result.source).toBe("category-default");
+    expect(result.templateId).toBe("category.cover");
+    expect(result.categoryId).toBe("cover");
+  });
+
+  it("ships required category and theme defaults without named artist imitation", () => {
+    for (const id of [
+      "character",
+      "creature",
+      "location",
+      "item",
+      "faction",
+      "event",
+      "note",
+      "cover",
+    ]) {
+      expect(CATEGORY_ART_DIRECTION_DEFAULTS[id]?.template).toContain(
+        "{subject}",
+      );
+    }
+
+    for (const id of [
+      "fantasy",
+      "scifi",
+      "cyberpunk",
+      "modern",
+      "post_apocalyptic",
+      "gothic_horror",
+      "steampunk",
+      "mythic",
+      "pulp_adventure",
+    ]) {
+      expect(THEME_ART_DIRECTION_DEFAULTS[id]?.template).toContain("{subject}");
+    }
+
+    const shippedText = [
+      GLOBAL_ART_DIRECTION_DEFAULT.template,
+      ...Object.values(CATEGORY_ART_DIRECTION_DEFAULTS).map((t) => t.template),
+      ...Object.values(THEME_ART_DIRECTION_DEFAULTS).map((t) => t.template),
+    ].join("\n");
+
+    expect(shippedText).not.toMatch(
+      /\b(in the style of|by artgerm|by greg rutkowski|by loish|by sakimichan|by beeple)\b/i,
+    );
+  });
+});

--- a/packages/schema/src/art-direction.test.ts
+++ b/packages/schema/src/art-direction.test.ts
@@ -99,6 +99,27 @@ describe("art direction resolver", () => {
     expect(result.categoryId).toBe("cover");
   });
 
+  it("does not alias real category ids unless they are marked as hints", () => {
+    const realCategory = resolveArtDirection({
+      subject: "Archivist Nara",
+      surface: "entity",
+      categoryId: "npc",
+      themeId: "fantasy",
+    });
+    const hintedCategory = resolveArtDirection({
+      subject: "Archivist Nara",
+      surface: "command",
+      categoryId: "npc",
+      categoryIdIsHint: true,
+      themeId: "fantasy",
+    });
+
+    expect(realCategory.source).toBe("theme-default");
+    expect(realCategory.categoryId).toBe("npc");
+    expect(hintedCategory.source).toBe("category-default");
+    expect(hintedCategory.categoryId).toBe("character");
+  });
+
   it("ships required category and theme defaults without named artist imitation", () => {
     for (const id of [
       "character",

--- a/packages/schema/src/art-direction.ts
+++ b/packages/schema/src/art-direction.ts
@@ -1,0 +1,314 @@
+export type ArtDirectionSource =
+  | "entity-context"
+  | "user-authored-context"
+  | "category-default"
+  | "theme-default"
+  | "global-default";
+
+export type DrawSurface =
+  | "command"
+  | "entity"
+  | "zen"
+  | "graph"
+  | "cover"
+  | "chat";
+
+export interface DrawRequestContext {
+  subject: string;
+  entityId?: string;
+  entityTitle?: string;
+  categoryId?: string;
+  categoryLabel?: string;
+  themeId?: string;
+  surface: DrawSurface;
+  entityArtDirection?: string;
+  userAuthoredArtDirection?: string;
+}
+
+export interface ArtDirectionTemplate {
+  id: string;
+  label: string;
+  template: string;
+  source: ArtDirectionSource;
+}
+
+export interface ResolvedArtDirection {
+  prompt: string;
+  source: ArtDirectionSource;
+  templateId?: string;
+  subject: string;
+  categoryId?: string;
+  themeId?: string;
+}
+
+const MAX_CONTEXT_TEMPLATE_LENGTH = 1200;
+
+export const GLOBAL_ART_DIRECTION_DEFAULT: ArtDirectionTemplate = {
+  id: "global.codex-cryptica",
+  label: "Codex Cryptica Default",
+  source: "global-default",
+  template:
+    "{subject}, a clear fantasy tabletop reference illustration with readable forms, grounded materials, cinematic lighting, and enough concrete detail to support worldbuilding.",
+};
+
+export const CATEGORY_ART_DIRECTION_DEFAULTS: Record<
+  string,
+  ArtDirectionTemplate
+> = {
+  character: {
+    id: "category.character",
+    label: "Character Default",
+    source: "category-default",
+    template:
+      "{subject}, full character concept art with readable silhouette, expressive pose, distinctive clothing, equipment, and clear face and body language.",
+  },
+  creature: {
+    id: "category.creature",
+    label: "Creature Default",
+    source: "category-default",
+    template:
+      "{subject}, creature design sheet with strong anatomy, scale cues, distinctive texture, habitat hints, and a pose that shows movement and threat.",
+  },
+  location: {
+    id: "category.location",
+    label: "Location Default",
+    source: "category-default",
+    template:
+      "{subject}, establishing environment art with atmosphere, architecture or landscape detail, lighting that reveals the mood, and a strong sense of place.",
+  },
+  item: {
+    id: "category.item",
+    label: "Item Default",
+    source: "category-default",
+    template:
+      "{subject}, detailed prop design on a simple presentation background, emphasizing materials, craftsmanship, wear, symbols, and readable silhouette.",
+  },
+  faction: {
+    id: "category.faction",
+    label: "Faction Default",
+    source: "category-default",
+    template:
+      "{subject}, faction visual identity with banners, colors, uniforms or regalia, symbolic motifs, and an organized group composition.",
+  },
+  event: {
+    id: "category.event",
+    label: "Event Default",
+    source: "category-default",
+    template:
+      "{subject}, dramatic scene illustration capturing the key moment, participants, environment, stakes, motion, and memorable visual consequences.",
+  },
+  note: {
+    id: "category.note",
+    label: "Note Default",
+    source: "category-default",
+    template:
+      "{subject}, evocative worldbuilding illustration focused on the central idea, with readable symbols, setting details, and clear visual hierarchy.",
+  },
+  cover: {
+    id: "category.cover",
+    label: "World Cover Default",
+    source: "category-default",
+    template:
+      "{subject}, atmospheric world cover art with a strong focal point, genre-defining setting details, cinematic depth, and room for title treatment.",
+  },
+};
+
+export const THEME_ART_DIRECTION_DEFAULTS: Record<string, ArtDirectionTemplate> =
+  {
+    fantasy: {
+      id: "theme.fantasy",
+      label: "Fantasy Default",
+      source: "theme-default",
+      template:
+        "{subject}, painterly high-fantasy art with ancient textures, candlelit warmth, mythic atmosphere, handcrafted materials, and subtle magic.",
+    },
+    scifi: {
+      id: "theme.scifi",
+      label: "Sci-Fi Default",
+      source: "theme-default",
+      template:
+        "{subject}, clean science-fiction concept art with advanced interfaces, engineered materials, controlled lighting, and frontier scale.",
+    },
+    cyberpunk: {
+      id: "theme.cyberpunk",
+      label: "Cyberpunk Default",
+      source: "theme-default",
+      template:
+        "{subject}, neon urban concept art with wet streets, dense signage, layered technology, hard shadows, and high-contrast color accents.",
+    },
+    modern: {
+      id: "theme.modern",
+      label: "Modern Default",
+      source: "theme-default",
+      template:
+        "{subject}, grounded modern cinematic illustration with natural materials, believable lighting, documentary detail, and restrained color.",
+    },
+    post_apocalyptic: {
+      id: "theme.post_apocalyptic",
+      label: "Post-Apocalyptic Default",
+      source: "theme-default",
+      template:
+        "{subject}, weathered post-apocalyptic concept art with scavenged materials, harsh daylight, survival details, and environmental decay.",
+    },
+    "post-apocalyptic": {
+      id: "theme.post-apocalyptic",
+      label: "Post-Apocalyptic Default",
+      source: "theme-default",
+      template:
+        "{subject}, weathered post-apocalyptic concept art with scavenged materials, harsh daylight, survival details, and environmental decay.",
+    },
+    gothic_horror: {
+      id: "theme.gothic_horror",
+      label: "Gothic Horror Default",
+      source: "theme-default",
+      template:
+        "{subject}, gothic horror illustration with oppressive architecture, dim candlelight, heavy atmosphere, ornate decay, and controlled dread.",
+    },
+    "gothic-horror": {
+      id: "theme.gothic-horror",
+      label: "Gothic Horror Default",
+      source: "theme-default",
+      template:
+        "{subject}, gothic horror illustration with oppressive architecture, dim candlelight, heavy atmosphere, ornate decay, and controlled dread.",
+    },
+    steampunk: {
+      id: "theme.steampunk",
+      label: "Steampunk Default",
+      source: "theme-default",
+      template:
+        "{subject}, brass-and-iron adventure illustration with visible mechanisms, steam, leather, polished gauges, and warm industrial lighting.",
+    },
+    mythic: {
+      id: "theme.mythic",
+      label: "Mythic Default",
+      source: "theme-default",
+      template:
+        "{subject}, mythic storybook illustration with monumental scale, symbolic composition, luminous atmosphere, and ancient ceremonial detail.",
+    },
+    pulp_adventure: {
+      id: "theme.pulp_adventure",
+      label: "Pulp Adventure Default",
+      source: "theme-default",
+      template:
+        "{subject}, bold pulp-adventure illustration with dynamic composition, practical danger, saturated accents, and crisp readable action.",
+    },
+    "pulp-adventure": {
+      id: "theme.pulp-adventure",
+      label: "Pulp Adventure Default",
+      source: "theme-default",
+      template:
+        "{subject}, bold pulp-adventure illustration with dynamic composition, practical danger, saturated accents, and crisp readable action.",
+    },
+  };
+
+const CATEGORY_ALIASES: Record<string, string> = {
+  npc: "character",
+  person: "character",
+  place: "location",
+  region: "location",
+  object: "item",
+  artifact: "item",
+  concept: "note",
+  world: "cover",
+};
+
+export function resolveArtDirection(
+  context: DrawRequestContext,
+): ResolvedArtDirection {
+  const subject = normalizeRequiredSubject(context);
+  const categoryId =
+    normalizeCategoryId(
+      context.surface === "cover" ? "cover" : context.categoryId,
+    ) ||
+    undefined;
+  const themeId = normalizeId(context.themeId) || undefined;
+
+  const candidates: ArtDirectionTemplate[] = [
+    contextTemplate(
+      "entity-context",
+      "entity.context",
+      "Entity Art Direction",
+      context.entityArtDirection,
+    ),
+    contextTemplate(
+      "user-authored-context",
+      "user.context",
+      "User Authored Art Direction",
+      context.userAuthoredArtDirection,
+    ),
+    categoryId ? CATEGORY_ART_DIRECTION_DEFAULTS[categoryId] : undefined,
+    themeId ? THEME_ART_DIRECTION_DEFAULTS[themeId] : undefined,
+    GLOBAL_ART_DIRECTION_DEFAULT,
+  ].filter((template): template is ArtDirectionTemplate =>
+    Boolean(template && normalizeTemplate(template.template)),
+  );
+
+  const selected = candidates[0] || GLOBAL_ART_DIRECTION_DEFAULT;
+  return {
+    prompt: applySubject(selected.template, subject),
+    source: selected.source,
+    templateId: selected.id,
+    subject,
+    categoryId,
+    themeId,
+  };
+}
+
+export function getCategoryArtDirectionDefault(
+  categoryId?: string,
+): ArtDirectionTemplate | undefined {
+  const normalized = normalizeCategoryId(categoryId);
+  return normalized ? CATEGORY_ART_DIRECTION_DEFAULTS[normalized] : undefined;
+}
+
+export function getThemeArtDirectionDefault(
+  themeId?: string,
+): ArtDirectionTemplate | undefined {
+  const normalized = normalizeId(themeId);
+  return normalized ? THEME_ART_DIRECTION_DEFAULTS[normalized] : undefined;
+}
+
+function normalizeRequiredSubject(context: DrawRequestContext) {
+  const subject = (context.subject || context.entityTitle || "").trim();
+  if (!subject) {
+    throw new Error("Draw request subject is required.");
+  }
+  return subject;
+}
+
+function contextTemplate(
+  source: ArtDirectionSource,
+  id: string,
+  label: string,
+  template?: string,
+): ArtDirectionTemplate | undefined {
+  const normalized = normalizeTemplate(template);
+  if (!normalized) return undefined;
+  return { id, label, source, template: normalized };
+}
+
+function normalizeTemplate(template?: string) {
+  const normalized = (template || "").trim().replace(/\s+/g, " ");
+  if (!normalized) return "";
+  return normalized.slice(0, MAX_CONTEXT_TEMPLATE_LENGTH);
+}
+
+function applySubject(template: string, subject: string) {
+  const normalized = normalizeTemplate(template);
+  if (normalized.includes("{subject}")) {
+    return normalized.replaceAll("{subject}", subject);
+  }
+  return `${subject}. ${normalized}`;
+}
+
+function normalizeId(id?: string) {
+  return (id || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-");
+}
+
+function normalizeCategoryId(id?: string) {
+  const normalized = normalizeId(id);
+  return CATEGORY_ALIASES[normalized] || normalized;
+}

--- a/packages/schema/src/art-direction.ts
+++ b/packages/schema/src/art-direction.ts
@@ -19,6 +19,7 @@ export interface DrawRequestContext {
   entityTitle?: string;
   categoryId?: string;
   categoryLabel?: string;
+  categoryIdIsHint?: boolean;
   themeId?: string;
   surface: DrawSurface;
   entityArtDirection?: string;
@@ -219,6 +220,7 @@ export function resolveArtDirection(
   const categoryId =
     normalizeCategoryId(
       context.surface === "cover" ? "cover" : context.categoryId,
+      context.surface === "cover" || context.categoryIdIsHint,
     ) ||
     undefined;
   const themeId = normalizeId(context.themeId) || undefined;
@@ -256,8 +258,9 @@ export function resolveArtDirection(
 
 export function getCategoryArtDirectionDefault(
   categoryId?: string,
+  options: { categoryIdIsHint?: boolean } = {},
 ): ArtDirectionTemplate | undefined {
-  const normalized = normalizeCategoryId(categoryId);
+  const normalized = normalizeCategoryId(categoryId, options.categoryIdIsHint);
   return normalized ? CATEGORY_ART_DIRECTION_DEFAULTS[normalized] : undefined;
 }
 
@@ -308,7 +311,7 @@ function normalizeId(id?: string) {
     .replace(/\s+/g, "-");
 }
 
-function normalizeCategoryId(id?: string) {
+function normalizeCategoryId(id?: string, applyAliases = false) {
   const normalized = normalizeId(id);
-  return CATEGORY_ALIASES[normalized] || normalized;
+  return applyAliases ? CATEGORY_ALIASES[normalized] || normalized : normalized;
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -8,3 +8,4 @@ export * from "./jargon";
 export * from "./map";
 export * from "./ai";
 export * from "./sync";
+export * from "./art-direction";

--- a/specs/115-default-art-prompts/checklists/requirements.md
+++ b/specs/115-default-art-prompts/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Default Art Prompts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed after separating this issue from neutral world theming.
+- The spec explicitly avoids named living-artist imitation in shipped default prompts.

--- a/specs/115-default-art-prompts/contracts/art-direction-resolver-contract.md
+++ b/specs/115-default-art-prompts/contracts/art-direction-resolver-contract.md
@@ -1,0 +1,120 @@
+# Contract: Art Direction Resolver
+
+## Public Resolver Contract
+
+```typescript
+type ArtDirectionSource =
+  | "entity-context"
+  | "user-authored-context"
+  | "category-default"
+  | "theme-default"
+  | "global-default";
+
+type DrawSurface =
+  | "command"
+  | "entity"
+  | "zen"
+  | "graph"
+  | "cover"
+  | "chat";
+
+interface DrawRequestContext {
+  subject: string;
+  entityId?: string;
+  entityTitle?: string;
+  categoryId?: string;
+  categoryLabel?: string;
+  themeId?: string;
+  surface: DrawSurface;
+  entityArtDirection?: string;
+  userAuthoredArtDirection?: string;
+}
+
+interface ResolvedArtDirection {
+  prompt: string;
+  source: ArtDirectionSource;
+  templateId?: string;
+  subject: string;
+  categoryId?: string;
+  themeId?: string;
+}
+
+interface ArtDirectionResolver {
+  resolve(context: DrawRequestContext): ResolvedArtDirection;
+}
+```
+
+## Fallback Contract
+
+The resolver checks candidates in this order:
+
+1. `entityArtDirection`
+2. `userAuthoredArtDirection`
+3. shipped category default for `categoryId`
+4. shipped theme default for `themeId`
+5. shipped global default
+
+Required behavior:
+
+- Empty or whitespace-only candidates are skipped.
+- The final prompt always includes the trimmed subject.
+- Missing `{subject}` in a template is handled by adding the subject to the prompt.
+- Multiple `{subject}` placeholders are all replaced.
+- Resolver metadata identifies which fallback level won.
+
+## Category Parsing Contract
+
+For `/draw` commands:
+
+- Recognized category words may set `categoryId` when no matched entity category is available.
+- If the subject resolves to an entity with metadata, the entity category wins over command-provided category words.
+- Unknown category words are treated as normal subject text unless existing command parsing already recognizes them.
+
+## Defaults Contract
+
+Shipped defaults include:
+
+- global Codex Cryptica default
+- category defaults for Character, Creature, Location, Item, Faction, Event, Note, and world cover
+- theme defaults for supported world themes where practical
+
+Default prompt rules:
+
+- Do not name living artists.
+- Do not instruct direct imitation of a living artist.
+- Prefer descriptive language for medium, composition, lighting, mood, materials, and readability.
+- Keep defaults concise enough to avoid unwieldy generated prompts.
+
+## Integration Contract
+
+All existing image generation entry points must call the resolver before image generation:
+
+- `/draw`
+- entity sidebar draw
+- Zen mode draw
+- graph context menu image generation
+- front page cover generation
+- Oracle chat draw where context is available
+
+The image generation service receives the resolver's `prompt` as final prompt text. Image model request/response behavior remains unchanged.
+
+## Gating Contract
+
+- Existing tier, capability, guest, and AI-disabled gates remain authoritative.
+- Resolver logic must not make unavailable draw controls visible.
+- Normal notes/entities remain editable according to existing permissions even when image generation is unavailable.
+
+## Verification Contract
+
+Automated coverage must assert:
+
+- entity/user-authored/category/theme/global fallback order
+- empty candidate fallback behavior
+- subject insertion when `{subject}` is present, missing, or repeated
+- category command hints and entity metadata precedence
+- shipped defaults avoid named living artists
+- `/draw` uses resolved prompt
+- entity sidebar and Zen mode draw use resolved prompt
+- graph context menu image generation uses resolved prompt
+- front page cover generation uses cover/world context
+- existing image generation still works with no user-authored art direction content

--- a/specs/115-default-art-prompts/data-model.md
+++ b/specs/115-default-art-prompts/data-model.md
@@ -1,0 +1,127 @@
+# Data Model: Default Art Prompts
+
+## ArtDirectionTemplate
+
+Prompt template that guides image style or composition.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Stable id for shipped defaults, such as `category.character` or `theme.fantasy`. |
+| `label` | `string` | Human-readable name for diagnostics/help. |
+| `template` | `string` | Prompt text. May include `{subject}`. |
+| `source` | `ArtDirectionSource` | Where this template came from. |
+
+### Validation Rules
+
+- Empty or whitespace-only templates are invalid.
+- Shipped templates must avoid named living-artist imitation.
+- If `{subject}` is missing, the resolver must still include the subject in the final prompt.
+- Templates should stay concise and descriptive.
+
+## ArtDirectionSource
+
+Identifies the fallback level used.
+
+Allowed values:
+
+```text
+entity-context
+user-authored-context
+category-default
+theme-default
+global-default
+```
+
+## DrawRequestContext
+
+Input to the resolver.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `subject` | `string` | User-facing subject to draw. |
+| `entityId` | `string?` | Optional entity id when the draw request maps to a known entity. |
+| `entityTitle` | `string?` | Entity title when available. |
+| `categoryId` | `string?` | Stable category id from entity metadata or command parsing. |
+| `categoryLabel` | `string?` | Display category label when available. |
+| `themeId` | `string?` | Active world theme id. |
+| `surface` | `"entity" \| "zen" \| "graph" \| "chat" \| "cover" \| "command"` | Entry point or surface requesting the image. |
+| `entityArtDirection` | `string?` | Entity-specific art direction when already available in context. |
+| `userAuthoredArtDirection` | `string?` | Relevant note/entity content selected by existing context mechanisms. |
+
+### Validation Rules
+
+- `subject` must be trimmed and non-empty before image generation.
+- `entityId` is optional; non-entity cover requests still resolve with vault/theme/global context.
+- `categoryId` should come from entity metadata when available; command category hints fill gaps only.
+- `userAuthoredArtDirection` must be skipped if empty.
+
+## ResolvedArtDirection
+
+Output from the resolver.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `prompt` | `string` | Final prompt passed to image generation. |
+| `source` | `ArtDirectionSource` | Fallback level used. |
+| `templateId` | `string?` | Shipped/default template id when applicable. |
+| `subject` | `string` | Subject used for insertion. |
+| `categoryId` | `string?` | Category context used, if any. |
+| `themeId` | `string?` | Theme context used, if any. |
+
+### Validation Rules
+
+- `prompt` must always include the subject.
+- Resolver metadata should be available for tests and troubleshooting.
+- Empty higher-priority values must not block lower-priority defaults.
+
+## CategoryArtDirectionDefault
+
+Shipped default for category composition.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `categoryId` | `string` | Stable category-like id, such as `character`, `location`, or `item`. |
+| `template` | `ArtDirectionTemplate` | Composition-focused default. |
+
+### Validation Rules
+
+- Category defaults should focus on framing and useful visual structure.
+- Defaults should be reusable across themes; theme defaults add mood/materials.
+- Real category ids should be used where the vault has stable category metadata.
+
+## ThemeArtDirectionDefault
+
+Shipped default for world/theme mood.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `themeId` | `string` | Theme id such as `fantasy`, `scifi`, `cyberpunk`, or `modern`. |
+| `template` | `ArtDirectionTemplate` | Mood/style-focused default. |
+
+### Validation Rules
+
+- Theme defaults must avoid living-artist imitation.
+- Missing theme defaults fall back to global default.
+- Theme defaults must not override relevant user-authored art direction context.
+
+## GlobalArtDirectionDefault
+
+Final fallback used when no more specific art direction exists.
+
+### Validation Rules
+
+- Must be safe, concise, descriptive, and broadly useful.
+- Must include or allow subject insertion.
+
+## Integration Surfaces
+
+Existing image generation entry points that must provide `DrawRequestContext`:
+
+| Surface | Context expectation |
+| --- | --- |
+| `/draw` command | Subject, command category hint, matched entity metadata if resolved. |
+| Entity sidebar | Entity id, title, category, active theme. |
+| Zen mode | Active entity id, title, category, active theme. |
+| Graph context menu | Selected node entity id, title, category, active theme. |
+| Front page cover | World/vault subject, cover surface, active theme. |
+| Oracle chat draw | Message subject plus entity/category context where available. |

--- a/specs/115-default-art-prompts/plan.md
+++ b/specs/115-default-art-prompts/plan.md
@@ -75,9 +75,11 @@ apps/
     │   │   │       ├── image-generation.service.ts
     │   │   │       └── image-generation.service.test.ts
     │   │   ├── stores/
+    │   │   │   ├── oracle.svelte.ts
     │   │   │   └── oracle/
     │   │   │       ├── action-manager.svelte.ts
-    │   │   │       ├── executor.svelte.ts
+    │   │   │       ├── types.ts
+    │   │   │       ├── context-manager.svelte.ts
     │   │   │       └── tests/
     │   │   │           └── action-manager.test.ts
     │   │   ├── config/

--- a/specs/115-default-art-prompts/plan.md
+++ b/specs/115-default-art-prompts/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Default Art Prompts
+
+**Branch**: `115-default-art-prompts` | **Date**: 2026-05-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/data/data/com.termux/files/home/proj/Codex-Cryptica/specs/115-default-art-prompts/spec.md`
+
+**Note**: This plan is aligned to the Speckit plan template and stops at Phase 2 planning artifacts. Implementation tasks will be generated separately.
+
+## Summary
+
+Add a single art direction resolver that prepares prompts before the existing image generation service is called. The resolver uses available entity/user-authored context first, then shipped category defaults, theme defaults, and a global default. It must serve all existing image generation entry points: `/draw`, entity sidebar draw, Zen mode draw, graph context menu image generation, front page cover generation, and Oracle chat draw where context is available. The first implementation does not add a dedicated Vault Settings art-style editor; custom style guidance remains ordinary notes/entities.
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.x, Svelte 5, Bun 1.3.x package workflow
+**Primary Dependencies**: SvelteKit, workspace `schema`, existing Oracle/image generation services, existing vault/entity/category stores, Vitest, Playwright
+**Storage**: No new settings storage. Shipped defaults live in code/shared package definitions. User-authored art direction remains ordinary vault content using existing entity/note persistence.
+**Testing**: Vitest for resolver/default/template behavior and draw integration units; Playwright for draw entry points where current E2E coverage already exists.
+**Target Platform**: Modern desktop and mobile browsers
+**Project Type**: Web application monorepo with shared packages
+**Performance Goals**: Prompt resolution must be synchronous or near-instant relative to image generation and must not add network calls before generation.
+**Constraints**: Do not add new runtime dependencies; do not add a dedicated art direction settings editor; preserve existing tier/capability gating; preserve current image model calls; avoid named living-artist imitation in shipped defaults; keep prompts concise.
+**Scale/Scope**: Shared resolver/defaults, prompt preparation integration in existing Oracle/image draw paths, draw command category parsing, front page cover context, graph/Zen/sidebar/chat entry point coverage, focused help copy if needed.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+1. **Library-First**: Resolver and shipped defaults should live in reusable code rather than inside individual Svelte components. Shared types/defaults belong in workspace packages where appropriate; web entry points consume the resolver. [PASS]
+2. **TDD**: Resolver fallback order, template insertion, category parsing, safety of empty values, and draw entry point integration require tests before implementation is complete. [PASS]
+3. **Simplicity & YAGNI**: No dedicated settings editor, no new storage layer, and no new image generation pipeline. The plan extends existing prompt preparation. [PASS]
+4. **AI-First Extraction**: Existing Oracle/image generation remains the model-facing layer. This feature prepares cleaner prompt input before the existing service call. [PASS]
+5. **Privacy & Client-Side Processing**: Resolver uses local vault content/defaults and does not introduce server persistence. [PASS]
+6. **Clean Implementation**: Implementation must follow Svelte 5 runes, TypeScript types, DI-friendly service construction, existing Iconify icon conventions where UI is touched, and repo lint hygiene. [PASS]
+7. **User Documentation**: Help copy should explain that art direction can be expressed in normal notes/entities and that defaults fill gaps automatically. [PASS]
+8. **Dependency Injection**: Resolver usage in Oracle/action flows must remain mockable in unit tests. [PASS]
+9. **Natural Language**: Labels and help text use plain terms: "Art Direction", "Default Art Style", and "Category Defaults"; no dedicated settings UI is implied. [PASS]
+10. **Coverage Enforcement**: New resolver and integration logic must be covered by focused tests. [PASS]
+
+**Post-Design Recheck**: Phase 1 artifacts preserve the same scope and introduce no new dependency, server storage, or dedicated settings editor. [PASS]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/115-default-art-prompts/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   └── art-direction-resolver-contract.md
+└── tasks.md                 # Created later by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+packages/
+└── schema/
+    └── src/
+        ├── art-direction.ts        # Shared types, defaults, resolver contract helpers
+        ├── art-direction.test.ts
+        └── index.ts
+
+apps/
+└── web/
+    ├── src/
+    │   ├── lib/
+    │   │   ├── services/
+    │   │   │   └── ai/
+    │   │   │       ├── image-generation.service.ts
+    │   │   │       └── image-generation.service.test.ts
+    │   │   ├── stores/
+    │   │   │   └── oracle/
+    │   │   │       ├── action-manager.svelte.ts
+    │   │   │       ├── executor.svelte.ts
+    │   │   │       └── tests/
+    │   │   │           └── action-manager.test.ts
+    │   │   ├── config/
+    │   │   │   ├── chat-commands.ts
+    │   │   │   └── chat-commands.test.ts
+    │   │   ├── components/
+    │   │   │   ├── graph/
+    │   │   │   │   ├── graph-context-menu-controller.svelte.ts
+    │   │   │   │   └── graph-context-menu-controller.test.ts
+    │   │   │   └── world/
+    │   │   │       ├── FrontPage.svelte
+    │   │   │       ├── CoverImage.svelte
+    │   │   │       └── FrontPage.test.ts
+    │   │   └── content/
+    │   │       └── help/
+    │   │           └── chat-commands.md
+    │   └── tests/
+    │       └── ai/
+    │           └── image-generation.svelte.spec.ts
+    └── tests/
+        ├── draw-autocomplete.spec.ts
+        ├── draw-button.spec.ts
+        └── graph-image-gen.spec.ts
+```
+
+**Structure Decision**: Put reusable art direction types/defaults and pure resolver behavior in `packages/schema` so Oracle, tests, and future non-web clients can share it. Keep web-specific context collection in existing Oracle/action-manager, graph, front-page, and command code. Do not put resolver rules inside Svelte components. Do not add new persistence; normal vault content stays in existing entity/note storage.
+
+## Phase 0: Research
+
+Research output is captured in [research.md](./research.md). Key decisions:
+
+- Use a pure resolver with a deterministic fallback order.
+- Ship category/theme/global defaults as code defaults, not user settings.
+- Treat user-authored art direction as ordinary content already available in draw context.
+- Integrate before the current image generation model call instead of replacing the image service.
+- Avoid named living-artist style references in shipped defaults.
+
+## Phase 1: Design And Contracts
+
+Design outputs:
+
+- [data-model.md](./data-model.md): Art direction templates, draw context, defaults, and resolved prompt model.
+- [contracts/art-direction-resolver-contract.md](./contracts/art-direction-resolver-contract.md): Resolver input/output, fallback, parsing, and integration contract.
+- [quickstart.md](./quickstart.md): Focused validation flow for resolver and draw entry points.
+
+## Complexity Tracking
+
+N/A - No constitution violations identified.

--- a/specs/115-default-art-prompts/quickstart.md
+++ b/specs/115-default-art-prompts/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart: Default Art Prompts
+
+## Goal
+
+Validate implementation of spec `115-default-art-prompts` after tasks are complete.
+
+## Prerequisites
+
+- Dependencies installed with the repository's supported Bun workflow.
+- Browser test environment available for Playwright checks.
+- A vault with at least Character, Location, and Item-like entities.
+- Advanced image generation tier or mocked E2E image generation enabled for browser tests.
+
+## Automated Checks
+
+Run focused resolver and integration tests:
+
+```bash
+bun run --filter schema test -- art-direction
+bun run --filter web test -- image-generation
+bun run --filter web test -- chat-commands
+```
+
+Run focused browser checks for draw entry points:
+
+```bash
+bun run --filter web test:e2e -- draw-button.spec.ts
+bun run --filter web test:e2e -- draw-autocomplete.spec.ts
+bun run --filter web test:e2e -- graph-image-gen.spec.ts
+```
+
+Run full validation before merge:
+
+```bash
+bun run lint
+bun run test
+```
+
+## Manual Validation
+
+1. Open a vault with no user-authored art direction content.
+2. Draw a Character entity from the entity sidebar.
+3. Confirm the generated prompt path uses Character category composition plus the active theme or global fallback.
+4. Open the same entity in Zen mode and draw it.
+5. Confirm Zen mode uses the same resolver behavior as the entity sidebar.
+6. Open the graph context menu for the same entity and generate an image.
+7. Confirm graph image generation uses the selected node's entity/category context.
+8. Use `/draw character Almos` and confirm `character` supplies category context when no stronger entity category is available.
+9. Use `/draw` for a known entity whose metadata category differs from the typed category hint.
+10. Confirm matched entity metadata wins over the typed category hint.
+11. Generate front page cover art.
+12. Confirm cover generation uses world/cover context rather than entity-specific context.
+13. Trigger Oracle chat draw where entity/category context exists.
+14. Confirm chat draw uses that context and otherwise falls back safely.
+15. Add a normal note/entity containing explicit art direction and include it in draw context.
+16. Confirm user-authored art direction wins over shipped category/theme/global defaults when available.
+
+## Regression Checks
+
+- Existing image generation still works when no user-authored art direction exists.
+- Lite tier or disabled AI still hides or blocks generation controls as before.
+- Guest/demo restrictions are unchanged.
+- Shipped defaults do not name living artists.
+- Defaults remain concise and include the requested subject in final resolved prompts.

--- a/specs/115-default-art-prompts/research.md
+++ b/specs/115-default-art-prompts/research.md
@@ -1,0 +1,77 @@
+# Research: Default Art Prompts
+
+## Decision 1: Add A Pure Art Direction Resolver
+
+**Decision**: Implement art direction resolution as a pure, testable function or service that accepts draw context and returns a resolved prompt plus metadata about the fallback level used.
+
+**Rationale**: The fallback hierarchy is the core feature. Keeping it pure makes it easy to test, reuse from every draw entry point, and reason about without coupling to image generation network behavior.
+
+**Alternatives considered**:
+
+- Build prompt rules directly into each draw button or command path. Rejected because it would create inconsistent behavior.
+- Add another AI call to rewrite prompts. Rejected because the feature needs predictable defaults and should not add latency before image generation.
+
+## Decision 2: No Dedicated Art Direction Settings Storage
+
+**Decision**: Do not add Vault Settings fields or new persistence for art direction in the first implementation. Custom user art direction should remain normal note/entity content that may be included in draw context.
+
+**Rationale**: The user explicitly prefers ordinary notes/entities for custom styles. This avoids product clutter and uses the vault's existing content model, sync, permissions, search, and editing behavior.
+
+**Alternatives considered**:
+
+- Add `AI Art Direction` settings with textareas for default and category overrides. Rejected because it duplicates a concept users can express as notes/entities.
+- Add a hybrid settings-plus-content model. Rejected for the first implementation because it increases ambiguity and persistence scope.
+
+## Decision 3: Ship Category Defaults For Composition
+
+**Decision**: Provide shipped category defaults for common category-like contexts: Character, Creature, Location, Item, Faction, Event, Note, and world cover.
+
+**Rationale**: Theme gives mood, but category gives composition. A location should lean toward establishing shots, while an item should lean toward prop presentation. This is the highest-value defaulting behavior from issue #867.
+
+**Alternatives considered**:
+
+- Ship only theme defaults. Rejected because every category would receive similar image composition.
+- Require user category prompts. Rejected because the MVP should improve first-use behavior without setup.
+
+## Decision 4: Theme Defaults Are Descriptive And Safe
+
+**Decision**: Theme defaults describe medium, mood, materials, lighting, and composition. They must not name living artists or instruct direct imitation of living artists.
+
+**Rationale**: The issue examples included artist-name style references, but shipped defaults should be legally and product-safe while still steering visual output.
+
+**Alternatives considered**:
+
+- Copy the issue's artist-name prompt examples. Rejected because shipped defaults should avoid living-artist imitation.
+- Make defaults so generic that they do not steer style. Rejected because the feature exists to create consistent visual direction.
+
+## Decision 5: Existing Image Generation Service Stays Intact
+
+**Decision**: Resolve art direction before calling the existing image generation service. Do not change the model request/response path except for passing the prepared prompt.
+
+**Rationale**: Existing code already handles AI enablement, direct/proxy calls, image response parsing, and errors. This feature should improve prompt preparation without changing image transport.
+
+**Alternatives considered**:
+
+- Replace the image generation service with a new art-aware service. Rejected because it increases blast radius and duplicates existing behavior.
+- Add resolver behavior inside `generateImage`. Rejected because `generateImage` should receive final prompt text and remain focused on model IO.
+
+## Decision 6: Draw Command Category Words Are Hints
+
+**Decision**: `/draw character Almos` may use `character` as category context, but if `Almos` resolves to an entity with a category, the entity metadata wins.
+
+**Rationale**: This gives users useful shorthand while preserving canonical vault metadata when the subject is a known entity.
+
+**Alternatives considered**:
+
+- Treat command category words as subject text only. Rejected because it loses a helpful composition hint.
+- Let command category words always override entity metadata. Rejected because it can accidentally contradict known entity data.
+
+## Decision 7: Entry Point Coverage Is Explicit
+
+**Decision**: The first implementation must route these existing entry points through the same resolver: `/draw`, entity sidebar draw, Zen mode draw, graph context menu image generation, front page cover generation, and Oracle chat draw where context exists.
+
+**Rationale**: Users should not see different art direction behavior depending on which button or command they use.
+
+**Alternatives considered**:
+
+- Cover only `/draw` and entity sidebar first. Rejected because the spec now explicitly names current draw buttons, and partial coverage would preserve inconsistency.

--- a/specs/115-default-art-prompts/spec.md
+++ b/specs/115-default-art-prompts/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Default Art Prompts
+
+**Feature Branch**: `115-default-art-prompts`  
+**Created**: 2026-05-23  
+**Status**: Draft  
+**Input**: User description: "GitHub issue #867 proposes default AI art prompts with a predictable fallback hierarchy: entity-specific art direction, category-specific art direction, vault/world art direction, theme default art style, and a global Codex Cryptica default. Users should be able to edit vault art direction and category overrides, and draw commands should resolve the right prompt automatically."
+
+## Clarifications
+
+### Session 2026-05-23
+
+- Q: Is this part of the neutral world theming spec? -> A: No. It is a separate spec because it affects AI art prompt resolution, vault settings, category overrides, and draw-command behavior rather than app chrome theming.
+- Q: Should shipped default prompts copy named artist styles? -> A: No. Defaults should use descriptive visual direction and avoid named living-artist imitation while preserving mood, composition, medium, lighting, and material guidance.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Predictable Art Prompt Resolution (Priority: P1)
+
+As a user generating an image for an entity, I want Codex Cryptica to apply the most specific available art direction so generated art feels consistent with my vault and the entity I am drawing.
+
+**Why this priority**: The current image prompt path can feel inconsistent from request to request. The core value is a deterministic fallback hierarchy that makes art generation feel attached to the world rather than a standalone AI feature.
+
+**Independent Test**: Configure art direction at multiple levels, trigger image generation for an entity, and verify the resolved prompt uses the highest-priority available art direction without skipping to less specific defaults.
+
+**Acceptance Scenarios**:
+
+1. **Given** an entity has entity-specific art direction, **When** the user draws that entity, **Then** the resolved prompt MUST use the entity-specific direction ahead of category, vault, theme, or global defaults.
+2. **Given** an entity lacks entity-specific art direction and its category has an art direction override, **When** the user draws that entity, **Then** the resolved prompt MUST use the category override.
+3. **Given** neither entity nor category art direction exists and the vault has default art direction, **When** the user draws an entity, **Then** the resolved prompt MUST use the vault default art direction.
+4. **Given** no entity, category, or vault art direction exists and the vault has a theme with default art direction, **When** the user draws an entity, **Then** the resolved prompt MUST use the theme default art direction.
+5. **Given** no specific art direction exists anywhere, **When** the user draws an entity, **Then** the resolved prompt MUST use the global Codex Cryptica default art direction.
+
+---
+
+### User Story 2 - Category-Aware Composition Defaults (Priority: P1)
+
+As a user drawing different kinds of world objects, I want category defaults to guide composition so characters, locations, items, factions, events, and notes do not all produce the same kind of image.
+
+**Why this priority**: Issue #867 identifies category-specific fallback as the strongest improvement. Theme supplies mood, but category supplies the shot type and framing needed for useful art.
+
+**Independent Test**: Draw entities in different categories with the same vault/theme art direction and verify the resolved prompts differ by category composition while retaining the same world style.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Character category default exists, **When** the user draws a character, **Then** the prompt SHOULD emphasize readable silhouette, pose, clothing, and character design.
+2. **Given** a Location category default exists, **When** the user draws a location, **Then** the prompt SHOULD emphasize establishing shot, atmosphere, architecture or landscape, and sense of place.
+3. **Given** an Item category default exists, **When** the user draws an item, **Then** the prompt SHOULD emphasize prop design, materials, craftsmanship, and a clear presentation background.
+4. **Given** categories such as Creature, Faction, Event, or Note have defaults, **When** the user draws matching entities, **Then** the prompt SHOULD use category-specific composition guidance rather than only the vault default.
+
+---
+
+### User Story 3 - Editable Vault Art Direction (Priority: P2)
+
+As a world owner, I want a Vault Settings area for AI Art Direction so I can control the visual style of generated art without rewriting every draw prompt.
+
+**Why this priority**: Defaults should be useful out of the box, but users need control because every vault has its own visual identity.
+
+**Independent Test**: Open vault settings, edit the default art style and one category override, save, reload the vault, and verify future draw prompts use the saved settings.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user opens Vault Settings, **When** they view AI Art Direction, **Then** they MUST be able to see and edit the vault's default art style.
+2. **Given** a user edits a category override, **When** they save settings, **Then** the override MUST persist for that vault and apply to future draws in that category.
+3. **Given** a user clears a category override, **When** they save settings, **Then** that category MUST fall back to the next available art direction level.
+4. **Given** a user changes art direction settings in one vault, **When** they open another vault, **Then** the other vault's art direction MUST remain unchanged.
+
+---
+
+### User Story 4 - Theme Defaults For Art Style (Priority: P2)
+
+As a user who selects a world theme, I want that theme to provide an appropriate default art style so image generation starts with a coherent mood before I customize anything.
+
+**Why this priority**: Theme defaults make first-use image generation consistent and reduce setup work, but they should not override explicit user choices.
+
+**Independent Test**: Select different world themes with no vault or category overrides, draw the same subject, and verify the resolved prompt reflects the selected theme's default art style.
+
+**Acceptance Scenarios**:
+
+1. **Given** a vault uses a fantasy theme and no art overrides, **When** the user draws a subject, **Then** the resolved prompt SHOULD use a fantasy-appropriate descriptive art style.
+2. **Given** a vault uses a sci-fi, cyberpunk, modern, post-apocalyptic, gothic horror, steampunk, mythic, or pulp-adventure theme and no art overrides, **When** the user draws a subject, **Then** the resolved prompt SHOULD reflect that theme's mood and materials.
+3. **Given** a vault has an explicit default art style, **When** the vault theme changes, **Then** the explicit vault art style MUST remain the active fallback until cleared or changed.
+4. **Given** a shipped default art style is used, **When** its prompt is assembled, **Then** it MUST avoid naming living artists as style targets.
+
+---
+
+### User Story 5 - Draw Command Uses Resolved Art Direction (Priority: P2)
+
+As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image generation entry points to use the same art direction resolver so generated results are consistent.
+
+**Why this priority**: Users should not get different style behavior depending on which draw button or command they use.
+
+**Independent Test**: Trigger image generation through `/draw`, entity sidepanel draw, and chat draw for the same subject and verify each path uses the same resolved art direction for equivalent subject/category context.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user enters `/draw character Almos`, **When** the command resolves the subject and category, **Then** it MUST apply the Character art direction fallback chain.
+2. **Given** the user draws from an entity sidepanel, **When** the entity has a category, **Then** the resolver MUST use that entity and category context.
+3. **Given** the user draws from an Oracle chat message, **When** the message is associated with an entity or category context, **Then** the resolver SHOULD use that context where available and fall back safely where it is not.
+4. **Given** a draw request is missing category context, **When** the resolver builds the prompt, **Then** it MUST fall back to vault, theme, or global art direction instead of failing.
+
+### Edge Cases
+
+- Entity-specific art direction is empty or whitespace-only.
+- Category override exists for a category that no longer exists in the vault.
+- A category is renamed after an art direction override was saved.
+- Vault art direction is extremely long.
+- Prompt templates omit the `{subject}` placeholder.
+- Prompt templates include multiple `{subject}` placeholders.
+- No theme art direction exists for the selected world theme.
+- Image generation is disabled by tier or capability guard.
+- Demo or shared-session vaults should not persist unauthorized art direction edits.
+- Existing image generation prompts and visual distillation should keep working when no art direction data exists.
+
+### Assumptions
+
+- Art direction is a text prompt template that may include `{subject}` as the subject insertion point.
+- Entity-specific art direction is optional and may be added later if entity editing UI is not part of the first implementation.
+- The first implementation should cover vault default art direction, category overrides, theme defaults, global default, and resolver integration for existing draw entry points.
+- Existing image generation model calls remain unchanged; this feature prepares the prompt before it reaches the image generation service.
+- Prompt defaults should be concise enough to guide style without producing unwieldy prompts.
+- Shipped defaults should describe style through medium, composition, lighting, mood, materials, and visual constraints rather than named artist imitation.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a single art direction resolver used by all image generation entry points.
+- **FR-002**: The resolver MUST apply this fallback order: entity-specific art direction, category-specific art direction, vault default art direction, theme default art direction, global Codex Cryptica default art direction.
+- **FR-003**: The resolver MUST skip empty, whitespace-only, or invalid art direction values and continue to the next fallback level.
+- **FR-004**: The resolver MUST insert the requested subject into the selected art direction template.
+- **FR-005**: If a selected template does not include `{subject}`, the system MUST still include the subject in the final prompt.
+- **FR-006**: Users MUST be able to configure vault default art direction per vault.
+- **FR-007**: Users MUST be able to configure category-specific art direction overrides per vault.
+- **FR-008**: Saved art direction settings MUST persist per vault and MUST NOT affect other vaults.
+- **FR-009**: Clearing a category-specific override MUST restore fallback to the next available art direction level.
+- **FR-010**: The system MUST provide shipped global default art direction.
+- **FR-011**: The system SHOULD provide shipped theme default art directions for supported world themes.
+- **FR-012**: The system SHOULD provide category-specific default templates for common categories including Character, Creature, Location, Item, Faction, Event, and Note.
+- **FR-013**: Theme default and category default prompts MUST avoid naming living artists or directly imitating a living artist's style.
+- **FR-014**: Default prompts SHOULD remain concise and focused on subject, medium, composition, lighting, mood, materials, and readability.
+- **FR-015**: Existing `/draw` command behavior MUST use the art direction resolver before calling image generation.
+- **FR-016**: Existing entity sidepanel draw behavior MUST use the art direction resolver before calling image generation.
+- **FR-017**: Existing Oracle chat draw behavior SHOULD use the art direction resolver when subject or category context is available.
+- **FR-018**: If AI image generation is unavailable because of tier, capability, or missing configuration, art direction settings MUST remain editable but generation controls MUST keep existing gating behavior.
+- **FR-019**: Users MUST be able to preview or understand which fallback level will be used for a category before saving settings.
+- **FR-020**: Automated verification MUST cover resolver fallback order, template subject insertion, empty-value fallback, per-vault persistence, category overrides, and at least one draw entry point.
+- **FR-021**: User-facing labels and help text MUST use clear wording such as "AI Art Direction", "Default Art Style", and "Category Overrides".
+
+### Key Entities _(include if feature involves data)_
+
+- **Art Direction Template**: A prompt template that guides image style and may include `{subject}`.
+- **Resolved Art Direction**: The final prompt text assembled for a draw request after applying fallback rules and subject insertion.
+- **Vault Art Direction Settings**: Per-vault settings containing a default art style and category overrides.
+- **Category Art Direction Override**: A per-vault art direction template assigned to a category or category-like type.
+- **Theme Art Direction Default**: A shipped default prompt associated with a world theme.
+- **Global Art Direction Default**: The final fallback prompt used when no more specific art direction is available.
+- **Draw Request Context**: Subject text plus optional entity id, category, vault id, and theme id used by the resolver.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A draw request with entity, category, vault, theme, and global art direction available uses the entity-specific art direction.
+- **SC-002**: A draw request without entity-specific art direction but with category art direction uses the category art direction.
+- **SC-003**: A user can edit vault default art direction and category overrides, reload the vault, and see those settings persist.
+- **SC-004**: Two vaults can maintain different art direction settings without affecting each other.
+- **SC-005**: `/draw` image generation uses the same resolver as at least one existing draw button path.
+- **SC-006**: Shipped default prompts pass review for concise descriptive language and avoid named living-artist style imitation.
+- **SC-007**: Verification covers the fallback hierarchy and existing image generation still works with no saved art direction settings.

--- a/specs/115-default-art-prompts/spec.md
+++ b/specs/115-default-art-prompts/spec.md
@@ -86,20 +86,23 @@ As a user who selects a world theme, I want that theme to provide an appropriate
 
 ---
 
-### User Story 5 - Draw Command Uses Resolved Art Direction (Priority: P2)
+### User Story 5 - Draw Entry Points Use Resolved Art Direction (Priority: P2)
 
-As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image generation entry points to use the same art direction resolver so generated results are consistent.
+As a user using `/draw`, entity sidebar draw, Zen mode draw, graph context menu draw, front page cover generation, or chat draw actions, I want all image generation entry points to use the same art direction resolver so generated results are consistent.
 
 **Why this priority**: Users should not get different style behavior depending on which draw button or command they use.
 
-**Independent Test**: Trigger image generation through `/draw`, entity sidepanel draw, and chat draw for the same subject and verify each path uses the same resolved art direction for equivalent subject/category context.
+**Independent Test**: Trigger image generation through `/draw`, entity sidebar draw, Zen mode draw, graph context menu draw, front page cover generation, and chat draw for the same or equivalent subject and verify each path uses the same resolver with the best available subject/category/vault/theme context.
 
 **Acceptance Scenarios**:
 
 1. **Given** the user enters `/draw character Almos`, **When** the command resolves the subject and category, **Then** it MUST apply the Character art direction fallback chain.
-2. **Given** the user draws from an entity sidepanel, **When** the entity has a category, **Then** the resolver MUST use that entity and category context.
-3. **Given** the user draws from an Oracle chat message, **When** the message is associated with an entity or category context, **Then** the resolver SHOULD use that context where available and fall back safely where it is not.
-4. **Given** a draw request is missing category context, **When** the resolver builds the prompt, **Then** it MUST fall back to vault, theme, or global art direction instead of failing.
+2. **Given** the user draws from an entity sidebar, **When** the entity has a category, **Then** the resolver MUST use that entity and category context.
+3. **Given** the user draws from Zen mode, **When** the active entity has a category, **Then** the resolver MUST use that entity and category context.
+4. **Given** the user draws from the graph context menu for a selected node, **When** the selected node maps to an entity, **Then** the resolver MUST use that entity and category context.
+5. **Given** the user generates front page cover art, **When** the request is for the world cover rather than a specific entity, **Then** the resolver MUST use vault, theme, and global art direction with cover/world composition context.
+6. **Given** the user draws from an Oracle chat message, **When** the message is associated with an entity or category context, **Then** the resolver SHOULD use that context where available and fall back safely where it is not.
+7. **Given** a draw request is missing category context, **When** the resolver builds the prompt, **Then** it MUST fall back to vault, theme, or global art direction instead of failing.
 
 ### Edge Cases
 
@@ -118,7 +121,7 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 
 - Art direction is a text prompt template that may include `{subject}` as the subject insertion point.
 - Entity-specific art direction remains the highest-priority resolver input, but entity-level editing UI is out of scope for the first implementation.
-- The first implementation should cover vault default art direction, category overrides, theme defaults, global default, and resolver integration for existing draw entry points.
+- The first implementation should cover vault default art direction, category overrides, theme defaults, global default, and resolver integration for existing draw entry points including `/draw`, entity sidebar draw, Zen mode draw, graph context menu draw, front page cover generation, and Oracle chat draw.
 - Existing image generation model calls remain unchanged; this feature prepares the prompt before it reaches the image generation service.
 - Prompt defaults should be concise enough to guide style without producing unwieldy prompts.
 - Shipped defaults should describe style through medium, composition, lighting, mood, materials, and visual constraints rather than named artist imitation.
@@ -145,11 +148,14 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 - **FR-014**: Default prompts SHOULD remain concise and focused on subject, medium, composition, lighting, mood, materials, and readability.
 - **FR-015**: Existing `/draw` command behavior MUST use the art direction resolver before calling image generation.
 - **FR-015a**: `/draw` command parsing MUST allow recognized category words to provide category context, while matched entity category metadata MUST take precedence when the subject resolves to an entity.
-- **FR-016**: Existing entity sidepanel draw behavior MUST use the art direction resolver before calling image generation.
+- **FR-016**: Existing entity sidebar draw behavior MUST use the art direction resolver before calling image generation.
+- **FR-016a**: Existing Zen mode draw behavior MUST use the art direction resolver before calling image generation.
+- **FR-016b**: Existing graph context menu image generation behavior MUST use the art direction resolver before calling image generation.
+- **FR-016c**: Existing front page cover generation behavior MUST use the art direction resolver with world cover context before calling image generation.
 - **FR-017**: Existing Oracle chat draw behavior SHOULD use the art direction resolver when subject or category context is available.
 - **FR-018**: If AI image generation is unavailable because of tier, capability, or missing configuration, art direction settings MUST remain editable but generation controls MUST keep existing gating behavior.
 - **FR-019**: Users MUST be able to preview or understand which fallback level will be used for a category before saving settings.
-- **FR-020**: Automated verification MUST cover resolver fallback order, template subject insertion, empty-value fallback, per-vault persistence, category overrides, and at least one draw entry point.
+- **FR-020**: Automated verification MUST cover resolver fallback order, template subject insertion, empty-value fallback, per-vault persistence, category overrides, and existing draw entry points including `/draw`, entity sidebar, Zen mode, graph context menu, front page cover generation, and Oracle chat where context is available.
 - **FR-021**: User-facing labels and help text MUST use clear wording such as "AI Art Direction", "Default Art Style", and "Category Overrides".
 
 ### Key Entities _(include if feature involves data)_
@@ -160,7 +166,7 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 - **Category Art Direction Override**: A per-vault art direction template assigned to a stable category ID or category-like type.
 - **Theme Art Direction Default**: A shipped default prompt associated with a world theme.
 - **Global Art Direction Default**: The final fallback prompt used when no more specific art direction is available.
-- **Draw Request Context**: Subject text plus optional entity id, category, vault id, and theme id used by the resolver.
+- **Draw Request Context**: Subject text plus optional entity id, category, vault id, theme id, and surface context such as entity visual, chat visual, graph node image, or world cover used by the resolver.
 
 ## Success Criteria _(mandatory)_
 
@@ -170,6 +176,6 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 - **SC-002**: A draw request without entity-specific art direction but with category art direction uses the category art direction.
 - **SC-003**: A user can edit vault default art direction and category overrides, reload the vault, and see those settings persist.
 - **SC-004**: Two vaults can maintain different art direction settings without affecting each other.
-- **SC-005**: `/draw` image generation uses the same resolver as at least one existing draw button path.
+- **SC-005**: `/draw`, entity sidebar draw, Zen mode draw, graph context menu image generation, front page cover generation, and Oracle chat draw all use the same resolver where context is available.
 - **SC-006**: Shipped default prompts pass review for concise descriptive language and avoid named living-artist style imitation.
 - **SC-007**: Verification covers the fallback hierarchy and existing image generation still works with no saved art direction settings.

--- a/specs/115-default-art-prompts/spec.md
+++ b/specs/115-default-art-prompts/spec.md
@@ -3,17 +3,18 @@
 **Feature Branch**: `115-default-art-prompts`  
 **Created**: 2026-05-23  
 **Status**: Draft  
-**Input**: User description: "GitHub issue #867 proposes default AI art prompts with a predictable fallback hierarchy: entity-specific art direction, category-specific art direction, vault/world art direction, theme default art style, and a global Codex Cryptica default. Users should be able to edit vault art direction and category overrides, and draw commands should resolve the right prompt automatically."
+**Input**: User description: "GitHub issue #867 proposes default AI art prompts with a predictable fallback hierarchy: entity-specific art direction, category-specific art direction, vault/world art direction, theme default art style, and a global Codex Cryptica default. The first implementation should make draw actions resolve consistent default art direction automatically; custom user art direction should come from normal notes/entities rather than a dedicated art-style settings editor."
 
 ## Clarifications
 
 ### Session 2026-05-23
 
-- Q: Is this part of the neutral world theming spec? -> A: No. It is a separate spec because it affects AI art prompt resolution, vault settings, category overrides, and draw-command behavior rather than app chrome theming.
+- Q: Is this part of the neutral world theming spec? -> A: No. It is a separate spec because it affects AI art prompt resolution, world-content context, category defaults, theme defaults, and draw-command behavior rather than app chrome theming.
 - Q: Should shipped default prompts copy named artist styles? -> A: No. Defaults should use descriptive visual direction and avoid named living-artist imitation while preserving mood, composition, medium, lighting, and material guidance.
 - Q: Should the first implementation include UI for editing entity-specific art direction? -> A: No. Keep entity-specific art direction as the highest-priority resolver slot, but do not build entity-level editing UI in the first implementation.
-- Q: How should category art direction overrides be stored so category renames are handled? -> A: Store category overrides by stable category ID.
+- Q: How should category art direction be keyed so category renames are handled? -> A: Resolve category art direction by stable category ID where a real category exists.
 - Q: How should `/draw character Almos` treat `character`? -> A: Command category words may supply category context, but matched entity metadata wins when the subject resolves to an entity with a category.
+- Q: Should custom art direction be edited in dedicated Vault Settings? -> A: No. The first implementation should not add a dedicated art-style settings editor; user-authored art direction should be represented through normal notes/entities.
 
 ## User Scenarios & Testing _(mandatory)_
 
@@ -27,10 +28,10 @@ As a user generating an image for an entity, I want Codex Cryptica to apply the 
 
 **Acceptance Scenarios**:
 
-1. **Given** an entity has entity-specific art direction, **When** the user draws that entity, **Then** the resolved prompt MUST use the entity-specific direction ahead of category, vault, theme, or global defaults.
-2. **Given** an entity lacks entity-specific art direction and its category has an art direction override, **When** the user draws that entity, **Then** the resolved prompt MUST use the category override.
-3. **Given** neither entity nor category art direction exists and the vault has default art direction, **When** the user draws an entity, **Then** the resolved prompt MUST use the vault default art direction.
-4. **Given** no entity, category, or vault art direction exists and the vault has a theme with default art direction, **When** the user draws an entity, **Then** the resolved prompt MUST use the theme default art direction.
+1. **Given** an entity has entity-specific art direction available from its content/context, **When** the user draws that entity, **Then** the resolved prompt MUST use the entity-specific direction ahead of user-authored vault art direction, category defaults, theme defaults, or global defaults.
+2. **Given** an entity lacks entity-specific art direction and relevant user-authored art direction content is available in the draw context, **When** the user draws that entity, **Then** the resolved prompt MUST use the user-authored art direction.
+3. **Given** neither entity-specific nor user-authored art direction exists and the entity category has a shipped category default, **When** the user draws an entity, **Then** the resolved prompt MUST use the category default art direction.
+4. **Given** no entity, user-authored, or category art direction exists and the vault has a theme with default art direction, **When** the user draws an entity, **Then** the resolved prompt MUST use the theme default art direction.
 5. **Given** no specific art direction exists anywhere, **When** the user draws an entity, **Then** the resolved prompt MUST use the global Codex Cryptica default art direction.
 
 ---
@@ -52,20 +53,20 @@ As a user drawing different kinds of world objects, I want category defaults to 
 
 ---
 
-### User Story 3 - Editable Vault Art Direction (Priority: P2)
+### User Story 3 - User Authored Art Direction Content (Priority: P2)
 
-As a world owner, I want a Vault Settings area for AI Art Direction so I can control the visual style of generated art without rewriting every draw prompt.
+As a world owner, I want custom art direction to live as normal world content so style guidance remains part of the vault rather than a separate settings form.
 
-**Why this priority**: Defaults should be useful out of the box, but users need control because every vault has its own visual identity.
+**Why this priority**: Users can already express world knowledge through notes and entities. Keeping custom art direction in that content model avoids adding another configuration surface and lets style guidance be discovered, edited, searched, and synced like other lore.
 
-**Independent Test**: Open vault settings, edit the default art style and one category override, save, reload the vault, and verify future draw prompts use the saved settings.
+**Independent Test**: Create or identify a note/entity intended as art direction, include it in the draw context, and verify the resolver can use user-authored art direction when available without requiring a dedicated settings editor.
 
 **Acceptance Scenarios**:
 
-1. **Given** a user opens Vault Settings, **When** they view AI Art Direction, **Then** they MUST be able to see and edit the vault's default art style.
-2. **Given** a user edits a category override, **When** they save settings, **Then** the override MUST persist for that vault and apply to future draws in that category.
-3. **Given** a user clears a category override, **When** they save settings, **Then** that category MUST fall back to the next available art direction level.
-4. **Given** a user changes art direction settings in one vault, **When** they open another vault, **Then** the other vault's art direction MUST remain unchanged.
+1. **Given** a vault contains user-authored art direction content, **When** a draw request includes that content in its context, **Then** the resolver SHOULD use that art direction ahead of shipped theme or global defaults.
+2. **Given** a user wants a custom art style, **When** they create a note/entity for that guidance, **Then** the feature MUST NOT require them to duplicate that guidance into a dedicated settings form.
+3. **Given** no user-authored art direction content is available, **When** the user draws an image, **Then** the resolver MUST fall back to shipped category, theme, and global defaults.
+4. **Given** a user-authored art direction note/entity is edited or deleted, **When** future draw context changes, **Then** the resolver MUST use the current available content and fall back safely if it is absent.
 
 ---
 
@@ -73,15 +74,15 @@ As a world owner, I want a Vault Settings area for AI Art Direction so I can con
 
 As a user who selects a world theme, I want that theme to provide an appropriate default art style so image generation starts with a coherent mood before I customize anything.
 
-**Why this priority**: Theme defaults make first-use image generation consistent and reduce setup work, but they should not override explicit user choices.
+**Why this priority**: Theme defaults make first-use image generation consistent and reduce setup work, but they should not override relevant user-authored art direction content.
 
-**Independent Test**: Select different world themes with no vault or category overrides, draw the same subject, and verify the resolved prompt reflects the selected theme's default art style.
+**Independent Test**: Select different world themes with no user-authored art direction in context, draw the same subject, and verify the resolved prompt reflects the selected theme's default art style.
 
 **Acceptance Scenarios**:
 
-1. **Given** a vault uses a fantasy theme and no art overrides, **When** the user draws a subject, **Then** the resolved prompt SHOULD use a fantasy-appropriate descriptive art style.
-2. **Given** a vault uses a sci-fi, cyberpunk, modern, post-apocalyptic, gothic horror, steampunk, mythic, or pulp-adventure theme and no art overrides, **When** the user draws a subject, **Then** the resolved prompt SHOULD reflect that theme's mood and materials.
-3. **Given** a vault has an explicit default art style, **When** the vault theme changes, **Then** the explicit vault art style MUST remain the active fallback until cleared or changed.
+1. **Given** a vault uses a fantasy theme and no user-authored art direction is available, **When** the user draws a subject, **Then** the resolved prompt SHOULD use a fantasy-appropriate descriptive art style.
+2. **Given** a vault uses a sci-fi, cyberpunk, modern, post-apocalyptic, gothic horror, steampunk, mythic, or pulp-adventure theme and no user-authored art direction is available, **When** the user draws a subject, **Then** the resolved prompt SHOULD reflect that theme's mood and materials.
+3. **Given** relevant user-authored art direction content is available, **When** the vault theme changes, **Then** the user-authored art direction MUST remain higher priority than the shipped theme default.
 4. **Given** a shipped default art style is used, **When** its prompt is assembled, **Then** it MUST avoid naming living artists as style targets.
 
 ---
@@ -107,40 +108,40 @@ As a user using `/draw`, entity sidebar draw, Zen mode draw, graph context menu 
 ### Edge Cases
 
 - Entity-specific art direction is empty or whitespace-only.
-- Category override exists for a category that no longer exists in the vault.
-- A category is renamed after an art direction override was saved.
-- Vault art direction is extremely long.
+- A category is renamed after shipped or inferred category art direction was resolved.
+- User-authored art direction content is extremely long.
 - Prompt templates omit the `{subject}` placeholder.
 - Prompt templates include multiple `{subject}` placeholders.
 - No theme art direction exists for the selected world theme.
 - Image generation is disabled by tier or capability guard.
-- Demo or shared-session vaults should not persist unauthorized art direction edits.
+- Demo or shared-session vaults should not persist unauthorized art direction content edits.
 - Existing image generation prompts and visual distillation should keep working when no art direction data exists.
 
 ### Assumptions
 
 - Art direction is a text prompt template that may include `{subject}` as the subject insertion point.
 - Entity-specific art direction remains the highest-priority resolver input, but entity-level editing UI is out of scope for the first implementation.
-- The first implementation should cover vault default art direction, category overrides, theme defaults, global default, and resolver integration for existing draw entry points including `/draw`, entity sidebar draw, Zen mode draw, graph context menu draw, front page cover generation, and Oracle chat draw.
+- The first implementation should cover resolver support for entity/user-authored context where already available, shipped category defaults, theme defaults, global default, and resolver integration for existing draw entry points including `/draw`, entity sidebar draw, Zen mode draw, graph context menu draw, front page cover generation, and Oracle chat draw.
 - Existing image generation model calls remain unchanged; this feature prepares the prompt before it reaches the image generation service.
 - Prompt defaults should be concise enough to guide style without producing unwieldy prompts.
 - Shipped defaults should describe style through medium, composition, lighting, mood, materials, and visual constraints rather than named artist imitation.
 - For `/draw` commands, a recognized category word may provide category context, but matched entity metadata takes precedence over the command-provided category when both are present.
+- The first implementation should not add a dedicated Vault Settings editor for art style. User-authored art direction belongs in ordinary notes/entities and can be included through existing context mechanisms or a later content-linking enhancement.
 
 ## Requirements _(mandatory)_
 
 ### Functional Requirements
 
 - **FR-001**: The system MUST provide a single art direction resolver used by all image generation entry points.
-- **FR-002**: The resolver MUST apply this fallback order: entity-specific art direction, category-specific art direction, vault default art direction, theme default art direction, global Codex Cryptica default art direction.
+- **FR-002**: The resolver MUST apply this fallback order: entity-specific art direction from context, relevant user-authored art direction content, shipped category default art direction, theme default art direction, global Codex Cryptica default art direction.
 - **FR-003**: The resolver MUST skip empty, whitespace-only, or invalid art direction values and continue to the next fallback level.
 - **FR-004**: The resolver MUST insert the requested subject into the selected art direction template.
 - **FR-005**: If a selected template does not include `{subject}`, the system MUST still include the subject in the final prompt.
-- **FR-006**: Users MUST be able to configure vault default art direction per vault.
-- **FR-007**: Users MUST be able to configure category-specific art direction overrides per vault.
-- **FR-007a**: Category-specific art direction overrides MUST be keyed by stable category ID so renaming a category does not detach its art direction.
-- **FR-008**: Saved art direction settings MUST persist per vault and MUST NOT affect other vaults.
-- **FR-009**: Clearing a category-specific override MUST restore fallback to the next available art direction level.
+- **FR-006**: The first implementation MUST NOT add a dedicated Vault Settings editor for art direction.
+- **FR-007**: User-authored art direction SHOULD be represented through ordinary notes/entities rather than separate art-style settings.
+- **FR-007a**: When user-authored art direction is available in draw context, the resolver SHOULD treat it as higher priority than shipped category, theme, or global defaults.
+- **FR-008**: Art direction represented as normal notes/entities MUST follow existing per-vault content persistence and sharing behavior.
+- **FR-009**: If user-authored art direction content is unavailable, removed, or empty, the resolver MUST fall back to shipped category, theme, or global defaults.
 - **FR-010**: The system MUST provide shipped global default art direction.
 - **FR-011**: The system SHOULD provide shipped theme default art directions for supported world themes.
 - **FR-012**: The system SHOULD provide category-specific default templates for common categories including Character, Creature, Location, Item, Faction, Event, and Note.
@@ -153,17 +154,17 @@ As a user using `/draw`, entity sidebar draw, Zen mode draw, graph context menu 
 - **FR-016b**: Existing graph context menu image generation behavior MUST use the art direction resolver before calling image generation.
 - **FR-016c**: Existing front page cover generation behavior MUST use the art direction resolver with world cover context before calling image generation.
 - **FR-017**: Existing Oracle chat draw behavior SHOULD use the art direction resolver when subject or category context is available.
-- **FR-018**: If AI image generation is unavailable because of tier, capability, or missing configuration, art direction settings MUST remain editable but generation controls MUST keep existing gating behavior.
-- **FR-019**: Users MUST be able to preview or understand which fallback level will be used for a category before saving settings.
-- **FR-020**: Automated verification MUST cover resolver fallback order, template subject insertion, empty-value fallback, per-vault persistence, category overrides, and existing draw entry points including `/draw`, entity sidebar, Zen mode, graph context menu, front page cover generation, and Oracle chat where context is available.
-- **FR-021**: User-facing labels and help text MUST use clear wording such as "AI Art Direction", "Default Art Style", and "Category Overrides".
+- **FR-018**: If AI image generation is unavailable because of tier, capability, or missing configuration, normal notes/entities MUST remain editable according to existing permissions but generation controls MUST keep existing gating behavior.
+- **FR-019**: Users SHOULD be able to understand which fallback level was used for a resolved draw prompt when troubleshooting art direction.
+- **FR-020**: Automated verification MUST cover resolver fallback order, template subject insertion, empty-value fallback, shipped category defaults, user-authored context fallback, and existing draw entry points including `/draw`, entity sidebar, Zen mode, graph context menu, front page cover generation, and Oracle chat where context is available.
+- **FR-021**: User-facing labels and help text MUST use clear wording such as "Art Direction", "Default Art Style", and "Category Defaults" without implying a dedicated settings editor.
 
 ### Key Entities _(include if feature involves data)_
 
 - **Art Direction Template**: A prompt template that guides image style and may include `{subject}`.
 - **Resolved Art Direction**: The final prompt text assembled for a draw request after applying fallback rules and subject insertion.
-- **Vault Art Direction Settings**: Per-vault settings containing a default art style and category overrides.
-- **Category Art Direction Override**: A per-vault art direction template assigned to a stable category ID or category-like type.
+- **User Authored Art Direction Content**: A normal note/entity that describes desired visual style, mood, materials, or composition and can be included in draw context.
+- **Category Art Direction Default**: A shipped art direction template associated with a category or category-like type.
 - **Theme Art Direction Default**: A shipped default prompt associated with a world theme.
 - **Global Art Direction Default**: The final fallback prompt used when no more specific art direction is available.
 - **Draw Request Context**: Subject text plus optional entity id, category, vault id, theme id, and surface context such as entity visual, chat visual, graph node image, or world cover used by the resolver.
@@ -173,9 +174,9 @@ As a user using `/draw`, entity sidebar draw, Zen mode draw, graph context menu 
 ### Measurable Outcomes
 
 - **SC-001**: A draw request with entity, category, vault, theme, and global art direction available uses the entity-specific art direction.
-- **SC-002**: A draw request without entity-specific art direction but with category art direction uses the category art direction.
-- **SC-003**: A user can edit vault default art direction and category overrides, reload the vault, and see those settings persist.
-- **SC-004**: Two vaults can maintain different art direction settings without affecting each other.
+- **SC-002**: A draw request without entity-specific art direction but with category default art direction uses the category default art direction.
+- **SC-003**: A draw request with relevant user-authored art direction content uses that content ahead of shipped category, theme, or global defaults.
+- **SC-004**: Custom art direction can be represented as ordinary vault content without adding a dedicated art-style settings editor.
 - **SC-005**: `/draw`, entity sidebar draw, Zen mode draw, graph context menu image generation, front page cover generation, and Oracle chat draw all use the same resolver where context is available.
 - **SC-006**: Shipped default prompts pass review for concise descriptive language and avoid named living-artist style imitation.
-- **SC-007**: Verification covers the fallback hierarchy and existing image generation still works with no saved art direction settings.
+- **SC-007**: Verification covers the fallback hierarchy and existing image generation still works with no user-authored art direction content.

--- a/specs/115-default-art-prompts/spec.md
+++ b/specs/115-default-art-prompts/spec.md
@@ -11,6 +11,9 @@
 
 - Q: Is this part of the neutral world theming spec? -> A: No. It is a separate spec because it affects AI art prompt resolution, vault settings, category overrides, and draw-command behavior rather than app chrome theming.
 - Q: Should shipped default prompts copy named artist styles? -> A: No. Defaults should use descriptive visual direction and avoid named living-artist imitation while preserving mood, composition, medium, lighting, and material guidance.
+- Q: Should the first implementation include UI for editing entity-specific art direction? -> A: No. Keep entity-specific art direction as the highest-priority resolver slot, but do not build entity-level editing UI in the first implementation.
+- Q: How should category art direction overrides be stored so category renames are handled? -> A: Store category overrides by stable category ID.
+- Q: How should `/draw character Almos` treat `character`? -> A: Command category words may supply category context, but matched entity metadata wins when the subject resolves to an entity with a category.
 
 ## User Scenarios & Testing _(mandatory)_
 
@@ -114,11 +117,12 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 ### Assumptions
 
 - Art direction is a text prompt template that may include `{subject}` as the subject insertion point.
-- Entity-specific art direction is optional and may be added later if entity editing UI is not part of the first implementation.
+- Entity-specific art direction remains the highest-priority resolver input, but entity-level editing UI is out of scope for the first implementation.
 - The first implementation should cover vault default art direction, category overrides, theme defaults, global default, and resolver integration for existing draw entry points.
 - Existing image generation model calls remain unchanged; this feature prepares the prompt before it reaches the image generation service.
 - Prompt defaults should be concise enough to guide style without producing unwieldy prompts.
 - Shipped defaults should describe style through medium, composition, lighting, mood, materials, and visual constraints rather than named artist imitation.
+- For `/draw` commands, a recognized category word may provide category context, but matched entity metadata takes precedence over the command-provided category when both are present.
 
 ## Requirements _(mandatory)_
 
@@ -131,6 +135,7 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 - **FR-005**: If a selected template does not include `{subject}`, the system MUST still include the subject in the final prompt.
 - **FR-006**: Users MUST be able to configure vault default art direction per vault.
 - **FR-007**: Users MUST be able to configure category-specific art direction overrides per vault.
+- **FR-007a**: Category-specific art direction overrides MUST be keyed by stable category ID so renaming a category does not detach its art direction.
 - **FR-008**: Saved art direction settings MUST persist per vault and MUST NOT affect other vaults.
 - **FR-009**: Clearing a category-specific override MUST restore fallback to the next available art direction level.
 - **FR-010**: The system MUST provide shipped global default art direction.
@@ -139,6 +144,7 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 - **FR-013**: Theme default and category default prompts MUST avoid naming living artists or directly imitating a living artist's style.
 - **FR-014**: Default prompts SHOULD remain concise and focused on subject, medium, composition, lighting, mood, materials, and readability.
 - **FR-015**: Existing `/draw` command behavior MUST use the art direction resolver before calling image generation.
+- **FR-015a**: `/draw` command parsing MUST allow recognized category words to provide category context, while matched entity category metadata MUST take precedence when the subject resolves to an entity.
 - **FR-016**: Existing entity sidepanel draw behavior MUST use the art direction resolver before calling image generation.
 - **FR-017**: Existing Oracle chat draw behavior SHOULD use the art direction resolver when subject or category context is available.
 - **FR-018**: If AI image generation is unavailable because of tier, capability, or missing configuration, art direction settings MUST remain editable but generation controls MUST keep existing gating behavior.
@@ -151,7 +157,7 @@ As a user using `/draw`, sidepanel draw, or chat draw actions, I want all image 
 - **Art Direction Template**: A prompt template that guides image style and may include `{subject}`.
 - **Resolved Art Direction**: The final prompt text assembled for a draw request after applying fallback rules and subject insertion.
 - **Vault Art Direction Settings**: Per-vault settings containing a default art style and category overrides.
-- **Category Art Direction Override**: A per-vault art direction template assigned to a category or category-like type.
+- **Category Art Direction Override**: A per-vault art direction template assigned to a stable category ID or category-like type.
 - **Theme Art Direction Default**: A shipped default prompt associated with a world theme.
 - **Global Art Direction Default**: The final fallback prompt used when no more specific art direction is available.
 - **Draw Request Context**: Subject text plus optional entity id, category, vault id, and theme id used by the resolver.

--- a/specs/115-default-art-prompts/tasks.md
+++ b/specs/115-default-art-prompts/tasks.md
@@ -20,8 +20,8 @@
 **Purpose**: Confirm the branch and add the empty resolver test/implementation files used by later phases.
 
 - [ ] T001 Confirm the working branch is `115-default-art-prompts` and the worktree is ready with `git status --short --branch`
-- [ ] T002 Create `packages/schema/src/art-direction.test.ts` with a skipped or placeholder `describe("art direction resolver")` block
-- [ ] T003 [P] Create `packages/schema/src/art-direction.ts` exporting placeholder resolver types needed by tests
+- [x] T002 Create `packages/schema/src/art-direction.test.ts` with a skipped or placeholder `describe("art direction resolver")` block
+- [x] T003 [P] Create `packages/schema/src/art-direction.ts` exporting placeholder resolver types needed by tests
 
 ---
 
@@ -31,12 +31,12 @@
 
 **CRITICAL**: User story work depends on these resolver contracts and shipped defaults.
 
-- [ ] T004 Add failing resolver tests for empty fallback, `{subject}` insertion, missing placeholder handling, repeated placeholder handling, and fallback metadata in `packages/schema/src/art-direction.test.ts`
-- [ ] T005 Implement `ArtDirectionSource`, `DrawSurface`, `DrawRequestContext`, `ResolvedArtDirection`, template validation, subject insertion, and `resolveArtDirection` in `packages/schema/src/art-direction.ts`
-- [ ] T006 Add failing tests that shipped defaults include global, world-cover, Character, Creature, Location, Item, Faction, Event, and Note templates and reject named living-artist references in `packages/schema/src/art-direction.test.ts`
-- [ ] T007 Implement shipped global, category, world-cover, and theme default template maps in `packages/schema/src/art-direction.ts`
-- [ ] T008 Export the art direction resolver, types, and shipped default helpers from `packages/schema/src/index.ts`
-- [ ] T009 Run the focused schema resolver tests with `bun test packages/schema/src/art-direction.test.ts`
+- [x] T004 Add failing resolver tests for empty fallback, `{subject}` insertion, missing placeholder handling, repeated placeholder handling, and fallback metadata in `packages/schema/src/art-direction.test.ts`
+- [x] T005 Implement `ArtDirectionSource`, `DrawSurface`, `DrawRequestContext`, `ResolvedArtDirection`, template validation, subject insertion, and `resolveArtDirection` in `packages/schema/src/art-direction.ts`
+- [x] T006 Add failing tests that shipped defaults include global, world-cover, Character, Creature, Location, Item, Faction, Event, and Note templates and reject named living-artist references in `packages/schema/src/art-direction.test.ts`
+- [x] T007 Implement shipped global, category, world-cover, and theme default template maps in `packages/schema/src/art-direction.ts`
+- [x] T008 Export the art direction resolver, types, and shipped default helpers from `packages/schema/src/index.ts`
+- [x] T009 Run the focused schema resolver tests with `bun test packages/schema/src/art-direction.test.ts`
 
 **Checkpoint**: Shared resolver returns deterministic prompts and metadata without using web state or network calls.
 
@@ -50,13 +50,13 @@
 
 ### Tests for User Story 1
 
-- [ ] T010 [US1] Add failing fallback-order tests for entity-specific, user-authored, category, theme, and global precedence in `packages/schema/src/art-direction.test.ts`
+- [x] T010 [US1] Add failing fallback-order tests for entity-specific, user-authored, category, theme, and global precedence in `packages/schema/src/art-direction.test.ts`
 - [ ] T011 [P] [US1] Add failing Oracle action-manager tests proving `drawEntity` passes resolved art direction metadata/context before executor image generation in `apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
 - [ ] T012 [P] [US1] Add failing Oracle store tests proving `drawEntity` still delegates through the action manager with an entity id and execution context in `apps/web/src/lib/stores/oracle.svelte.test.ts`
 
 ### Implementation for User Story 1
 
-- [ ] T013 [US1] Implement fallback precedence and source metadata for entity, user-authored, category, theme, and global candidates in `packages/schema/src/art-direction.ts`
+- [x] T013 [US1] Implement fallback precedence and source metadata for entity, user-authored, category, theme, and global candidates in `packages/schema/src/art-direction.ts`
 - [ ] T014 [US1] Extend Oracle draw context types to carry resolved art direction input/output fields in `apps/web/src/lib/stores/oracle/types.ts`
 - [ ] T015 [US1] Collect entity title, stable category id/label, theme id, entity art direction, and user-authored art direction candidates for `drawEntity` in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
 - [ ] T016 [US1] Pass the resolved prompt and resolver metadata through the Oracle store execution context in `apps/web/src/lib/stores/oracle.svelte.ts`
@@ -75,12 +75,12 @@
 
 ### Tests for User Story 2
 
-- [ ] T019 [US2] Add failing category composition tests for Character, Creature, Location, Item, Faction, Event, Note, and world-cover defaults in `packages/schema/src/art-direction.test.ts`
+- [x] T019 [US2] Add failing category composition tests for Character, Creature, Location, Item, Faction, Event, Note, and world-cover defaults in `packages/schema/src/art-direction.test.ts`
 - [ ] T020 [P] [US2] Add failing `/draw character Almos` parsing tests for command category hints and entity metadata precedence in `apps/web/src/lib/config/chat-commands.test.ts`
 
 ### Implementation for User Story 2
 
-- [ ] T021 [US2] Implement category default lookup by stable category id, including normalized fallback aliases only when no real category id is available, in `packages/schema/src/art-direction.ts`
+- [x] T021 [US2] Implement category default lookup by stable category id, including normalized fallback aliases only when no real category id is available, in `packages/schema/src/art-direction.ts`
 - [ ] T022 [US2] Add category hint parsing for recognized `/draw` category words without treating unknown words as categories in `apps/web/src/lib/config/chat-commands.ts`
 - [ ] T023 [US2] Make entity metadata category ids override command-provided category hints when `/draw` resolves a known entity in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
 - [ ] T024 [US2] Run focused category and command tests: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/config/chat-commands.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
@@ -120,12 +120,12 @@
 
 ### Tests for User Story 4
 
-- [ ] T032 [US4] Add failing theme default tests for fantasy, sci-fi, cyberpunk, modern, post-apocalyptic, gothic horror, steampunk, mythic, and pulp-adventure theme ids in `packages/schema/src/art-direction.test.ts`
+- [x] T032 [US4] Add failing theme default tests for fantasy, sci-fi, cyberpunk, modern, post-apocalyptic, gothic horror, steampunk, mythic, and pulp-adventure theme ids in `packages/schema/src/art-direction.test.ts`
 - [ ] T033 [P] [US4] Add failing Oracle context-manager tests proving the active theme id is available in draw execution context in `apps/web/src/lib/stores/oracle/tests/context-manager.test.ts`
 
 ### Implementation for User Story 4
 
-- [ ] T034 [US4] Implement supported theme defaults and missing-theme fallback to global default in `packages/schema/src/art-direction.ts`
+- [x] T034 [US4] Implement supported theme defaults and missing-theme fallback to global default in `packages/schema/src/art-direction.ts`
 - [ ] T035 [US4] Include active world theme id in Oracle draw context snapshots in `apps/web/src/lib/stores/oracle/context-manager.svelte.ts`
 - [ ] T036 [US4] Thread active theme id into entity and chat draw resolver calls in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
 - [ ] T037 [US4] Run focused theme tests: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/stores/oracle/tests/context-manager.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
@@ -145,7 +145,7 @@
 - [ ] T038 [US5] Add failing image generation service tests proving it receives the resolver's final prompt without changing model request behavior in `apps/web/src/lib/services/ai/image-generation.service.test.ts`
 - [ ] T039 [P] [US5] Add failing chat message action tests proving Oracle chat draw requests use resolver context when message/entity/category data exists in `apps/web/src/lib/components/oracle/chat-message.actions.test.ts`
 - [ ] T040 [P] [US5] Add failing graph context menu tests proving selected graph nodes call the central entity draw path with entity/category context in `apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts`
-- [ ] T041 [P] [US5] Add failing front page tests proving cover generation uses world-cover context and active theme defaults in `apps/web/src/lib/components/world/FrontPage.test.ts`
+- [x] T041 [P] [US5] Add failing front page tests proving cover generation uses world-cover context and active theme defaults in `apps/web/src/lib/components/world/FrontPage.test.ts`
 - [ ] T042 [P] [US5] Add failing E2E coverage for `/draw`, entity sidebar, and Zen mode draw buttons using resolved art direction in `apps/web/tests/draw-button.spec.ts`
 - [ ] T043 [P] [US5] Add failing E2E coverage for graph image generation using resolved art direction in `apps/web/tests/graph-image-gen.spec.ts`
 
@@ -156,7 +156,7 @@
 - [ ] T046 [US5] Verify entity sidebar draw remains a thin central `oracle.drawEntity(entity.id)` call with no duplicate resolver logic in `apps/web/src/lib/components/entity-detail/DetailImage.svelte`
 - [ ] T047 [US5] Verify Zen mode draw remains a thin central `oracle.drawEntity(entity.id)` call with no duplicate resolver logic in `apps/web/src/lib/components/zen/ZenSidebar.svelte`
 - [ ] T048 [US5] Ensure graph context menu image generation uses the central Oracle draw path and preserves existing selected-node gating in `apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts`
-- [ ] T049 [US5] Resolve front page cover prompts with `surface: "cover"`, world subject, cover category default, and active theme before upload/generation in `apps/web/src/lib/components/world/FrontPage.svelte`
+- [x] T049 [US5] Resolve front page cover prompts with `surface: "cover"`, world subject, cover category default, and active theme before upload/generation in `apps/web/src/lib/components/world/FrontPage.svelte`
 - [ ] T050 [US5] Keep `CoverImage` upload/drop behavior unchanged while allowing generated cover prompts to come from `FrontPage` resolver context in `apps/web/src/lib/components/world/CoverImage.svelte`
 - [ ] T051 [US5] Route Oracle chat draw actions through resolver-aware `drawMessage` context where message/entity/category context is available in `apps/web/src/lib/components/oracle/chat-message.actions.ts`
 - [ ] T052 [US5] Run focused draw entry point tests: `bun test apps/web/src/lib/services/ai/image-generation.service.test.ts apps/web/src/lib/components/oracle/chat-message.actions.test.ts apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts apps/web/src/lib/components/world/FrontPage.test.ts`

--- a/specs/115-default-art-prompts/tasks.md
+++ b/specs/115-default-art-prompts/tasks.md
@@ -1,0 +1,243 @@
+# Tasks: Default Art Prompts
+
+**Input**: Design documents from `/specs/115-default-art-prompts/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/art-direction-resolver-contract.md
+
+**Tests**: Required by FR-020. Write tests first and confirm they fail before implementation.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently after the shared resolver foundation is in place.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on another incomplete task
+- **[Story]**: Which user story the task supports
+- Every task includes exact file paths
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the branch and add the empty resolver test/implementation files used by later phases.
+
+- [ ] T001 Confirm the working branch is `115-default-art-prompts` and the worktree is ready with `git status --short --branch`
+- [ ] T002 Create `packages/schema/src/art-direction.test.ts` with a skipped or placeholder `describe("art direction resolver")` block
+- [ ] T003 [P] Create `packages/schema/src/art-direction.ts` exporting placeholder resolver types needed by tests
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the pure shared resolver and exports. No draw surface should be integrated before this phase is complete.
+
+**CRITICAL**: User story work depends on these resolver contracts and shipped defaults.
+
+- [ ] T004 Add failing resolver tests for empty fallback, `{subject}` insertion, missing placeholder handling, repeated placeholder handling, and fallback metadata in `packages/schema/src/art-direction.test.ts`
+- [ ] T005 Implement `ArtDirectionSource`, `DrawSurface`, `DrawRequestContext`, `ResolvedArtDirection`, template validation, subject insertion, and `resolveArtDirection` in `packages/schema/src/art-direction.ts`
+- [ ] T006 Add failing tests that shipped defaults include global, world-cover, Character, Creature, Location, Item, Faction, Event, and Note templates and reject named living-artist references in `packages/schema/src/art-direction.test.ts`
+- [ ] T007 Implement shipped global, category, world-cover, and theme default template maps in `packages/schema/src/art-direction.ts`
+- [ ] T008 Export the art direction resolver, types, and shipped default helpers from `packages/schema/src/index.ts`
+- [ ] T009 Run the focused schema resolver tests with `bun test packages/schema/src/art-direction.test.ts`
+
+**Checkpoint**: Shared resolver returns deterministic prompts and metadata without using web state or network calls.
+
+---
+
+## Phase 3: User Story 1 - Predictable Art Prompt Resolution (Priority: P1) MVP
+
+**Goal**: Drawing an entity uses the most specific available art direction in the required fallback order.
+
+**Independent Test**: Provide entity, user-authored, category, theme, and global candidates in resolver/context tests and verify the highest-priority non-empty candidate wins.
+
+### Tests for User Story 1
+
+- [ ] T010 [US1] Add failing fallback-order tests for entity-specific, user-authored, category, theme, and global precedence in `packages/schema/src/art-direction.test.ts`
+- [ ] T011 [P] [US1] Add failing Oracle action-manager tests proving `drawEntity` passes resolved art direction metadata/context before executor image generation in `apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
+- [ ] T012 [P] [US1] Add failing Oracle store tests proving `drawEntity` still delegates through the action manager with an entity id and execution context in `apps/web/src/lib/stores/oracle.svelte.test.ts`
+
+### Implementation for User Story 1
+
+- [ ] T013 [US1] Implement fallback precedence and source metadata for entity, user-authored, category, theme, and global candidates in `packages/schema/src/art-direction.ts`
+- [ ] T014 [US1] Extend Oracle draw context types to carry resolved art direction input/output fields in `apps/web/src/lib/stores/oracle/types.ts`
+- [ ] T015 [US1] Collect entity title, stable category id/label, theme id, entity art direction, and user-authored art direction candidates for `drawEntity` in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
+- [ ] T016 [US1] Pass the resolved prompt and resolver metadata through the Oracle store execution context in `apps/web/src/lib/stores/oracle.svelte.ts`
+- [ ] T017 [US1] Ensure Oracle context snapshots keep existing tier, capability, guest, and AI-disabled gates unchanged in `apps/web/src/lib/stores/oracle/context-manager.svelte.ts`
+- [ ] T018 [US1] Run focused tests for resolver and Oracle entity draw paths: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts apps/web/src/lib/stores/oracle.svelte.test.ts`
+
+**Checkpoint**: Entity draw requests resolve art direction deterministically and expose the winning source for troubleshooting.
+
+---
+
+## Phase 4: User Story 2 - Category-Aware Composition Defaults (Priority: P1)
+
+**Goal**: Common entity categories produce category-specific composition guidance while retaining the same world/theme style chain.
+
+**Independent Test**: Draw the same subject as Character, Location, Item, Creature, Faction, Event, and Note and verify the resolved prompts differ by category composition.
+
+### Tests for User Story 2
+
+- [ ] T019 [US2] Add failing category composition tests for Character, Creature, Location, Item, Faction, Event, Note, and world-cover defaults in `packages/schema/src/art-direction.test.ts`
+- [ ] T020 [P] [US2] Add failing `/draw character Almos` parsing tests for command category hints and entity metadata precedence in `apps/web/src/lib/config/chat-commands.test.ts`
+
+### Implementation for User Story 2
+
+- [ ] T021 [US2] Implement category default lookup by stable category id, including normalized fallback aliases only when no real category id is available, in `packages/schema/src/art-direction.ts`
+- [ ] T022 [US2] Add category hint parsing for recognized `/draw` category words without treating unknown words as categories in `apps/web/src/lib/config/chat-commands.ts`
+- [ ] T023 [US2] Make entity metadata category ids override command-provided category hints when `/draw` resolves a known entity in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
+- [ ] T024 [US2] Run focused category and command tests: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/config/chat-commands.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
+
+**Checkpoint**: Category defaults control composition and command category hints never override matched entity metadata.
+
+---
+
+## Phase 5: User Story 3 - User Authored Art Direction Content (Priority: P2)
+
+**Goal**: Custom art direction comes from normal notes/entities already present in draw context, with no dedicated settings editor or new settings storage.
+
+**Independent Test**: Include a note/entity art direction candidate in draw context and verify it wins over shipped defaults; remove or empty it and verify fallback continues safely.
+
+### Tests for User Story 3
+
+- [ ] T025 [US3] Add failing user-authored context tests for present, edited, deleted, empty, and overly long art direction values in `packages/schema/src/art-direction.test.ts`
+- [ ] T026 [P] [US3] Add failing Oracle action-manager tests proving normal draw context can provide `userAuthoredArtDirection` without reading settings storage in `apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
+- [ ] T027 [P] [US3] Add a failing settings test or static guard proving no dedicated art direction settings controls are added to `apps/web/src/lib/components/settings/AISettings.svelte` in `apps/web/src/lib/components/settings/AISettings.test.ts`
+
+### Implementation for User Story 3
+
+- [ ] T028 [US3] Normalize, trim, cap, and skip invalid user-authored art direction candidates in `packages/schema/src/art-direction.ts`
+- [ ] T029 [US3] Extract user-authored art direction from existing Oracle draw context content, notes, or entity context without adding new persistence in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
+- [ ] T030 [US3] Preserve existing settings UI by avoiding new art direction settings controls in `apps/web/src/lib/components/settings/AISettings.svelte`
+- [ ] T031 [US3] Run focused user-authored context tests: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts apps/web/src/lib/components/settings/AISettings.test.ts`
+
+**Checkpoint**: User-authored art direction behaves like normal vault content and there is still no dedicated art-style settings editor.
+
+---
+
+## Phase 6: User Story 4 - Theme Defaults For Art Style (Priority: P2)
+
+**Goal**: Active world themes provide descriptive default art style when no higher-priority art direction exists.
+
+**Independent Test**: Resolve the same subject with different supported themes and no entity/user/category art direction, then verify each theme changes mood/style while avoiding named living artists.
+
+### Tests for User Story 4
+
+- [ ] T032 [US4] Add failing theme default tests for fantasy, sci-fi, cyberpunk, modern, post-apocalyptic, gothic horror, steampunk, mythic, and pulp-adventure theme ids in `packages/schema/src/art-direction.test.ts`
+- [ ] T033 [P] [US4] Add failing Oracle context-manager tests proving the active theme id is available in draw execution context in `apps/web/src/lib/stores/oracle/tests/context-manager.test.ts`
+
+### Implementation for User Story 4
+
+- [ ] T034 [US4] Implement supported theme defaults and missing-theme fallback to global default in `packages/schema/src/art-direction.ts`
+- [ ] T035 [US4] Include active world theme id in Oracle draw context snapshots in `apps/web/src/lib/stores/oracle/context-manager.svelte.ts`
+- [ ] T036 [US4] Thread active theme id into entity and chat draw resolver calls in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
+- [ ] T037 [US4] Run focused theme tests: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/stores/oracle/tests/context-manager.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
+
+**Checkpoint**: Theme defaults affect generated prompts only after higher-priority entity, user-authored, and category inputs are absent.
+
+---
+
+## Phase 7: User Story 5 - Draw Entry Points Use Resolved Art Direction (Priority: P2)
+
+**Goal**: `/draw`, entity sidebar draw, Zen mode draw, graph context menu draw, front page cover generation, and Oracle chat draw all use the same resolver.
+
+**Independent Test**: Trigger each entry point with equivalent subject/category/theme context and verify each path resolves art direction before image generation.
+
+### Tests for User Story 5
+
+- [ ] T038 [US5] Add failing image generation service tests proving it receives the resolver's final prompt without changing model request behavior in `apps/web/src/lib/services/ai/image-generation.service.test.ts`
+- [ ] T039 [P] [US5] Add failing chat message action tests proving Oracle chat draw requests use resolver context when message/entity/category data exists in `apps/web/src/lib/components/oracle/chat-message.actions.test.ts`
+- [ ] T040 [P] [US5] Add failing graph context menu tests proving selected graph nodes call the central entity draw path with entity/category context in `apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts`
+- [ ] T041 [P] [US5] Add failing front page tests proving cover generation uses world-cover context and active theme defaults in `apps/web/src/lib/components/world/FrontPage.test.ts`
+- [ ] T042 [P] [US5] Add failing E2E coverage for `/draw`, entity sidebar, and Zen mode draw buttons using resolved art direction in `apps/web/tests/draw-button.spec.ts`
+- [ ] T043 [P] [US5] Add failing E2E coverage for graph image generation using resolved art direction in `apps/web/tests/graph-image-gen.spec.ts`
+
+### Implementation for User Story 5
+
+- [ ] T044 [US5] Ensure `ImageGenerationService` accepts the resolved prompt as its final prompt while preserving existing visual distillation behavior in `apps/web/src/lib/services/ai/image-generation.service.ts`
+- [ ] T045 [US5] Route `/draw` command execution through the shared resolver and central Oracle draw context in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
+- [ ] T046 [US5] Verify entity sidebar draw remains a thin central `oracle.drawEntity(entity.id)` call with no duplicate resolver logic in `apps/web/src/lib/components/entity-detail/DetailImage.svelte`
+- [ ] T047 [US5] Verify Zen mode draw remains a thin central `oracle.drawEntity(entity.id)` call with no duplicate resolver logic in `apps/web/src/lib/components/zen/ZenSidebar.svelte`
+- [ ] T048 [US5] Ensure graph context menu image generation uses the central Oracle draw path and preserves existing selected-node gating in `apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts`
+- [ ] T049 [US5] Resolve front page cover prompts with `surface: "cover"`, world subject, cover category default, and active theme before upload/generation in `apps/web/src/lib/components/world/FrontPage.svelte`
+- [ ] T050 [US5] Keep `CoverImage` upload/drop behavior unchanged while allowing generated cover prompts to come from `FrontPage` resolver context in `apps/web/src/lib/components/world/CoverImage.svelte`
+- [ ] T051 [US5] Route Oracle chat draw actions through resolver-aware `drawMessage` context where message/entity/category context is available in `apps/web/src/lib/components/oracle/chat-message.actions.ts`
+- [ ] T052 [US5] Run focused draw entry point tests: `bun test apps/web/src/lib/services/ai/image-generation.service.test.ts apps/web/src/lib/components/oracle/chat-message.actions.test.ts apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts apps/web/src/lib/components/world/FrontPage.test.ts`
+- [ ] T053 [US5] Run focused Playwright entry point tests: `bun playwright test apps/web/tests/draw-button.spec.ts apps/web/tests/graph-image-gen.spec.ts`
+
+**Checkpoint**: All existing image generation entry points use the shared resolver and preserve current capability/tier gating.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, validation, and regression checks across all stories.
+
+- [ ] T054 [P] Update user-facing help text to mention normal notes/entities as Art Direction context without implying a settings editor in `apps/web/src/lib/content/help/chat-commands.md`
+- [ ] T055 [P] Update quickstart validation notes with the final focused commands and manual draw surfaces in `specs/115-default-art-prompts/quickstart.md`
+- [ ] T056 [P] Add or update troubleshooting labels to expose resolver source names using "Art Direction", "Default Art Style", and "Category Defaults" wording in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
+- [ ] T057 Run all resolver and unit coverage for the feature: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts apps/web/src/lib/config/chat-commands.test.ts apps/web/src/lib/components/world/FrontPage.test.ts apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts apps/web/src/lib/services/ai/image-generation.service.test.ts`
+- [ ] T058 Run E2E validation for existing draw paths: `bun playwright test apps/web/tests/draw-button.spec.ts apps/web/tests/draw-autocomplete.spec.ts apps/web/tests/graph-image-gen.spec.ts`
+- [ ] T059 Run repository lint/typecheck/test command used for this branch and record any unrelated failures in the PR notes
+- [ ] T060 Review changed shipped prompt defaults for concise descriptive language and absence of named living-artist imitation in `packages/schema/src/art-direction.ts`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories
+- **US1 and US2 (P1)**: Depend on Foundational; implement before P2 stories
+- **US3, US4, US5 (P2)**: Depend on Foundational; US5 benefits from US1/US2 context but should still be tested by surface
+- **Polish (Phase 8)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 Predictable Art Prompt Resolution**: First MVP story after foundation; no dependency on other stories
+- **US2 Category-Aware Composition Defaults**: Can start after foundation; depends on shared category default support
+- **US3 User Authored Art Direction Content**: Can start after US1 resolver precedence exists
+- **US4 Theme Defaults For Art Style**: Can start after foundation; must preserve US1 precedence
+- **US5 Draw Entry Points Use Resolved Art Direction**: Can start after US1 central entity draw context exists; each entry point remains independently testable
+
+### Within Each User Story
+
+- Write failing tests before implementation
+- Implement shared schema behavior before web integration that consumes it
+- Preserve existing tier/capability/guest/AI-disabled gates before changing prompt behavior
+- Complete each story's focused test command before moving to the next checkpoint
+
+### Parallel Opportunities
+
+- T003 can run in parallel with T002
+- T011 and T012 can run in parallel after T010
+- T020 can run in parallel with T019
+- T026 and T027 can run in parallel after T025
+- T033 can run in parallel with T032
+- T039 through T043 can run in parallel because they cover different entry point files
+- T054 through T056 can run in parallel during polish
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete US1 and US2.
+3. Validate with focused schema, Oracle action-manager, and `/draw` command tests.
+4. Stop for review before expanding to P2 surfaces if needed.
+
+### Incremental Delivery
+
+1. Shared resolver and defaults.
+2. Entity and `/draw` fallback hierarchy.
+3. User-authored context and theme defaults.
+4. Remaining draw entry points.
+5. Documentation and broad regression checks.
+
+### Notes
+
+- Do not add a dedicated Vault Settings art-style editor.
+- Do not add new runtime dependencies or new settings storage.
+- Keep resolver logic in `packages/schema`; components should stay thin and call existing central draw actions.
+- Preserve existing image model calls, upload behavior, and capability gating.
+- Commit after each logical group or completed story checkpoint.

--- a/specs/115-default-art-prompts/tasks.md
+++ b/specs/115-default-art-prompts/tasks.md
@@ -51,7 +51,7 @@
 ### Tests for User Story 1
 
 - [x] T010 [US1] Add failing fallback-order tests for entity-specific, user-authored, category, theme, and global precedence in `packages/schema/src/art-direction.test.ts`
-- [ ] T011 [P] [US1] Add failing Oracle action-manager tests proving `drawEntity` passes resolved art direction metadata/context before executor image generation in `apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
+- [x] T011 [P] [US1] Add failing Oracle action-manager tests proving `drawEntity` passes resolved art direction metadata/context before executor image generation in `apps/web/src/lib/stores/oracle/tests/action-manager.test.ts`
 - [ ] T012 [P] [US1] Add failing Oracle store tests proving `drawEntity` still delegates through the action manager with an entity id and execution context in `apps/web/src/lib/stores/oracle.svelte.test.ts`
 
 ### Implementation for User Story 1
@@ -60,7 +60,7 @@
 - [ ] T014 [US1] Extend Oracle draw context types to carry resolved art direction input/output fields in `apps/web/src/lib/stores/oracle/types.ts`
 - [ ] T015 [US1] Collect entity title, stable category id/label, theme id, entity art direction, and user-authored art direction candidates for `drawEntity` in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
 - [ ] T016 [US1] Pass the resolved prompt and resolver metadata through the Oracle store execution context in `apps/web/src/lib/stores/oracle.svelte.ts`
-- [ ] T017 [US1] Ensure Oracle context snapshots keep existing tier, capability, guest, and AI-disabled gates unchanged in `apps/web/src/lib/stores/oracle/context-manager.svelte.ts`
+- [x] T017 [US1] Ensure Oracle context snapshots keep existing tier, capability, guest, and AI-disabled gates unchanged in `apps/web/src/lib/stores/oracle/context-manager.svelte.ts`
 - [ ] T018 [US1] Run focused tests for resolver and Oracle entity draw paths: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts apps/web/src/lib/stores/oracle.svelte.test.ts`
 
 **Checkpoint**: Entity draw requests resolve art direction deterministically and expose the winning source for troubleshooting.
@@ -121,7 +121,7 @@
 ### Tests for User Story 4
 
 - [x] T032 [US4] Add failing theme default tests for fantasy, sci-fi, cyberpunk, modern, post-apocalyptic, gothic horror, steampunk, mythic, and pulp-adventure theme ids in `packages/schema/src/art-direction.test.ts`
-- [ ] T033 [P] [US4] Add failing Oracle context-manager tests proving the active theme id is available in draw execution context in `apps/web/src/lib/stores/oracle/tests/context-manager.test.ts`
+- [x] T033 [P] [US4] Add failing Oracle context-manager tests proving the active theme id is available in draw execution context in `apps/web/src/lib/stores/oracle/tests/context-manager.test.ts`
 
 ### Implementation for User Story 4
 
@@ -142,9 +142,9 @@
 
 ### Tests for User Story 5
 
-- [ ] T038 [US5] Add failing image generation service tests proving it receives the resolver's final prompt without changing model request behavior in `apps/web/src/lib/services/ai/image-generation.service.test.ts`
+- [x] T038 [US5] Add failing image generation service tests proving it receives the resolver's final prompt without changing model request behavior in `apps/web/src/lib/services/ai/image-generation.service.test.ts`
 - [ ] T039 [P] [US5] Add failing chat message action tests proving Oracle chat draw requests use resolver context when message/entity/category data exists in `apps/web/src/lib/components/oracle/chat-message.actions.test.ts`
-- [ ] T040 [P] [US5] Add failing graph context menu tests proving selected graph nodes call the central entity draw path with entity/category context in `apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts`
+- [x] T040 [P] [US5] Add failing graph context menu tests proving selected graph nodes call the central entity draw path with entity/category context in `apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts`
 - [x] T041 [P] [US5] Add failing front page tests proving cover generation uses world-cover context and active theme defaults in `apps/web/src/lib/components/world/FrontPage.test.ts`
 - [ ] T042 [P] [US5] Add failing E2E coverage for `/draw`, entity sidebar, and Zen mode draw buttons using resolved art direction in `apps/web/tests/draw-button.spec.ts`
 - [ ] T043 [P] [US5] Add failing E2E coverage for graph image generation using resolved art direction in `apps/web/tests/graph-image-gen.spec.ts`
@@ -170,7 +170,7 @@
 
 **Purpose**: Documentation, validation, and regression checks across all stories.
 
-- [ ] T054 [P] Update user-facing help text to mention normal notes/entities as Art Direction context without implying a settings editor in `apps/web/src/lib/content/help/chat-commands.md`
+- [x] T054 [P] Update user-facing help text to mention normal notes/entities as Art Direction context without implying a settings editor in `apps/web/src/lib/content/help/chat-commands.md`
 - [ ] T055 [P] Update quickstart validation notes with the final focused commands and manual draw surfaces in `specs/115-default-art-prompts/quickstart.md`
 - [ ] T056 [P] Add or update troubleshooting labels to expose resolver source names using "Art Direction", "Default Art Style", and "Category Defaults" wording in `apps/web/src/lib/stores/oracle/action-manager.svelte.ts`
 - [ ] T057 Run all resolver and unit coverage for the feature: `bun test packages/schema/src/art-direction.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts apps/web/src/lib/config/chat-commands.test.ts apps/web/src/lib/components/world/FrontPage.test.ts apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts apps/web/src/lib/services/ai/image-generation.service.test.ts`


### PR DESCRIPTION
## Summary

Implements the first Default Art Prompts slice from spec `115-default-art-prompts`.

- Adds a shared art direction resolver with entity, user-authored, category, theme, and global fallback behavior.
- Ships category defaults, world cover defaults, theme defaults, and a global Codex Cryptica default without named living-artist style imitation.
- Wires the resolver into Oracle entity/chat image prompt generation and front page cover prompt generation.
- Adds `/draw character Almos` category hint behavior while preserving linked entity metadata precedence.
- Adds focused coverage for resolver behavior, Oracle generator integration, central draw action flow, graph draw routing, image prompt preservation, and front page cover prompt expectations.
- Updates help text to explain Art Direction via normal notes/entities rather than a dedicated settings editor.

## Validation

Passed locally:

```bash
bun test packages/schema/src/art-direction.test.ts packages/oracle-engine/src/oracle-generator.test.ts apps/web/src/lib/stores/oracle/tests/action-manager.test.ts
```

Result: 29 pass, 0 fail.

Also passed:

```bash
git diff --check
```

Not fully runnable in this Termux environment:

- Some direct web tests fail because the local runner does not load the web/Svelte Vitest setup (`$state`, `vi.stubGlobal`) and has missing module resolution for `comlink` / `@testing-library/svelte` in this install.

## Notes

This PR intentionally does not add a Vault Settings art-style editor or new settings storage. Custom art direction remains normal notes/entities via sections such as `Art Direction`, `Default Art Style`, or `Visual Direction`.