### PR TITLE
:sparkles: feat(art): Art Direction Update release notes

### DIFF
--- a/apps/web/src/lib/content/changelog/releases.json
+++ b/apps/web/src/lib/content/changelog/releases.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "0.25.0",
+    "title": "The Art Direction Update",
+    "date": "2026-05-23",
+    "type": "minor",
+    "highlights": [
+      "Default Art Prompts: Image generation now resolves consistent Art Direction before drawing, so visuals stay grounded in your world instead of starting from a generic prompt.",
+      "Category Defaults: Characters, creatures, locations, items, factions, events, notes, and world covers now receive composition guidance tailored to what you are drawing.",
+      "Theme-Aware Visual Style: Active world themes now contribute Default Art Style guidance for generated images while preserving stronger entity and note-based art direction.",
+      "World Cover Direction: Front page cover generation now combines world-cover composition with the active theme's visual style for more coherent campaign covers.",
+      "Lore-Native Customization: Add sections such as Art Direction, Default Art Style, or Visual Direction to normal notes/entities to guide image generation without a separate settings form.",
+      "Smarter Draw Commands: Commands like /draw character Almos can use category hints when no matched entity metadata is available, while real entity categories still take precedence."
+    ]
+  },
+  {
+    "version": "0.24.0",
+    "title": "The Dual-Layer Theming & Chrome Stabilization Update",
+    "date": "2026-05-23",
+    "type": "minor",
+    "highlights": [
+      "Dual-Layer Appearance: App chrome and world genre themes are now separated, keeping navigation, settings, and workspace controls stable while vault themes change.",
+      "Neutral App Chrome: Headers, sidebars, panels, and status indicators now use consistent neutral light/dark styling instead of inheriting campaign texture and genre colors.",
+      "System Appearance Support: The workspace can follow the device's light or dark preference while preserving the active world theme for campaign content.",
+      "Theme Counterparts: Selectable world themes now resolve matching light and dark counterparts so campaign mood survives appearance changes.",
+      "Settings Clarity: Appearance controls now distinguish app-level display mode from vault-level world themes."
+    ]
+  },
+  {
     "version": "0.23.0",
     "title": "The Animated Transitions & State Persistence Update",
     "date": "2026-05-22",

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -18,6 +18,12 @@ The following high-impact candidate specifications target performance, scaling, 
 
 ## 🏛️ Historical Roadmap & Release Timeline
 
+### v0.25.0 — The Art Direction Update (2026-05-23)
+
+- **Highlights**: Deterministic default Art Direction for AI image generation across Oracle entity/chat draw flows and front page cover art. The resolver now applies entity-specific art direction, normal user-authored art direction content, category composition defaults, active theme Default Art Style, and a global Codex Cryptica fallback. Category defaults tailor composition for characters, creatures, locations, items, factions, events, notes, and world covers, while `/draw` category hints fill gaps without overriding matched entity metadata. Custom art direction remains lore-native through ordinary notes/entities rather than a dedicated settings editor.
+- **Associated Specifications**:
+  - [115-default-art-prompts](./115-default-art-prompts/spec.md) (Default art prompt resolver, category/theme defaults, draw-command category hints, and lore-native art direction content)
+
 ### v0.24.0 — The Dual-Layer Theming & Chrome Stabilization Update (2026-05-23)
 
 - **Highlights**: Separate global app appearance layers (neutral light, neutral dark, and system matching device preferences) and vault-specific world theme genre layers. Fully neutralized, stable, and texture-free app chrome (headers, sidebar panels, settings screens, and status indicators) that remains consistent when changing or previewing campaign genres, with strict color/font isolation for all chrome controls. Support for dynamic light and dark counterpart resolution for all 10 selectable world themes.


### PR DESCRIPTION
## Summary

Prepares the release documentation for the Art Direction Update.

- Adds `v0.25.0` to the in-app changelog for Default Art Prompts, Category Defaults, theme-aware visual style, front page cover direction, lore-native customization, and smarter `/draw` category hints.
- Adds the missing `v0.24.0` in-app changelog entry so the release timeline remains contiguous with the roadmap.
- Updates `specs/roadmap.md` with the `v0.25.0` historical release entry linked to spec `115-default-art-prompts`.

## Release Notes

`RELEASING.md` says formal releases require a `minor` or `major` label before merging to `staging`. This PR should be labeled `minor` for the `0.25.0` release.

## Validation

```bash
node -e "JSON.parse(require('fs').readFileSync('apps/web/src/lib/content/changelog/releases.json','utf8')); console.log('valid json')"
```

Result: `valid json`.