### PR TITLE
:sparkles: feat(theme): resolve art direction templates, composition, and normalization

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@ Auto-generated from all feature plans. Last updated: 2026-05-23
 
 ## Active Technologies
 
-- TypeScript 6.0.3 + None (Browser Native APIs) / Zod (874-art-direction-clarification)
+- TypeScript 6.0.3 + zod (874-art-direction-clarification)
 
 - TypeScript 6.0.3, Svelte 5 Runes + Svelte 5, Dexie (IndexedDB), Cytoscape.js (109-quicknote-scratchpad)
 - IndexedDB (`quick_notes` store) (109-quicknote-scratchpad)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,8 +1,10 @@
 # Codex-Cryptica Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-05-21
+Auto-generated from all feature plans. Last updated: 2026-05-23
 
 ## Active Technologies
+
+- TypeScript 6.0.3 + None (Browser Native APIs) / Zod (874-art-direction-clarification)
 
 - TypeScript 6.0.3, Svelte 5 Runes + Svelte 5, Dexie (IndexedDB), Cytoscape.js (109-quicknote-scratchpad)
 - IndexedDB (`quick_notes` store) (109-quicknote-scratchpad)
@@ -184,6 +186,8 @@ TypeScript: Follow standard conventions
 - **Branching Strategy**: Always create a new branch for code changes, fixes, improvements, or refactoring. Never commit directly to the main branch.
 
 ## Recent Changes
+
+- 874-art-direction-clarification: Added TypeScript 6.0.3 + None (Browser Native APIs) / Zod
 
 - 109-quicknote-scratchpad: Added Svelte 5, Svelte 5 Runes, Dexie (IndexedDB), and Cytoscape.js integration.
 

--- a/apps/web/src/lib/components/world/FrontPage.test.ts
+++ b/apps/web/src/lib/components/world/FrontPage.test.ts
@@ -342,7 +342,9 @@ describe("FrontPage", () => {
       expect.stringContaining("atmospheric world cover art"),
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
-      expect.stringContaining("Theme Style: Moonfall, neon urban concept art"),
+      expect.stringContaining(
+        "Theme Style: Moonfall. Digital concept art style",
+      ),
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining(

--- a/packages/schema/src/art-direction.test.ts
+++ b/packages/schema/src/art-direction.test.ts
@@ -210,4 +210,52 @@ describe("art direction resolver", () => {
       /\b(in the style of|by artgerm|by greg rutkowski|by loish|by sakimichan|by beeple)\b/i,
     );
   });
+
+  it("resolves each canonical theme id and alias correctly and includes expected text", () => {
+    const testCases: Array<{ themeId: string; expectedSubstring: string }> = [
+      { themeId: "fantasy", expectedSubstring: "Oil painting style" },
+      { themeId: "scifi", expectedSubstring: "Digital concept art style" },
+      { themeId: "cyberpunk", expectedSubstring: "wet streets" },
+      { themeId: "modern", expectedSubstring: "Photographic" },
+      {
+        themeId: "apocalyptic",
+        expectedSubstring: "Desaturated digital illustration",
+      },
+      {
+        themeId: "post-apocalyptic",
+        expectedSubstring: "Desaturated digital illustration",
+      },
+      {
+        themeId: "post_apocalyptic",
+        expectedSubstring: "Desaturated digital illustration",
+      },
+      { themeId: "horror", expectedSubstring: "Tenebrist oil painting" },
+      { themeId: "gothic-horror", expectedSubstring: "Tenebrist oil painting" },
+      { themeId: "gothic_horror", expectedSubstring: "Tenebrist oil painting" },
+      { themeId: "steampunk", expectedSubstring: "Gouache painting style" },
+      { themeId: "mythic", expectedSubstring: "Tempera illustration style" },
+      { themeId: "pulp_adventure", expectedSubstring: "Screen print style" },
+      { themeId: "pulp-adventure", expectedSubstring: "Screen print style" },
+      { themeId: "fallout", expectedSubstring: "Americana illustration style" },
+      { themeId: "starwars", expectedSubstring: "McQuarrie-era" },
+      { themeId: "startrek", expectedSubstring: "Clean 1990s sci-fi" },
+      // suffix variants
+      {
+        themeId: "scifi_light",
+        expectedSubstring: "Digital concept art style",
+      },
+      { themeId: "fantasy-dark", expectedSubstring: "Oil painting style" },
+    ];
+
+    for (const { themeId, expectedSubstring } of testCases) {
+      const result = resolveArtDirection({
+        subject: "TestSubject",
+        surface: "entity",
+        themeId,
+      });
+
+      expect(result.themeId).toBeDefined();
+      expect(result.prompt).toContain(expectedSubstring);
+    }
+  });
 });

--- a/packages/schema/src/art-direction.test.ts
+++ b/packages/schema/src/art-direction.test.ts
@@ -64,6 +64,21 @@ describe("art direction resolver", () => {
     ).toBe("global-default");
   });
 
+  it("composes category default, theme default, and global default prompts", () => {
+    const result = resolveArtDirection({
+      subject: "Mara",
+      surface: "entity",
+      categoryId: "character",
+      themeId: "scifi",
+    });
+
+    expect(result.prompt).toContain("Mara, full character concept art");
+    expect(result.prompt).toContain("Mara. Digital concept art style");
+    expect(result.prompt).toContain(
+      "Mara, illustrated worldbuilding reference",
+    );
+  });
+
   it("inserts the subject when the template has no placeholder", () => {
     const result = resolveArtDirection({
       subject: "The Ember Crown",
@@ -120,6 +135,33 @@ describe("art direction resolver", () => {
     expect(hintedCategory.categoryId).toBe("character");
   });
 
+  it("normalizes and strips theme suffixes (light/dark)", () => {
+    const resultScifiLight = resolveArtDirection({
+      subject: "Mara",
+      surface: "entity",
+      themeId: "scifi_light",
+    });
+    const resultScifiDark = resolveArtDirection({
+      subject: "Mara",
+      surface: "entity",
+      themeId: "scifi-dark",
+    });
+    const resultHorrorLight = resolveArtDirection({
+      subject: "Mara",
+      surface: "entity",
+      themeId: "gothic_horror_light",
+    });
+
+    expect(resultScifiLight.themeId).toBe("scifi");
+    expect(resultScifiLight.prompt).toContain("Digital concept art style");
+
+    expect(resultScifiDark.themeId).toBe("scifi");
+    expect(resultScifiDark.prompt).toContain("Digital concept art style");
+
+    expect(resultHorrorLight.themeId).toBe("horror");
+    expect(resultHorrorLight.prompt).toContain("Tenebrist oil painting");
+  });
+
   it("ships required category and theme defaults without named artist imitation", () => {
     for (const id of [
       "character",
@@ -142,10 +184,18 @@ describe("art direction resolver", () => {
       "cyberpunk",
       "modern",
       "post_apocalyptic",
+      "post-apocalyptic",
+      "apocalyptic",
       "gothic_horror",
+      "gothic-horror",
+      "horror",
       "steampunk",
       "mythic",
       "pulp_adventure",
+      "pulp-adventure",
+      "fallout",
+      "starwars",
+      "startrek",
     ]) {
       expect(THEME_ART_DIRECTION_DEFAULTS[id]?.template).toContain("{subject}");
     }

--- a/packages/schema/src/art-direction.ts
+++ b/packages/schema/src/art-direction.ts
@@ -44,6 +44,12 @@ export interface ResolvedArtDirection {
 
 const MAX_CONTEXT_TEMPLATE_LENGTH = 1200;
 
+function capPrompt(prompt: string): string {
+  return prompt.length > MAX_CONTEXT_TEMPLATE_LENGTH
+    ? prompt.slice(0, MAX_CONTEXT_TEMPLATE_LENGTH)
+    : prompt;
+}
+
 export const GLOBAL_ART_DIRECTION_DEFAULT: ArtDirectionTemplate = {
   id: "global.codex-cryptica",
   label: "Codex Cryptica Default",
@@ -360,7 +366,7 @@ export function resolveArtDirection(
   );
   if (entityTemplate) {
     return {
-      prompt: applySubject(entityTemplate.template, subject),
+      prompt: capPrompt(applySubject(entityTemplate.template, subject)),
       source: "entity-context",
       templateId: entityTemplate.id,
       subject,
@@ -377,7 +383,7 @@ export function resolveArtDirection(
   );
   if (userTemplate) {
     return {
-      prompt: applySubject(userTemplate.template, subject),
+      prompt: capPrompt(applySubject(userTemplate.template, subject)),
       source: "user-authored-context",
       templateId: userTemplate.id,
       subject,
@@ -414,7 +420,7 @@ export function resolveArtDirection(
   parts.push(applySubject(globalTemplate.template, subject));
 
   return {
-    prompt: parts.join(" "),
+    prompt: capPrompt(parts.join(" ")),
     source,
     templateId,
     subject,

--- a/packages/schema/src/art-direction.ts
+++ b/packages/schema/src/art-direction.ts
@@ -49,7 +49,7 @@ export const GLOBAL_ART_DIRECTION_DEFAULT: ArtDirectionTemplate = {
   label: "Codex Cryptica Default",
   source: "global-default",
   template:
-    "{subject}, a clear fantasy tabletop reference illustration with readable forms, grounded materials, cinematic lighting, and enough concrete detail to support worldbuilding.",
+    "{subject}, illustrated worldbuilding reference, grounded materials, readable forms, natural light, and enough concrete detail to support worldbuilding.",
 };
 
 export const CATEGORY_ART_DIRECTION_DEFAULTS: Record<
@@ -110,97 +110,213 @@ export const CATEGORY_ART_DIRECTION_DEFAULTS: Record<
     label: "World Cover Default",
     source: "category-default",
     template:
-      "{subject}, atmospheric world cover art with a strong focal point, genre-defining setting details, cinematic depth, and room for title treatment.",
+      "{subject}, atmospheric world cover art with a strong focal point, genre-defining setting details, layered depth, and room for title treatment.",
   },
 };
 
-export const THEME_ART_DIRECTION_DEFAULTS: Record<string, ArtDirectionTemplate> =
-  {
-    fantasy: {
-      id: "theme.fantasy",
-      label: "Fantasy Default",
-      source: "theme-default",
-      template:
-        "{subject}, painterly high-fantasy art with ancient textures, candlelit warmth, mythic atmosphere, handcrafted materials, and subtle magic.",
-    },
-    scifi: {
-      id: "theme.scifi",
-      label: "Sci-Fi Default",
-      source: "theme-default",
-      template:
-        "{subject}, clean science-fiction concept art with advanced interfaces, engineered materials, controlled lighting, and frontier scale.",
-    },
-    cyberpunk: {
-      id: "theme.cyberpunk",
-      label: "Cyberpunk Default",
-      source: "theme-default",
-      template:
-        "{subject}, neon urban concept art with wet streets, dense signage, layered technology, hard shadows, and high-contrast color accents.",
-    },
-    modern: {
-      id: "theme.modern",
-      label: "Modern Default",
-      source: "theme-default",
-      template:
-        "{subject}, grounded modern cinematic illustration with natural materials, believable lighting, documentary detail, and restrained color.",
-    },
-    post_apocalyptic: {
-      id: "theme.post_apocalyptic",
-      label: "Post-Apocalyptic Default",
-      source: "theme-default",
-      template:
-        "{subject}, weathered post-apocalyptic concept art with scavenged materials, harsh daylight, survival details, and environmental decay.",
-    },
-    "post-apocalyptic": {
-      id: "theme.post-apocalyptic",
-      label: "Post-Apocalyptic Default",
-      source: "theme-default",
-      template:
-        "{subject}, weathered post-apocalyptic concept art with scavenged materials, harsh daylight, survival details, and environmental decay.",
-    },
-    gothic_horror: {
-      id: "theme.gothic_horror",
-      label: "Gothic Horror Default",
-      source: "theme-default",
-      template:
-        "{subject}, gothic horror illustration with oppressive architecture, dim candlelight, heavy atmosphere, ornate decay, and controlled dread.",
-    },
-    "gothic-horror": {
-      id: "theme.gothic-horror",
-      label: "Gothic Horror Default",
-      source: "theme-default",
-      template:
-        "{subject}, gothic horror illustration with oppressive architecture, dim candlelight, heavy atmosphere, ornate decay, and controlled dread.",
-    },
-    steampunk: {
-      id: "theme.steampunk",
-      label: "Steampunk Default",
-      source: "theme-default",
-      template:
-        "{subject}, brass-and-iron adventure illustration with visible mechanisms, steam, leather, polished gauges, and warm industrial lighting.",
-    },
-    mythic: {
-      id: "theme.mythic",
-      label: "Mythic Default",
-      source: "theme-default",
-      template:
-        "{subject}, mythic storybook illustration with monumental scale, symbolic composition, luminous atmosphere, and ancient ceremonial detail.",
-    },
-    pulp_adventure: {
-      id: "theme.pulp_adventure",
-      label: "Pulp Adventure Default",
-      source: "theme-default",
-      template:
-        "{subject}, bold pulp-adventure illustration with dynamic composition, practical danger, saturated accents, and crisp readable action.",
-    },
-    "pulp-adventure": {
-      id: "theme.pulp-adventure",
-      label: "Pulp Adventure Default",
-      source: "theme-default",
-      template:
-        "{subject}, bold pulp-adventure illustration with dynamic composition, practical danger, saturated accents, and crisp readable action.",
-    },
-  };
+const fantasy: ArtDirectionTemplate = {
+  id: "theme.fantasy",
+  label: "Fantasy Default",
+  source: "theme-default",
+  template:
+    "{subject}. Oil painting style, painterly brushwork, handcrafted materials (worn leather, hammered iron, stained wood, candle-soot stone), warm earth palette of ochre, umber, and tarnished gold, occasional cool shadow, subtle magical detail rather than overt VFX, lighting that suits the scene.",
+};
+
+const scifi: ArtDirectionTemplate = {
+  id: "theme.scifi",
+  label: "Sci-Fi Default",
+  source: "theme-default",
+  template:
+    "{subject}. Digital concept art style, matte painting, engineered materials (brushed chrome, carbon fiber, matte polymer), clean slate-grey and cool white palette with cyan accents, even practical or soft ambient lighting, frontier scale.",
+};
+
+const cyberpunk: ArtDirectionTemplate = {
+  id: "theme.cyberpunk",
+  label: "Cyberpunk Default",
+  source: "theme-default",
+  template:
+    "{subject}. Digital concept art style, wet streets, dense signage, layered technology, hard shadows, high-contrast neon palette with hot pink and electric blue accents.",
+};
+
+const modern: ArtDirectionTemplate = {
+  id: "theme.modern",
+  label: "Modern Default",
+  source: "theme-default",
+  template:
+    "{subject}. Photographic, 35mm film grain, available light, muted contemporary palette of asphalt grey, denim, and warm skin tones, restrained color grading, documentary framing, no fantasy ornamentation.",
+};
+
+const apocalyptic: ArtDirectionTemplate = {
+  id: "theme.apocalyptic",
+  label: "Post-Apocalyptic Default",
+  source: "theme-default",
+  template:
+    "{subject}. Desaturated digital illustration, weathered and scavenged materials, harsh daylight with long shadows, gritty palette of rust, bone, dried blood, and dust.",
+};
+
+const horror: ArtDirectionTemplate = {
+  id: "theme.horror",
+  label: "Horror Default",
+  source: "theme-default",
+  template:
+    "{subject}. Tenebrist oil painting or desaturated photograph, chiaroscuro lighting from a single practical source where the scene allows, palette of bone, ash, dried blood, and bruise purple, ornate decay and texture detail, controlled dread rather than gore.",
+};
+
+const steampunk: ArtDirectionTemplate = {
+  id: "theme.steampunk",
+  label: "Steampunk Default",
+  source: "theme-default",
+  template:
+    "{subject}. Gouache painting style, brass-and-iron visible mechanisms, steam, leather, polished gauges, warm amber and sepia palette, dramatic industrial lighting.",
+};
+
+const mythic: ArtDirectionTemplate = {
+  id: "theme.mythic",
+  label: "Mythic Default",
+  source: "theme-default",
+  template:
+    "{subject}. Tempera illustration style, monumental scale, symbolic composition, luminous ambient glow, palette of cerulean, gold leaf, and ivory, ancient ceremonial detail.",
+};
+
+const pulp_adventure: ArtDirectionTemplate = {
+  id: "theme.pulp_adventure",
+  label: "Pulp Adventure Default",
+  source: "theme-default",
+  template:
+    "{subject}. Screen print style, bold ink lines, dynamic composition, practical danger, saturated palette of primary reds and yellows with high-contrast shadows, crisp readable action.",
+};
+
+const fallout: ArtDirectionTemplate = {
+  id: "theme.fallout",
+  label: "Fallout Default",
+  source: "theme-default",
+  template:
+    "{subject}. 1950s Americana illustration style crossed with post-war ruin, palette of vault blue, rust, bone, and dust, atomic-age industrial design with retro-futurist optimism decayed by time.",
+};
+
+const starwars: ArtDirectionTemplate = {
+  id: "theme.starwars",
+  label: "Star Wars Default",
+  source: "theme-default",
+  template:
+    "{subject}. Ralph McQuarrie-era concept painting style, lived-in tactile technology with visible wear, dusty desert ochre or cold imperial monochrome depending on the scene, dramatic rim lighting, practical-effects sensibility.",
+};
+
+const startrek: ArtDirectionTemplate = {
+  id: "theme.startrek",
+  label: "Star Trek Default",
+  source: "theme-default",
+  template:
+    "{subject}. Clean 1990s sci-fi production illustration style, smooth surfaces and primary-coded technology (red, blue, gold), even practical lighting, optimistic palette, no grime, engineered rather than salvaged.",
+};
+
+export const THEME_ART_DIRECTION_DEFAULTS: Record<
+  string,
+  ArtDirectionTemplate
+> = {
+  fantasy: {
+    id: "theme.fantasy",
+    label: "Fantasy Default",
+    source: "theme-default",
+    template: fantasy.template,
+  },
+  scifi: {
+    id: "theme.scifi",
+    label: "Sci-Fi Default",
+    source: "theme-default",
+    template: scifi.template,
+  },
+  cyberpunk: {
+    id: "theme.cyberpunk",
+    label: "Cyberpunk Default",
+    source: "theme-default",
+    template: cyberpunk.template,
+  },
+  modern: {
+    id: "theme.modern",
+    label: "Modern Default",
+    source: "theme-default",
+    template: modern.template,
+  },
+  apocalyptic: {
+    id: "theme.apocalyptic",
+    label: "Post-Apocalyptic Default",
+    source: "theme-default",
+    template: apocalyptic.template,
+  },
+  "post-apocalyptic": {
+    id: "theme.post-apocalyptic",
+    label: "Post-Apocalyptic Default",
+    source: "theme-default",
+    template: apocalyptic.template,
+  },
+  post_apocalyptic: {
+    id: "theme.post_apocalyptic",
+    label: "Post-Apocalyptic Default",
+    source: "theme-default",
+    template: apocalyptic.template,
+  },
+  horror: {
+    id: "theme.horror",
+    label: "Horror Default",
+    source: "theme-default",
+    template: horror.template,
+  },
+  "gothic-horror": {
+    id: "theme.gothic-horror",
+    label: "Gothic Horror Default",
+    source: "theme-default",
+    template: horror.template,
+  },
+  gothic_horror: {
+    id: "theme.gothic_horror",
+    label: "Gothic Horror Default",
+    source: "theme-default",
+    template: horror.template,
+  },
+  steampunk: {
+    id: "theme.steampunk",
+    label: "Steampunk Default",
+    source: "theme-default",
+    template: steampunk.template,
+  },
+  mythic: {
+    id: "theme.mythic",
+    label: "Mythic Default",
+    source: "theme-default",
+    template: mythic.template,
+  },
+  pulp_adventure: {
+    id: "theme.pulp_adventure",
+    label: "Pulp Adventure Default",
+    source: "theme-default",
+    template: pulp_adventure.template,
+  },
+  "pulp-adventure": {
+    id: "theme.pulp-adventure",
+    label: "Pulp Adventure Default",
+    source: "theme-default",
+    template: pulp_adventure.template,
+  },
+  fallout: {
+    id: "theme.fallout",
+    label: "Fallout Default",
+    source: "theme-default",
+    template: fallout.template,
+  },
+  starwars: {
+    id: "theme.starwars",
+    label: "Star Wars Default",
+    source: "theme-default",
+    template: starwars.template,
+  },
+  startrek: {
+    id: "theme.startrek",
+    label: "Star Trek Default",
+    source: "theme-default",
+    template: startrek.template,
+  },
+};
 
 const CATEGORY_ALIASES: Record<string, string> = {
   npc: "character",
@@ -213,6 +329,14 @@ const CATEGORY_ALIASES: Record<string, string> = {
   world: "cover",
 };
 
+const THEME_ALIASES: Record<string, string> = {
+  "gothic-horror": "horror",
+  gothic_horror: "horror",
+  "post-apocalyptic": "apocalyptic",
+  post_apocalyptic: "apocalyptic",
+  "pulp-adventure": "pulp_adventure",
+};
+
 export function resolveArtDirection(
   context: DrawRequestContext,
 ): ResolvedArtDirection {
@@ -221,35 +345,78 @@ export function resolveArtDirection(
     normalizeCategoryId(
       context.surface === "cover" ? "cover" : context.categoryId,
       context.surface === "cover" || context.categoryIdIsHint,
-    ) ||
-    undefined;
-  const themeId = normalizeId(context.themeId) || undefined;
+    ) || undefined;
 
-  const candidates: ArtDirectionTemplate[] = [
-    contextTemplate(
-      "entity-context",
-      "entity.context",
-      "Entity Art Direction",
-      context.entityArtDirection,
-    ),
-    contextTemplate(
-      "user-authored-context",
-      "user.context",
-      "User Authored Art Direction",
-      context.userAuthoredArtDirection,
-    ),
-    categoryId ? CATEGORY_ART_DIRECTION_DEFAULTS[categoryId] : undefined,
-    themeId ? THEME_ART_DIRECTION_DEFAULTS[themeId] : undefined,
-    GLOBAL_ART_DIRECTION_DEFAULT,
-  ].filter((template): template is ArtDirectionTemplate =>
-    Boolean(template && normalizeTemplate(template.template)),
+  const rawThemeId = normalizeThemeId(context.themeId) || undefined;
+  const themeId = rawThemeId
+    ? THEME_ALIASES[rawThemeId] || rawThemeId
+    : undefined;
+
+  const entityTemplate = contextTemplate(
+    "entity-context",
+    "entity.context",
+    "Entity Art Direction",
+    context.entityArtDirection,
   );
+  if (entityTemplate) {
+    return {
+      prompt: applySubject(entityTemplate.template, subject),
+      source: "entity-context",
+      templateId: entityTemplate.id,
+      subject,
+      categoryId,
+      themeId,
+    };
+  }
 
-  const selected = candidates[0] || GLOBAL_ART_DIRECTION_DEFAULT;
+  const userTemplate = contextTemplate(
+    "user-authored-context",
+    "user.context",
+    "User Authored Art Direction",
+    context.userAuthoredArtDirection,
+  );
+  if (userTemplate) {
+    return {
+      prompt: applySubject(userTemplate.template, subject),
+      source: "user-authored-context",
+      templateId: userTemplate.id,
+      subject,
+      categoryId,
+      themeId,
+    };
+  }
+
+  let source: ArtDirectionSource = "global-default";
+  let templateId: string | undefined = GLOBAL_ART_DIRECTION_DEFAULT.id;
+
+  const categoryTemplate = categoryId
+    ? CATEGORY_ART_DIRECTION_DEFAULTS[categoryId]
+    : undefined;
+  const themeTemplate = themeId
+    ? THEME_ART_DIRECTION_DEFAULTS[themeId]
+    : undefined;
+  const globalTemplate = GLOBAL_ART_DIRECTION_DEFAULT;
+
+  const parts: string[] = [];
+  if (categoryTemplate) {
+    parts.push(applySubject(categoryTemplate.template, subject));
+    source = "category-default";
+    templateId = categoryTemplate.id;
+  }
+  if (themeTemplate) {
+    parts.push(applySubject(themeTemplate.template, subject));
+    if (source === "global-default") {
+      source = "theme-default";
+      templateId = themeTemplate.id;
+    }
+  }
+
+  parts.push(applySubject(globalTemplate.template, subject));
+
   return {
-    prompt: applySubject(selected.template, subject),
-    source: selected.source,
-    templateId: selected.id,
+    prompt: parts.join(" "),
+    source,
+    templateId,
     subject,
     categoryId,
     themeId,
@@ -267,8 +434,11 @@ export function getCategoryArtDirectionDefault(
 export function getThemeArtDirectionDefault(
   themeId?: string,
 ): ArtDirectionTemplate | undefined {
-  const normalized = normalizeId(themeId);
-  return normalized ? THEME_ART_DIRECTION_DEFAULTS[normalized] : undefined;
+  const normalized = normalizeThemeId(themeId);
+  const mapped = normalized
+    ? THEME_ALIASES[normalized] || normalized
+    : undefined;
+  return mapped ? THEME_ART_DIRECTION_DEFAULTS[mapped] : undefined;
 }
 
 function normalizeRequiredSubject(context: DrawRequestContext) {
@@ -305,13 +475,18 @@ function applySubject(template: string, subject: string) {
 }
 
 function normalizeId(id?: string) {
-  return (id || "")
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, "-");
+  return (id || "").trim().toLowerCase().replace(/\s+/g, "-");
 }
 
 function normalizeCategoryId(id?: string, applyAliases = false) {
   const normalized = normalizeId(id);
   return applyAliases ? CATEGORY_ALIASES[normalized] || normalized : normalized;
+}
+
+function normalizeThemeId(id?: string) {
+  const normalized = (id || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[_-](light|dark)$/, "");
+  return normalized.replace(/\s+/g, "-");
 }

--- a/specs/115-default-art-prompts/plan.md
+++ b/specs/115-default-art-prompts/plan.md
@@ -128,3 +128,21 @@ Design outputs:
 ## Complexity Tracking
 
 N/A - No constitution violations identified.
+
+---
+
+## 2026-05-23 Update: Art Direction Clarification (#874)
+
+### Proposed Changes
+
+#### packages/schema/src/art-direction.ts
+
+- Modify `resolveArtDirection` to compose the final prompt from the category default (if any), the theme default (if any), and the global default (always) when no custom overrides (`entityArtDirection` or `userAuthoredArtDirection`) are present.
+- Implement theme normalization mapping using `THEME_ALIASES` to ensure theme IDs used in `theme.ts` map correctly.
+- Update global, cover, and theme prompt wording according to the explicit prompt list (adding medium, palette, and conditional lighting; removing "cinematic"; making the global default genre-neutral).
+- Add new theme prompts: `fallout`, `starwars`, `startrek`.
+
+#### packages/schema/src/art-direction.test.ts
+
+- Update the unit tests to assert composed prompts instead of single selected ones.
+- Add test coverage for all 9 theme templates resolving correctly.

--- a/specs/115-default-art-prompts/spec.md
+++ b/specs/115-default-art-prompts/spec.md
@@ -180,3 +180,14 @@ As a user using `/draw`, entity sidebar draw, Zen mode draw, graph context menu 
 - **SC-005**: `/draw`, entity sidebar draw, Zen mode draw, graph context menu image generation, front page cover generation, and Oracle chat draw all use the same resolver where context is available.
 - **SC-006**: Shipped default prompts pass review for concise descriptive language and avoid named living-artist style imitation.
 - **SC-007**: Verification covers the fallback hierarchy and existing image generation still works with no user-authored art direction content.
+
+---
+
+## 2026-05-23 Update: Art Direction Clarification (#874)
+
+An architectural and content review of the initial implementation identified a few key issues to address as an improvement to this spec:
+
+1. **Composition Over Selection**: Instead of picking only one template (e.g., category blocking theme), category and theme default templates must compose with the global default: `category template + theme template + global template`.
+2. **Normalized Theme Mapping**: Aligned theme IDs to match `theme.ts` definitions, adding explicit theme mapping/aliases (horror, apocalyptic).
+3. **Missing Themes**: Implemented fallout, starwars, and startrek default templates.
+4. **Visual Quality Refinements**: Theme prompts updated with explicit medium, palette, and conditional lighting. Banned "cinematic" word removed. Global default is genre-neutral.


### PR DESCRIPTION
Refines the art direction prompt generation system by composing prompt parts sequentially, normalizing theme suffixes to resolve themes properly, adding missing themes, and improving default prompt wording. Closes #874.