### PR TITLE
🎨 style(theme): refine leather.svg filter values for realistic grain

### DIFF
--- a/apps/web/static/themes/leather.svg
+++ b/apps/web/static/themes/leather.svg
@@ -1,21 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256">
   <filter id="leather" x="0%" y="0%" width="100%" height="100%">
-    <!-- High frequency noise for the fine pores -->
-    <feTurbulence type="fractalNoise" baseFrequency="0.08" numOctaves="4" result="fineNoise" stitchTiles="stitch"/>
-    <!-- Medium frequency noise for the organic creases -->
-    <feTurbulence type="fractalNoise" baseFrequency="0.025" numOctaves="3" result="coarseNoise" stitchTiles="stitch"/>
-    <!-- Combine them to create a complex heightmap -->
-    <feBlend mode="multiply" in="fineNoise" in2="coarseNoise" result="heightmap"/>
+    <!-- Coarse creases using turbulence (which has natural sharp ridges/valleys) -->
+    <feTurbulence type="turbulence" baseFrequency="0.015" numOctaves="3" result="creases" stitchTiles="stitch"/>
+    <!-- Fine pores using fractalNoise -->
+    <feTurbulence type="fractalNoise" baseFrequency="0.15" numOctaves="3" result="pores" stitchTiles="stitch"/>
+    <!-- Combine the two heightmaps: blend creases and pores -->
+    <feBlend mode="multiply" in="creases" in2="pores" result="heightmap"/>
     <!-- Apply diffuse lighting to get beautiful 3D bumps and shadows -->
-    <feDiffuseLighting in="heightmap" lighting-color="#ffffff" surfaceScale="1.5" result="light">
-      <feDistantLight azimuth="45" elevation="60" />
+    <feDiffuseLighting in="heightmap" lighting-color="#ffffff" surfaceScale="2.5" result="light">
+      <feDistantLight azimuth="60" elevation="45" />
     </feDiffuseLighting>
-    <!-- Map the light output to a dark, semi-transparent warm tone that overlays nicely on the background -->
+    <!-- Map the light output to a dark, warm, semi-transparent tone that overlays nicely on the background -->
     <feColorMatrix type="matrix" values="
       0.35 0 0 0 0
       0 0.28 0 0 0
-      0 0 0.20 0 0
-      -0.2 -0.2 -0.2 0.5 0" result="colored"/>
+      0 0 0.22 0 0
+      0 0 0 0.35 0" result="colored"/>
   </filter>
   <rect width="100%" height="100%" filter="url(#leather)"/>
 </svg>


### PR DESCRIPTION
Upgrades the leather.svg texture with proper coarse creases, fine pores, golden color highlights/shadows mapping, and a correct alpha opacity level to give a premium, textured look for the dark fantasy theme.