### PR TITLE
[codex] Fix mobile viewport height

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -128,6 +128,8 @@
 @layer base {
   :root {
     --header-height: 65px;
+    --app-viewport-height: 100vh;
+    --app-content-height: calc(var(--app-viewport-height) - var(--header-height));
     --color-bg-primary: #fdf6e3;
     --chrome-bg: #fafaf9;
     --frontpage-vignette: radial-gradient(circle at top, transparent, transparent), linear-gradient(to bottom, transparent, transparent);
@@ -201,6 +203,18 @@
     /* Fix for EdgeLabel white box artifacts */
     --xy-edge-label-background-color-default: transparent;
     --xy-edge-label-background-color: transparent;
+  }
+
+  @supports (height: 100dvh) {
+    :root {
+      --app-viewport-height: 100dvh;
+    }
+  }
+
+  html,
+  body {
+    min-height: 100%;
+    min-height: var(--app-viewport-height);
   }
 
   html.skip-landing .marketing-layer {
@@ -347,6 +361,14 @@
     transition:
       background-color 0.3s ease,
       color 0.3s ease;
+  }
+
+  .app-layout {
+    overflow: hidden;
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-left: env(safe-area-inset-left, 0px);
   }
 
   .world-canvas {

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -3,7 +3,10 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta
+		name="viewport"
+		content="width=device-width, initial-scale=1, viewport-fit=cover"
+	/>
 	<!-- Non-blocking Google Fonts: preconnect + preload/swap to avoid render-blocking -->
 	<link rel="dns-prefetch" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
@@ -16,6 +19,7 @@
 				href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Inter:wght@300;400;700&family=Orbitron:wght@400;700&family=Spectral:ital,wght@0,400;0,700;1,400&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Cormorant+Garamond:ital,wght@0,300..700;1,300..700&display=swap" />	</noscript>
 	<script src="https://accounts.google.com/gsi/client" async defer></script>
 	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+	<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
 	<link rel="llms" href="%sveltekit.assets%/llms.txt" />
 	<script>
 		// Prevent FOUC for Skip Welcome and Theme

--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
@@ -170,7 +170,7 @@
 <div
   class="canvas-container {logic.isConnecting
     ? 'is-connecting'
-    : ''} flex h-[calc(100vh-var(--header-height,65px))] w-full overflow-hidden relative"
+    : ''} flex h-[var(--app-content-height)] w-full overflow-hidden relative"
   tabindex="-1"
   role="none"
 >

--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -283,7 +283,7 @@
     <div
       class="pointer-events-auto w-[320px] max-w-[calc(100vw-2rem)] rounded-lg border border-theme-primary/25 bg-theme-surface/95 px-3 py-2 text-xs text-theme-text shadow-lg backdrop-blur overflow-hidden"
       style:height={`${guestPanelHeight}px`}
-      style:max-height="calc(100vh - 6rem)"
+      style:max-height="calc(var(--app-viewport-height) - 6rem)"
       transition:fade
     >
       <div class="flex items-center justify-between gap-3 mb-2">

--- a/apps/web/src/lib/components/world/FrontPage.svelte
+++ b/apps/web/src/lib/components/world/FrontPage.svelte
@@ -286,7 +286,7 @@
 
 <section
   data-testid="front-page-shell"
-  class="front-page-shell world-canvas relative isolate min-h-[calc(100vh-var(--header-height,65px)-2rem)] overflow-hidden rounded-[2rem] border border-theme-border p-4 sm:p-5 md:p-8 xl:p-10 shadow-[0_30px_120px_rgba(0,0,0,0.35)]"
+  class="front-page-shell world-canvas relative isolate min-h-[calc(var(--app-content-height)-2rem)] overflow-hidden rounded-[2rem] border border-theme-border p-4 sm:p-5 md:p-8 xl:p-10 shadow-[0_30px_120px_rgba(0,0,0,0.35)]"
   style={`background-color: ${themeTokens.background}; background-image: var(--bg-texture-overlay), radial-gradient(circle at top, rgba(${hexToRgb(
     themeTokens.primary,
   )}, 0.16), transparent 48%), linear-gradient(180deg, rgba(${hexToRgb(

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -373,7 +373,7 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <div
-  class="h-[100dvh] bg-chrome-bg text-chrome-text flex flex-col font-body app-layout"
+  class="h-[var(--app-viewport-height)] bg-chrome-bg text-chrome-text flex flex-col font-body app-layout"
 >
   <NotificationToast />
 

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -159,7 +159,7 @@
 <svelte:window onkeydown={handleFrontPageOverlayKeydown} />
 
 <div
-  class="h-[calc(100vh-var(--header-height,65px))] flex bg-chrome-bg text-chrome-text overflow-hidden relative"
+  class="h-[var(--app-content-height)] flex bg-chrome-bg text-chrome-text overflow-hidden relative"
 >
   <div class="flex-1 relative overflow-hidden">
     {#if layoutUIStore.mainViewMode === "focus" && layoutUIStore.focusedEntityId && EmbeddedEntityView}

--- a/apps/web/static/manifest.webmanifest
+++ b/apps/web/static/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Codex Cryptica",
+  "short_name": "Codex",
+  "description": "A worldbuilding and campaign workspace for Codex Cryptica.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#fafaf9",
+  "theme_color": "#fafaf9",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "1024x1024"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "1024x1024"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `viewport-fit=cover` and a standalone web manifest for installed mobile app behavior.
- Centralizes app viewport sizing behind `--app-viewport-height` with a `100vh` fallback and `100dvh` support.
- Updates nested app surfaces that still used `100vh` calculations to use the shared viewport/content height variables.
- Applies safe-area padding to the app shell for notches and home indicators.

## Why
Issue #871 asks for the mobile app to use the full screen height and avoid showing unnecessary browser chrome. Regular web pages cannot force-hide the browser top bar, so the implementation follows the standard path: dynamic viewport units for in-browser sizing and standalone PWA display mode when installed.

## Validation
- `git diff --check`
- Parsed `apps/web/static/manifest.webmanifest` with Node JSON parsing

Could not run `npm run check --workspace=web` locally because dependencies are unavailable (`svelte-kit: not found`). `npm install` also fails in this environment with `EUNSUPPORTEDPROTOCOL workspace:*`.