### PR TITLE
feat(web): add active entity counts to graph label filter

### DIFF
--- a/.agent/skills/codex-review/references/patterns.md
+++ b/.agent/skills/codex-review/references/patterns.md
@@ -66,6 +66,26 @@ This reference documents specific anti-patterns and quality standards for the Co
 - **Issue**: Using `lucide-svelte` components instead of Iconify classes.
 - **Pattern**: Use `class="icon-[lucide--name] ..."`.
 
+### Flexbox Truncation Layouts
+
+- **Issue**: Using Tailwind's `truncate` utility on elements inside a flex container (such as a dropdown row or card) does not truncate correctly and can push adjacent sibling elements off-screen or cause layouts to overflow. Flexbox's default behavior is to use `min-content` for flex items, preventing them from shrinking below their content size.
+- **Pattern**: Always add an explicit `min-w-0` to the flex item that contains the `truncate` element to allow it to shrink and truncate correctly.
+- **Example**:
+
+  ```svelte
+  <!-- Bad: can overflow or push sibling elements off-screen -->
+  <div class="flex items-center gap-2">
+    <span class="truncate">{label}</span>
+    <span class="shrink-0">(12)</span>
+  </div>
+
+  <!-- Good: truncates correctly within flexbox bounds -->
+  <div class="flex items-center gap-2">
+    <span class="truncate min-w-0 flex-1">{label}</span>
+    <span class="shrink-0">(12)</span>
+  </div>
+  ```
+
 ## Event Bus & Lifecycles
 
 ### Subscription Memory Leaks in Stores & Tests
@@ -100,6 +120,29 @@ class FeatureStore {
 - **Issue**: Running debounced auto-save effects that trigger on mere selection or opening of existing entries, causing redundant database writes and unnecessary load.
 - **Pattern**: Track the active item's original content and ID. Only trigger the debounce routine when the content has _actually_ diverged from the loaded state, and skip/gate empty brand-new entries until the user has typed.
 
+### Unique Value Counting per Record (De-duplication)
+
+- **Issue**: Standard mapping/iteration over list-based properties (like `entity.labels`) to calculate item frequencies or metrics will overcount entries if a single record contains duplicate values in that array.
+- **Pattern**: Always de-duplicate array-like properties per record using `new Set()` before counting or executing metrics logic.
+- **Example**:
+
+  ```typescript
+  // Bad: overcounts if entity.labels has duplicate values
+  for (const entity of entities) {
+    for (const label of entity.labels) {
+      counts[label] = (counts[label] || 0) + 1;
+    }
+  }
+
+  // Good: counts each label once per entity
+  for (const entity of entities) {
+    const uniqueLabels = new Set(entity.labels);
+    for (const label of uniqueLabels) {
+      counts[label] = (counts[label] || 0) + 1;
+    }
+  }
+  ```
+
 ## JavaScript & HTML Best Practices
 
 ### Coordinate Check Nullish Coalescing (Falsy 0)
@@ -121,6 +164,7 @@ class FeatureStore {
 - **Issue**: Dynamically importing a component inside Svelte's `{#await}` block on-demand saves bundle size but breaks exit transitions if the wrapping conditional unmounts it immediately.
 - **Pattern**: Use a sticky boolean flag (e.g., `hasOpened = true` on first interaction) that triggers the dynamic import, and keep the flag `true` to ensure the component remains in the DOM for exit animations to play.
 - **Example**:
+
   ```svelte
   <script>
     let hasOpened = $state(false);

--- a/apps/web/src/lib/components/labels/LabelFilter.svelte
+++ b/apps/web/src/lib/components/labels/LabelFilter.svelte
@@ -130,7 +130,7 @@
                 ></span>
               {/if}
             </span>
-            <span class="truncate flex-1">{label}</span>
+            <span class="truncate flex-1 min-w-0">{label}</span>
             <span
               class="text-[9px] text-theme-muted/80 font-mono font-bold shrink-0"
               >({vault.labelCounts[label] ?? 0})</span

--- a/apps/web/src/lib/components/labels/LabelFilter.svelte
+++ b/apps/web/src/lib/components/labels/LabelFilter.svelte
@@ -110,6 +110,7 @@
       <div class="p-2 space-y-1 overflow-y-auto custom-scrollbar flex-1">
         {#each filteredLabels as label}
           <button
+            type="button"
             onclick={() => onToggle(label)}
             class="w-full flex items-center gap-2 px-2 py-1.5 rounded text-left text-[10px] font-mono uppercase tracking-wider transition-colors {activeLabels.has(
               label,
@@ -129,7 +130,11 @@
                 ></span>
               {/if}
             </span>
-            <span class="truncate">{label}</span>
+            <span class="truncate flex-1">{label}</span>
+            <span
+              class="text-[9px] text-theme-muted/80 font-mono font-bold shrink-0"
+              >({vault.labelCounts[label] ?? 0})</span
+            >
           </button>
         {:else}
           <div

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -105,6 +105,9 @@ export class VaultStore {
   get labelIndex() {
     return this.entityStore.labelIndex;
   }
+  get labelCounts() {
+    return this.entityStore.labelCounts;
+  }
   get maps() {
     return mapRegistry.maps;
   }

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -140,7 +140,8 @@ export class EntityStore {
       const counts: Record<string, number> = {};
       for (const entity of this.allActiveEntities) {
         if (entity.labels) {
-          for (const l of entity.labels) {
+          const uniqueLabels = new Set(entity.labels);
+          for (const l of uniqueLabels) {
             counts[l] = (counts[l] || 0) + 1;
           }
         }

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -46,6 +46,7 @@ export class EntityStore {
   allActiveEntities: LocalEntity[];
   inboundConnections: InboundMap;
   labelIndex: string[];
+  labelCounts: Record<string, number>;
 
   constructor(
     depsOrRepository: EntityStoreDependencies | VaultRepository,
@@ -134,6 +135,17 @@ export class EntityStore {
         }
       }
       return Array.from(labels).sort();
+    });
+    this.labelCounts = $derived.by(() => {
+      const counts: Record<string, number> = {};
+      for (const entity of this.allActiveEntities) {
+        if (entity.labels) {
+          for (const l of entity.labels) {
+            counts[l] = (counts[l] || 0) + 1;
+          }
+        }
+      }
+      return counts;
     });
   }
 

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -120,6 +120,53 @@ describe("EntityStore", () => {
     expect(store.allEntities).toHaveLength(2);
   });
 
+  it("derives the label counts and excludes drafts from counts but keeps them in index", () => {
+    repository.entities.draftPlace = {
+      id: "draftPlace",
+      title: "Draft Place",
+      content: "",
+      lore: "",
+      type: "location",
+      status: "draft",
+      labels: ["important", "new-label"],
+      aliases: [],
+      connections: [],
+    } as LocalEntity;
+
+    repository.entities.activePlace = {
+      id: "activePlace",
+      title: "Active Place",
+      content: "",
+      lore: "",
+      type: "location",
+      status: "active",
+      labels: ["new-label"],
+      aliases: [],
+      connections: [],
+    } as LocalEntity;
+
+    const testStore = new EntityStore({
+      repository: repository as any,
+      activeVaultId: () => "vault-1",
+      isGuest: () => false,
+      getGuestFile: vi.fn(),
+      setStatus: vi.fn(),
+      setErrorMessage: vi.fn(),
+      getActiveVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+      getSpecificVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+      getActiveFolderHandle: vi.fn().mockResolvedValue(undefined),
+      getServices: () => ({ ai: { clearStyleCache: vi.fn() } }),
+      invalidateUrlCache: vi.fn(),
+      updateEntityCount: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(testStore.labelIndex).toEqual(["important", "new-label"]);
+    expect(testStore.labelCounts).toEqual({
+      important: 1,
+      "new-label": 1,
+    });
+  });
+
   it("creates an entity and marks it as loaded and updates count", async () => {
     const newEntity = { id: "new-entity", title: "New Entity" };
     vi.mocked(vaultEntities.createEntity).mockReturnValue(newEntity as any);

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -140,7 +140,7 @@ describe("EntityStore", () => {
       lore: "",
       type: "location",
       status: "active",
-      labels: ["new-label"],
+      labels: ["new-label", "new-label"], // Duplicate labels on single entity
       aliases: [],
       connections: [],
     } as LocalEntity;
@@ -163,7 +163,7 @@ describe("EntityStore", () => {
     expect(testStore.labelIndex).toEqual(["important", "new-label"]);
     expect(testStore.labelCounts).toEqual({
       important: 1,
-      "new-label": 1,
+      "new-label": 1, // Correctly de-duplicated and counted as 1
     });
   });
 


### PR DESCRIPTION
Closes #882

This pull request introduces active entity counts to the graph label filter dropdown.

### Changes
- **Derived State (`EntityStore`)**: Added a reactive `labelCounts` derivation using `$derived.by` in `entity-store.svelte.ts` mapping labels to their counts on non-draft (active) entities in the vault.
- **Store Exposure (`VaultStore`)**: Exposed `labelCounts` on `VaultStore` to delegate to `EntityStore`.
- **Dropdown List UI (`LabelFilter.svelte`)**: Appended a right-aligned, monospaced parenthesized count `(count)` to each label in the filter dropdown menu, ensuring long labels truncate while the count remains locked. Added explicit `type="button"` to conform to accessibility/HTML best practices.
- **Unit Tests**: Added coverage in `entity-store.test.ts` ensuring active labels count accurately and draft statuses are strictly excluded from the dynamic count while remaining indexed.