### PR TITLE
:sparkles: feat(zen): allow quick label adding in zen mode non-edit state #887

### DIFF
--- a/apps/web/src/lib/components/labels/LabelInput.svelte
+++ b/apps/web/src/lib/components/labels/LabelInput.svelte
@@ -10,9 +10,11 @@
   let {
     entityId,
     placeholder = "Add label...",
+    ariaLabel = "",
   }: {
     entityId: string;
     placeholder?: string;
+    ariaLabel?: string;
   } = $props();
 
   let inputValue = $state("");
@@ -131,6 +133,7 @@
     {id}
     bind:value={inputValue}
     {placeholder}
+    aria-label={ariaLabel || placeholder}
     role="combobox"
     aria-autocomplete="list"
     aria-expanded={showSuggestions && suggestions.length > 0}

--- a/apps/web/src/lib/components/zen/ZenSidebar.labels.test.ts
+++ b/apps/web/src/lib/components/zen/ZenSidebar.labels.test.ts
@@ -3,7 +3,6 @@ import { render } from "@testing-library/svelte";
 import { describe, it, expect, vi } from "vitest";
 import ZenSidebar from "./ZenSidebar.svelte";
 import { vault } from "$lib/stores/vault.svelte";
-import LabelInput from "$lib/components/labels/LabelInput.svelte";
 
 // Mock stores
 vi.mock("$lib/stores/vault.svelte", () => ({
@@ -11,6 +10,7 @@ vi.mock("$lib/stores/vault.svelte", () => ({
     isGuest: false,
     entities: {},
     inboundConnections: {},
+    labelIndex: [],
   },
 }));
 
@@ -33,12 +33,8 @@ vi.mock("$lib/stores/ui/discovery-policy.svelte", () => ({
   },
 }));
 
-// Mock sub-components
+// Mock sub-components except LabelInput (to render it for real and assert robustly)
 vi.mock("$lib/components/labels/LabelBadge.svelte", () => ({
-  default: vi.fn(),
-}));
-
-vi.mock("$lib/components/labels/LabelInput.svelte", () => ({
   default: vi.fn(),
 }));
 
@@ -47,7 +43,7 @@ vi.mock("$lib/components/labels/AliasInput.svelte", () => ({
 }));
 
 describe("ZenSidebar labels addition when not editing", () => {
-  it("renders LabelInput when not editing and user is not a guest", () => {
+  it("renders LabelInput when not editing, user is not a guest, and entity has labels", () => {
     vault.isGuest = false;
 
     const mockEntity = {
@@ -57,7 +53,7 @@ describe("ZenSidebar labels addition when not editing", () => {
       aliases: [],
     } as any;
 
-    render(ZenSidebar, {
+    const { queryByRole } = render(ZenSidebar, {
       entity: mockEntity,
       editState: { isEditing: false, aliases: [] },
       resolvedImageUrl: "",
@@ -66,6 +62,53 @@ describe("ZenSidebar labels addition when not editing", () => {
       onDelete: async () => {},
     });
 
-    expect(LabelInput).toHaveBeenCalled();
+    const combobox = queryByRole("combobox", { name: "Quick add label" });
+    expect(combobox).toBeTruthy();
+  });
+
+  it("renders LabelInput when not editing, user is not a guest, and entity has NO labels", () => {
+    vault.isGuest = false;
+
+    const mockEntity = {
+      id: "entity-1",
+      title: "Test Entity",
+      labels: [], // EMPTY LABELS
+      aliases: [],
+    } as any;
+
+    const { queryByRole } = render(ZenSidebar, {
+      entity: mockEntity,
+      editState: { isEditing: false, aliases: [] },
+      resolvedImageUrl: "",
+      onShowLightbox: () => {},
+      onNavigate: () => {},
+      onDelete: async () => {},
+    });
+
+    const combobox = queryByRole("combobox", { name: "Quick add label" });
+    expect(combobox).toBeTruthy();
+  });
+
+  it("does NOT render LabelInput when user is a guest", () => {
+    vault.isGuest = true; // GUEST
+
+    const mockEntity = {
+      id: "entity-1",
+      title: "Test Entity",
+      labels: [],
+      aliases: [],
+    } as any;
+
+    const { queryByRole } = render(ZenSidebar, {
+      entity: mockEntity,
+      editState: { isEditing: false, aliases: [] },
+      resolvedImageUrl: "",
+      onShowLightbox: () => {},
+      onNavigate: () => {},
+      onDelete: async () => {},
+    });
+
+    const combobox = queryByRole("combobox", { name: "Quick add label" });
+    expect(combobox).toBeFalsy();
   });
 });

--- a/apps/web/src/lib/components/zen/ZenSidebar.labels.test.ts
+++ b/apps/web/src/lib/components/zen/ZenSidebar.labels.test.ts
@@ -1,0 +1,71 @@
+/** @vitest-environment jsdom */
+import { render } from "@testing-library/svelte";
+import { describe, it, expect, vi } from "vitest";
+import ZenSidebar from "./ZenSidebar.svelte";
+import { vault } from "$lib/stores/vault.svelte";
+import LabelInput from "$lib/components/labels/LabelInput.svelte";
+
+// Mock stores
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    isGuest: false,
+    entities: {},
+    inboundConnections: {},
+  },
+}));
+
+vi.mock("$lib/stores/oracle.svelte", () => ({
+  oracle: {
+    tier: "advanced",
+    isVisualizingEntity: vi.fn().mockReturnValue(false),
+  },
+}));
+
+vi.mock("$lib/services/RegenerationService.svelte", () => ({
+  regenerationService: {
+    isGenerating: false,
+  },
+}));
+
+vi.mock("$lib/stores/ui/discovery-policy.svelte", () => ({
+  discoveryPolicyStore: {
+    aiDisabled: false,
+  },
+}));
+
+// Mock sub-components
+vi.mock("$lib/components/labels/LabelBadge.svelte", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("$lib/components/labels/LabelInput.svelte", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("$lib/components/labels/AliasInput.svelte", () => ({
+  default: vi.fn(),
+}));
+
+describe("ZenSidebar labels addition when not editing", () => {
+  it("renders LabelInput when not editing and user is not a guest", () => {
+    vault.isGuest = false;
+
+    const mockEntity = {
+      id: "entity-1",
+      title: "Test Entity",
+      labels: ["label1"],
+      aliases: [],
+    } as any;
+
+    render(ZenSidebar, {
+      entity: mockEntity,
+      editState: { isEditing: false, aliases: [] },
+      resolvedImageUrl: "",
+      onShowLightbox: () => {},
+      onNavigate: () => {},
+      onDelete: async () => {},
+    });
+
+    expect(LabelInput).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -105,23 +105,30 @@
   <div class="mb-4 space-y-4">
     {#if !editState.isEditing}
       <div class="space-y-2">
-        {#if entity?.labels?.length}
-          <div class="flex flex-wrap gap-1.5">
-            {#each entity.labels as label}
-              <LabelBadge
-                {label}
-                removable={!vault.isGuest}
-                onRemove={() => {
-                  if (entity) {
-                    vault.removeLabel(entity.id, label).catch((err) => {
-                      console.error(
-                        `[ZenSidebar] Failed to remove label: ${err}`,
-                      );
-                    });
-                  }
-                }}
-              />
-            {/each}
+        {#if entity?.labels?.length || !vault.isGuest}
+          <div class="space-y-1">
+            {#if entity?.labels?.length}
+              <div class="flex flex-wrap gap-1.5">
+                {#each entity.labels as label}
+                  <LabelBadge
+                    {label}
+                    removable={!vault.isGuest}
+                    onRemove={() => {
+                      if (entity) {
+                        vault.removeLabel(entity.id, label).catch((err) => {
+                          console.error(
+                            `[ZenSidebar] Failed to remove label: ${err}`,
+                          );
+                        });
+                      }
+                    }}
+                  />
+                {/each}
+              </div>
+            {/if}
+            {#if !vault.isGuest}
+              <LabelInput entityId={entity?.id || ""} />
+            {/if}
           </div>
         {/if}
 

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -127,7 +127,10 @@
               </div>
             {/if}
             {#if !vault.isGuest}
-              <LabelInput entityId={entity?.id || ""} />
+              <LabelInput
+                entityId={entity?.id || ""}
+                ariaLabel="Quick add label"
+              />
             {/if}
           </div>
         {/if}
@@ -151,7 +154,7 @@
             class="block text-[10px] tracking-widest uppercase font-header text-theme-secondary font-bold"
             for="zen-labels">Labels</label
           >
-          <LabelInput entityId={entity?.id || ""} />
+          <LabelInput entityId={entity?.id || ""} ariaLabel="Labels" />
         </div>
 
         <div class="space-y-1">


### PR DESCRIPTION
Closes #887. Allows quick label adding in Zen Mode non-edit state by showing LabelInput directly under the badges when the user is not a guest.