### PR TITLE
:sparkles: feat: enable save to folder for active vault and hide restore button

### DIFF
--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -293,20 +293,19 @@
               : 'px-3 md:px-4 py-1.5 text-[10px] md:text-xs gap-2'} {vault.status ===
             'saving'
               ? 'opacity-75 cursor-wait'
-              : ''} {!vault.hasFolderHandle || !vault.isDirty
+              : ''} {vault.hasFolderHandle && !vault.isDirty
               ? 'opacity-50'
               : ''}"
             onclick={() => vault.saveToFolder()}
             title={!vault.hasFolderHandle
-              ? "No folder linked — connect a local folder first to enable saving."
+              ? "No folder linked — select a local folder to enable saving."
               : vault.isDirty
                 ? "Save to folder — writes all changes from the internal archive to your linked folder."
                 : "Up to date with local folder."}
             aria-label="SAVE TO FOLDER"
             aria-busy={vault.status === "saving"}
             disabled={vault.status === "saving" ||
-              !vault.hasFolderHandle ||
-              !vault.isDirty}
+              (vault.hasFolderHandle && !vault.isDirty)}
           >
             {#if vault.status === "saving"}
               <span
@@ -316,7 +315,7 @@
               SAVING...
             {:else}
               <span
-                class={vault.isDirty
+                class={vault.isDirty || !vault.hasFolderHandle
                   ? "icon-[lucide--upload-cloud] w-3.5 h-3.5"
                   : "icon-[lucide--cloud-check] w-3.5 h-3.5"}
               ></span>

--- a/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
+++ b/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
@@ -292,13 +292,31 @@
 
                 <button
                   type="button"
-                  class="p-1.5 hover:bg-theme-border rounded text-theme-accent hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                  class="p-1.5 hover:bg-theme-border rounded text-theme-accent hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity disabled:opacity-30 disabled:cursor-not-allowed"
                   onclick={() => vault.saveToFolder()}
-                  title="Save to Folder — writes all changes from your internal archive to your linked folder."
+                  title={!vault.hasFolderHandle
+                    ? "No folder linked — connect a local folder first to enable saving."
+                    : vault.isDirty
+                      ? "Save to folder — writes all changes from the internal archive to your linked folder."
+                      : "Up to date with local folder."}
                   aria-label="Save to Folder"
-                  disabled={isLoading || !!editingId}
+                  aria-busy={vault.status === "saving"}
+                  disabled={isLoading ||
+                    !!editingId ||
+                    vault.status === "saving" ||
+                    !vault.hasFolderHandle ||
+                    !vault.isDirty}
                 >
-                  <span class="icon-[lucide--upload-cloud] w-3.5 h-3.5"></span>
+                  {#if vault.status === "saving"}
+                    <span
+                      class="icon-[lucide--loader-2] w-3.5 h-3.5 animate-spin"
+                    ></span>
+                  {:else if !vault.isDirty && vault.hasFolderHandle}
+                    <span class="icon-[lucide--cloud-check] w-3.5 h-3.5"></span>
+                  {:else}
+                    <span class="icon-[lucide--upload-cloud] w-3.5 h-3.5"
+                    ></span>
+                  {/if}
                 </button>
               {:else}
                 <button

--- a/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
+++ b/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
@@ -289,17 +289,28 @@
                   <span class="icon-[lucide--download-cloud] w-3.5 h-3.5"
                   ></span>
                 </button>
-              {/if}
 
-              <button
-                class="p-1.5 hover:bg-theme-border rounded text-theme-muted hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
-                onclick={() => handleImportToVault(v)}
-                title="Restore from Folder"
-                aria-label="Restore {v.name} from Folder"
-                disabled={isLoading || !!editingId}
-              >
-                <span class="icon-[lucide--folder-up] w-3.5 h-3.5"></span>
-              </button>
+                <button
+                  type="button"
+                  class="p-1.5 hover:bg-theme-border rounded text-theme-accent hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                  onclick={() => vault.saveToFolder()}
+                  title="Save to Folder — writes all changes from your internal archive to your linked folder."
+                  aria-label="Save to Folder"
+                  disabled={isLoading || !!editingId}
+                >
+                  <span class="icon-[lucide--upload-cloud] w-3.5 h-3.5"></span>
+                </button>
+              {:else}
+                <button
+                  class="p-1.5 hover:bg-theme-border rounded text-theme-muted hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                  onclick={() => handleImportToVault(v)}
+                  title="Restore from Folder"
+                  aria-label="Restore {v.name} from Folder"
+                  disabled={isLoading || !!editingId}
+                >
+                  <span class="icon-[lucide--folder-up] w-3.5 h-3.5"></span>
+                </button>
+              {/if}
 
               <button
                 class="p-1.5 hover:bg-theme-border rounded text-theme-muted hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"

--- a/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
+++ b/apps/web/src/lib/components/vaults/VaultSwitcherModal.svelte
@@ -295,7 +295,7 @@
                   class="p-1.5 hover:bg-theme-border rounded text-theme-accent hover:text-theme-primary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity disabled:opacity-30 disabled:cursor-not-allowed"
                   onclick={() => vault.saveToFolder()}
                   title={!vault.hasFolderHandle
-                    ? "No folder linked — connect a local folder first to enable saving."
+                    ? "No folder linked — select a local folder to enable saving."
                     : vault.isDirty
                       ? "Save to folder — writes all changes from the internal archive to your linked folder."
                       : "Up to date with local folder."}
@@ -304,8 +304,7 @@
                   disabled={isLoading ||
                     !!editingId ||
                     vault.status === "saving" ||
-                    !vault.hasFolderHandle ||
-                    !vault.isDirty}
+                    (vault.hasFolderHandle && !vault.isDirty)}
                 >
                   {#if vault.status === "saving"}
                     <span

--- a/apps/web/tests/sync-directional.spec.ts
+++ b/apps/web/tests/sync-directional.spec.ts
@@ -22,7 +22,9 @@ test.describe("Directional Vault Sync UI", () => {
     await page.getByTestId("open-vault-button").click();
     await expect(page.getByText("VAULT SELECTOR")).toBeVisible();
 
-    const activeVaultRow = page.locator(".bg-theme-primary\\/10");
+    const activeVaultRow = page.locator(
+      "[data-testid='vault-switcher-modal'] .bg-theme-primary\\/10",
+    );
     await expect(activeVaultRow).toBeVisible();
 
     const loadButton = activeVaultRow.getByLabel("Load from Folder");
@@ -36,12 +38,17 @@ test.describe("Directional Vault Sync UI", () => {
     await page.getByTestId("open-vault-button").click();
     await expect(page.getByText("VAULT SELECTOR")).toBeVisible();
 
-    const activeVaultRow = page.locator(".bg-theme-primary\\/10");
+    const activeVaultRow = page.locator(
+      "[data-testid='vault-switcher-modal'] .bg-theme-primary\\/10",
+    );
     await expect(activeVaultRow).toBeVisible();
 
     const saveButton = activeVaultRow.getByLabel("Save to Folder");
     await expect(saveButton).toBeVisible();
-    await expect(saveButton).toHaveAttribute("title", /Save to Folder/);
+    await expect(saveButton).toHaveAttribute(
+      "title",
+      /Save to [fF]older|No folder linked/,
+    );
   });
 
   test("should enable Save button when internal changes are made", async ({

--- a/apps/web/tests/sync-directional.spec.ts
+++ b/apps/web/tests/sync-directional.spec.ts
@@ -22,12 +22,26 @@ test.describe("Directional Vault Sync UI", () => {
     await page.getByTestId("open-vault-button").click();
     await expect(page.getByText("VAULT SELECTOR")).toBeVisible();
 
-    const activeVaultRow = page.locator(".bg-theme-primary/10");
+    const activeVaultRow = page.locator(".bg-theme-primary\\/10");
     await expect(activeVaultRow).toBeVisible();
 
     const loadButton = activeVaultRow.getByLabel("Load from Folder");
     await expect(loadButton).toBeVisible();
     await expect(loadButton).toHaveAttribute("title", /Load from Folder/);
+  });
+
+  test("should show Save button in Vault Selector for active vault", async ({
+    page,
+  }) => {
+    await page.getByTestId("open-vault-button").click();
+    await expect(page.getByText("VAULT SELECTOR")).toBeVisible();
+
+    const activeVaultRow = page.locator(".bg-theme-primary\\/10");
+    await expect(activeVaultRow).toBeVisible();
+
+    const saveButton = activeVaultRow.getByLabel("Save to Folder");
+    await expect(saveButton).toBeVisible();
+    await expect(saveButton).toHaveAttribute("title", /Save to Folder/);
   });
 
   test("should enable Save button when internal changes are made", async ({

--- a/apps/web/tests/vault-switcher-a11y.spec.ts
+++ b/apps/web/tests/vault-switcher-a11y.spec.ts
@@ -12,9 +12,7 @@ test.describe("Vault Switching Accessibility", () => {
       }
     });
     await page.goto("/");
-    await expect(page.getByTestId("graph-canvas")).toBeVisible({
-      timeout: 10000,
-    });
+    await page.waitForFunction(() => (window as any).vault?.status === "idle");
   });
 
   test("action buttons should be accessible via keyboard and have proper labels", async ({
@@ -26,6 +24,7 @@ test.describe("Vault Switching Accessibility", () => {
     await page.getByRole("button", { name: "NEW VAULT" }).click();
     await page.getByPlaceholder("Vault Name...").fill("A11yTestVault");
     await page.getByRole("button", { name: "CREATE" }).click();
+    await expect(page.getByTestId("vault-switcher-modal")).toBeHidden();
 
     // Re-open the vault switcher (creating a vault closes the modal)
     await page.getByTestId("open-vault-button").click();
@@ -36,7 +35,7 @@ test.describe("Vault Switching Accessibility", () => {
     // Check that buttons are discoverable by role + accessible name (confirms aria-label)
     const renameButtons = modal.getByRole("button", { name: "Rename" });
     const restoreButtons = modal.getByRole("button", {
-      name: "Restore from Folder",
+      name: /Restore/,
     });
     const deleteButtons = modal.getByRole("button", { name: "Delete" });
 
@@ -47,11 +46,11 @@ test.describe("Vault Switching Accessibility", () => {
     // Scope to the non-active vault row (the only row that has a Delete button)
     const nonActiveRow = modal
       .locator(".group")
-      .filter({ has: modal.getByRole("button", { name: "Delete" }) })
+      .filter({ has: page.getByRole("button", { name: "Delete" }) })
       .first();
 
     const restoreBtn = nonActiveRow.getByRole("button", {
-      name: "Restore from Folder",
+      name: /Restore/,
     });
     const renameBtn = nonActiveRow.getByRole("button", { name: "Rename" });
     const deleteBtn = nonActiveRow.getByRole("button", { name: "Delete" });

--- a/apps/web/tests/vault-switcher-a11y.spec.ts
+++ b/apps/web/tests/vault-switcher-a11y.spec.ts
@@ -35,7 +35,7 @@ test.describe("Vault Switching Accessibility", () => {
     // Check that buttons are discoverable by role + accessible name (confirms aria-label)
     const renameButtons = modal.getByRole("button", { name: "Rename" });
     const restoreButtons = modal.getByRole("button", {
-      name: /Restore/,
+      name: /Restore .* from Folder/i,
     });
     const deleteButtons = modal.getByRole("button", { name: "Delete" });
 
@@ -50,7 +50,7 @@ test.describe("Vault Switching Accessibility", () => {
       .first();
 
     const restoreBtn = nonActiveRow.getByRole("button", {
-      name: /Restore/,
+      name: /Restore .* from Folder/i,
     });
     const renameBtn = nonActiveRow.getByRole("button", { name: "Rename" });
     const deleteBtn = nonActiveRow.getByRole("button", { name: "Delete" });


### PR DESCRIPTION
This PR resolves issue #888 by adding a 'Save to Folder' action next to 'Load from Folder' for the currently active vault in the Vault Selector modal. It also hides the redundant 'Restore from Folder' action for the active vault, while retaining it for inactive vaults.

### Changes
- **VaultSwitcherModal.svelte**: Add 'Save to Folder' button and make it mutually exclusive with 'Restore from Folder' for active vaults.
- **sync-directional.spec.ts**: Added E2E assertions for the active vault's 'Save to Folder' button.
- **vault-switcher-a11y.spec.ts**: Updated locators to wait for vault initialization and match dynamic ARIA labels.

Closes #888.