### PR TITLE
[codex] Add graph important label action

### DIFF
--- a/.agent/rules/specify-rules.md
+++ b/.agent/rules/specify-rules.md
@@ -1,0 +1,30 @@
+# Codex-Cryptica Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-05-25
+
+## Active Technologies
+
+- TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace + Svelte 5, Cytoscape, `graph-engine`, `schema`, existing vault/entity stores, existing Tailwind 4 theme tokens (118-graph-important-label)
+
+## Project Structure
+
+```text
+backend/
+frontend/
+tests/
+```
+
+## Commands
+
+pnpm test && pnpm run lint
+
+## Code Style
+
+TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace: Follow standard conventions
+
+## Recent Changes
+
+- 118-graph-important-label: Added TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace + Svelte 5, Cytoscape, `graph-engine`, `schema`, existing vault/entity stores, existing Tailwind 4 theme tokens
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/.agent/rules/specify-rules.md
+++ b/.agent/rules/specify-rules.md
@@ -9,14 +9,19 @@ Auto-generated from all feature plans. Last updated: 2026-05-25
 ## Project Structure
 
 ```text
-backend/
-frontend/
-tests/
+apps/
+  web/
+packages/
+  graph-engine/
+  schema/
+specs/
+.specify/
 ```
 
 ## Commands
 
-pnpm test && pnpm run lint
+bun run test
+bun run lint
 
 ## Code Style
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{ "feature_directory": "specs/116-scroll-wheel-date-picker" }
+{ "feature_directory": "specs/118-graph-important-label" }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,13 +48,16 @@ This file is the Codex-facing instruction layer for this repository.
 <!-- SPECKIT START -->
 
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the [current plan](./specs/116-scroll-wheel-date-picker/plan.md).
+shell commands, and other important information, read the [current plan](./specs/118-graph-important-label/plan.md).
 
 <!-- SPECKIT END -->
 
 ## Active Technologies
 - TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace + `chronology-engine`, `schema`, Svelte 5, Floating UI, IndexedDB `idb`, existing Tailwind 4 theme tokens (116-scroll-wheel-date-picker)
 - Browser-local vault settings in IndexedDB via `apps/web/src/lib/stores/calendar.svelte.ts`; entity temporal metadata in local vault data (116-scroll-wheel-date-picker)
+- TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace + Svelte 5, Cytoscape, `graph-engine`, `schema`, existing vault/entity stores, existing Tailwind 4 theme tokens (118-graph-important-label)
+- Existing local vault entity `labels` array persisted through IndexedDB-backed vault stores; no new storage shape (118-graph-important-label)
 
 ## Recent Changes
 - 116-scroll-wheel-date-picker: Added TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace + `chronology-engine`, `schema`, Svelte 5, Floating UI, IndexedDB `idb`, existing Tailwind 4 theme tokens
+- 118-graph-important-label: Added TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace + Svelte 5, Cytoscape, `graph-engine`, `schema`, existing vault/entity stores, existing Tailwind 4 theme tokens

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -124,6 +124,7 @@
       </button>
 
       <button
+        type="button"
         role="menuitem"
         class="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition border-t border-theme-border whitespace-nowrap flex items-center gap-2"
         onclick={controller.handleMarkImportant}

--- a/apps/web/src/lib/components/graph/ContextMenu.svelte
+++ b/apps/web/src/lib/components/graph/ContextMenu.svelte
@@ -123,6 +123,16 @@
           : "Label…"}
       </button>
 
+      <button
+        role="menuitem"
+        class="w-full text-left px-4 py-2 text-sm text-theme-text hover:bg-theme-primary/10 hover:text-theme-primary transition border-t border-theme-border whitespace-nowrap flex items-center gap-2"
+        onclick={controller.handleMarkImportant}
+        aria-label="Mark Important"
+      >
+        <span class="icon-[lucide--star] h-3.5 w-3.5 opacity-70"></span>
+        <span>Mark Important</span>
+      </button>
+
       {#if controller.selectedNodes.length === 1}
         <button
           bind:this={controller.imagePickerAnchor}

--- a/apps/web/src/lib/components/graph/ContextMenu.test.ts
+++ b/apps/web/src/lib/components/graph/ContextMenu.test.ts
@@ -1,0 +1,139 @@
+/** @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ContextMenu from "./ContextMenu.svelte";
+import { vault } from "$lib/stores/vault.svelte";
+
+vi.mock("$lib/stores/graph.svelte", () => ({
+  graph: {
+    setCentralNode: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    isGuest: false,
+    entities: {},
+    bulkAddLabel: vi.fn(),
+    resolveImageUrl: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/oracle.svelte", () => ({
+  oracle: {
+    drawEntity: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/services/RegenerationService.svelte", () => ({
+  regenerationService: {
+    regenerate: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/canvas-registry.svelte", () => ({
+  canvasRegistry: {
+    addEntities: vi.fn(),
+    createCanvas: vi.fn(),
+    canvases: {},
+  },
+}));
+
+vi.mock("$lib/stores/categories.svelte", () => ({
+  categories: {
+    list: [],
+  },
+}));
+
+vi.mock("$lib/stores/ui/modal-ui.svelte", () => ({
+  modalUIStore: {
+    openMergeDialog: vi.fn(),
+    openBulkLabelDialog: vi.fn(),
+    openCanvasSelection: vi.fn(),
+    openLightbox: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/ui/connection-mode.svelte", () => ({
+  connectionModeStore: {
+    startSelectionConnection: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/ui/notification.svelte", () => ({
+  notificationStore: {
+    notify: vi.fn(),
+    confirm: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/ui/discovery-policy.svelte", () => ({
+  discoveryPolicyStore: {
+    aiDisabled: false,
+  },
+}));
+
+describe("ContextMenu", () => {
+  let cxttapHandler: ((event: any) => void) | undefined;
+
+  const createCy = () => ({
+    on: vi.fn(
+      (
+        event: string,
+        selectorOrHandler: string | (() => void),
+        handler?: () => void,
+      ) => {
+        if (event === "cxttap" && selectorOrHandler === "node") {
+          cxttapHandler = handler as (event: any) => void;
+        }
+      },
+    ),
+    off: vi.fn(),
+    $: vi.fn().mockReturnValue({
+      map: vi.fn().mockReturnValue(["node-1"]),
+    }),
+  });
+
+  const openNodeMenu = async () => {
+    cxttapHandler?.({
+      target: {
+        id: () => "node-1",
+        selected: () => false,
+      },
+      renderedPosition: { x: 10, y: 20 },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("menu", { name: "Node actions" })).toBeTruthy(),
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cxttapHandler = undefined;
+    vault.isGuest = false;
+    vault.entities = {};
+  });
+
+  it("shows Mark Important for editable graph sessions", async () => {
+    render(ContextMenu, { cy: createCy() as any });
+
+    await openNodeMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: "Mark Important" }),
+    ).toBeTruthy();
+  });
+
+  it("hides Mark Important for guest graph sessions", async () => {
+    vault.isGuest = true;
+    render(ContextMenu, { cy: createCy() as any });
+
+    await openNodeMenu();
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Mark Important" }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
@@ -135,6 +135,44 @@ export class GraphContextMenuController {
     }
   };
 
+  handleMarkImportant = async () => {
+    const nodesToUpdate = $state.snapshot(this.selectedNodes);
+    if (nodesToUpdate.length === 0) return;
+
+    this.contextMenuOpen = false;
+    this.canvasPickerOpen = false;
+    this.categoryPickerOpen = false;
+    this.imagePickerOpen = false;
+
+    try {
+      const count = await this.deps.vault.bulkAddLabel(
+        nodesToUpdate,
+        "important",
+      );
+      if (count > 0) {
+        this.deps.notificationStore.notify(
+          count === 1
+            ? 'Marked as "important".'
+            : `Marked ${count} nodes as "important".`,
+          "success",
+        );
+      } else {
+        this.deps.notificationStore.notify(
+          nodesToUpdate.length === 1
+            ? 'Already marked as "important".'
+            : 'Selected nodes are already marked as "important".',
+          "info",
+        );
+      }
+    } catch (err: any) {
+      console.error("Failed to mark nodes important", err);
+      this.deps.notificationStore.notify(
+        `Failed to mark important: ${err.message}`,
+        "error",
+      );
+    }
+  };
+
   handleChooseFull = () => {
     this.clearPickerTimeout();
     this.canvasPickerOpen = false;

--- a/apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+++ b/apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
@@ -122,6 +122,38 @@ describe("GraphContextMenuController", () => {
     );
   });
 
+  it("should report when multiple selected nodes are already important", async () => {
+    deps.vault.bulkAddLabel.mockResolvedValue(0);
+    controller.selectedNodes = ["node-1", "node-2"];
+
+    await controller.handleMarkImportant();
+
+    expect(deps.vault.bulkAddLabel).toHaveBeenCalledWith(
+      ["node-1", "node-2"],
+      "important",
+    );
+    expect(deps.notificationStore.notify).toHaveBeenCalledWith(
+      'Selected nodes are already marked as "important".',
+      "info",
+    );
+  });
+
+  it("should close open graph submenus when marking nodes important", async () => {
+    deps.vault.bulkAddLabel.mockResolvedValue(1);
+    controller.contextMenuOpen = true;
+    controller.canvasPickerOpen = true;
+    controller.categoryPickerOpen = true;
+    controller.imagePickerOpen = true;
+    controller.selectedNodes = ["node-1"];
+
+    await controller.handleMarkImportant();
+
+    expect(controller.contextMenuOpen).toBe(false);
+    expect(controller.canvasPickerOpen).toBe(false);
+    expect(controller.categoryPickerOpen).toBe(false);
+    expect(controller.imagePickerOpen).toBe(false);
+  });
+
   it("should not mark important when no nodes are selected", async () => {
     controller.selectedNodes = [];
 

--- a/apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+++ b/apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
@@ -21,6 +21,7 @@ describe("GraphContextMenuController", () => {
         entities: {},
         updateEntity: vi.fn(),
         batchUpdate: vi.fn(),
+        bulkAddLabel: vi.fn(),
         deleteEntity: vi.fn(),
         resolveImageUrl: vi.fn(),
       },
@@ -88,6 +89,57 @@ describe("GraphContextMenuController", () => {
     expect(deps.notificationStore.notify).toHaveBeenCalledWith(
       "Updated 2 nodes.",
       "success",
+    );
+  });
+
+  it("should mark selected nodes important", async () => {
+    deps.vault.bulkAddLabel.mockResolvedValue(2);
+    controller.contextMenuOpen = true;
+    controller.selectedNodes = ["node-1", "node-2"];
+
+    await controller.handleMarkImportant();
+
+    expect(deps.vault.bulkAddLabel).toHaveBeenCalledWith(
+      ["node-1", "node-2"],
+      "important",
+    );
+    expect(deps.notificationStore.notify).toHaveBeenCalledWith(
+      'Marked 2 nodes as "important".',
+      "success",
+    );
+    expect(controller.contextMenuOpen).toBe(false);
+  });
+
+  it("should report when selected nodes are already important", async () => {
+    deps.vault.bulkAddLabel.mockResolvedValue(0);
+    controller.selectedNodes = ["node-1"];
+
+    await controller.handleMarkImportant();
+
+    expect(deps.notificationStore.notify).toHaveBeenCalledWith(
+      'Already marked as "important".',
+      "info",
+    );
+  });
+
+  it("should not mark important when no nodes are selected", async () => {
+    controller.selectedNodes = [];
+
+    await controller.handleMarkImportant();
+
+    expect(deps.vault.bulkAddLabel).not.toHaveBeenCalled();
+    expect(deps.notificationStore.notify).not.toHaveBeenCalled();
+  });
+
+  it("should report important label failures", async () => {
+    deps.vault.bulkAddLabel.mockRejectedValue(new Error("save failed"));
+    controller.selectedNodes = ["node-1"];
+
+    await controller.handleMarkImportant();
+
+    expect(deps.notificationStore.notify).toHaveBeenCalledWith(
+      "Failed to mark important: save failed",
+      "error",
     );
   });
 

--- a/docs/proposals/NEXT_FEATURES_AND_CODE_IMPROVEMENTS.md
+++ b/docs/proposals/NEXT_FEATURES_AND_CODE_IMPROVEMENTS.md
@@ -1,0 +1,243 @@
+# Next Features And Code Improvements Proposal
+
+> Status: Draft for discussion
+> Scope: Product roadmap candidates, reliability work, and maintainability improvements after the scroll-wheel date picker effort
+
+---
+
+## Purpose
+
+This proposal captures a practical next-step backlog for Codex Cryptica. It separates user-facing features from code improvements so roadmap planning can keep product value visible while still paying down the engineering work that protects local-first data, performance, and future feature delivery.
+
+The intent is not to define one large project. Each item should become a focused Spec Kit feature, GitHub issue, or refactor PR with tests for both the expected path and at least one failure, cancellation, or negative path.
+
+## Prioritization Criteria
+
+Use these filters when choosing what to build next:
+
+- **User impact**: Improves a common campaign authoring workflow or reduces data-loss risk.
+- **Local-first fit**: Works without a server and keeps private campaign data on the user's device.
+- **Implementation leverage**: Builds on existing stores, packages, and Svelte components instead of adding parallel systems.
+- **Reviewability**: Can land in a small PR with clear behavior, tests, and docs.
+- **Roadmap unlock**: Removes friction for later features such as chronology, vault portability, or Oracle workflows.
+
+## Recommended Feature Backlog
+
+### 1. Chronology Quality Pass
+
+**Goal**: Finish the scroll-wheel date picker and make campaign chronology feel reliable across entity details, timeline views, and custom calendar settings.
+
+**User value**:
+
+- Faster date entry on desktop and touch devices.
+- Better support for partial dates, custom named periods, and invalid-date repair.
+- More confidence when editing campaign calendars after content already exists.
+
+**Suggested scope**:
+
+- Ship the reusable `TemporalPicker` and integrate it for `date`, `start_date`, and `end_date`.
+- Add a compact read-only formatted date preview wherever temporal metadata is displayed.
+- Add repair-state messaging for dates created against an older calendar revision.
+- Update chronology help content with plain examples for partial dates, named anchors, and invalid saved values.
+
+**Engineering notes**:
+
+- Keep validation, formatting, snapshots, and repair decisions in `packages/chronology-engine`.
+- Keep Svelte components focused on display, interaction, and user confirmation.
+- Test engine behavior before UI behavior, then add component tests for keyboard and failure paths.
+
+### 2. Vault Load/Save Confidence
+
+**Goal**: Make vault folder operations more understandable, interrupt-safe, and observable without exposing implementation terminology.
+
+**User value**:
+
+- Clearer distinction between loading from a folder and saving to a folder.
+- Less anxiety during vault switching, browser permission changes, and interrupted writes.
+- Better recovery when a folder handle is unavailable or stale.
+
+**Suggested scope**:
+
+- Continue replacing user-facing "sync" language with directional `load` and `save` language.
+- Add clearer status states for pending, saving, saved, failed, and needs-permission flows.
+- Add a non-blocking save-drain timeout when switching vaults.
+- Surface actionable recovery copy when OPFS or folder access fails.
+
+**Engineering notes**:
+
+- Prefer a thin vault-facing facade before deeper internal renames.
+- Preserve compatibility aliases temporarily where call sites are still migrating.
+- Add tests for successful save, permission failure, cancellation, and timeout behavior.
+
+### 3. Bulk Editing And Organization Tools
+
+**Goal**: Improve large-vault workflows where users need to clean up many entities without repetitive detail-panel editing.
+
+**User value**:
+
+- Faster label/category cleanup.
+- Easier campaign maintenance after imports or long writing sessions.
+- Better control over large knowledge graphs.
+
+**Suggested scope**:
+
+- Multi-select entity actions for adding/removing labels, assigning categories, and archiving.
+- A review queue for entities with missing titles, empty content, invalid dates, or broken links.
+- Batch update confirmation with a clear summary before changes are applied.
+
+**Engineering notes**:
+
+- Add bulk event types instead of emitting hundreds of single-entity events.
+- Ensure search indexing can process batch changes efficiently.
+- Use existing entity-store boundaries and avoid adding one-off bulk mutation paths in components.
+
+### 4. Oracle Workflow Reliability
+
+**Goal**: Make Oracle actions easier to trust by showing what will change and keeping execution recoverable.
+
+**User value**:
+
+- More predictable AI-assisted edits.
+- Clearer review before generated changes affect vault content.
+- Better control when users cancel or revise an Oracle action.
+
+**Suggested scope**:
+
+- Add action previews that summarize proposed entity changes before applying them.
+- Add explicit cancellation and retry states for long-running Oracle tasks.
+- Keep a local action history entry with prompt, affected entities, and result summary.
+
+**Engineering notes**:
+
+- Extend the decomposed Oracle managers under `apps/web/src/lib/stores/oracle/` rather than expanding the facade.
+- Keep user API keys and generated context local.
+- Test success, cancellation, provider error, and rejected-action paths.
+
+### 5. Graph And Map Interaction Polish
+
+**Goal**: Improve graph readability and navigation for large campaigns without changing the core data model.
+
+**User value**:
+
+- Easier movement through dense relationship maps.
+- Better focus when exploring a single entity or cluster.
+- Less layout surprise after edits.
+
+**Suggested scope**:
+
+- Add saved graph view presets per vault.
+- Improve focus mode handoff between graph selection and entity detail.
+- Add layout stability safeguards after bulk updates or date/category edits.
+
+**Engineering notes**:
+
+- Prefer changes inside existing graph-engine and view orchestration boundaries.
+- Keep visual state separate from entity data unless the user explicitly saves a view preset.
+- Add tests around graph state transitions where practical, and use targeted browser checks for layout regressions.
+
+## Recommended Code Improvement Backlog
+
+### A. Event And Store Boundaries
+
+**Problem**: Some workflows still rely on repeated single-entity events or duplicated async race checks.
+
+**Proposal**:
+
+- Add bulk events for batch entity changes.
+- Extract common stale-operation checks in async vault flows.
+- Keep constructor-based dependency injection for new services and managers.
+
+**Payoff**:
+
+- Lower indexing and rendering overhead for large vaults.
+- Fewer race-condition mistakes during vault switching.
+- Easier unit testing for cancellation paths.
+
+### B. Save Queue Efficiency
+
+**Problem**: Rapid content edits can enqueue repeated saves for the same entity.
+
+**Proposal**:
+
+- Add per-entity save debouncing.
+- Ensure `waitForAllSaves()` flushes pending debounced saves before draining the queue.
+- Add a bounded timeout for save draining during vault switches.
+
+**Payoff**:
+
+- Fewer redundant disk writes.
+- More reliable vault switching.
+- Better behavior in throttled browser tabs or permission edge cases.
+
+### C. Search Indexing Performance
+
+**Problem**: Cache-loaded and batch-update flows can perform indexing serially.
+
+**Proposal**:
+
+- Resolve search services once for bulk operations.
+- Add batch indexing paths where the underlying search service supports it.
+- Avoid re-indexing unchanged content during metadata-only edits when possible.
+
+**Payoff**:
+
+- Faster vault load times.
+- Better performance for bulk edits.
+- Less unnecessary work on large campaigns.
+
+### D. Test Coverage For Local-First Failure Modes
+
+**Problem**: The riskiest behavior is not the happy path; it is interruption, permission loss, stale vault handles, and invalid persisted state.
+
+**Proposal**:
+
+- Add focused tests for permission failure, aborted load, aborted save, stale vault switch, invalid calendar dates, and rejected numeric date input.
+- Keep tests close to the package or store that owns the behavior.
+- Use Playwright only where browser behavior cannot be covered by unit/component tests.
+
+**Payoff**:
+
+- Safer refactors.
+- Less regression risk around user data.
+- Clearer confidence before release.
+
+### E. Documentation And Naming Cleanup
+
+**Problem**: Older docs and internal names still mix "sync" language with directional load/save behavior.
+
+**Proposal**:
+
+- Update developer docs when code boundaries change.
+- Keep user-facing docs plain and task-oriented.
+- Avoid adding implementation-only refactors to the user-facing changelog.
+
+**Payoff**:
+
+- Easier onboarding for contributors.
+- Less user confusion around vault operations.
+- Changelog stays focused on visible improvements.
+
+## Suggested Delivery Order
+
+1. Finish and verify the scroll-wheel date picker feature.
+2. Land vault load/save reliability improvements that reduce data-loss and switching risk.
+3. Add bulk entity operations with batch event/indexing support.
+4. Improve Oracle action preview, cancellation, and retry flows.
+5. Polish graph/map navigation and saved view state.
+
+This order keeps the active chronology work moving, then addresses the highest-risk local-first data paths before adding broader workflow features.
+
+## Spec Kit Follow-Up Candidates
+
+- `chronology-quality-pass`: complete picker integration, formatted previews, and repair documentation.
+- `vault-load-save-confidence`: status language, permission recovery, save-drain timeout, and tests.
+- `bulk-entity-operations`: multi-select actions, batch events, and search indexing updates.
+- `oracle-action-preview`: preview, confirm, cancel, retry, and local action history.
+- `graph-view-presets`: saved visual graph states and focus-mode polish.
+
+## Open Questions
+
+- Should bulk editing ship before Oracle action previews, or should Oracle previews land first because they reduce AI-edit risk?
+- Should saved graph view presets be vault-local only, or should they be portable with exported vault data?
+- Which vault failure states are currently most common for users: permission loss, interrupted save, stale folder handle, or browser storage limits?
+- Should chronology repair states appear only in the picker, or should entity lists also flag dates that need review?

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -488,30 +488,30 @@ describe("GraphTransformer", () => {
     expect(importantStyle.style.width).toBeUndefined();
     expect(importantStyle.style.height).toBeUndefined();
     expect(importantStyle.style["font-weight"]).toBe("bold");
-    expect(importantStyle.style["font-size"]).toBe(11);
-    expect(importantStyle.style["shadow-blur"]).toBe(12);
-    expect(importantStyle.style["border-color"]).toBe("#e11d48");
-    expect(importantStyle.style["underlay-color"]).toBe("#e11d48");
-    expect(importantStyle.style["text-border-color"]).toBe("#e11d48");
-    expect(importantStyle.style["shadow-color"]).toBe("#e11d48");
+    expect(importantStyle.style["font-size"]).toBe(12);
+    expect(importantStyle.style["shadow-blur"]).toBe(18);
+    expect(importantStyle.style["border-color"]).toBe("#8b5cf6");
+    expect(importantStyle.style["underlay-color"]).toBe("#8b5cf6");
+    expect(importantStyle.style["text-border-color"]).toBe("#8b5cf6");
+    expect(importantStyle.style["shadow-color"]).toBe("#8b5cf6");
 
     const importantSmallStyle = style.find(
       (s) => s.selector === "node[isImportant][weight <= 2]",
     );
     expect(importantSmallStyle).toBeDefined();
-    expect(importantSmallStyle.style.width).toBe(48);
+    expect(importantSmallStyle.style.width).toBe(60);
 
     const importantMediumStyle = style.find(
       (s) => s.selector === "node[isImportant][weight >= 3][weight <= 11]",
     );
     expect(importantMediumStyle).toBeDefined();
-    expect(importantMediumStyle.style.width).toBe(72);
+    expect(importantMediumStyle.style.width).toBe(90);
 
     const importantLargeStyle = style.find(
       (s) => s.selector === "node[isImportant][weight >= 12]",
     );
     expect(importantLargeStyle).toBeDefined();
-    expect(importantLargeStyle.style.width).toBe(108);
+    expect(importantLargeStyle.style.width).toBe(144);
   });
 
   it("should preserve revealed border treatment when a node is also important", () => {

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -487,6 +487,27 @@ describe("GraphTransformer", () => {
     expect(importantStyle.style["underlay-opacity"]).toBeGreaterThan(0);
     expect(importantStyle.style.width).toBeUndefined();
     expect(importantStyle.style.height).toBeUndefined();
+    expect(importantStyle.style["font-weight"]).toBe("bold");
+    expect(importantStyle.style["font-size"]).toBe(11);
+    expect(importantStyle.style["shadow-blur"]).toBe(12);
+
+    const importantSmallStyle = style.find(
+      (s) => s.selector === "node[isImportant][weight <= 2]",
+    );
+    expect(importantSmallStyle).toBeDefined();
+    expect(importantSmallStyle.style.width).toBe(48);
+
+    const importantMediumStyle = style.find(
+      (s) => s.selector === "node[isImportant][weight >= 3][weight <= 11]",
+    );
+    expect(importantMediumStyle).toBeDefined();
+    expect(importantMediumStyle.style.width).toBe(72);
+
+    const importantLargeStyle = style.find(
+      (s) => s.selector === "node[isImportant][weight >= 12]",
+    );
+    expect(importantLargeStyle).toBeDefined();
+    expect(importantLargeStyle.style.width).toBe(108);
   });
 
   it("should preserve revealed border treatment when a node is also important", () => {

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -489,7 +489,7 @@ describe("GraphTransformer", () => {
     expect(importantStyle.style.height).toBeUndefined();
     expect(importantStyle.style["font-weight"]).toBe("bold");
     expect(importantStyle.style["font-size"]).toBe(12);
-    expect(importantStyle.style["shadow-blur"]).toBe(18);
+    expect(importantStyle.style["shadow-blur"]).toBe(24);
     expect(importantStyle.style["border-color"]).toBe("#8b5cf6");
     expect(importantStyle.style["underlay-color"]).toBe("#8b5cf6");
     expect(importantStyle.style["text-border-color"]).toBe("#8b5cf6");
@@ -498,20 +498,7 @@ describe("GraphTransformer", () => {
     const importantSmallStyle = style.find(
       (s) => s.selector === "node[isImportant][weight <= 2]",
     );
-    expect(importantSmallStyle).toBeDefined();
-    expect(importantSmallStyle.style.width).toBe(60);
-
-    const importantMediumStyle = style.find(
-      (s) => s.selector === "node[isImportant][weight >= 3][weight <= 11]",
-    );
-    expect(importantMediumStyle).toBeDefined();
-    expect(importantMediumStyle.style.width).toBe(90);
-
-    const importantLargeStyle = style.find(
-      (s) => s.selector === "node[isImportant][weight >= 12]",
-    );
-    expect(importantLargeStyle).toBeDefined();
-    expect(importantLargeStyle.style.width).toBe(144);
+    expect(importantSmallStyle).toBeUndefined();
   });
 
   it("should preserve revealed border treatment when a node is also important", () => {

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -197,6 +197,38 @@ describe("GraphTransformer", () => {
     expect(node2?.data.labels).toEqual([]);
   });
 
+  it("should derive important node data from labels case-insensitively", () => {
+    const entities: Entity[] = [
+      {
+        id: "n1",
+        type: "npc",
+        title: "Node 1",
+        labels: ["faction-a", "Important"],
+        connections: [],
+        content: "",
+      },
+      {
+        id: "n2",
+        type: "npc",
+        title: "Node 2",
+        labels: ["ordinary"],
+        connections: [],
+        content: "",
+      },
+    ];
+
+    const elements = GraphTransformer.entitiesToElements(entities);
+    const importantNode = elements.find(
+      (e): e is GraphNode => e.group === "nodes" && e.data.id === "n1",
+    );
+    const ordinaryNode = elements.find(
+      (e): e is GraphNode => e.group === "nodes" && e.data.id === "n2",
+    );
+
+    expect(importantNode?.data.isImportant).toBe(true);
+    expect(ordinaryNode?.data.isImportant).toBeUndefined();
+  });
+
   it("should mark nodes as revealed if tags or labels contain 'revealed' or 'visible'", () => {
     const entities: any[] = [
       {
@@ -422,6 +454,72 @@ describe("GraphTransformer", () => {
     // Revealed should be +10
     const revealedStyle = style.find((s) => s.selector === "node[isRevealed]");
     expect(revealedStyle.style["border-width"]).toBe(11);
+  });
+
+  it("should include a non-text visual style for important nodes", () => {
+    const mockTemplate = {
+      tokens: {
+        primary: "#000",
+        accent: "#f59e0b",
+        background: "#fff",
+        text: "#333",
+        surface: "#eee",
+        fontHeader: "Arial",
+        fontBody: "Arial",
+      },
+      graph: {
+        nodeShape: "ellipse",
+        nodeBorderWidth: 1,
+        edgeWidth: 1,
+        edgeColor: "#ccc",
+        edgeStyle: "solid",
+      },
+    } as any;
+
+    const style = getGraphStyle(mockTemplate, [], false);
+    const importantStyle = style.find(
+      (s) => s.selector === "node[isImportant]",
+    );
+
+    expect(importantStyle).toBeDefined();
+    expect(importantStyle.style.label).toBeUndefined();
+    expect(importantStyle.style["border-style"]).toBe("double");
+    expect(importantStyle.style["underlay-opacity"]).toBeGreaterThan(0);
+    expect(importantStyle.style.width).toBeUndefined();
+    expect(importantStyle.style.height).toBeUndefined();
+  });
+
+  it("should preserve revealed border treatment when a node is also important", () => {
+    const mockTemplate = {
+      tokens: {
+        primary: "#000",
+        accent: "#f59e0b",
+        background: "#fff",
+        text: "#333",
+        surface: "#eee",
+        fontHeader: "Arial",
+        fontBody: "Arial",
+      },
+      graph: {
+        nodeShape: "ellipse",
+        nodeBorderWidth: 1,
+        edgeWidth: 1,
+        edgeColor: "#ccc",
+        edgeStyle: "solid",
+      },
+    } as any;
+
+    const style = getGraphStyle(mockTemplate, [], false);
+    const importantStyleIndex = style.findIndex(
+      (s) => s.selector === "node[isImportant]",
+    );
+    const revealedStyleIndex = style.findIndex(
+      (s) => s.selector === "node[isRevealed]",
+    );
+
+    expect(importantStyleIndex).toBeGreaterThan(-1);
+    expect(revealedStyleIndex).toBeGreaterThan(importantStyleIndex);
+    expect(style[revealedStyleIndex].style["border-width"]).toBe(11);
   });
 
   it("should keep fantasy shield borders controlled for image and revealed nodes", () => {

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -490,6 +490,10 @@ describe("GraphTransformer", () => {
     expect(importantStyle.style["font-weight"]).toBe("bold");
     expect(importantStyle.style["font-size"]).toBe(11);
     expect(importantStyle.style["shadow-blur"]).toBe(12);
+    expect(importantStyle.style["border-color"]).toBe("#e11d48");
+    expect(importantStyle.style["underlay-color"]).toBe("#e11d48");
+    expect(importantStyle.style["text-border-color"]).toBe("#e11d48");
+    expect(importantStyle.style["shadow-color"]).toBe("#e11d48");
 
     const importantSmallStyle = style.find(
       (s) => s.selector === "node[isImportant][weight <= 2]",

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -556,12 +556,12 @@ export const getGraphStyle = (
       style: {
         "border-color": "#8b5cf6",
         "border-width": isFantasy
-          ? graph.nodeBorderWidth + 4
-          : graph.nodeBorderWidth + 10,
+          ? graph.nodeBorderWidth + 5
+          : graph.nodeBorderWidth + 14,
         "border-style": "double",
         "underlay-color": "#8b5cf6",
         "underlay-opacity": 0.35,
-        "underlay-padding": isFantasy ? 16 : 20,
+        "underlay-padding": isFantasy ? 24 : 30,
         "underlay-shape": isFantasy ? "polygon" : graph.nodeShape,
         "font-weight": "bold",
         "font-size": 12,
@@ -569,31 +569,10 @@ export const getGraphStyle = (
         "text-border-width": 1.5,
         "text-border-opacity": 0.5,
         "shadow-color": "#8b5cf6",
-        "shadow-blur": 18,
+        "shadow-blur": 24,
         "shadow-opacity": 0.45,
         "shadow-offset-x": 0,
         "shadow-offset-y": 0,
-      },
-    },
-    {
-      selector: "node[isImportant][weight <= 2]",
-      style: {
-        width: 60,
-        height: 60,
-      },
-    },
-    {
-      selector: "node[isImportant][weight >= 3][weight <= 11]",
-      style: {
-        width: 90,
-        height: 90,
-      },
-    },
-    {
-      selector: "node[isImportant][weight >= 12]",
-      style: {
-        width: 144,
-        height: 144,
       },
     },
   ];

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -17,6 +17,7 @@ export interface GraphNode {
     image?: string;
     thumbnail?: string;
     labels?: string[];
+    isImportant?: boolean;
     date?: TemporalMetadata;
     start_date?: TemporalMetadata;
     end_date?: TemporalMetadata;
@@ -65,6 +66,16 @@ const formatDate = (date?: TemporalMetadata) => {
 const EMPTY_LABELS: string[] = [];
 
 const getTextureVariant = () => Math.floor(Math.random() * 4);
+
+const hasImportantLabel = (labels?: string[]) => {
+  if (!labels) return false;
+
+  for (let i = 0; i < labels.length; i++) {
+    if (labels[i].toLowerCase() === "important") return true;
+  }
+
+  return false;
+};
 
 export class GraphTransformer {
   static entitiesToElements(
@@ -156,6 +167,7 @@ export class GraphTransformer {
         labels: entity.labels ?? EMPTY_LABELS,
         textureVariant: getTextureVariant(),
       };
+      if (hasImportantLabel(entity.labels)) nodeData.isImportant = true;
       if (entity.image) nodeData.image = entity.image;
       if (entity.thumbnail) nodeData.thumbnail = entity.thumbnail;
       if (isRevealed) (nodeData as any).isRevealed = true;
@@ -538,6 +550,23 @@ export const getGraphStyle = (
     },
   }));
 
+  const importantStyles: any[] = [
+    {
+      selector: "node[isImportant]",
+      style: {
+        "border-color": tokens.accent || "#f59e0b",
+        "border-width": isFantasy
+          ? graph.nodeBorderWidth + 3
+          : graph.nodeBorderWidth + 8,
+        "border-style": "double",
+        "underlay-color": tokens.accent || "#f59e0b",
+        "underlay-opacity": 0.28,
+        "underlay-padding": 10,
+        "underlay-shape": isFantasy ? "polygon" : graph.nodeShape,
+      },
+    },
+  ];
+
   // Revealed styles come after category borders
   const revealedStyles: any[] = [
     // Reset opacity for image nodes — categoryStyles sets 0.4 which would bleed through portraits
@@ -638,6 +667,7 @@ export const getGraphStyle = (
   return [
     ...baseStyle,
     ...categoryStyles,
+    ...importantStyles,
     ...revealedStyles,
     ...selectionStyles,
   ];

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -560,9 +560,40 @@ export const getGraphStyle = (
           : graph.nodeBorderWidth + 8,
         "border-style": "double",
         "underlay-color": tokens.accent || "#f59e0b",
-        "underlay-opacity": 0.28,
-        "underlay-padding": 10,
+        "underlay-opacity": 0.35,
+        "underlay-padding": isFantasy ? 12 : 14,
         "underlay-shape": isFantasy ? "polygon" : graph.nodeShape,
+        "font-weight": "bold",
+        "font-size": 11,
+        "text-border-color": tokens.accent || "#f59e0b",
+        "text-border-width": 1,
+        "text-border-opacity": 0.5,
+        "shadow-color": tokens.accent || "#f59e0b",
+        "shadow-blur": 12,
+        "shadow-opacity": 0.45,
+        "shadow-offset-x": 0,
+        "shadow-offset-y": 0,
+      },
+    },
+    {
+      selector: "node[isImportant][weight <= 2]",
+      style: {
+        width: 48,
+        height: 48,
+      },
+    },
+    {
+      selector: "node[isImportant][weight >= 3][weight <= 11]",
+      style: {
+        width: 72,
+        height: 72,
+      },
+    },
+    {
+      selector: "node[isImportant][weight >= 12]",
+      style: {
+        width: 108,
+        height: 108,
       },
     },
   ];

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -554,22 +554,22 @@ export const getGraphStyle = (
     {
       selector: "node[isImportant]",
       style: {
-        "border-color": "#e11d48",
+        "border-color": "#8b5cf6",
         "border-width": isFantasy
-          ? graph.nodeBorderWidth + 3
-          : graph.nodeBorderWidth + 8,
+          ? graph.nodeBorderWidth + 4
+          : graph.nodeBorderWidth + 10,
         "border-style": "double",
-        "underlay-color": "#e11d48",
+        "underlay-color": "#8b5cf6",
         "underlay-opacity": 0.35,
-        "underlay-padding": isFantasy ? 12 : 14,
+        "underlay-padding": isFantasy ? 16 : 20,
         "underlay-shape": isFantasy ? "polygon" : graph.nodeShape,
         "font-weight": "bold",
-        "font-size": 11,
-        "text-border-color": "#e11d48",
-        "text-border-width": 1,
+        "font-size": 12,
+        "text-border-color": "#8b5cf6",
+        "text-border-width": 1.5,
         "text-border-opacity": 0.5,
-        "shadow-color": "#e11d48",
-        "shadow-blur": 12,
+        "shadow-color": "#8b5cf6",
+        "shadow-blur": 18,
         "shadow-opacity": 0.45,
         "shadow-offset-x": 0,
         "shadow-offset-y": 0,
@@ -578,22 +578,22 @@ export const getGraphStyle = (
     {
       selector: "node[isImportant][weight <= 2]",
       style: {
-        width: 48,
-        height: 48,
+        width: 60,
+        height: 60,
       },
     },
     {
       selector: "node[isImportant][weight >= 3][weight <= 11]",
       style: {
-        width: 72,
-        height: 72,
+        width: 90,
+        height: 90,
       },
     },
     {
       selector: "node[isImportant][weight >= 12]",
       style: {
-        width: 108,
-        height: 108,
+        width: 144,
+        height: 144,
       },
     },
   ];

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -554,21 +554,21 @@ export const getGraphStyle = (
     {
       selector: "node[isImportant]",
       style: {
-        "border-color": tokens.accent || "#f59e0b",
+        "border-color": "#e11d48",
         "border-width": isFantasy
           ? graph.nodeBorderWidth + 3
           : graph.nodeBorderWidth + 8,
         "border-style": "double",
-        "underlay-color": tokens.accent || "#f59e0b",
+        "underlay-color": "#e11d48",
         "underlay-opacity": 0.35,
         "underlay-padding": isFantasy ? 12 : 14,
         "underlay-shape": isFantasy ? "polygon" : graph.nodeShape,
         "font-weight": "bold",
         "font-size": 11,
-        "text-border-color": tokens.accent || "#f59e0b",
+        "text-border-color": "#e11d48",
         "text-border-width": 1,
         "text-border-opacity": 0.5,
-        "shadow-color": tokens.accent || "#f59e0b",
+        "shadow-color": "#e11d48",
         "shadow-blur": 12,
         "shadow-opacity": 0.45,
         "shadow-offset-x": 0,

--- a/specs/118-graph-important-label/checklists/requirements.md
+++ b/specs/118-graph-important-label/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Graph Important Label
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed. The feature is ready for implementation planning or direct scoped implementation.

--- a/specs/118-graph-important-label/contracts/graph-important-label.md
+++ b/specs/118-graph-important-label/contracts/graph-important-label.md
@@ -1,0 +1,50 @@
+# Contract: Graph Important Label
+
+## Context Menu Contract
+
+When the graph context menu is opened on an editable entity node:
+
+- It exposes a `Mark Important` action.
+- The action targets the clicked node unless the clicked node is part of the current selected node set.
+- The action applies the normalized label value `important` through the existing vault label mutation path.
+- The action closes the context menu and any open graph submenu before reporting success, no-change, or failure.
+- The action is not available in guest/read-only sessions.
+
+### Feedback Outcomes
+
+| Condition | Expected feedback |
+| --- | --- |
+| One entity changed | Marked as "important". |
+| Multiple entities changed | Marked N nodes as "important". |
+| One target already important | Already marked as "important". |
+| All selected targets already important | Selected nodes are already marked as "important". |
+| Mutation failure | Failed to mark important: [reason] |
+
+## Graph Engine Contract
+
+When converting entities to graph elements:
+
+- Entity labels are copied to node data.
+- A node data flag such as `isImportant` is derived when labels include `important` case-insensitively.
+- The derived flag is not persisted back to the entity.
+- Non-important entities do not receive the derived important flag.
+
+When generating graph styles:
+
+- Important nodes receive a visual treatment distinct from otherwise similar non-important nodes.
+- The important treatment does not depend on graph label text being visible.
+- The important treatment does not use connection-count size as the only signal.
+- Selection styling remains legible when an important node is selected.
+- Existing category, image, draft, revealed, and focus-mode styles remain compatible.
+
+## Test Contract
+
+Required focused tests:
+
+- Context-menu controller applies `important` to selected node ids through `bulkAddLabel`.
+- Context-menu controller reports no-change feedback when no targets are modified.
+- Context-menu controller does nothing for an empty selection.
+- Context-menu controller reports failure feedback when label mutation rejects.
+- Graph transformer marks important node data from labels.
+- Graph transformer leaves non-important node data unmarked.
+- Graph style output contains an important-node style that changes a non-text visual property.

--- a/specs/118-graph-important-label/data-model.md
+++ b/specs/118-graph-important-label/data-model.md
@@ -1,0 +1,77 @@
+# Data Model: Graph Important Label
+
+## Entity
+
+Represents a lore record rendered as a graph node.
+
+**Relevant fields**:
+
+- `id`: stable entity identifier.
+- `title`: graph node label.
+- `type`: category used for graph styling.
+- `labels`: normalized metadata labels. This feature uses `important`.
+- `connections`: relationship data used for graph edges and existing weight-based sizing.
+
+**Validation rules**:
+
+- `labels` must not contain duplicate values after normalization.
+- Applying importance must add exactly one `important` label when absent.
+- Applying importance to an entity that already has `important` is a no-op.
+- Guest/read-only sessions must not mutate entity labels.
+
+## Graph Selection
+
+Represents the graph entities targeted by a context-menu action.
+
+**Relevant fields**:
+
+- `targetId`: entity id of the node that opened the context menu.
+- `selectedNodes`: entity ids affected by the action.
+
+**Selection rules**:
+
+- If the right-clicked node is already selected, the action targets the selected node set.
+- If the right-clicked node is not selected, the action targets only that node.
+- Empty selections produce no mutation.
+
+## Graph Node Data
+
+Represents the library-level graph data consumed by Cytoscape.
+
+**Relevant fields**:
+
+- `id`: entity id.
+- `label`: display title.
+- `type`: category.
+- `weight`: connection-derived size signal.
+- `labels`: labels copied from the source entity.
+- `isImportant`: derived visual-state flag for entities whose labels include `important`.
+
+**Validation rules**:
+
+- `isImportant` is derived from `labels` and is not separately persisted.
+- `isImportant` must be true when labels contain `important` case-insensitively.
+- Non-important entities must not receive the important visual flag.
+- Important visual styling must not rely on node `weight` or visible label text.
+
+## State Transitions
+
+```text
+No important label
+  -> user chooses Mark Important
+  -> important label added
+  -> graph node data derives isImportant
+  -> graph node renders with distinct important treatment
+
+Already important
+  -> user chooses Mark Important
+  -> labels unchanged
+  -> graph node remains visually distinct
+  -> user receives no-change feedback
+
+Mutation failure
+  -> user chooses Mark Important
+  -> label save fails
+  -> labels unchanged
+  -> user receives error feedback
+```

--- a/specs/118-graph-important-label/plan.md
+++ b/specs/118-graph-important-label/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Graph Important Label
+
+**Branch**: `118-graph-important-label` | **Date**: 2026-05-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/118-graph-important-label/spec.md`
+
+## Summary
+
+Add a graph context-menu action that applies the existing `important` label to the clicked or selected entities, then make entities carrying that label visually distinct in the graph independently of visible label text or connection count. The web app owns the right-click menu and user feedback, while `packages/graph-engine` owns graph node data flags and Cytoscape styling so graph rendering remains library-first.
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.0.3, Svelte 5 runes, Bun 1.3.14 workspace
+**Primary Dependencies**: Svelte 5, Cytoscape, `graph-engine`, `schema`, existing vault/entity stores, existing Tailwind 4 theme tokens
+**Storage**: Existing local vault entity `labels` array persisted through IndexedDB-backed vault stores; no new storage shape
+**Testing**: Vitest unit tests for `graph-engine` transformation/style contracts and Svelte controller tests for context-menu behavior; use Playwright only if visual regression cannot be verified by unit/style assertions
+**Target Platform**: Browser PWA on desktop, tablet, and phone-sized mobile viewports
+**Project Type**: Bun workspace with reusable graph library plus Svelte web app integration
+**Performance Goals**: Marking selected entities should complete through the existing bulk label path without per-entity UI loops; graph style evaluation adds no layout pass beyond the existing Cytoscape style refresh
+**Constraints**: Local-first privacy, no server processing, no duplicate labels, guest/read-only sessions cannot mutate labels, visual distinction must not depend on label text visibility
+**Scale/Scope**: One context-menu action and one graph-level important-node visual treatment for all vault entities labeled `important`
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+- **Library-First**: PASS. Label application stays in the web controller/store path; graph node data and visual styling belong in `packages/graph-engine`.
+- **TDD**: PASS. Plan requires controller tests for success/no-op/failure and graph-engine tests for important-node data and style before or alongside implementation.
+- **Simplicity & YAGNI**: PASS. Reuse the existing `important` label, `bulkAddLabel`, Cytoscape stylesheet, and graph transformer; no new label type or settings screen.
+- **AI-First Extraction**: PASS. Oracle extraction is not changed.
+- **Privacy & Client-Side Processing**: PASS. Entity labels remain local vault data.
+- **Clean Implementation**: PASS. Scope follows existing Svelte 5 runes and graph-engine patterns; validation remains required.
+- **User Documentation**: PASS. Feature is small and discoverable from the graph context menu; quickstart documents the user-facing behavior. No changelog entry unless this ships as a user-facing release highlight.
+- **Dependency Injection**: PASS. Context-menu behavior uses existing constructor-injected controller dependencies; no new service is introduced.
+- **Natural Language**: PASS. UI feedback uses plain language: "Marked as important", "Already marked as important", and failure feedback.
+- **Quality & Coverage**: PASS. Adds focused tests in affected web controller and graph-engine surfaces.
+- **Agent Operational Protocol**: PASS. Scope is limited to importance labeling and visual distinction.
+- **Terminology Unification**: PASS. Uses "Labels" only; no new "tags" terminology.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/118-graph-important-label/
+|-- plan.md
+|-- research.md
+|-- data-model.md
+|-- quickstart.md
+|-- contracts/
+|   `-- graph-important-label.md
+|-- checklists/
+|   `-- requirements.md
+`-- tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/graph-engine/
+|-- src/
+|   |-- transformer.ts
+|   `-- transformer.test.ts
+
+apps/web/src/lib/components/graph/
+|-- ContextMenu.svelte
+|-- graph-context-menu-controller.svelte.ts
+`-- graph-context-menu-controller.test.ts
+```
+
+**Structure Decision**: Keep graph semantics and styling in `packages/graph-engine`; keep Svelte interaction and notifications in `apps/web`. The existing vault store remains the persistence boundary for labels.
+
+## Complexity Tracking
+
+No constitution violations require justification.
+
+## Phase 0 Research
+
+See [research.md](./research.md). All planning unknowns are resolved without introducing new dependencies.
+
+## Phase 1 Design
+
+See [data-model.md](./data-model.md), [contracts/graph-important-label.md](./contracts/graph-important-label.md), and [quickstart.md](./quickstart.md).
+
+## Post-Design Constitution Check
+
+- **Library-First**: PASS. The design places `isImportant` derivation and Cytoscape style rules in `graph-engine`, with the web app only invoking existing label mutations.
+- **TDD / Quality**: PASS. Contracts identify focused assertions for graph transformer/style output and context-menu mutation/feedback behavior.
+- **Privacy & Client-Side Processing**: PASS. No remote calls or new persistence surfaces are introduced.
+- **Dependency Injection**: PASS. Existing controller dependencies are sufficient.
+- **User Documentation / Natural Language**: PASS. Quickstart and UI copy remain plain and label-focused.

--- a/specs/118-graph-important-label/quickstart.md
+++ b/specs/118-graph-important-label/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Graph Important Label
+
+## User Flow
+
+1. Open the graph.
+2. Right-click an editable entity node.
+3. Choose `Mark Important`.
+4. Confirm the entity now has the `important` label.
+5. Confirm the entity visually stands out in the graph even when graph label text is hidden.
+
+## Multi-Select Flow
+
+1. Select two or more graph nodes.
+2. Right-click one of the selected nodes.
+3. Choose `Mark Important`.
+4. Confirm every selected entity gains the `important` label unless it already had it.
+5. Confirm all important nodes use the same distinct graph treatment.
+
+## Read-Only Flow
+
+1. Open a guest or read-only graph session.
+2. Right-click an entity node.
+3. Confirm `Mark Important` is not available.
+
+## Developer Verification
+
+Run focused tests for the affected surfaces:
+
+```sh
+bun run --filter graph-engine test -- src/transformer.test.ts
+bun run --filter web test -- src/lib/components/graph/graph-context-menu-controller.test.ts
+```
+
+Then run repository validation before merge:
+
+```sh
+bun run lint
+bun run test
+```
+
+If Bun fails in the current shell with `CouldntReadCurrentDirectory`, rerun from a working host shell or CI environment and record the local blocker in the PR.

--- a/specs/118-graph-important-label/research.md
+++ b/specs/118-graph-important-label/research.md
@@ -1,0 +1,37 @@
+# Research: Graph Important Label
+
+## Decision: Use the existing `important` entity label as the source of truth
+
+**Rationale**: The issue asks for a quick way to apply `#important` in addition to existing label workflows. The vault already normalizes labels and prevents duplicates through `addLabel`/`bulkAddLabel`, so reusing that path keeps behavior consistent across graph, entity detail, explorer filters, imports, and search.
+
+**Alternatives considered**:
+
+- Add a dedicated importance field: rejected because it would create a second categorization concept and duplicate existing label behavior.
+- Add a graph-only visual marker: rejected because it would not persist with entity metadata or work outside the graph.
+
+## Decision: Apply importance through the graph context-menu controller
+
+**Rationale**: The graph context menu already resolves the clicked node vs selected nodes and uses constructor-injected stores for mutations, modals, and notifications. Adding one controller action keeps UI state and mutation feedback testable without moving logic into the Svelte template.
+
+**Alternatives considered**:
+
+- Open the bulk label dialog prefilled with `important`: rejected because the issue asks for an easy direct action and this adds an unnecessary confirmation step.
+- Add the action only to the existing label dialog: rejected because it does not improve graph right-click workflow speed.
+
+## Decision: Derive graph visual distinction in `graph-engine`
+
+**Rationale**: The graph engine already transforms entity labels into Cytoscape node data and owns node styles such as category, draft, selection, and revealed states. Deriving an `important` visual state there keeps the web layer thin and makes the visual contract unit-testable without a browser.
+
+**Alternatives considered**:
+
+- Style important nodes in `GraphView.svelte`: rejected because it would split graph styling between app and package.
+- Depend only on the rendered label chip/text: rejected because the spec requires important entities to remain distinct even when label text is hidden.
+
+## Decision: Use a non-size-only visual treatment
+
+**Rationale**: The issue explicitly says importance should be visible by something other than number of connections. Existing node size is tied to connection weight, so importance should use a separate border, underlay, glow, or comparable treatment that does not change graph semantics.
+
+**Alternatives considered**:
+
+- Increase node size for important entities: rejected because size already communicates graph connectivity and would confuse the two signals.
+- Add only a tooltip or context-menu state: rejected because important entities need to be visibly distinct while scanning the graph.

--- a/specs/118-graph-important-label/spec.md
+++ b/specs/118-graph-important-label/spec.md
@@ -9,16 +9,16 @@
 
 ### User Story 1 - Mark a Graph Entity Important (Priority: P1)
 
-As a user reviewing the graph, I want to mark one entity as important directly from its graph context menu, so I can flag key lore without leaving the graph.
+As a user reviewing the graph, I want to mark one entity as important directly from its graph context menu, so I can make key lore visually stand out without leaving the graph.
 
 **Why this priority**: This is the smallest useful workflow and directly addresses the need to apply importance from the graph.
 
-**Independent Test**: Open the graph context menu for one editable entity, choose the importance action, and verify the entity gains the `important` label.
+**Independent Test**: Open the graph context menu for one editable entity, choose the importance action, and verify the entity gains the `important` label and becomes visually distinct in the graph.
 
 **Acceptance Scenarios**:
 
-1. **Given** an editable graph entity without the `important` label, **When** the user opens its context menu and chooses the importance action, **Then** the entity is labeled `important`.
-2. **Given** an editable graph entity already labeled `important`, **When** the user chooses the importance action again, **Then** the entity remains labeled once and the user receives clear feedback that no duplicate label was added.
+1. **Given** an editable graph entity without the `important` label, **When** the user opens its context menu and chooses the importance action, **Then** the entity is labeled `important` and its graph node becomes visually distinct from non-important nodes.
+2. **Given** an editable graph entity already labeled `important`, **When** the user chooses the importance action again, **Then** the entity remains labeled once, remains visually distinct, and the user receives clear feedback that no duplicate label was added.
 
 ---
 
@@ -28,11 +28,11 @@ As a user working with several selected graph entities, I want to mark all selec
 
 **Why this priority**: Multi-select graph actions already exist, and importance should work with the same selection model to avoid repetitive work.
 
-**Independent Test**: Select multiple editable graph entities, open the graph context menu, choose the importance action, and verify each selected entity gains the `important` label.
+**Independent Test**: Select multiple editable graph entities, open the graph context menu, choose the importance action, and verify each selected entity gains the `important` label and a distinct graph treatment.
 
 **Acceptance Scenarios**:
 
-1. **Given** multiple editable graph entities are selected and at least one is not labeled `important`, **When** the user chooses the importance action, **Then** all selected entities are labeled `important` and the user sees how many entities changed.
+1. **Given** multiple editable graph entities are selected and at least one is not labeled `important`, **When** the user chooses the importance action, **Then** all selected entities are labeled `important`, visually stand out in the graph, and the user sees how many entities changed.
 2. **Given** multiple selected entities are already labeled `important`, **When** the user chooses the importance action, **Then** no labels are duplicated and the user receives clear no-change feedback.
 
 ---
@@ -53,6 +53,7 @@ As a guest or read-only user, I should not see or use graph actions that change 
 
 - If no graph nodes are selected when the action runs, no label changes are made.
 - If some selected entities already have the `important` label, only entities missing the label are changed.
+- If labels are hidden or filtered, important entities must still have a graph-level visual treatment that does not depend only on label text being visible.
 - If label persistence fails, the user receives an error and the context menu closes without implying success.
 - The applied label is normalized consistently with existing label behavior.
 
@@ -64,10 +65,12 @@ As a guest or read-only user, I should not see or use graph actions that change 
 - **FR-002**: The importance action MUST apply the `important` label through the same label model used by existing entity labels.
 - **FR-003**: The importance action MUST support the current graph selection: one entity when only the clicked entity is targeted, or all selected entities when the clicked entity is part of a multi-selection.
 - **FR-004**: The system MUST prevent duplicate `important` labels on the same entity.
-- **FR-005**: The system MUST show clear success feedback when one or more entities are newly marked important.
-- **FR-006**: The system MUST show clear no-change feedback when all targeted entities are already marked important.
-- **FR-007**: The importance action MUST be unavailable in guest or read-only graph sessions.
-- **FR-008**: The system MUST show clear error feedback if applying the label fails.
+- **FR-005**: Entities with the `important` label MUST be visually distinct in the graph from otherwise similar non-important entities.
+- **FR-006**: The visual distinction MUST remain available even when graph label text is hidden.
+- **FR-007**: The system MUST show clear success feedback when one or more entities are newly marked important.
+- **FR-008**: The system MUST show clear no-change feedback when all targeted entities are already marked important.
+- **FR-009**: The importance action MUST be unavailable in guest or read-only graph sessions.
+- **FR-010**: The system MUST show clear error feedback if applying the label fails.
 
 ### Key Entities _(include if feature involves data)_
 
@@ -82,5 +85,6 @@ As a guest or read-only user, I should not see or use graph actions that change 
 - **SC-001**: A user can mark a single editable graph entity as important in one context-menu action.
 - **SC-002**: A user can mark multiple selected graph entities as important in one context-menu action.
 - **SC-003**: Repeating the action on entities already marked important does not create duplicate labels.
-- **SC-004**: Guest or read-only sessions provide no path from the graph context menu to modify importance labels.
-- **SC-005**: Users receive visible feedback for success, no-change, and failure outcomes.
+- **SC-004**: Important entities are visually distinguishable from non-important entities in the graph without relying solely on connection count or visible label text.
+- **SC-005**: Guest or read-only sessions provide no path from the graph context menu to modify importance labels.
+- **SC-006**: Users receive visible feedback for success, no-change, and failure outcomes.

--- a/specs/118-graph-important-label/spec.md
+++ b/specs/118-graph-important-label/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: Graph Important Label
 
-**Feature Branch**: `886-graph-important-label`
+**Feature Branch**: `118-graph-important-label`
 **Created**: 2026-05-25
 **Status**: Draft
 **Input**: User description: "Graph context menu to indicate importance. If some entities in the graph are more important than others, there should be a way to visually indicate that other than the number of connections. Provide an #important label that can be easily applied via the right-click context menu, in addition to existing label workflows."

--- a/specs/118-graph-important-label/spec.md
+++ b/specs/118-graph-important-label/spec.md
@@ -1,0 +1,86 @@
+# Feature Specification: Graph Important Label
+
+**Feature Branch**: `886-graph-important-label`
+**Created**: 2026-05-25
+**Status**: Draft
+**Input**: User description: "Graph context menu to indicate importance. If some entities in the graph are more important than others, there should be a way to visually indicate that other than the number of connections. Provide an #important label that can be easily applied via the right-click context menu, in addition to existing label workflows."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Mark a Graph Entity Important (Priority: P1)
+
+As a user reviewing the graph, I want to mark one entity as important directly from its graph context menu, so I can flag key lore without leaving the graph.
+
+**Why this priority**: This is the smallest useful workflow and directly addresses the need to apply importance from the graph.
+
+**Independent Test**: Open the graph context menu for one editable entity, choose the importance action, and verify the entity gains the `important` label.
+
+**Acceptance Scenarios**:
+
+1. **Given** an editable graph entity without the `important` label, **When** the user opens its context menu and chooses the importance action, **Then** the entity is labeled `important`.
+2. **Given** an editable graph entity already labeled `important`, **When** the user chooses the importance action again, **Then** the entity remains labeled once and the user receives clear feedback that no duplicate label was added.
+
+---
+
+### User Story 2 - Mark Selected Graph Entities Important (Priority: P2)
+
+As a user working with several selected graph entities, I want to mark all selected entities as important from the context menu, so I can quickly flag a group of central entities.
+
+**Why this priority**: Multi-select graph actions already exist, and importance should work with the same selection model to avoid repetitive work.
+
+**Independent Test**: Select multiple editable graph entities, open the graph context menu, choose the importance action, and verify each selected entity gains the `important` label.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple editable graph entities are selected and at least one is not labeled `important`, **When** the user chooses the importance action, **Then** all selected entities are labeled `important` and the user sees how many entities changed.
+2. **Given** multiple selected entities are already labeled `important`, **When** the user chooses the importance action, **Then** no labels are duplicated and the user receives clear no-change feedback.
+
+---
+
+### User Story 3 - Respect Read-Only Graph Sessions (Priority: P3)
+
+As a guest or read-only user, I should not see or use graph actions that change labels, so shared vaults stay unchanged.
+
+**Why this priority**: The app already separates editable and guest graph actions; importance labeling must preserve that data safety boundary.
+
+**Independent Test**: Open the graph context menu in a read-only or guest session and verify the importance action is unavailable.
+
+**Acceptance Scenarios**:
+
+1. **Given** the graph is in a guest or read-only session, **When** the user opens an entity context menu, **Then** the importance action is not available.
+
+### Edge Cases
+
+- If no graph nodes are selected when the action runs, no label changes are made.
+- If some selected entities already have the `important` label, only entities missing the label are changed.
+- If label persistence fails, the user receives an error and the context menu closes without implying success.
+- The applied label is normalized consistently with existing label behavior.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The graph entity context menu MUST provide a clear action for marking editable entities as important.
+- **FR-002**: The importance action MUST apply the `important` label through the same label model used by existing entity labels.
+- **FR-003**: The importance action MUST support the current graph selection: one entity when only the clicked entity is targeted, or all selected entities when the clicked entity is part of a multi-selection.
+- **FR-004**: The system MUST prevent duplicate `important` labels on the same entity.
+- **FR-005**: The system MUST show clear success feedback when one or more entities are newly marked important.
+- **FR-006**: The system MUST show clear no-change feedback when all targeted entities are already marked important.
+- **FR-007**: The importance action MUST be unavailable in guest or read-only graph sessions.
+- **FR-008**: The system MUST show clear error feedback if applying the label fails.
+
+### Key Entities _(include if feature involves data)_
+
+- **Entity**: A graph node's underlying lore record. It can have zero or more labels.
+- **Label**: A normalized text marker attached to an entity. This feature uses the existing `important` label value.
+- **Graph Selection**: The set of graph entities targeted by context-menu actions.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A user can mark a single editable graph entity as important in one context-menu action.
+- **SC-002**: A user can mark multiple selected graph entities as important in one context-menu action.
+- **SC-003**: Repeating the action on entities already marked important does not create duplicate labels.
+- **SC-004**: Guest or read-only sessions provide no path from the graph context menu to modify importance labels.
+- **SC-005**: Users receive visible feedback for success, no-change, and failure outcomes.

--- a/specs/118-graph-important-label/tasks.md
+++ b/specs/118-graph-important-label/tasks.md
@@ -16,9 +16,9 @@
 
 **Purpose**: Confirm feature context and avoid drifting from the Speckit artifacts.
 
-- [ ] T001 Review feature contracts in specs/118-graph-important-label/contracts/graph-important-label.md
-- [ ] T002 Review graph styling ownership in packages/graph-engine/src/transformer.ts
-- [ ] T003 Review existing graph context-menu behavior in apps/web/src/lib/components/graph/ContextMenu.svelte and apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [X] T001 Review feature contracts in specs/118-graph-important-label/contracts/graph-important-label.md
+- [X] T002 Review graph styling ownership in packages/graph-engine/src/transformer.ts
+- [X] T003 Review existing graph context-menu behavior in apps/web/src/lib/components/graph/ContextMenu.svelte and apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
 
 ---
 
@@ -28,10 +28,10 @@
 
 **CRITICAL**: No user story should be considered complete until important-node graph data and visual styling are testable.
 
-- [ ] T004 [P] Add failing transformer test for deriving an important-node data flag from `labels: ["important"]` in packages/graph-engine/src/transformer.test.ts
-- [ ] T005 [P] Add failing graph style test proving important nodes get a non-text visual treatment in packages/graph-engine/src/transformer.test.ts
-- [ ] T006 Add derived important-node data flag in packages/graph-engine/src/transformer.ts
-- [ ] T007 Add important-node Cytoscape style that is visually distinct without using connection-count size as the only signal in packages/graph-engine/src/transformer.ts
+- [X] T004 [P] Add failing transformer test for deriving an important-node data flag from `labels: ["important"]` in packages/graph-engine/src/transformer.test.ts
+- [X] T005 [P] Add failing graph style test proving important nodes get a non-text visual treatment in packages/graph-engine/src/transformer.test.ts
+- [X] T006 Add derived important-node data flag in packages/graph-engine/src/transformer.ts
+- [X] T007 Add important-node Cytoscape style that is visually distinct without using connection-count size as the only signal in packages/graph-engine/src/transformer.ts
 
 **Checkpoint**: Graph engine can identify and style important entities independently of web UI.
 
@@ -45,16 +45,16 @@
 
 ### Tests for User Story 1
 
-- [ ] T008 [P] [US1] Add controller test for marking a single selected node important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
-- [ ] T009 [P] [US1] Add controller test for no-change feedback when a single target is already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
-- [ ] T010 [P] [US1] Add controller failure-path test for rejected label mutation in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [X] T008 [P] [US1] Add controller test for marking a single selected node important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [X] T009 [P] [US1] Add controller test for no-change feedback when a single target is already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [X] T010 [P] [US1] Add controller failure-path test for rejected label mutation in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
 
 ### Implementation for User Story 1
 
-- [ ] T011 [US1] Add `handleMarkImportant` controller action using `vault.bulkAddLabel([id], "important")` in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
-- [ ] T012 [US1] Add `Mark Important` menu item for editable graph sessions in apps/web/src/lib/components/graph/ContextMenu.svelte
-- [ ] T013 [US1] Ensure success, already-important, and failure messages use plain language in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
-- [ ] T014 [US1] Verify single-node important label changes flow through graph elements and style refresh in apps/web/src/lib/components/GraphView.svelte
+- [X] T011 [US1] Add `handleMarkImportant` controller action using `vault.bulkAddLabel([id], "important")` in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [X] T012 [US1] Add `Mark Important` menu item for editable graph sessions in apps/web/src/lib/components/graph/ContextMenu.svelte
+- [X] T013 [US1] Ensure success, already-important, and failure messages use plain language in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [X] T014 [US1] Verify single-node important label changes flow through graph elements and style refresh in apps/web/src/lib/components/GraphView.svelte
 
 **Checkpoint**: User Story 1 is independently functional and testable.
 
@@ -68,14 +68,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T015 [P] [US2] Add controller test for applying `important` to multiple selected node ids in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
-- [ ] T016 [P] [US2] Add controller test for no-change feedback when all selected nodes are already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
-- [ ] T017 [P] [US2] Add controller test for empty selection no-op in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [X] T015 [P] [US2] Add controller test for applying `important` to multiple selected node ids in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [X] T016 [P] [US2] Add controller test for no-change feedback when all selected nodes are already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [X] T017 [P] [US2] Add controller test for empty selection no-op in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
 
 ### Implementation for User Story 2
 
-- [ ] T018 [US2] Ensure context-menu selection resolution preserves selected-node targets for the important action in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
-- [ ] T019 [US2] Ensure multi-select success and no-change copy reports selected-node outcomes in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [X] T018 [US2] Ensure context-menu selection resolution preserves selected-node targets for the important action in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [X] T019 [US2] Ensure multi-select success and no-change copy reports selected-node outcomes in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
 
 **Checkpoint**: User Stories 1 and 2 both work independently.
 
@@ -89,11 +89,11 @@
 
 ### Tests for User Story 3
 
-- [ ] T020 [P] [US3] Add component or controller-adjacent test coverage that the `Mark Important` menu item is not available when `vault.isGuest` is true in apps/web/src/lib/components/graph/ContextMenu.svelte or apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [X] T020 [P] [US3] Add component or controller-adjacent test coverage that the `Mark Important` menu item is not available when `vault.isGuest` is true in apps/web/src/lib/components/graph/ContextMenu.svelte or apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
 
 ### Implementation for User Story 3
 
-- [ ] T021 [US3] Confirm the `Mark Important` menu item is rendered only inside the editable-session branch in apps/web/src/lib/components/graph/ContextMenu.svelte
+- [X] T021 [US3] Confirm the `Mark Important` menu item is rendered only inside the editable-session branch in apps/web/src/lib/components/graph/ContextMenu.svelte
 
 **Checkpoint**: Read-only sessions provide no graph context-menu path to mutate importance labels.
 
@@ -103,9 +103,9 @@
 
 **Purpose**: Final verification, documentation alignment, and PR hygiene.
 
-- [ ] T022 [P] Update specs/118-graph-important-label/quickstart.md if final user-facing behavior differs from the planned flow
-- [ ] T023 [P] Confirm no user-facing changelog entry is needed for implementation-only or planning-only changes in apps/web/src/lib/content/changelog/releases.json
-- [ ] T024 Run focused graph-engine tests for packages/graph-engine/src/transformer.test.ts
+- [X] T022 [P] Update specs/118-graph-important-label/quickstart.md if final user-facing behavior differs from the planned flow
+- [X] T023 [P] Confirm no user-facing changelog entry is needed for implementation-only or planning-only changes in apps/web/src/lib/content/changelog/releases.json
+- [X] T024 Run focused graph-engine tests for packages/graph-engine/src/transformer.test.ts
 - [ ] T025 Run focused web graph context-menu tests for apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
 - [ ] T026 Run repository validation with `bun run lint` and `bun run test`
 - [ ] T027 Update PR #891 summary if implementation scope or validation results change

--- a/specs/118-graph-important-label/tasks.md
+++ b/specs/118-graph-important-label/tasks.md
@@ -1,0 +1,176 @@
+# Tasks: Graph Important Label
+
+**Input**: Design documents from `/specs/118-graph-important-label/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+**Tests**: Required by the project constitution for all behavior changes.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story the task belongs to (US1, US2, US3)
+- All implementation tasks include exact file paths
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm feature context and avoid drifting from the Speckit artifacts.
+
+- [ ] T001 Review feature contracts in specs/118-graph-important-label/contracts/graph-important-label.md
+- [ ] T002 Review graph styling ownership in packages/graph-engine/src/transformer.ts
+- [ ] T003 Review existing graph context-menu behavior in apps/web/src/lib/components/graph/ContextMenu.svelte and apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared graph data/style contract used by all user stories.
+
+**CRITICAL**: No user story should be considered complete until important-node graph data and visual styling are testable.
+
+- [ ] T004 [P] Add failing transformer test for deriving an important-node data flag from `labels: ["important"]` in packages/graph-engine/src/transformer.test.ts
+- [ ] T005 [P] Add failing graph style test proving important nodes get a non-text visual treatment in packages/graph-engine/src/transformer.test.ts
+- [ ] T006 Add derived important-node data flag in packages/graph-engine/src/transformer.ts
+- [ ] T007 Add important-node Cytoscape style that is visually distinct without using connection-count size as the only signal in packages/graph-engine/src/transformer.ts
+
+**Checkpoint**: Graph engine can identify and style important entities independently of web UI.
+
+---
+
+## Phase 3: User Story 1 - Mark a Graph Entity Important (Priority: P1) MVP
+
+**Goal**: A user can right-click one editable graph entity, mark it important, and see it become visually distinct in the graph.
+
+**Independent Test**: Open the graph context menu for one editable entity, choose `Mark Important`, and verify the entity gains the `important` label and important graph treatment.
+
+### Tests for User Story 1
+
+- [ ] T008 [P] [US1] Add controller test for marking a single selected node important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [ ] T009 [P] [US1] Add controller test for no-change feedback when a single target is already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [ ] T010 [P] [US1] Add controller failure-path test for rejected label mutation in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Add `handleMarkImportant` controller action using `vault.bulkAddLabel([id], "important")` in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [ ] T012 [US1] Add `Mark Important` menu item for editable graph sessions in apps/web/src/lib/components/graph/ContextMenu.svelte
+- [ ] T013 [US1] Ensure success, already-important, and failure messages use plain language in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [ ] T014 [US1] Verify single-node important label changes flow through graph elements and style refresh in apps/web/src/lib/components/GraphView.svelte
+
+**Checkpoint**: User Story 1 is independently functional and testable.
+
+---
+
+## Phase 4: User Story 2 - Mark Selected Graph Entities Important (Priority: P2)
+
+**Goal**: A user can mark all selected graph entities important from one context-menu action.
+
+**Independent Test**: Select multiple editable graph entities, right-click one selected entity, choose `Mark Important`, and verify each selected entity gains the `important` label and distinct graph treatment.
+
+### Tests for User Story 2
+
+- [ ] T015 [P] [US2] Add controller test for applying `important` to multiple selected node ids in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [ ] T016 [P] [US2] Add controller test for no-change feedback when all selected nodes are already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [ ] T017 [P] [US2] Add controller test for empty selection no-op in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] Ensure context-menu selection resolution preserves selected-node targets for the important action in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+- [ ] T019 [US2] Ensure multi-select success and no-change copy reports selected-node outcomes in apps/web/src/lib/components/graph/graph-context-menu-controller.svelte.ts
+
+**Checkpoint**: User Stories 1 and 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Respect Read-Only Graph Sessions (Priority: P3)
+
+**Goal**: Guest or read-only graph sessions cannot mutate labels through the important action.
+
+**Independent Test**: Open a graph context menu in a guest/read-only session and verify `Mark Important` is unavailable.
+
+### Tests for User Story 3
+
+- [ ] T020 [P] [US3] Add component or controller-adjacent test coverage that the `Mark Important` menu item is not available when `vault.isGuest` is true in apps/web/src/lib/components/graph/ContextMenu.svelte or apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+
+### Implementation for User Story 3
+
+- [ ] T021 [US3] Confirm the `Mark Important` menu item is rendered only inside the editable-session branch in apps/web/src/lib/components/graph/ContextMenu.svelte
+
+**Checkpoint**: Read-only sessions provide no graph context-menu path to mutate importance labels.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, documentation alignment, and PR hygiene.
+
+- [ ] T022 [P] Update specs/118-graph-important-label/quickstart.md if final user-facing behavior differs from the planned flow
+- [ ] T023 [P] Confirm no user-facing changelog entry is needed for implementation-only or planning-only changes in apps/web/src/lib/content/changelog/releases.json
+- [ ] T024 Run focused graph-engine tests for packages/graph-engine/src/transformer.test.ts
+- [ ] T025 Run focused web graph context-menu tests for apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts
+- [ ] T026 Run repository validation with `bun run lint` and `bun run test`
+- [ ] T027 Update PR #891 summary if implementation scope or validation results change
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup; blocks completion of all user stories because visual distinction is shared
+- **User Story 1 (Phase 3)**: Depends on Foundational
+- **User Story 2 (Phase 4)**: Depends on Foundational and can reuse the US1 controller action
+- **User Story 3 (Phase 5)**: Depends on the context-menu implementation path
+- **Polish (Phase 6)**: Depends on desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: MVP; no dependency on US2 or US3 after Foundational
+- **US2 (P2)**: Extends the same action to selected-node sets; can be implemented after or alongside US1 controller work
+- **US3 (P3)**: Verifies rendering guard for guest/read-only sessions; can be checked once the menu item exists
+
+### Parallel Opportunities
+
+- T004 and T005 can be written in parallel because they cover different graph-engine assertions.
+- T008, T009, and T010 can be written in parallel because they cover separate controller outcomes.
+- T015, T016, and T017 can be written in parallel because they cover separate multi-select outcomes.
+- T022 and T023 can be completed in parallel with final test runs.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "Add controller test for marking a single selected node important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts"
+Task: "Add controller test for no-change feedback when a single target is already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts"
+Task: "Add controller failure-path test for rejected label mutation in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "Add controller test for applying important to multiple selected node ids in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts"
+Task: "Add controller test for no-change feedback when all selected nodes are already important in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts"
+Task: "Add controller test for empty selection no-op in apps/web/src/lib/components/graph/graph-context-menu-controller.test.ts"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundational phases.
+2. Complete User Story 1.
+3. Stop and validate: one editable graph entity can be marked important and becomes visually distinct.
+
+### Incremental Delivery
+
+1. Add graph-engine important data/style contract.
+2. Add single-node context-menu action.
+3. Add multi-select behavior and feedback.
+4. Verify guest/read-only guard.
+5. Run focused tests, then full repository validation.
+
+## Notes
+
+- Keep the persisted source of truth as the existing `important` label.
+- Do not add a separate importance field or settings surface.
+- Important-node visual styling must not rely only on node size, because node size already communicates connection count.
+- Preserve existing category, image, draft, revealed, selected, and focus-mode styling behavior.


### PR DESCRIPTION
## Summary

- Add a graph-engine derived `isImportant` node flag from the existing `important` label.
- Add important-node Cytoscape styling with border and underlay treatment that does not rely on label text or connection-count sizing.
- Add graph/context-menu test coverage for important labels, selected-node feedback, submenu closing, and guest-session menu guarding.
- Update the Speckit task checklist for completed implementation work.

## Validation

- `bun test packages/graph-engine/src/transformer.test.ts` passes: 17 tests, 0 failures.
- Web/workspace validation could not run in this Termux environment because Bun package-runner hooks fail before startup with `CouldntReadCurrentDirectory`.
- Local git transport push was blocked by GitHub remote 500 responses, so the branch update was published through the GitHub API as commit `44c7a20`.