### PR TITLE
:fire: Remove inventory tab in entity sidebar and zen mode

### DIFF
--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -366,18 +366,7 @@
                   />
                 {/if}
               </div>
-              <div
-                role="tabpanel"
-                id={panelIds.inventory}
-                aria-labelledby={tabIds.inventory}
-                hidden={activeTab !== "inventory"}
-              >
-                {#if activeTab === "inventory"}
-                  <div class="text-theme-muted italic text-sm">
-                    Inventory coming soon...
-                  </div>
-                {/if}
-              </div>
+
               <div
                 role="tabpanel"
                 id={panelIds.map}

--- a/apps/web/src/lib/components/entity-detail/DetailTabs.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailTabs.svelte
@@ -141,30 +141,7 @@
         }}>{themeStore.jargon.tab_lore.toUpperCase()}</button
       >
     {/if}
-    <button
-      id={tabIds.inventory}
-      type="button"
-      role="tab"
-      aria-selected={activeTab === "inventory"}
-      aria-controls={panelIds.inventory}
-      tabindex={activeTab === "inventory" ? 0 : -1}
-      data-testid="tab-inventory"
-      class={activeTab === "inventory"
-        ? isFantasyTheme
-          ? "border px-3 py-1.5 rounded-sm text-[color:var(--color-accent-primary)]"
-          : "text-theme-primary border-b-2 border-theme-primary pb-2 -mb-2.5"
-        : isFantasyTheme
-          ? "transition text-[color:var(--theme-meta-text)] hover:text-[color:var(--theme-title-ink)]"
-          : "hover:text-theme-text transition"}
-      style:border-color={activeTab === "inventory" && isFantasyTheme
-        ? "var(--theme-focus-border)"
-        : undefined}
-      style:background-color={activeTab === "inventory" && isFantasyTheme
-        ? "var(--theme-focus-bg)"
-        : undefined}
-      onclick={() => (activeTab = "inventory")}
-      >{themeStore.jargon.tab_inventory.toUpperCase()}</button
-    >
+
     <button
       id={tabIds.map}
       type="button"

--- a/apps/web/src/lib/components/entity-detail/detail-tabs.test.ts
+++ b/apps/web/src/lib/components/entity-detail/detail-tabs.test.ts
@@ -23,11 +23,10 @@ describe("entity detail tab ids", () => {
 
   it("wraps keyboard navigation across the tab list", () => {
     expect(getNextEntityDetailTab("status", "ArrowRight")).toBe("lore");
-    expect(getNextEntityDetailTab("lore", "ArrowRight")).toBe("inventory");
+    expect(getNextEntityDetailTab("lore", "ArrowRight")).toBe("map");
     expect(getNextEntityDetailTab("map", "ArrowRight")).toBe("status");
     expect(getNextEntityDetailTab("status", "ArrowLeft")).toBe("map");
-    expect(getNextEntityDetailTab("inventory", "ArrowLeft")).toBe("lore");
-    expect(getNextEntityDetailTab("inventory", "Home")).toBe("status");
+    expect(getNextEntityDetailTab("map", "ArrowLeft")).toBe("lore");
     expect(getNextEntityDetailTab("status", "End")).toBe("map");
   });
 
@@ -36,10 +35,10 @@ describe("entity detail tab ids", () => {
 
     expect(
       getNextEntityDetailTabInList(visibleTabs, "status", "ArrowRight"),
-    ).toBe("inventory");
-    expect(
-      getNextEntityDetailTabInList(visibleTabs, "inventory", "ArrowLeft"),
-    ).toBe("status");
+    ).toBe("map");
+    expect(getNextEntityDetailTabInList(visibleTabs, "map", "ArrowLeft")).toBe(
+      "status",
+    );
     expect(getNextEntityDetailTabInList(visibleTabs, "status", "End")).toBe(
       "map",
     );

--- a/apps/web/src/lib/components/entity-detail/detail-tabs.ts
+++ b/apps/web/src/lib/components/entity-detail/detail-tabs.ts
@@ -1,4 +1,4 @@
-export const entityDetailTabs = ["status", "lore", "inventory", "map"] as const;
+export const entityDetailTabs = ["status", "lore", "map"] as const;
 
 export type EntityDetailTab = (typeof entityDetailTabs)[number];
 

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -53,7 +53,6 @@
   let scrollContainer = $state<HTMLDivElement>();
   let mobileScroller = $state<HTMLDivElement>();
   let tabOverview = $state<HTMLButtonElement>();
-  let tabInventory = $state<HTMLButtonElement>();
   let tabMap = $state<HTMLButtonElement>();
 
   let resolvedImageUrl = $state("");
@@ -169,11 +168,7 @@
   const handleTabKeydown = (e: KeyboardEvent) => {
     if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
       e.preventDefault();
-      const tabs: ("overview" | "inventory" | "map")[] = [
-        "overview",
-        "inventory",
-        "map",
-      ];
+      const tabs: ("overview" | "map")[] = ["overview", "map"];
       const currentIndex = tabs.indexOf(activeTab);
       const nextIndex =
         e.key === "ArrowRight"
@@ -183,7 +178,6 @@
       modalUIStore.zenModeActiveTab = tabs[nextIndex];
       const nextTab = modalUIStore.zenModeActiveTab;
       if (nextTab === "overview") tabOverview?.focus();
-      else if (nextTab === "inventory") tabInventory?.focus();
       else if (nextTab === "map") tabMap?.focus();
     }
   };
@@ -316,22 +310,6 @@
       </button>
       {#if !vault.isGuest}
         <button
-          bind:this={tabInventory}
-          role="tab"
-          id="tab-inventory"
-          aria-selected={activeTab === "inventory"}
-          aria-controls="panel-inventory"
-          tabindex={activeTab === "inventory" ? 0 : -1}
-          class="py-2 text-xs font-bold tracking-widest transition-colors border-b-2 font-header {activeTab ===
-          'inventory'
-            ? 'text-theme-primary border-theme-primary'
-            : 'text-theme-muted border-transparent hover:text-theme-text'}"
-          onclick={() => (modalUIStore.zenModeActiveTab = "inventory")}
-          onkeydown={handleTabKeydown}
-        >
-          INVENTORY
-        </button>
-        <button
           bind:this={tabMap}
           role="tab"
           id="tab-map"
@@ -399,15 +377,6 @@
           >
             <DetailMapTab {entity} />
           </div>
-        </div>
-      {:else if activeTab === "inventory"}
-        <div
-          role="tabpanel"
-          id="panel-inventory"
-          aria-labelledby="tab-inventory"
-          class="flex-1 p-8 flex items-center justify-center text-theme-muted font-header text-sm italic"
-        >
-          Inventory system initialization pending...
         </div>
       {/if}
     </div>

--- a/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
@@ -16,7 +16,7 @@ export class ModalUIStore {
 
   showZenMode = $state(false);
   zenModeEntityId = $state<string | null>(null);
-  zenModeActiveTab = $state<"overview" | "inventory" | "map">("overview");
+  zenModeActiveTab = $state<"overview" | "map">("overview");
 
   mergeDialog = $state<{
     open: boolean;
@@ -128,10 +128,7 @@ export class ModalUIStore {
     }
   }
 
-  openZenMode(
-    entityId: string,
-    tab: "overview" | "inventory" | "map" = "overview",
-  ) {
+  openZenMode(entityId: string, tab: "overview" | "map" = "overview") {
     this.zenModeEntityId = entityId;
     this.zenModeActiveTab = tab;
     this.showZenMode = true;


### PR DESCRIPTION
Closes #898. This PR completely removes the unused Inventory tab from both the entity sidebar details panel and the Zen mode view, including all associated test cases and reactive state bindings.