### PR TITLE
:bug: fix(graph): remove unsupported Cytoscape shadow styles

### DIFF
--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -489,11 +489,9 @@ describe("GraphTransformer", () => {
     expect(importantStyle.style.height).toBeUndefined();
     expect(importantStyle.style["font-weight"]).toBe("bold");
     expect(importantStyle.style["font-size"]).toBe(12);
-    expect(importantStyle.style["shadow-blur"]).toBe(24);
     expect(importantStyle.style["border-color"]).toBe("#8b5cf6");
     expect(importantStyle.style["underlay-color"]).toBe("#8b5cf6");
     expect(importantStyle.style["text-border-color"]).toBe("#8b5cf6");
-    expect(importantStyle.style["shadow-color"]).toBe("#8b5cf6");
 
     const importantSmallStyle = style.find(
       (s) => s.selector === "node[isImportant][weight <= 2]",

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -568,11 +568,6 @@ export const getGraphStyle = (
         "text-border-color": "#8b5cf6",
         "text-border-width": 1.5,
         "text-border-opacity": 0.5,
-        "shadow-color": "#8b5cf6",
-        "shadow-blur": 24,
-        "shadow-opacity": 0.45,
-        "shadow-offset-x": 0,
-        "shadow-offset-y": 0,
       },
     },
   ];


### PR DESCRIPTION
Removes obsolete shadow properties from Cytoscape stylesheets to clear style parsing warnings in the console.