### PR TITLE
:bug: fix(oracle): bypass systemInstruction for Gemini TTS to prevent 500 error

### DIFF
--- a/apps/web/src/lib/services/SoundBiteService.svelte.ts
+++ b/apps/web/src/lib/services/SoundBiteService.svelte.ts
@@ -337,7 +337,7 @@ class ProxiedGeminiTTSService implements TTSService {
       const model = await aiClientManager.getModel(
         apiKey,
         "gemini-2.5-flash-preview-tts",
-        styleInstruction || undefined,
+        undefined, // bypass systemInstruction for TTS to prevent Google 500 error
       );
 
       const ttsRequest: Record<string, unknown> = {
@@ -351,10 +351,6 @@ class ProxiedGeminiTTSService implements TTSService {
           },
         },
       };
-
-      if (styleInstruction) {
-        ttsRequest.systemInstruction = styleInstruction;
-      }
 
       const result = await (model as any).generateContent(ttsRequest);
 

--- a/apps/web/src/lib/services/SoundBiteService.svelte.ts
+++ b/apps/web/src/lib/services/SoundBiteService.svelte.ts
@@ -330,7 +330,7 @@ class ProxiedGeminiTTSService implements TTSService {
       const styleInstruction = buildVoiceStyleInstruction(voiceProfile);
       if (styleInstruction) {
         debugStore.log(
-          `[ProxiedGeminiTTS] style instruction: "${styleInstruction}"`,
+          `[ProxiedGeminiTTS] style instruction: "${styleInstruction}" (computed but ignored for gemini-2.5-flash-preview-tts due to Google 500 bug)`,
         );
       }
 

--- a/packages/oracle-engine/src/sound-bite-generator.ts
+++ b/packages/oracle-engine/src/sound-bite-generator.ts
@@ -79,7 +79,7 @@ class GeminiTTSService implements TTSService {
     }
     try {
       const voiceName = buildGeminiVoiceName(voiceProfile);
-      const styleInstruction = buildVoiceStyleInstruction(voiceProfile);
+      const _styleInstruction = buildVoiceStyleInstruction(voiceProfile);
       const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=${apiKey}`;
 
       const requestBody: Record<string, unknown> = {
@@ -94,13 +94,9 @@ class GeminiTTSService implements TTSService {
         },
       };
 
-      // Pass accent + tone to Gemini as a natural-language style instruction.
-      // Gemini 2.5 Flash TTS honours this alongside the prebuilt voice name.
-      if (styleInstruction) {
-        requestBody.systemInstruction = {
-          parts: [{ text: styleInstruction }],
-        };
-      }
+      // Note: Passing styleInstruction/systemInstruction to gemini-2.5-flash-preview-tts
+      // currently causes Google's backend to throw an internal HTTP 500 crash.
+      // So we bypass it entirely.
 
       const response = await fetch(url, {
         method: "POST",

--- a/packages/oracle-engine/src/sound-bite-generator.ts
+++ b/packages/oracle-engine/src/sound-bite-generator.ts
@@ -79,7 +79,7 @@ class GeminiTTSService implements TTSService {
     }
     try {
       const voiceName = buildGeminiVoiceName(voiceProfile);
-      const _styleInstruction = buildVoiceStyleInstruction(voiceProfile);
+      // const _styleInstruction = buildVoiceStyleInstruction(voiceProfile); // Bypassed due to Google TTS 500 crash on systemInstruction
       const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=${apiKey}`;
 
       const requestBody: Record<string, unknown> = {


### PR DESCRIPTION
Currently, passing any system instructions to gemini-2.5-flash-preview-tts causes Google's backend to crash with HTTP 500. This PR bypasses passing system instructions to prevent those crashes.