### PR TITLE
feat: resolve guest soundbite playback and host file path resolution bugs

### DIFF
--- a/apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.test.ts
@@ -112,4 +112,39 @@ describe("FileHandler", () => {
       }),
     );
   });
+
+  it("should handle GET_FILE for subdirectories (e.g. audio/test.wav)", async () => {
+    const mockFileHandle = {
+      getFile: vi.fn().mockResolvedValue({
+        size: 2048,
+        type: "audio/wav",
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(2048)),
+      }),
+    };
+    const mockAudioDirHandle = {
+      getFileHandle: vi.fn().mockResolvedValue(mockFileHandle),
+    };
+    const mockVaultHandle = {
+      getDirectoryHandle: vi.fn().mockResolvedValue(mockAudioDirHandle),
+    };
+    mockContext.vault.getActiveVaultHandle.mockResolvedValue(mockVaultHandle);
+
+    const msg = {
+      type: "GET_FILE",
+      path: "audio/test.wav",
+      requestId: "reqSub",
+    } as any;
+    await handler.handle(msg, mockConn, mockContext);
+
+    expect(mockVaultHandle.getDirectoryHandle).toHaveBeenCalledWith("audio");
+    expect(mockAudioDirHandle.getFileHandle).toHaveBeenCalledWith("test.wav");
+    expect(mockConn.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "FILE_RESPONSE",
+        requestId: "reqSub",
+        found: true,
+        mime: "audio/wav",
+      }),
+    );
+  });
 });

--- a/apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.ts
@@ -79,6 +79,12 @@ export class FileHandler extends BaseHandler {
               }
             }
           }
+        } else if (parts.length > 1) {
+          let currentDir = vaultHandle;
+          for (let i = 0; i < parts.length - 1; i++) {
+            currentDir = await currentDir.getDirectoryHandle(parts[i]);
+          }
+          fileHandle = await currentDir.getFileHandle(parts[parts.length - 1]);
         }
       } catch (err) {
         console.error(`[P2P Host] Error accessing path: ${path}`, err);

--- a/apps/web/src/lib/cloud-bridge/p2p/handlers/guest-sound-bite-handler.test.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/handlers/guest-sound-bite-handler.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GuestSoundBiteHandler } from "./guest-sound-bite-handler";
+import { soundBiteService } from "../../../services/SoundBiteService.svelte";
+
+vi.mock("../../../services/SoundBiteService.svelte", () => {
+  return {
+    soundBiteService: {
+      loadFromEntity: vi.fn(),
+      pendingAutoPlay: false,
+    },
+  };
+});
+
+describe("GuestSoundBiteHandler", () => {
+  let handler: GuestSoundBiteHandler;
+  let mockContext: any;
+  const conn = { peer: "host", send: vi.fn(), close: vi.fn() } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GuestSoundBiteHandler();
+    soundBiteService.pendingAutoPlay = false;
+
+    mockContext = {
+      vault: {
+        entities: {
+          "entity-1": {
+            id: "entity-1",
+            title: "Bobbie Draper",
+            soundBite: {
+              transcript: "Hooray!",
+              audioFile: "audio/entity-1_soundbite.wav",
+            },
+          },
+          "entity-no-soundbite": {
+            id: "entity-no-soundbite",
+            title: "No Sound",
+          },
+        },
+      },
+      modalUIStore: {
+        openSoundBite: vi.fn(),
+      },
+    };
+  });
+
+  it("can handle SOUND_BITE_PLAY type messages", () => {
+    expect(handler.canHandle({ type: "SOUND_BITE_PLAY" } as any)).toBe(true);
+    expect(handler.canHandle({ type: "ENTITY_UPDATE" } as any)).toBe(false);
+  });
+
+  it("loads sound bite, sets autoplay, and opens the modal if entity has sound bite", async () => {
+    const msg = {
+      type: "SOUND_BITE_PLAY",
+      entityId: "entity-1",
+    } as any;
+
+    await handler.handle(msg, conn, mockContext);
+
+    expect(soundBiteService.loadFromEntity).toHaveBeenCalledWith(
+      mockContext.vault.entities["entity-1"],
+    );
+    expect(soundBiteService.pendingAutoPlay).toBe(true);
+    expect(mockContext.modalUIStore.openSoundBite).toHaveBeenCalledWith(
+      "entity-1",
+    );
+  });
+
+  it("returns early and does not open modal if entity has no sound bite", async () => {
+    const msg = {
+      type: "SOUND_BITE_PLAY",
+      entityId: "entity-no-soundbite",
+    } as any;
+
+    await handler.handle(msg, conn, mockContext);
+
+    expect(soundBiteService.loadFromEntity).not.toHaveBeenCalled();
+    expect(soundBiteService.pendingAutoPlay).toBe(false);
+    expect(mockContext.modalUIStore.openSoundBite).not.toHaveBeenCalled();
+  });
+
+  it("returns early and does not open modal if entity does not exist", async () => {
+    const msg = {
+      type: "SOUND_BITE_PLAY",
+      entityId: "non-existent-entity",
+    } as any;
+
+    await handler.handle(msg, conn, mockContext);
+
+    expect(soundBiteService.loadFromEntity).not.toHaveBeenCalled();
+    expect(soundBiteService.pendingAutoPlay).toBe(false);
+    expect(mockContext.modalUIStore.openSoundBite).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/entity-detail/DetailSoundBite.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailSoundBite.svelte
@@ -135,6 +135,8 @@
     };
   });
 
+  let autoplayBlocked = $state(false);
+
   // Auto-play when the host broadcasts a sound bite to all guests.
   // Fires once the audio URL is resolved and the <audio> element is mounted.
   $effect(() => {
@@ -143,8 +145,10 @@
     if (!audioEl) return;
 
     soundBiteService.pendingAutoPlay = false;
+    autoplayBlocked = false;
     audioEl.play().catch(() => {
       // Auto-play blocked by browser policy — user can click play manually.
+      autoplayBlocked = true;
     });
   });
 
@@ -284,6 +288,14 @@
             aria-label="Sound bite audio player"
             class="w-full h-8 mb-3 rounded"
           ></audio>
+          {#if autoplayBlocked}
+            <div
+              class="flex items-center gap-1.5 text-xs text-amber-500 font-medium mb-3"
+            >
+              <span class="icon-[lucide--volume-x] w-3.5 h-3.5 shrink-0"></span>
+              <span>Autoplay blocked by browser. Click Play to listen!</span>
+            </div>
+          {/if}
         {:else if audioLoading}
           <div class="flex items-center gap-1.5 text-xs text-theme-muted mb-3">
             <span class="icon-[lucide--loader-2] w-3 h-3 animate-spin"></span>

--- a/apps/web/src/lib/components/vtt/VTTSharedImageLightbox.svelte
+++ b/apps/web/src/lib/components/vtt/VTTSharedImageLightbox.svelte
@@ -51,7 +51,7 @@
 
   // Synchronize store back to onClose if it's closed manually
   $effect(() => {
-    if (!modalUIStore.lightbox.show && imageState) {
+    if (!modalUIStore.lightbox.show && imageState && resolvedImageUrl) {
       onClose();
     }
   });


### PR DESCRIPTION
### Goal
Resolve guest-side issues for image sharing and soundbite playback. Specifically:
1. Ensure the P2P file-handler on the host resolves files from subdirectories (such as `audio/` or custom folders) rather than only root and `images/`.
2. Handle modern browser autoplay block restrictions in Svelte 5 with an explicit UX prompt warning the guest, so they can manually play if autoplay is blocked.

### Proposed Changes
- **Host P2P File Handler (`apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.ts`)**: Upgraded to recurse into all vault subdirectories to locate requested assets like soundbites (`audio/*.wav`).
- **Soundbite UX (`apps/web/src/lib/components/entity-detail/DetailSoundBite.svelte`)**: Catches autoplay promise rejections and gracefully shows a yellow accent banner telling the guest to click Play if blocked by browser policy.
- **Unit Tests**:
  - `apps/web/src/lib/cloud-bridge/p2p/handlers/guest-sound-bite-handler.test.ts` (New test suite verifying message handlers)
  - `apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.test.ts` (Updated to cover directory recursion/traversal logic)