### PR TITLE
chore: bump web version to match release 0.26.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.26.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
Bumps the SvelteKit web application's package version to match the latest changelog release  so that the settings about page displays the correct version instead of .