### PR TITLE
:bug: fix: preserve in-memory nested parent metadata on content hydration

### DIFF
--- a/apps/web/src/lib/stores/vault/entity-content-loader.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-content-loader.svelte.ts
@@ -184,8 +184,8 @@ export class EntityContentLoader {
             const path = entityToUpdate._path || [`${id}.md`];
 
             const updatedEntity = {
-              ...entityToUpdate,
               ...(result.metadata || {}),
+              ...entityToUpdate,
               content: finalContent,
               lore: finalLore,
             };
@@ -259,8 +259,8 @@ export class EntityContentLoader {
       const result = await this._readFromOpfs(id);
       if (result) {
         this.deps.repository.entities[id] = {
-          ...currentEntity,
           ...(result.metadata || {}),
+          ...currentEntity,
           content: result.content,
           lore: result.lore,
         };

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -1088,5 +1088,38 @@ describe("EntityStore", () => {
       await store.internalLoadContent("nonexistent");
       // Should not throw
     });
+
+    it("should preserve in-memory metadata (like parent relationship) and not overwrite it with old data from disk", async () => {
+      const markdownUtils = await import("../../utils/markdown");
+      const opfsUtils = await import("../../utils/opfs");
+
+      // In-memory has parent set
+      repository.entities.hero = {
+        ...repository.entities.hero,
+        parent: "parent-node",
+      };
+
+      // Disk has older metadata (no parent) and the actual file content
+      vi.mocked(opfsUtils.readFileAsText).mockResolvedValue(
+        "Old content from disk",
+      );
+      vi.mocked(markdownUtils.parseMarkdown).mockReturnValue({
+        metadata: {
+          id: "hero",
+          title: "Hero",
+          type: "character",
+          // no parent field on disk
+        },
+        content: "Hydrated content from disk",
+      });
+
+      await store.internalLoadContent("hero");
+
+      // Verifies content is hydrated, but in-memory parent is preserved!
+      expect(repository.entities.hero.content).toBe(
+        "Hydrated content from disk",
+      );
+      expect(repository.entities.hero.parent).toBe("parent-node");
+    });
   });
 });


### PR DESCRIPTION
This PR resolves the issue where restructuring / nesting entities does not survive a reload/refresh of the page. It fixes the metadata merging order inside the loader so that active in-memory edits take priority and survive OPFS hydration.