### PR TITLE
🎨 Palette: Add focus visible styles to VTT Share Button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,8 @@
 
 **Learning:** Icon-only buttons or buttons with sparse descriptions often miss `aria-label` attributes which makes them inaccessible for screen-readers. Examples include the delete button in the label settings and era editor, as well as apply/dismiss proposal buttons.
 **Action:** When working on Svelte components or reviewing existing ones, ensure that `aria-label` is populated using context variables (e.g., `{era.name}`) to provide clear actions for screen readers.
+
+## 2026-03-12 - Missing Focus Visible Styles on Icon-only Buttons
+
+**Learning:** Icon-only buttons often miss `focus-visible:ring-2` or similar keyboard focus classes in Tailwind which makes them harder to locate for keyboard users.
+**Action:** When working on Svelte components or reviewing existing ones, ensure that `focus-visible` classes are populated to provide clear focus indicators for keyboard navigation.

--- a/apps/web/src/lib/components/map/VTTShareButton.svelte
+++ b/apps/web/src/lib/components/map/VTTShareButton.svelte
@@ -10,7 +10,7 @@
 
 {#if canShareVtt}
   <button
-    class="w-8 h-8 flex flex-shrink-0 items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-muted transition hover:text-theme-primary"
+    class="w-8 h-8 flex flex-shrink-0 items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-muted transition hover:text-theme-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-1 focus-visible:ring-offset-theme-surface"
     onclick={() => {
       console.log("[VTTShareButton] click", {
         canShareVtt,


### PR DESCRIPTION
💡 **What:** Added `focus-visible` CSS classes (`focus-visible:outline-none`, `focus-visible:ring-2`, `focus-visible:ring-theme-primary`, `focus-visible:ring-offset-1`, `focus-visible:ring-offset-theme-surface`) to the VTT Share button.
🎯 **Why:** To improve keyboard navigation accessibility. Icon-only utility buttons must have clear focus rings when a user tabs to them, avoiding visual states that rely purely on mouse hover.
♿ **Accessibility:** Enhances the visual focus indicator for screen-reader and keyboard-only users, meeting WCAG focus visibility requirements.

---
*PR created automatically by Jules for task [287674331974512684](https://jules.google.com/task/287674331974512684) started by @eserlan*