### PR TITLE
:bug: fix: ensure hierarchical parent structures render on Google Drive sync and cache load

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -57,6 +57,16 @@
   };
 
   const isFantasyTheme = $derived(themeStore.activeTheme.id === "fantasy");
+
+  const parentEntity = $derived(
+    entity?.parent ? vault.entities[entity.parent] : null,
+  );
+
+  const handleOpenParent = () => {
+    if (parentEntity) {
+      vault.selectedEntityId = parentEntity.id;
+    }
+  };
 </script>
 
 {#if isObscured}
@@ -200,6 +210,24 @@
                   {alias}
                 </div>
               {/each}
+            </div>
+          {/if}
+          {#if parentEntity}
+            <div
+              class="flex items-center gap-1.5 text-xs text-theme-muted mt-1.5"
+              data-testid="sidebar-parent-indicator"
+            >
+              <span
+                class="icon-[lucide--folder-up] h-3.5 w-3.5 text-theme-muted"
+              ></span>
+              <span>Parent:</span>
+              <button
+                type="button"
+                onclick={handleOpenParent}
+                class="text-theme-primary hover:text-theme-primary/80 hover:underline font-semibold focus:outline-none transition-all"
+              >
+                {parentEntity.title}
+              </button>
             </div>
           {/if}
         </div>

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.test.ts
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.test.ts
@@ -22,6 +22,12 @@ vi.mock("$lib/stores/vault.svelte", () => ({
     selectedEntityId: "entity-1",
     addLabel: vi.fn(),
     removeLabel: vi.fn(),
+    entities: {
+      "parent-id": {
+        id: "parent-id",
+        title: "Mock Parent Entity",
+      },
+    },
   },
 }));
 
@@ -135,5 +141,27 @@ describe("DetailHeader Duplicate Key Reproduction", () => {
         onClose: () => {},
       });
     }).not.toThrow();
+  });
+
+  it("renders parent indicator when entity has a parent", () => {
+    const mockEntity = {
+      id: "entity-1",
+      title: "Child Entity",
+      parent: "parent-id",
+      aliases: [],
+      labels: [],
+    } as any;
+
+    const { getByTestId, getByText } = render(DetailHeader, {
+      entity: mockEntity,
+      isEditing: false,
+      editTitle: "",
+      editAliases: [],
+      onClose: () => {},
+    });
+
+    const indicator = getByTestId("sidebar-parent-indicator");
+    expect(indicator).toBeTruthy();
+    expect(getByText("Mock Parent Entity")).toBeTruthy();
   });
 });

--- a/apps/web/src/lib/components/explorer/EntityListItem.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListItem.svelte
@@ -55,9 +55,12 @@
     ? 'opacity-50'
     : ''} {entity.id === focusedEntityId
     ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'
-    : 'border-theme-border bg-theme-surface/50 hover:border-theme-primary/50 hover:bg-theme-primary/5'} {isDragOver
+    : 'border-theme-border bg-theme-surface/50 hover:border-theme-primary/50 hover:bg-theme-primary/5'} {isDragOver &&
+  !(entity as any).isVirtual
     ? 'border-theme-accent bg-theme-accent/10 ring-2 ring-theme-accent/20'
-    : ''} {!sessionModeStore.isGuestMode && draggable
+    : ''} {!sessionModeStore.isGuestMode &&
+  draggable &&
+  !(entity as any).isVirtual
     ? 'cursor-grab active:cursor-grabbing'
     : ''} {isDragging ? 'dragging-active' : ''} {isDragSource
     ? 'dragging-source'
@@ -65,9 +68,11 @@
   role="listitem"
   data-testid="entity-list-item"
   data-entity-id={entity.id}
-  draggable={!sessionModeStore.isGuestMode && draggable}
+  draggable={!sessionModeStore.isGuestMode &&
+    draggable &&
+    !(entity as any).isVirtual}
   ondragstart={(e) => {
-    if (!draggable) return;
+    if (!draggable || (entity as any).isVirtual) return;
     if (e.dataTransfer) {
       e.dataTransfer.setData("application/x-codex-entity-id", entity.id);
       e.dataTransfer.setData("text/plain", entity.id);
@@ -79,12 +84,12 @@
     onDragEnd?.();
   }}
   ondragover={(e) => {
-    if (!sessionModeStore.isGuestMode) {
+    if (!sessionModeStore.isGuestMode && !(entity as any).isVirtual) {
       e.preventDefault();
     }
   }}
   ondragenter={(e) => {
-    if (!sessionModeStore.isGuestMode) {
+    if (!sessionModeStore.isGuestMode && !(entity as any).isVirtual) {
       e.preventDefault();
       isDragOver = true;
     }
@@ -93,7 +98,7 @@
     isDragOver = false;
   }}
   ondrop={async (e) => {
-    if (sessionModeStore.isGuestMode) return;
+    if (sessionModeStore.isGuestMode || (entity as any).isVirtual) return;
     e.preventDefault();
     isDragOver = false;
     const draggedId =
@@ -132,14 +137,28 @@
 
   <button
     type="button"
-    onclick={() => onSelect?.(entity)}
-    title={`Select ${entity.title}`}
-    class="flex flex-1 min-w-0 items-center gap-2 p-2.5 pl-1 text-left select-none focus:outline-none focus-visible:ring-1 focus-visible:ring-theme-primary rounded-l-xl"
+    onclick={() => {
+      if ((entity as any).isVirtual) {
+        explorerUIStore.toggleExplorerEntityCollapse(activeVaultId, entity.id);
+      } else {
+        onSelect?.(entity);
+      }
+    }}
+    title={(entity as any).isVirtual
+      ? `Toggle ${entity.title}`
+      : `Select ${entity.title}`}
+    class="flex flex-1 min-w-0 items-center gap-2 p-2.5 pl-1 text-left select-none focus:outline-none focus-visible:ring-1 focus-visible:ring-theme-primary rounded-l-xl {(
+      entity as any
+    ).isVirtual
+      ? 'rounded-r-xl'
+      : ''}"
   >
     <span
-      class="{getIconClass(
-        cat?.icon,
-      )} h-3.5 w-3.5 shrink-0 text-theme-muted transition-colors group-hover:text-theme-primary"
+      class="{(entity as any).isVirtual
+        ? 'icon-[lucide--folder]'
+        : getIconClass(
+            cat?.icon,
+          )} h-3.5 w-3.5 shrink-0 text-theme-muted transition-colors group-hover:text-theme-primary"
     ></span>
     <div class="flex-1 min-w-0 flex flex-col gap-0.5">
       <div
@@ -203,7 +222,7 @@
     </button>
   {/if}
 
-  {#if onFindInGraph}
+  {#if onFindInGraph && !(entity as any).isVirtual}
     <button
       type="button"
       onclick={(e) => {
@@ -218,7 +237,7 @@
       <span class="icon-[lucide--target] h-3.5 w-3.5"></span>
     </button>
   {/if}
-  {#if onOpenZen}
+  {#if onOpenZen && !(entity as any).isVirtual}
     <button
       type="button"
       onclick={(e) => {

--- a/apps/web/src/lib/components/explorer/entityTree.test.ts
+++ b/apps/web/src/lib/components/explorer/entityTree.test.ts
@@ -84,4 +84,67 @@ describe("entityTree helper", () => {
     expect(roots[0].children[0].children[0].entity.id).toBe("e3");
     expect(roots[0].children[0].children[0].isMatchingQuery).toBe(true); // e3 matches query
   });
+
+  it("should dynamically create virtual folders for missing parent entities or subdirectories", () => {
+    const childWithMissingParent: Entity = {
+      id: "bob",
+      title: "Bob",
+      type: "character",
+      status: "active",
+      tags: [],
+      labels: [],
+      connections: [],
+      aliases: [],
+      content: "",
+      parent: "npcs",
+      _path: ["NPCs", "Bob.md"] as any,
+    };
+
+    const roots = buildEntityTree(
+      [childWithMissingParent],
+      [childWithMissingParent],
+    );
+
+    // npcs should have been dynamically generated as a virtual parent root node
+    expect(roots).toHaveLength(1);
+    expect(roots[0].entity.id).toBe("npcs");
+    expect(roots[0].entity.title).toBe("NPCs");
+    expect(roots[0].children).toHaveLength(1);
+    expect(roots[0].children[0].entity.id).toBe("bob");
+  });
+
+  it("should recursively generate virtual directory chains from nested path structures", () => {
+    const deeplyNestedChild: Entity = {
+      id: "spellbook",
+      title: "Spellbook",
+      type: "item",
+      status: "active",
+      tags: [],
+      labels: [],
+      connections: [],
+      aliases: [],
+      content: "",
+      parent: "gear",
+      _path: ["NPCs", "Equipment", "Gear", "Spellbook.md"] as any,
+    };
+
+    const roots = buildEntityTree([deeplyNestedChild], [deeplyNestedChild]);
+
+    // Tree should recursively resolve and build: npcs -> equipment -> gear -> spellbook
+    expect(roots).toHaveLength(1);
+    expect(roots[0].entity.id).toBe("npcs");
+    expect(roots[0].entity.title).toBe("NPCs");
+
+    const equipmentNode = roots[0].children[0];
+    expect(equipmentNode.entity.id).toBe("equipment");
+    expect(equipmentNode.entity.title).toBe("Equipment");
+
+    const gearNode = equipmentNode.children[0];
+    expect(gearNode.entity.id).toBe("gear");
+    expect(gearNode.entity.title).toBe("Gear");
+
+    const spellbookNode = gearNode.children[0];
+    expect(spellbookNode.entity.id).toBe("spellbook");
+    expect(spellbookNode.entity.title).toBe("Spellbook");
+  });
 });

--- a/apps/web/src/lib/components/explorer/entityTree.test.ts
+++ b/apps/web/src/lib/components/explorer/entityTree.test.ts
@@ -145,6 +145,40 @@ describe("entityTree helper", () => {
 
     const spellbookNode = gearNode.children[0];
     expect(spellbookNode.entity.id).toBe("spellbook");
-    expect(spellbookNode.entity.title).toBe("Spellbook");
+  });
+
+  it("should match parent relationships case-insensitively with mixed-case IDs", () => {
+    const parentEntity: Entity = {
+      id: "NPCs",
+      title: "NPCs Section",
+      type: "note",
+      status: "active",
+      tags: [],
+      labels: [],
+      connections: [],
+      aliases: [],
+      content: "",
+    };
+    const childEntity: Entity = {
+      id: "bob",
+      title: "Bob",
+      type: "character",
+      status: "active",
+      tags: [],
+      labels: [],
+      connections: [],
+      aliases: [],
+      content: "",
+      parent: "NPCs", // mixed-case reference to mixed-case ID
+    };
+
+    const roots = buildEntityTree(
+      [parentEntity, childEntity],
+      [parentEntity, childEntity],
+    );
+    expect(roots).toHaveLength(1);
+    expect(roots[0].entity.id).toBe("NPCs");
+    expect(roots[0].children).toHaveLength(1);
+    expect(roots[0].children[0].entity.id).toBe("bob");
   });
 });

--- a/apps/web/src/lib/components/explorer/entityTree.ts
+++ b/apps/web/src/lib/components/explorer/entityTree.ts
@@ -32,7 +32,13 @@ export function buildEntityTree(
         const parentId = sanitizeId(e.parent);
         if (!allEntitiesMap.has(parentId) && !virtualEntities.has(parentId)) {
           let title = e.parent;
-          const path = (e as any)._path;
+          const pathRaw = (e as any)._path;
+          const path: string[] | undefined = Array.isArray(pathRaw)
+            ? pathRaw
+            : typeof pathRaw === "string"
+              ? pathRaw.split("/")
+              : undefined;
+
           if (path && path.length > 1) {
             for (let i = path.length - 2; i >= 0; i--) {
               if (sanitizeId(path[i]) === parentId) {
@@ -69,6 +75,7 @@ export function buildEntityTree(
             lore: "",
             _path: path,
             updatedAt: Date.now(),
+            isVirtual: true,
           } as any);
 
           foundNewMissing = true;

--- a/apps/web/src/lib/components/explorer/entityTree.ts
+++ b/apps/web/src/lib/components/explorer/entityTree.ts
@@ -1,4 +1,5 @@
 import type { Entity } from "schema";
+import { sanitizeId } from "../../utils/markdown";
 
 export interface TreeNode {
   entity: Entity;
@@ -16,6 +17,71 @@ export function buildEntityTree(
     allEntitiesMap.set(e.id, e);
   }
 
+  // 1b. Recursively discover missing parents (directories/folders) and create virtual entities
+  const virtualEntities = new Map<string, Entity>();
+  let foundNewMissing = true;
+  while (foundNewMissing) {
+    foundNewMissing = false;
+    const currentCandidates = [
+      ...allEntitiesMap.values(),
+      ...virtualEntities.values(),
+    ];
+
+    for (const e of currentCandidates) {
+      if (e.parent) {
+        const parentId = sanitizeId(e.parent);
+        if (!allEntitiesMap.has(parentId) && !virtualEntities.has(parentId)) {
+          let title = e.parent;
+          const path = (e as any)._path;
+          if (path && path.length > 1) {
+            for (let i = path.length - 2; i >= 0; i--) {
+              if (sanitizeId(path[i]) === parentId) {
+                title = path[i];
+                break;
+              }
+            }
+          }
+
+          if (title === parentId && title.length > 0) {
+            title = title.charAt(0).toUpperCase() + title.slice(1);
+          }
+
+          let virtualParent: string | undefined = undefined;
+          if (path && path.length > 1) {
+            for (let i = path.length - 2; i >= 0; i--) {
+              if (sanitizeId(path[i]) === parentId && i > 0) {
+                virtualParent = sanitizeId(path[i - 1]);
+                break;
+              }
+            }
+          }
+
+          virtualEntities.set(parentId, {
+            id: parentId,
+            type: "note",
+            title: title,
+            status: "active",
+            parent: virtualParent,
+            tags: [],
+            labels: [],
+            connections: [],
+            content: "",
+            lore: "",
+            _path: path,
+            updatedAt: Date.now(),
+          } as any);
+
+          foundNewMissing = true;
+        }
+      }
+    }
+  }
+
+  // Add virtual entities to the main map
+  for (const [id, ve] of virtualEntities.entries()) {
+    allEntitiesMap.set(id, ve);
+  }
+
   // 2. Identify the set of all visible entities.
   // It contains all matching entities (filteredEntities) plus all their ancestors.
   const visibleIds = new Set<string>();
@@ -26,7 +92,7 @@ export function buildEntityTree(
     while (current) {
       visibleIds.add(current.id);
       if (current.parent) {
-        current = allEntitiesMap.get(current.parent);
+        current = allEntitiesMap.get(sanitizeId(current.parent));
       } else {
         break;
       }
@@ -49,7 +115,9 @@ export function buildEntityTree(
   // 4. Build the tree links
   const roots: TreeNode[] = [];
   for (const node of treeNodesMap.values()) {
-    const parentId = node.entity.parent;
+    const parentId = node.entity.parent
+      ? sanitizeId(node.entity.parent)
+      : undefined;
     if (parentId && treeNodesMap.has(parentId)) {
       const parentNode = treeNodesMap.get(parentId)!;
       parentNode.children.push(node);

--- a/apps/web/src/lib/components/explorer/entityTree.ts
+++ b/apps/web/src/lib/components/explorer/entityTree.ts
@@ -11,10 +11,10 @@ export function buildEntityTree(
   entities: Entity[],
   filteredEntities: Entity[],
 ): TreeNode[] {
-  // 1. Build a lookup record of all entities in the vault by ID
+  // 1. Build a lookup record of all entities in the vault by SANITIZED ID
   const allEntitiesMap = new Map<string, Entity>();
   for (const e of entities) {
-    allEntitiesMap.set(e.id, e);
+    allEntitiesMap.set(sanitizeId(e.id), e);
   }
 
   // 1b. Recursively discover missing parents (directories/folders) and create virtual entities
@@ -85,12 +85,15 @@ export function buildEntityTree(
   // 2. Identify the set of all visible entities.
   // It contains all matching entities (filteredEntities) plus all their ancestors.
   const visibleIds = new Set<string>();
-  const matchingIds = new Set<string>(filteredEntities.map((e) => e.id));
+  const matchingIds = new Set<string>(
+    filteredEntities.map((e) => sanitizeId(e.id)),
+  );
 
   for (const match of filteredEntities) {
     let current: Entity | undefined = match;
     while (current) {
-      visibleIds.add(current.id);
+      const currentSanitizedId = sanitizeId(current.id);
+      visibleIds.add(currentSanitizedId);
       if (current.parent) {
         current = allEntitiesMap.get(sanitizeId(current.parent));
       } else {

--- a/apps/web/src/lib/components/zen/ZenHeader.svelte
+++ b/apps/web/src/lib/components/zen/ZenHeader.svelte
@@ -70,6 +70,10 @@
       layoutUIStore.findInGraph();
     }, 300);
   };
+
+  const parentEntity = $derived(
+    entity?.parent ? vault.entities[entity.parent] : null,
+  );
 </script>
 
 <header
@@ -140,6 +144,24 @@
                   {alias}
                 </div>
               {/each}
+            </div>
+          {/if}
+          {#if parentEntity}
+            <div
+              class="flex items-center gap-1.5 text-xs text-theme-muted mt-1.5"
+              data-testid="zen-parent-indicator"
+            >
+              <span
+                class="icon-[lucide--folder-up] h-3.5 w-3.5 text-theme-muted"
+              ></span>
+              <span>Parent:</span>
+              <button
+                type="button"
+                onclick={() => modalUIStore.openZenMode(parentEntity.id)}
+                class="text-theme-primary hover:text-theme-primary/80 hover:underline font-semibold focus:outline-none transition-all"
+              >
+                {parentEntity.title}
+              </button>
             </div>
           {/if}
         </div>

--- a/apps/web/src/lib/services/cache.svelte.ts
+++ b/apps/web/src/lib/services/cache.svelte.ts
@@ -69,6 +69,7 @@ export class CacheService {
           // Content starts as empty — loaded lazily when the entity is opened.
           content: "",
           lore: undefined,
+          _path: graphData._path || filePath.split("/"),
         };
         map.set(`${vaultId}:${filePath}`, { lastModified, entity });
       }
@@ -127,6 +128,7 @@ export class CacheService {
         ...graphData,
         content: "",
         lore: undefined,
+        _path: graphData._path || _fp.split("/"),
       };
       return { lastModified, entity };
     } catch (err) {
@@ -216,6 +218,7 @@ export class CacheService {
           ...graphData,
           content: "",
           lore: undefined,
+          _path: graphData._path || filePath.split("/"),
         } as LocalEntity;
         this.preloaded.set(path, { lastModified, entity: graphEntity });
       }

--- a/apps/web/src/lib/services/cache.svelte.ts
+++ b/apps/web/src/lib/services/cache.svelte.ts
@@ -16,6 +16,14 @@ function parseKey(key: string): { vaultId: string; filePath: string } {
   };
 }
 
+function normalizePath(
+  path: string | string[] | undefined,
+  filePath: string,
+): string[] {
+  const raw = path || filePath.split("/");
+  return typeof raw === "string" ? raw.split("/") : raw;
+}
+
 export class CacheService {
   /**
    * In-memory snapshot of the Dexie `graphEntities` table for the currently
@@ -69,7 +77,7 @@ export class CacheService {
           // Content starts as empty — loaded lazily when the entity is opened.
           content: "",
           lore: undefined,
-          _path: graphData._path || filePath.split("/"),
+          _path: normalizePath(graphData._path, filePath),
         };
         map.set(`${vaultId}:${filePath}`, { lastModified, entity });
       }
@@ -128,7 +136,7 @@ export class CacheService {
         ...graphData,
         content: "",
         lore: undefined,
-        _path: graphData._path || _fp.split("/"),
+        _path: normalizePath(graphData._path, _fp),
       };
       return { lastModified, entity };
     } catch (err) {
@@ -218,7 +226,7 @@ export class CacheService {
           ...graphData,
           content: "",
           lore: undefined,
-          _path: graphData._path || filePath.split("/"),
+          _path: normalizePath(graphData._path, filePath),
         } as LocalEntity;
         this.preloaded.set(path, { lastModified, entity: graphEntity });
       }

--- a/apps/web/src/lib/services/gdrive-sync.ts
+++ b/apps/web/src/lib/services/gdrive-sync.ts
@@ -290,6 +290,9 @@ export async function importVaultFromDrive(
       payload: { vaultId: newId, folderId: driveFolderId },
       metadata: { timestamp: Date.now(), vaultId: newId },
     });
+  } else if (vault.activeVaultId !== targetVaultId) {
+    // Switch to the existing matching vault so the user is taken to it
+    await vault.switchVault(targetVaultId);
   }
 
   // Pull — DiffAlgorithm only downloads files newer than local (via registry)

--- a/apps/web/src/lib/stores/vault-registry.svelte.ts
+++ b/apps/web/src/lib/stores/vault-registry.svelte.ts
@@ -115,6 +115,14 @@ class VaultRegistryStore {
     await this.listVaults();
   }
 
+  async clearActiveVault(): Promise<void> {
+    this.activeVaultId = null;
+    this.vaultName = "Local Vault";
+    const db = await getDB();
+    await db.delete("settings", "activeVaultId");
+    await this.listVaults();
+  }
+
   async updateEntityCount(id: string, count: number): Promise<void> {
     const db = await getDB();
     const vaultRecord = await db.get("vaults", id);

--- a/apps/web/src/lib/stores/vault/adapters.svelte.ts
+++ b/apps/web/src/lib/stores/vault/adapters.svelte.ts
@@ -8,6 +8,7 @@ import {
   parseMarkdown,
   stringifyEntity,
   deriveIdFromPath,
+  sanitizeId,
 } from "../../utils/markdown";
 import { cacheService } from "../../services/cache.svelte";
 import type { IFileIOAdapter } from "@codex/vault-engine/src/repository.svelte";
@@ -51,6 +52,22 @@ export const fileIOAdapter: IFileIOAdapter = {
     const parsed = parseMarkdown(text);
     const id = parsed.metadata.id || deriveIdFromPath(path);
     const connections = parsed.metadata.connections || [];
+
+    let parent = parsed.metadata.parent
+      ? sanitizeId(parsed.metadata.parent)
+      : undefined;
+
+    // Derive parent from subdirectories if not explicitly defined in frontmatter
+    if (!parent && path && path.length > 1) {
+      for (let i = path.length - 2; i >= 0; i--) {
+        const dirId = sanitizeId(path[i]);
+        if (dirId !== id) {
+          parent = dirId;
+          break;
+        }
+      }
+    }
+
     const entity = {
       ...parsed.metadata,
       id: id!,
@@ -63,6 +80,7 @@ export const fileIOAdapter: IFileIOAdapter = {
       connections,
       content: parsed.content,
       lore: parsed.metadata.lore || "",
+      parent,
       _path: path,
     };
 

--- a/apps/web/src/lib/stores/vault/adapters.svelte.ts
+++ b/apps/web/src/lib/stores/vault/adapters.svelte.ts
@@ -50,7 +50,8 @@ export const fileIOAdapter: IFileIOAdapter = {
   },
   parseMarkdown: (text, path) => {
     const parsed = parseMarkdown(text);
-    const id = parsed.metadata.id || deriveIdFromPath(path);
+    const rawId = parsed.metadata.id || deriveIdFromPath(path);
+    const id = sanitizeId(rawId);
     const connections = parsed.metadata.connections || [];
 
     let parent = parsed.metadata.parent
@@ -72,7 +73,11 @@ export const fileIOAdapter: IFileIOAdapter = {
       ...parsed.metadata,
       id: id!,
       type: parsed.metadata.type || DEFAULT_ENTITY_TYPE,
-      title: parsed.metadata.title || id!,
+      title:
+        parsed.metadata.title ||
+        (path && path.length > 0
+          ? path[path.length - 1].replace(/\.(md|markdown)$/i, "")
+          : rawId),
       status: parsed.metadata.status || "active",
       tags: parsed.metadata.tags || [],
       labels: parsed.metadata.labels || parsed.metadata.tags || [],

--- a/apps/web/src/lib/stores/vault/adapters.test.ts
+++ b/apps/web/src/lib/stores/vault/adapters.test.ts
@@ -21,6 +21,14 @@ vi.mock("../../utils/markdown", () => ({
   parseMarkdown: vi.fn(),
   stringifyEntity: vi.fn(),
   deriveIdFromPath: vi.fn(),
+  sanitizeId: vi.fn((x) =>
+    x
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, ""),
+  ),
 }));
 
 vi.mock("../../services/cache.svelte", () => ({
@@ -147,7 +155,7 @@ describe("Adapters", () => {
       vi.mocked(markdown.deriveIdFromPath).mockReturnValue("derived-id");
       const entity = adapters.fileIOAdapter.parseMarkdown("text", ["path"]);
       expect(entity!.id).toBe("derived-id");
-      expect(entity!.title).toBe("derived-id");
+      expect(entity!.title).toBe("path");
       expect(entity!.type).toBe("note");
       expect(entity!.tags).toEqual([]);
       expect(entity!.labels).toEqual([]);

--- a/apps/web/src/lib/stores/vault/entities.ts
+++ b/apps/web/src/lib/stores/vault/entities.ts
@@ -61,6 +61,10 @@ export function createEntity(
     ...initialData,
   } as LocalEntity;
 
+  if (entity.parent) {
+    entity.parent = sanitizeId(entity.parent);
+  }
+
   return applyAutoLabels(entity);
 }
 
@@ -77,6 +81,10 @@ export function updateEntity(
     ...updates,
     updatedAt: Date.now(),
   } as LocalEntity;
+
+  if (updated.parent) {
+    updated.parent = sanitizeId(updated.parent);
+  }
 
   updated = applyAutoLabels(updated);
 

--- a/apps/web/src/lib/stores/vault/entity-content-loader.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-content-loader.svelte.ts
@@ -2,7 +2,7 @@ import { vaultEventBus } from "./events.svelte";
 import { debugStore } from "../debug.svelte";
 import { cacheService } from "../../services/cache.svelte";
 import { readFileAsText } from "../../utils/opfs";
-import { parseMarkdown } from "../../utils/markdown";
+import { parseMarkdown, sanitizeId } from "../../utils/markdown";
 import { VaultRepository } from "@codex/vault-engine";
 
 export interface ContentLoaderDependencies {
@@ -99,9 +99,21 @@ export class EntityContentLoader {
             return;
           }
 
-          const { content: freshContent } = parseMarkdown(text);
+          const { content: freshContent, metadata: freshMetadata } =
+            parseMarkdown(text);
+          const mergedMetadata = { ...(freshMetadata || {}) };
+          delete mergedMetadata.id;
+          if (mergedMetadata.parent) {
+            mergedMetadata.parent = sanitizeId(mergedMetadata.parent);
+          }
+          for (const key of Object.keys(mergedMetadata)) {
+            if (mergedMetadata[key] === undefined) {
+              delete mergedMetadata[key];
+            }
+          }
           this.deps.repository.entities[id] = {
             ...currentEntity,
+            ...mergedMetadata,
             content: freshContent || currentEntity.content || "",
             lore: "",
           };
@@ -164,7 +176,7 @@ export class EntityContentLoader {
                 const text = await readFileAsText(localHandle, path);
                 if (text) {
                   const { metadata, content } = parseMarkdown(text);
-                  result = { content, lore: metadata.lore || "" };
+                  result = { content, lore: metadata.lore || "", metadata };
                 }
               }
             } catch (err) {
@@ -183,9 +195,21 @@ export class EntityContentLoader {
             const finalLore = result.lore || entityToUpdate.lore || "";
             const path = entityToUpdate._path || [`${id}.md`];
 
+            // Normalize and merge metadata
+            const mergedMetadata = { ...(result.metadata || {}) };
+            delete mergedMetadata.id;
+            if (mergedMetadata.parent) {
+              mergedMetadata.parent = sanitizeId(mergedMetadata.parent);
+            }
+            for (const key of Object.keys(mergedMetadata)) {
+              if (mergedMetadata[key] === undefined) {
+                delete mergedMetadata[key];
+              }
+            }
+
             const updatedEntity = {
-              ...(result.metadata || {}),
               ...entityToUpdate,
+              ...mergedMetadata,
               content: finalContent,
               lore: finalLore,
             };
@@ -258,9 +282,20 @@ export class EntityContentLoader {
     try {
       const result = await this._readFromOpfs(id);
       if (result) {
+        const mergedMetadata = { ...(result.metadata || {}) };
+        delete mergedMetadata.id;
+        if (mergedMetadata.parent) {
+          mergedMetadata.parent = sanitizeId(mergedMetadata.parent);
+        }
+        for (const key of Object.keys(mergedMetadata)) {
+          if (mergedMetadata[key] === undefined) {
+            delete mergedMetadata[key];
+          }
+        }
+
         this.deps.repository.entities[id] = {
-          ...(result.metadata || {}),
           ...currentEntity,
+          ...mergedMetadata,
           content: result.content,
           lore: result.lore,
         };

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -36,6 +36,11 @@ vi.mock("./entities", () => ({
 vi.mock("../../utils/opfs", () => ({
   readFileAsText: vi.fn(),
   deleteOpfsEntry: vi.fn(),
+  walkOpfsDirectory: vi.fn(),
+  writeOpfsFile: vi.fn(),
+  isNotFoundError: vi.fn(() => false),
+  readOpfsBlob: vi.fn(),
+  getDirHandle: vi.fn(),
 }));
 
 vi.mock("../../utils/markdown", () => ({

--- a/apps/web/src/lib/stores/vault/lifecycle.test.ts
+++ b/apps/web/src/lib/stores/vault/lifecycle.test.ts
@@ -40,6 +40,7 @@ vi.mock("../vault-registry.svelte", () => ({
     createVault: vi.fn(),
     deleteVault: vi.fn(),
     setActiveVault: vi.fn(),
+    clearActiveVault: vi.fn(),
     updateEntityCount: vi.fn().mockResolvedValue(undefined),
     availableVaults: [],
     isInitialized: false,
@@ -128,6 +129,7 @@ describe("VaultLifecycleManager", () => {
         createVault: vi.fn().mockResolvedValue("test-id"),
         deleteVault: vi.fn(),
         setActiveVault: vi.fn(),
+        clearActiveVault: vi.fn().mockResolvedValue(undefined),
         updateEntityCount: vi.fn().mockResolvedValue(undefined),
         availableVaults: [],
         isInitialized: false,
@@ -189,6 +191,22 @@ describe("VaultLifecycleManager", () => {
         "end-vault-2",
       ]);
     });
+
+    it("should recover the switchLock chain if a switch fails", async () => {
+      vi.mocked(deps.vaultRegistry.setActiveVault).mockRejectedValueOnce(
+        new Error("Switch failed"),
+      );
+
+      await expect(manager.switchVault("failing-vault")).rejects.toThrow(
+        "Switch failed",
+      );
+
+      // Subsequent switch should succeed and not be blocked or ignored
+      await manager.switchVault("working-vault");
+      expect(deps.vaultRegistry.setActiveVault).toHaveBeenCalledWith(
+        "working-vault",
+      );
+    });
   });
 
   describe("deleteVault", () => {
@@ -226,6 +244,7 @@ describe("VaultLifecycleManager", () => {
 
       await manager.deleteVault("only-vault");
 
+      expect(deps.vaultRegistry.clearActiveVault).toHaveBeenCalled();
       expect(deps.setInitialized).toHaveBeenCalledWith(false);
       expect(deps.syncStore.setStatus).toHaveBeenCalledWith("idle");
       expect(deps.vaultRegistry.deleteVault).toHaveBeenCalledWith("only-vault");

--- a/apps/web/src/lib/stores/vault/lifecycle.ts
+++ b/apps/web/src/lib/stores/vault/lifecycle.ts
@@ -108,11 +108,14 @@ export class VaultLifecycleManager {
       this.deps.canvasRegistry.clear();
       this.deps.setSelectedEntityId(null);
 
-      const nextVault = this.deps.vaultRegistry.availableVaults[0];
+      const nextVault = this.deps.vaultRegistry.availableVaults.find(
+        (v: any) => v.id !== id,
+      );
       if (nextVault) {
         await this.switchVault(nextVault.id);
       } else {
         // No other vaults remain; clear active state.
+        await this.deps.vaultRegistry.clearActiveVault();
         this.deps.setInitialized(false);
         this.deps.syncStore.setStatus("idle");
       }
@@ -163,39 +166,41 @@ export class VaultLifecycleManager {
   }
 
   async switchVault(id: string) {
-    this.switchLock = this.switchLock.then(async () => {
-      if (this.deps.activeVaultId() === id) return;
+    this.switchLock = this.switchLock
+      .catch(() => {}) // Recover from any previous switch failure
+      .then(async () => {
+        if (this.deps.activeVaultId() === id) return;
 
-      this.deps.syncStore.setStatus("loading");
+        this.deps.syncStore.setStatus("loading");
 
-      // Flush debounced saves and drain the queue before clearing state
-      await this.deps.flushPendingSaves();
+        // Flush debounced saves and drain the queue before clearing state
+        await this.deps.flushPendingSaves();
 
-      // HARD CLEAR: Wipe all traces of the previous vault
-      this.deps.repository.clear();
-      this.deps.assetStore.clear();
-      this.deps.mapRegistry.maps = {};
-      this.deps.canvasRegistry.clear();
-      this.deps.setSelectedEntityId(null);
-      this.deps.syncStore.setHasConflictFiles(false);
+        // HARD CLEAR: Wipe all traces of the previous vault
+        this.deps.repository.clear();
+        this.deps.assetStore.clear();
+        this.deps.mapRegistry.maps = {};
+        this.deps.canvasRegistry.clear();
+        this.deps.setSelectedEntityId(null);
+        this.deps.syncStore.setHasConflictFiles(false);
 
-      // Invalidate cache preloads to ensure no leakage from previous vault
-      cacheService.invalidatePreload();
+        // Invalidate cache preloads to ensure no leakage from previous vault
+        cacheService.invalidatePreload();
 
-      await this.deps.vaultRegistry.setActiveVault(id);
-      this.deps.clearStorageCache();
+        await this.deps.vaultRegistry.setActiveVault(id);
+        this.deps.clearStorageCache();
 
-      // Load Oracle chat history for the new vault
-      const { oracle } = await import("../oracle.svelte");
-      await oracle.loadForVault(id);
+        // Load Oracle chat history for the new vault
+        const { oracle } = await import("../oracle.svelte");
+        await oracle.loadForVault(id);
 
-      await this.deps.themeStore.loadForVault(id);
-      await this.deps.loadFiles();
-      this.deps.setInitialized(true);
-      this.deps.syncStore.setStatus("idle");
+        await this.deps.themeStore.loadForVault(id);
+        await this.deps.loadFiles();
+        this.deps.setInitialized(true);
+        this.deps.syncStore.setStatus("idle");
 
-      vaultEventBus.emit({ type: "VAULT_SWITCHED", vaultId: id });
-    });
+        vaultEventBus.emit({ type: "VAULT_SWITCHED", vaultId: id });
+      });
 
     return this.switchLock;
   }

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -54,17 +54,29 @@ export class SyncStore {
 
   private syncAbortController: AbortController | null = null;
 
+  private unsubscribe: (() => void) | null = null;
+
   constructor(private deps: SyncStoreDependencies) {
-    appEventBus.subscribe("SYNC:DRIVE_PULL_COMPLETE", async (event) => {
-      const activeId = this.deps.activeVaultId();
-      if (activeId && event.payload?.vaultId === activeId) {
-        debugStore.log(
-          `[SyncStore] GDrive pull completed for active vault ${activeId}. Reloading files...`,
-        );
-        await cacheService.clearVault(activeId);
-        await this.loadFiles(false);
-      }
-    });
+    this.unsubscribe = appEventBus.subscribe(
+      "SYNC:DRIVE_PULL_COMPLETE",
+      async (event) => {
+        const activeId = this.deps.activeVaultId();
+        if (activeId && event.payload?.vaultId === activeId) {
+          debugStore.log(
+            `[SyncStore] GDrive pull completed for active vault ${activeId}. Reloading files...`,
+          );
+          await cacheService.clearVault(activeId);
+          await this.loadFiles(false);
+        }
+      },
+    );
+  }
+
+  destroy() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
   }
 
   private isStale(vaultIdAtStart: string, signal: AbortSignal): boolean {

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -61,7 +61,7 @@ export class SyncStore {
         debugStore.log(
           `[SyncStore] GDrive pull completed for active vault ${activeId}. Reloading files...`,
         );
-        cacheService.invalidatePreload();
+        await cacheService.clearVault(activeId);
         await this.loadFiles(false);
       }
     });

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -54,7 +54,18 @@ export class SyncStore {
 
   private syncAbortController: AbortController | null = null;
 
-  constructor(private deps: SyncStoreDependencies) {}
+  constructor(private deps: SyncStoreDependencies) {
+    appEventBus.subscribe("SYNC:DRIVE_PULL_COMPLETE", async (event) => {
+      const activeId = this.deps.activeVaultId();
+      if (activeId && event.payload?.vaultId === activeId) {
+        debugStore.log(
+          `[SyncStore] GDrive pull completed for active vault ${activeId}. Reloading files...`,
+        );
+        cacheService.invalidatePreload();
+        await this.loadFiles(false);
+      }
+    });
+  }
 
   private isStale(vaultIdAtStart: string, signal: AbortSignal): boolean {
     return this.deps.activeVaultId() !== vaultIdAtStart || signal.aborted;

--- a/packages/sync-engine/src/DiffAlgorithm.ts
+++ b/packages/sync-engine/src/DiffAlgorithm.ts
@@ -118,6 +118,7 @@ export class DiffAlgorithm {
           return {
             type: "EXPORT_TO_FS",
             path,
+            fsMetadata: fs,
             opfsMetadata: opfs,
             registryEntry: registry,
           };
@@ -140,6 +141,7 @@ export class DiffAlgorithm {
       return {
         type: "EXPORT_TO_FS",
         path,
+        fsMetadata: fs,
         opfsMetadata: opfs,
         registryEntry: registry,
       };
@@ -162,6 +164,7 @@ export class DiffAlgorithm {
         return {
           type: "EXPORT_TO_FS",
           path,
+          fsMetadata: fs,
           opfsMetadata: opfs,
           registryEntry: registry,
         };

--- a/packages/sync-engine/src/GDriveBackend.test.ts
+++ b/packages/sync-engine/src/GDriveBackend.test.ts
@@ -103,6 +103,50 @@ describe("GDriveBackend", () => {
       expect(result.files[1].handle).toBe("file2");
       expect((result as any).nextToken).toBeUndefined();
     });
+
+    it("should recursively scan subfolders", async () => {
+      (global.fetch as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              files: [
+                {
+                  id: "folder1",
+                  name: "NPCs",
+                  mimeType: "application/vnd.google-apps.folder",
+                },
+                {
+                  id: "file-root",
+                  name: "root.md",
+                  modifiedTime: "2023-01-01T00:00:00Z",
+                  size: "100",
+                },
+              ],
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              files: [
+                {
+                  id: "file-nested",
+                  name: "Bob.md",
+                  modifiedTime: "2023-01-02T00:00:00Z",
+                  size: "200",
+                },
+              ],
+            }),
+        });
+
+      const result = await backend.scan(vaultId);
+      expect(result.files).toHaveLength(2);
+      expect(result.files[0].path).toBe("NPCs/Bob.md");
+      expect(result.files[0].handle).toBe("file-nested");
+      expect(result.files[1].path).toBe("root.md");
+      expect(result.files[1].handle).toBe("file-root");
+    });
   });
 
   describe("download", () => {

--- a/packages/sync-engine/src/GDriveBackend.ts
+++ b/packages/sync-engine/src/GDriveBackend.ts
@@ -69,7 +69,7 @@ export class GDriveBackend implements ISyncBackend {
   }
 
   /**
-   * Scans the Drive folder for files.
+   * Scans the Drive folder for files recursively.
    */
   async scan(
     _vaultId: string,
@@ -77,38 +77,52 @@ export class GDriveBackend implements ISyncBackend {
   ): Promise<{ files: FileMetadata[]; nextToken?: string }> {
     if (!this.folderId) return { files: [] };
 
-    const query = `'${this.folderId}' in parents and trashed = false`;
-    const fields = "nextPageToken, files(id, name, modifiedTime, size)";
-    const baseUrl = `/files?q=${encodeURIComponent(query)}&fields=${encodeURIComponent(fields)}&pageSize=1000`;
-
-    let url = baseUrl;
-    if (sinceToken) {
-      url += `&pageToken=${encodeURIComponent(sinceToken)}`;
-    }
-
     const allFiles: FileMetadata[] = [];
-    let hasMore = true;
 
-    while (hasMore) {
-      const response = await this.driveFetch(url);
-      const data = await response.json();
+    const scanFolder = async (
+      folderId: string,
+      pathPrefix: string[] = [],
+    ): Promise<void> => {
+      const query = `'${folderId}' in parents and trashed = false`;
+      const fields =
+        "nextPageToken, files(id, name, mimeType, modifiedTime, size)";
+      const baseUrl = `/files?q=${encodeURIComponent(query)}&fields=${encodeURIComponent(fields)}&pageSize=1000`;
 
-      const files = data.files.map((f: any) => ({
-        path: f.name,
-        lastModified: new Date(f.modifiedTime).getTime(),
-        size: parseInt(f.size || "0"),
-        handle: f.id,
-      }));
-
-      allFiles.push(...files);
-
-      if (data.nextPageToken) {
-        url = `${baseUrl}&pageToken=${encodeURIComponent(data.nextPageToken)}`;
-      } else {
-        hasMore = false;
+      let url = baseUrl;
+      if (folderId === this.folderId && sinceToken) {
+        url += `&pageToken=${encodeURIComponent(sinceToken)}`;
       }
-    }
 
+      let hasMore = true;
+      while (hasMore) {
+        const response = await this.driveFetch(url);
+        const data = await response.json();
+
+        if (data.files) {
+          for (const f of data.files) {
+            const currentPath = [...pathPrefix, f.name].join("/");
+            if (f.mimeType === "application/vnd.google-apps.folder") {
+              await scanFolder(f.id, [...pathPrefix, f.name]);
+            } else {
+              allFiles.push({
+                path: currentPath,
+                lastModified: new Date(f.modifiedTime || Date.now()).getTime(),
+                size: parseInt(f.size || "0"),
+                handle: f.id,
+              });
+            }
+          }
+        }
+
+        if (data.nextPageToken) {
+          url = `${baseUrl}&pageToken=${encodeURIComponent(data.nextPageToken)}`;
+        } else {
+          hasMore = false;
+        }
+      }
+    };
+
+    await scanFolder(this.folderId);
     return { files: allFiles };
   }
 


### PR DESCRIPTION
Resolves issues where parent-child hierarchical directory structures did not render in the explorer panel under warm-cache conditions. Reconstructs the _path string-array segment property from filePath on preloaded and individual cache hits, and imports sanitizeId in adapters.svelte.ts.