### PR TITLE
:zap: perf: truncate long history messages to prevent quota exceeded errors

### DIFF
--- a/apps/web/src/lib/services/ai/text-generation.service.svelte.ts
+++ b/apps/web/src/lib/services/ai/text-generation.service.svelte.ts
@@ -61,7 +61,14 @@ export class DefaultTextGenerationService implements TextGenerationService {
 
       const conversationContext = cleanHistory
         .slice(-4)
-        .map((m) => `${m.role.toUpperCase()}: ${m.content}`)
+        .map((m) => {
+          const role = m.role.toUpperCase();
+          const content =
+            m.content.length > 2000
+              ? m.content.slice(0, 2000) + "... [truncated for length]"
+              : m.content;
+          return `${role}: ${content}`;
+        })
         .join("\n");
 
       const prompt = buildQueryExpansionPrompt(conversationContext, query);
@@ -382,7 +389,11 @@ export class DefaultTextGenerationService implements TextGenerationService {
       if (m.role !== "user" && m.role !== "assistant") continue;
 
       const role = m.role === "assistant" ? "model" : "user";
-      const content = m.content?.trim() || "(empty message)";
+      const rawContent = m.content?.trim() || "(empty message)";
+      const content =
+        rawContent.length > 4000
+          ? rawContent.slice(0, 4000) + "\n\n... [truncated for length]"
+          : rawContent;
 
       if (sanitizedHistory.length === 0) {
         if (role === "user") {

--- a/apps/web/src/lib/services/ai/text-generation.service.test.ts
+++ b/apps/web/src/lib/services/ai/text-generation.service.test.ts
@@ -110,6 +110,19 @@ describe("DefaultTextGenerationService", () => {
       expect(consoleSpy).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+
+    it("should truncate long history content to keep payload small", async () => {
+      const veryLongContent = "A".repeat(3000);
+      await service.expandQuery("key", "him?", [
+        { role: "user", content: veryLongContent },
+      ]);
+
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "A".repeat(2000) + "... [truncated for length]",
+        ),
+      );
+    });
   });
 
   describe("distillContext", () => {
@@ -366,6 +379,29 @@ describe("DefaultTextGenerationService", () => {
       expect(chatOptions.history[0].role).toBe("user");
       expect(chatOptions.history[0].parts[0].text).toContain("User message 2");
       expect(chatOptions.history[1].role).toBe("model");
+    });
+
+    it("should truncate long chat history messages to prevent token bloat", async () => {
+      const onUpdate = vi.fn();
+      const veryLongContent = "B".repeat(5000);
+      const history = [
+        { role: "user", content: veryLongContent },
+        { role: "assistant", content: "Short reply" },
+      ];
+
+      await service.generateResponse(
+        "key",
+        "Query",
+        history,
+        "Context",
+        "model",
+        onUpdate,
+      );
+
+      const chatOptions = vi.mocked(mockModel.startChat).mock.calls[0][0];
+      expect(chatOptions.history[0].parts[0].text).toBe(
+        "B".repeat(4000) + "\n\n... [truncated for length]",
+      );
     });
   });
 


### PR DESCRIPTION
Optimizes text generation service by truncating very large chat history messages for both query expansion (to 2000 chars) and chat response generation (to 4000 chars), preventing rate limit/quota errors without losing essential conversational intent.