### PR TITLE
:zap: feat(vault): optimize save queue efficiency and flush pending saves

### DIFF
--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -180,7 +180,7 @@ export class VaultStore {
       updateEntityCount: (vId, count) =>
         vaultRegistry.updateEntityCount(vId, count),
       flushPendingSaves: (timeoutMs) =>
-        this.entityStore.flushPendingSaves(timeoutMs),
+        this.entityStore?.flushPendingSaves(timeoutMs),
     });
 
     const persistence = new EntityPersistenceService({

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -179,6 +179,8 @@ export class VaultStore {
       loadCanvases: (vId) => canvasRegistry.loadFromVault(vId),
       updateEntityCount: (vId, count) =>
         vaultRegistry.updateEntityCount(vId, count),
+      flushPendingSaves: (timeoutMs) =>
+        this.entityStore.flushPendingSaves(timeoutMs),
     });
 
     const persistence = new EntityPersistenceService({

--- a/apps/web/src/lib/stores/vault/entity-persistence.ts
+++ b/apps/web/src/lib/stores/vault/entity-persistence.ts
@@ -92,7 +92,8 @@ export class EntityPersistenceService {
     });
   }
 
-  async flushPendingSaves(): Promise<void> {
+  async flushPendingSaves(timeoutMs?: number): Promise<void> {
+    const promises: Promise<void>[] = [];
     for (const [id, timer] of this._saveTimers) {
       clearTimeout(timer);
       this._saveTimers.delete(id);
@@ -104,13 +105,21 @@ export class EntityPersistenceService {
       const vaultId = this._saveVaultIds.get(id);
       this._saveVaultIds.delete(id);
       if (vaultId) {
-        await this.deps.repository.enqueueSave(id, () =>
-          this._persistEntity(id, vaultId),
-        );
+        const p = this.deps.repository
+          .enqueueSave(id, () => this._persistEntity(id, vaultId))
+          .then(() => {
+            resolvers.forEach((r) => r());
+          })
+          .catch(() => {
+            resolvers.forEach((r) => r());
+          });
+        promises.push(p);
+      } else {
+        resolvers.forEach((r) => r());
       }
-      resolvers.forEach((r) => r());
     }
-    await this.deps.repository.waitForAllSaves();
+    await Promise.all(promises);
+    await this.deps.repository.waitForAllSaves(timeoutMs);
   }
 
   private async _persistEntity(

--- a/apps/web/src/lib/stores/vault/entity-persistence.ts
+++ b/apps/web/src/lib/stores/vault/entity-persistence.ts
@@ -85,8 +85,8 @@ export class EntityPersistenceService {
           this._saveVaultIds.delete(id);
           this.deps.repository
             .enqueueSave(id, () => this._persistEntity(id, vaultIdAtStart))
-            .then(() => resolvers.forEach((r) => r()))
-            .catch(() => resolvers.forEach((r) => r()));
+            .catch(() => {})
+            .finally(() => resolvers.forEach((r) => r()));
         }, SAVE_DEBOUNCE_MS),
       );
     });
@@ -107,10 +107,8 @@ export class EntityPersistenceService {
       if (vaultId) {
         const p = this.deps.repository
           .enqueueSave(id, () => this._persistEntity(id, vaultId))
-          .then(() => {
-            resolvers.forEach((r) => r());
-          })
-          .catch(() => {
+          .catch(() => {})
+          .finally(() => {
             resolvers.forEach((r) => r());
           });
         promises.push(p);

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -172,8 +172,8 @@ export class EntityStore {
     return this.persistence.scheduleSave(entity);
   }
 
-  async flushPendingSaves(): Promise<void> {
-    return this.persistence.flushPendingSaves();
+  async flushPendingSaves(timeoutMs?: number): Promise<void> {
+    return this.persistence.flushPendingSaves(timeoutMs);
   }
 
   // --- Loader Delegation ---

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -1136,4 +1136,137 @@ describe("EntityStore", () => {
       expect(repository.entities.hero.parent).toBe("parent-node");
     });
   });
+
+  describe("flushPendingSaves", () => {
+    it("should clear timeouts and flush all pending saves concurrently", async () => {
+      const repositoryMock = {
+        entities: {
+          "entity-1": { id: "entity-1", title: "E1" },
+          "entity-2": { id: "entity-2", title: "E2" },
+        },
+        enqueueSave: vi.fn().mockImplementation((id, cb) => cb()),
+        waitForAllSaves: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const setStatus = vi.fn();
+      const storeWithPending = new EntityStore({
+        repository: repositoryMock as any,
+        activeVaultId: () => "vault-1",
+        isGuest: () => false,
+        setStatus,
+        setErrorMessage: vi.fn(),
+        getActiveVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+        getSpecificVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+        getActiveFolderHandle: vi.fn().mockResolvedValue(undefined),
+        getServices: () => ({}),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      // Schedule two saves (will be debounced)
+      const save1 = storeWithPending.scheduleSave(
+        repositoryMock.entities["entity-1"],
+      );
+      const save2 = storeWithPending.scheduleSave(
+        repositoryMock.entities["entity-2"],
+      );
+
+      // Flush them immediately before their 400ms timer runs
+      await storeWithPending.flushPendingSaves();
+
+      // Check both enqueueSave were called
+      expect(repositoryMock.enqueueSave).toHaveBeenCalledWith(
+        "entity-1",
+        expect.any(Function),
+      );
+      expect(repositoryMock.enqueueSave).toHaveBeenCalledWith(
+        "entity-2",
+        expect.any(Function),
+      );
+      // Check that waitForAllSaves was called at the end
+      expect(repositoryMock.waitForAllSaves).toHaveBeenCalled();
+
+      // The promises from scheduleSave should resolve
+      await Promise.all([save1, save2]);
+    });
+
+    it("should propagate timeoutMs to waitForAllSaves", async () => {
+      const repositoryMock = {
+        entities: {
+          "entity-1": { id: "entity-1", title: "E1" },
+        },
+        enqueueSave: vi.fn().mockImplementation((id, cb) => cb()),
+        waitForAllSaves: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const storeWithPending = new EntityStore({
+        repository: repositoryMock as any,
+        activeVaultId: () => "vault-1",
+        isGuest: () => false,
+        setStatus: vi.fn(),
+        setErrorMessage: vi.fn(),
+        getActiveVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+        getSpecificVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+        getActiveFolderHandle: vi.fn().mockResolvedValue(undefined),
+        getServices: () => ({}),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      storeWithPending.scheduleSave(repositoryMock.entities["entity-1"]);
+      await storeWithPending.flushPendingSaves(2000);
+
+      expect(repositoryMock.waitForAllSaves).toHaveBeenCalledWith(2000);
+    });
+
+    it("should handle individual save rejections gracefully and still wait for other saves", async () => {
+      const repositoryMock = {
+        entities: {
+          "entity-1": { id: "entity-1", title: "E1" },
+          "entity-2": { id: "entity-2", title: "E2" },
+        },
+        enqueueSave: vi.fn().mockImplementation((id, cb) => {
+          if (id === "entity-1") {
+            return Promise.reject(new Error("Failure"));
+          }
+          return cb();
+        }),
+        waitForAllSaves: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const storeWithPending = new EntityStore({
+        repository: repositoryMock as any,
+        activeVaultId: () => "vault-1",
+        isGuest: () => false,
+        setStatus: vi.fn(),
+        setErrorMessage: vi.fn(),
+        getActiveVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+        getSpecificVaultHandle: vi.fn().mockResolvedValue({ name: "vault-1" }),
+        getActiveFolderHandle: vi.fn().mockResolvedValue(undefined),
+        getServices: () => ({}),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const save1 = storeWithPending.scheduleSave(
+        repositoryMock.entities["entity-1"],
+      );
+      const save2 = storeWithPending.scheduleSave(
+        repositoryMock.entities["entity-2"],
+      );
+
+      // Should not throw, should resolve successfully
+      await storeWithPending.flushPendingSaves();
+
+      expect(repositoryMock.enqueueSave).toHaveBeenCalledWith(
+        "entity-1",
+        expect.any(Function),
+      );
+      expect(repositoryMock.enqueueSave).toHaveBeenCalledWith(
+        "entity-2",
+        expect.any(Function),
+      );
+      expect(repositoryMock.waitForAllSaves).toHaveBeenCalled();
+
+      // Ensure save promises are resolved/settled (either resolve or swallow error in scheduleSave)
+      await Promise.all([save1, save2]);
+    });
+  });
 });

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -85,6 +85,14 @@ export class SyncStore {
     }
   }
 
+  private async waitForSaves(timeoutMs?: number): Promise<void> {
+    if (this.deps.flushPendingSaves) {
+      await this.deps.flushPendingSaves(timeoutMs);
+    } else {
+      await this.deps.repository.waitForAllSaves(timeoutMs);
+    }
+  }
+
   private async ensureFolderPermission(
     localHandle: FileSystemDirectoryHandle,
   ): Promise<boolean> {
@@ -245,10 +253,7 @@ export class SyncStore {
               vaultDir,
               "pull",
               this.deps.repository.entities,
-              () =>
-                this.deps.flushPendingSaves
-                  ? this.deps.flushPendingSaves()
-                  : this.deps.repository.waitForAllSaves(),
+              () => this.waitForSaves(),
               (state: {
                 status: "saving" | "loading" | "idle" | "error";
                 syncType: "local" | null;
@@ -384,10 +389,7 @@ export class SyncStore {
       vaultIdAtStart,
       opfsHandle,
       this.deps.repository.entities,
-      () =>
-        this.deps.flushPendingSaves
-          ? this.deps.flushPendingSaves()
-          : this.deps.repository.waitForAllSaves(),
+      () => this.waitForSaves(),
       (state) => {
         if (this.deps.activeVaultId() === vaultIdAtStart) {
           this.setStatus(state.status);
@@ -453,10 +455,7 @@ export class SyncStore {
       vaultIdAtStart,
       opfsHandle,
       this.deps.repository.entities,
-      () =>
-        this.deps.flushPendingSaves
-          ? this.deps.flushPendingSaves()
-          : this.deps.repository.waitForAllSaves(),
+      () => this.waitForSaves(),
       (state) => {
         if (this.deps.activeVaultId() === vaultIdAtStart) {
           this.setStatus(state.status);

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -20,6 +20,7 @@ export interface SyncStoreDependencies {
   loadMaps: (vaultId: string) => Promise<void>;
   loadCanvases: (vaultId: string) => Promise<void>;
   updateEntityCount: (vaultId: string, count: number) => Promise<void>;
+  flushPendingSaves?: (timeoutMs?: number) => Promise<void>;
 }
 
 export class SyncStore {
@@ -244,7 +245,10 @@ export class SyncStore {
               vaultDir,
               "pull",
               this.deps.repository.entities,
-              () => this.deps.repository.waitForAllSaves(),
+              () =>
+                this.deps.flushPendingSaves
+                  ? this.deps.flushPendingSaves()
+                  : this.deps.repository.waitForAllSaves(),
               (state: {
                 status: "saving" | "loading" | "idle" | "error";
                 syncType: "local" | null;
@@ -380,7 +384,10 @@ export class SyncStore {
       vaultIdAtStart,
       opfsHandle,
       this.deps.repository.entities,
-      () => this.deps.repository.waitForAllSaves(),
+      () =>
+        this.deps.flushPendingSaves
+          ? this.deps.flushPendingSaves()
+          : this.deps.repository.waitForAllSaves(),
       (state) => {
         if (this.deps.activeVaultId() === vaultIdAtStart) {
           this.setStatus(state.status);
@@ -446,7 +453,10 @@ export class SyncStore {
       vaultIdAtStart,
       opfsHandle,
       this.deps.repository.entities,
-      () => this.deps.repository.waitForAllSaves(),
+      () =>
+        this.deps.flushPendingSaves
+          ? this.deps.flushPendingSaves()
+          : this.deps.repository.waitForAllSaves(),
       (state) => {
         if (this.deps.activeVaultId() === vaultIdAtStart) {
           this.setStatus(state.status);

--- a/apps/web/src/lib/stores/vault/sync-store.test.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.test.ts
@@ -424,4 +424,92 @@ describe("SyncStore", () => {
       vi.useRealTimers();
     });
   });
+
+  describe("waitForSaves integration", () => {
+    it("should trigger flushPendingSaves when pull, push, or syncWithLocalFolder is executed", async () => {
+      const flushPendingSavesSpy = vi.fn().mockResolvedValue(undefined);
+      const syncWithLocalFolderSpy = vi
+        .fn()
+        .mockImplementation(async (_a, _b, _c, _d, waitForSaves, _e) => {
+          await waitForSaves();
+        });
+
+      const mockFolderHandle = {
+        queryPermission: vi.fn().mockResolvedValue("granted"),
+      };
+
+      const testStore = new SyncStore({
+        activeVaultId: () => "vault-1",
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue({
+          syncWithLocalFolder: syncWithLocalFolderSpy,
+        } as any),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi
+          .fn()
+          .mockResolvedValue(mockFolderHandle as any),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+        flushPendingSaves: flushPendingSavesSpy,
+      });
+
+      await testStore.loadFiles(false); // Force sync, triggers syncWithLocalFolder
+
+      expect(syncWithLocalFolderSpy).toHaveBeenCalled();
+      expect(flushPendingSavesSpy).toHaveBeenCalled();
+    });
+
+    it("should trigger flushPendingSaves during saveToFolder and loadFromFolder", async () => {
+      const flushPendingSavesSpy = vi.fn().mockResolvedValue(undefined);
+      const pushSpy = vi
+        .fn()
+        .mockImplementation(async (_a, _b, _c, waitForSaves, _d) => {
+          await waitForSaves();
+        });
+      const pullSpy = vi
+        .fn()
+        .mockImplementation(async (_a, _b, _c, waitForSaves, _d) => {
+          await waitForSaves();
+        });
+
+      const mockFolderHandle = {
+        queryPermission: vi.fn().mockResolvedValue("granted"),
+      };
+
+      const testStore = new SyncStore({
+        activeVaultId: () => "vault-1",
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue({
+          push: pushSpy,
+          pull: pullSpy,
+          syncWithLocalFolder: vi.fn().mockResolvedValue({
+            created: [],
+            updated: [],
+            deleted: [],
+          }),
+        } as any),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi
+          .fn()
+          .mockResolvedValue(mockFolderHandle as any),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+        flushPendingSaves: flushPendingSavesSpy,
+      });
+
+      await testStore.saveToFolder();
+      expect(pushSpy).toHaveBeenCalled();
+      expect(flushPendingSavesSpy).toHaveBeenCalledTimes(1);
+
+      await testStore.loadFromFolder();
+      expect(pullSpy).toHaveBeenCalled();
+      expect(flushPendingSavesSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/apps/web/src/lib/stores/vault/sync-store.test.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.test.ts
@@ -62,6 +62,7 @@ describe("SyncStore", () => {
       loadMaps: vi.fn().mockResolvedValue(undefined),
       loadCanvases: vi.fn().mockResolvedValue(undefined),
       updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      flushPendingSaves: vi.fn().mockResolvedValue(undefined),
     });
   });
 

--- a/docs/proposals/NEXT_FEATURES_AND_CODE_IMPROVEMENTS.md
+++ b/docs/proposals/NEXT_FEATURES_AND_CODE_IMPROVEMENTS.md
@@ -137,7 +137,7 @@ Use these filters when choosing what to build next:
 
 ## Recommended Code Improvement Backlog
 
-### A. Event And Store Boundaries
+### A. Event And Store Boundaries (Implemented)
 
 **Problem**: Some workflows still rely on repeated single-entity events or duplicated async race checks.
 


### PR DESCRIPTION
This pull request implements optimization of save queue operations and flushes pending saves before sync/pull/push operations, closing #920.

All unit tests have been updated and are passing successfully.