### PR TITLE
:sparkles: feat(ui): connection editing in Zen mode and key shortcuts for inputs

### DIFF
--- a/apps/web/src/lib/components/connections/ConnectionEditor.svelte
+++ b/apps/web/src/lib/components/connections/ConnectionEditor.svelte
@@ -38,6 +38,16 @@
     );
     onSave();
   };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onCancel();
+    }
+  };
 </script>
 
 <div class="p-3 bg-theme-bg border border-theme-primary rounded-md space-y-3">
@@ -50,6 +60,7 @@
     <select
       id="relationship-type"
       bind:value={type}
+      onkeydown={handleKeyDown}
       class="w-full bg-theme-surface text-theme-text border border-theme-border rounded px-2 py-1 text-sm focus:outline-none focus:border-theme-primary"
     >
       {#each options as opt}
@@ -68,6 +79,7 @@
       id="custom-label"
       type="text"
       bind:value={label}
+      onkeydown={handleKeyDown}
       placeholder="e.g. Brother, Rival, Employer"
       class="w-full bg-theme-surface text-theme-text border border-theme-border rounded px-2 py-1 text-sm focus:outline-none focus:border-theme-primary"
     />

--- a/apps/web/src/lib/components/connections/ConnectionEditor.svelte
+++ b/apps/web/src/lib/components/connections/ConnectionEditor.svelte
@@ -40,17 +40,23 @@
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.repeat || e.isComposing) return;
     if (e.key === "Enter") {
       e.preventDefault();
+      e.stopPropagation();
       handleSave();
     } else if (e.key === "Escape") {
       e.preventDefault();
+      e.stopPropagation();
       onCancel();
     }
   };
 </script>
 
-<div class="p-3 bg-theme-bg border border-theme-primary rounded-md space-y-3">
+<div
+  data-shortcuts="ignore"
+  class="p-3 bg-theme-bg border border-theme-primary rounded-md space-y-3"
+>
   <div>
     <label
       for="relationship-type"

--- a/apps/web/src/lib/components/labels/AliasInput.svelte
+++ b/apps/web/src/lib/components/labels/AliasInput.svelte
@@ -40,6 +40,7 @@
 </script>
 
 <div
+  data-shortcuts="ignore"
   class="flex flex-wrap items-center gap-1.5 p-1.5 bg-theme-bg/30 border border-theme-border rounded-lg focus-within:border-theme-primary/50 focus-within:ring-1 focus-within:ring-theme-primary/20 transition-all min-h-[36px]"
 >
   {#each aliases as alias, i}

--- a/apps/web/src/lib/components/labels/LabelInput.svelte
+++ b/apps/web/src/lib/components/labels/LabelInput.svelte
@@ -131,6 +131,7 @@
   <input
     type="text"
     {id}
+    data-shortcuts="ignore"
     bind:value={inputValue}
     {placeholder}
     aria-label={ariaLabel || placeholder}

--- a/apps/web/src/lib/components/zen/ZenContent.connections.test.ts
+++ b/apps/web/src/lib/components/zen/ZenContent.connections.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { render } from "@testing-library/svelte";
+import { render, fireEvent } from "@testing-library/svelte";
 import { describe, it, expect, vi } from "vitest";
 import ZenContent from "./ZenContent.svelte";
 import { vault } from "$lib/stores/vault.svelte";
@@ -66,6 +66,7 @@ vi.mock("$lib/stores/vault.svelte", () => {
       entities: mockEntities,
       inboundConnections: mockInbound,
       labelIndex: [],
+      updateConnection: vi.fn(),
     },
   };
 });
@@ -110,5 +111,46 @@ describe("ZenContent with duplicate/mutual connections", () => {
     // Connections should render successfully
     const items = queryAllByText("Entity Two");
     expect(items.length).toBeGreaterThan(0);
+  });
+
+  it("renders edit button for outbound connections and toggles ConnectionEditor on click", async () => {
+    const mockEntity = vault.entities["entity-1"];
+
+    const { getAllByLabelText, getAllByRole, queryAllByRole } = render(
+      ZenContent,
+      {
+        entity: mockEntity,
+        editState: { isEditing: false, aliases: [] },
+        scrollContainer: undefined,
+        onNavigate: () => {},
+      },
+    );
+
+    // Verify edit buttons are present (for the two outbound connections)
+    const editBtns = getAllByLabelText("Edit connection");
+    expect(editBtns.length).toBe(2);
+
+    // ConnectionEditor select/input should NOT be in the document initially
+    expect(
+      queryAllByRole("combobox", { name: /relationship type/i }).length,
+    ).toBe(0);
+
+    // Click the first edit button
+    await fireEvent.click(editBtns[0]);
+
+    // ConnectionEditor should be rendered
+    const selectEl = getAllByRole("combobox", {
+      name: /relationship type/i,
+    })[0];
+    expect(selectEl).toBeTruthy();
+
+    // Click cancel button inside ConnectionEditor
+    const cancelBtn = getAllByRole("button", { name: /cancel/i })[0];
+    await fireEvent.click(cancelBtn);
+
+    // ConnectionEditor should be removed
+    expect(
+      queryAllByRole("combobox", { name: /relationship type/i }).length,
+    ).toBe(0);
   });
 });

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -27,7 +27,8 @@
   interface ConnectionListItem {
     id: string;
     key: string;
-    label: string;
+    displayLabel: string;
+    rawLabel?: string;
     title: string;
     type: string;
     isOutbound: boolean;
@@ -53,7 +54,8 @@
         result.push({
           id: c.target,
           key: `${c.target}-out-${c.type}-${i}`,
-          label: c.label || c.type,
+          displayLabel: c.label || c.type,
+          rawLabel: c.label,
           title: vault.entities[c.target]?.title || c.target,
           type: c.type,
           isOutbound: true,
@@ -68,7 +70,8 @@
         result.push({
           id: item.sourceId,
           key: `${item.sourceId}-in-${item.connection.type}-${i}`,
-          label: item.connection.label || item.connection.type,
+          displayLabel: item.connection.label || item.connection.type,
+          rawLabel: item.connection.label,
           title: vault.entities[item.sourceId]?.title || item.sourceId,
           type: item.connection.type,
           isOutbound: false,
@@ -303,7 +306,7 @@
                     connection={{
                       target: conn.id,
                       type: conn.type,
-                      label: conn.label || "",
+                      label: conn.rawLabel || "",
                     }}
                     onSave={() => (editingConnectionTarget = null)}
                     onCancel={() => (editingConnectionTarget = null)}
@@ -327,7 +330,7 @@
                       <div
                         class="text-xs text-theme-muted uppercase tracking-widest font-header"
                       >
-                        {conn.label}
+                        {conn.displayLabel}
                       </div>
                       <div
                         class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -5,7 +5,10 @@
   import TemporalEditor from "$lib/components/timeline/TemporalEditor.svelte";
   import { regenerationService } from "$lib/services/RegenerationService.svelte";
   import DetailProposals from "$lib/components/entity-detail/proposals/DetailProposals.svelte";
+  import ConnectionEditor from "$lib/components/connections/ConnectionEditor.svelte";
   import { isEntityVisible, type Entity } from "schema";
+
+  let editingConnectionTarget = $state<string | null>(null);
 
   let {
     entity,
@@ -293,58 +296,95 @@
         {#if allConnections.length > 0}
           <div class="space-y-2">
             {#each allConnections as conn (conn.key)}
-              <div
-                class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
-              >
-                <button
-                  type="button"
-                  onclick={() => onNavigate(conn.id)}
-                  class="flex-1 min-w-0 flex items-center gap-3 text-left"
+              {#if editingConnectionTarget === conn.id && conn.isOutbound}
+                <div class="p-1">
+                  <ConnectionEditor
+                    sourceId={entity?.id || ""}
+                    connection={{
+                      target: conn.id,
+                      type: conn.type,
+                      label: conn.label || "",
+                    }}
+                    onSave={() => (editingConnectionTarget = null)}
+                    onCancel={() => (editingConnectionTarget = null)}
+                  />
+                </div>
+              {:else}
+                <div
+                  class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
                 >
-                  <span
-                    class="w-1.5 h-1.5 rounded-full shrink-0 {conn.isOutbound
-                      ? 'bg-theme-primary'
-                      : 'bg-blue-500'}"
-                  ></span>
-                  <div class="flex-1 min-w-0">
-                    <div
-                      class="text-xs text-theme-muted uppercase tracking-widest font-header"
-                    >
-                      {conn.label}
-                    </div>
-                    <div
-                      class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"
-                    >
-                      {conn.title}
-                    </div>
-                  </div>
-                </button>
-                {#if !vault.isGuest}
                   <button
                     type="button"
-                    onclick={() => {
-                      const entityId = entity?.id;
-                      if (!entityId) return;
-                      if (conn.isOutbound) {
-                        vault.removeConnection(entityId, conn.id, conn.type);
-                      } else {
-                        vault.removeConnection(conn.id, entityId, conn.type);
-                      }
-                    }}
-                    class="text-theme-muted hover:text-theme-danger transition p-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0"
-                    aria-label="Delete connection"
-                    title="Delete connection"
+                    onclick={() => onNavigate(conn.id)}
+                    class="flex-1 min-w-0 flex items-center gap-3 text-left"
                   >
-                    <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+                    <span
+                      class="w-1.5 h-1.5 rounded-full shrink-0 {conn.isOutbound
+                        ? 'bg-theme-primary'
+                        : 'bg-blue-500'}"
+                    ></span>
+                    <div class="flex-1 min-w-0">
+                      <div
+                        class="text-xs text-theme-muted uppercase tracking-widest font-header"
+                      >
+                        {conn.label}
+                      </div>
+                      <div
+                        class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"
+                      >
+                        {conn.title}
+                      </div>
+                    </div>
                   </button>
-                {/if}
-                <button
-                  type="button"
-                  onclick={() => onNavigate(conn.id)}
-                  class="icon-[lucide--chevron-right] w-4 h-4 text-theme-muted group-hover:text-theme-primary group-focus-within:text-theme-primary focus-visible:text-theme-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition shrink-0"
-                  aria-label="Navigate to {conn.title}"
-                ></button>
-              </div>
+                  {#if !vault.isGuest}
+                    <div class="flex items-center gap-1">
+                      {#if conn.isOutbound}
+                        <button
+                          type="button"
+                          onclick={() => (editingConnectionTarget = conn.id)}
+                          class="text-theme-muted hover:text-theme-primary transition p-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0"
+                          aria-label="Edit connection"
+                          title="Edit connection"
+                        >
+                          <span class="icon-[lucide--pencil] w-3.5 h-3.5"
+                          ></span>
+                        </button>
+                      {/if}
+                      <button
+                        type="button"
+                        onclick={() => {
+                          const entityId = entity?.id;
+                          if (!entityId) return;
+                          if (conn.isOutbound) {
+                            vault.removeConnection(
+                              entityId,
+                              conn.id,
+                              conn.type,
+                            );
+                          } else {
+                            vault.removeConnection(
+                              conn.id,
+                              entityId,
+                              conn.type,
+                            );
+                          }
+                        }}
+                        class="text-theme-muted hover:text-theme-danger transition p-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0"
+                        aria-label="Delete connection"
+                        title="Delete connection"
+                      >
+                        <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+                      </button>
+                    </div>
+                  {/if}
+                  <button
+                    type="button"
+                    onclick={() => onNavigate(conn.id)}
+                    class="icon-[lucide--chevron-right] w-4 h-4 text-theme-muted group-hover:text-theme-primary group-focus-within:text-theme-primary focus-visible:text-theme-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition shrink-0"
+                    aria-label="Navigate to {conn.title}"
+                  ></button>
+                </div>
+              {/if}
             {/each}
           </div>
         {:else}

--- a/apps/web/src/lib/components/zen/ZenSidebar.connections.test.ts
+++ b/apps/web/src/lib/components/zen/ZenSidebar.connections.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { render } from "@testing-library/svelte";
+import { render, fireEvent } from "@testing-library/svelte";
 import { describe, it, expect, vi } from "vitest";
 import ZenSidebar from "./ZenSidebar.svelte";
 import { vault } from "$lib/stores/vault.svelte";
@@ -69,6 +69,7 @@ vi.mock("$lib/stores/vault.svelte", () => {
       entities: mockEntities,
       inboundConnections: mockInbound,
       labelIndex: [],
+      updateConnection: vi.fn(),
     },
   };
 });
@@ -116,5 +117,39 @@ describe("ZenSidebar with duplicate/mutual connections", () => {
     // The connections header and elements should be rendered correctly
     const items = queryAllByText("Entity Two");
     expect(items.length).toBeGreaterThan(0);
+  });
+
+  it("renders edit button for outbound connections and toggles ConnectionEditor on click", async () => {
+    const mockEntity = vault.entities["entity-1"];
+
+    const { getByLabelText, getByRole, queryByRole } = render(ZenSidebar, {
+      entity: mockEntity,
+      editState: { isEditing: false, aliases: [] },
+      resolvedImageUrl: "",
+      onShowLightbox: () => {},
+      onNavigate: () => {},
+      onDelete: async () => {},
+    });
+
+    // Verify edit button is present
+    const editBtn = getByLabelText("Edit connection");
+    expect(editBtn).toBeTruthy();
+
+    // ConnectionEditor select/input should NOT be in the document initially
+    expect(queryByRole("combobox", { name: /relationship type/i })).toBeNull();
+
+    // Click edit button
+    await fireEvent.click(editBtn);
+
+    // ConnectionEditor should be rendered
+    const selectEl = getByRole("combobox", { name: /relationship type/i });
+    expect(selectEl).toBeTruthy();
+
+    // Click cancel button inside ConnectionEditor
+    const cancelBtn = getByRole("button", { name: /cancel/i });
+    await fireEvent.click(cancelBtn);
+
+    // ConnectionEditor should be removed
+    expect(queryByRole("combobox", { name: /relationship type/i })).toBeNull();
   });
 });

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -4,9 +4,12 @@
   import LabelBadge from "$lib/components/labels/LabelBadge.svelte";
   import LabelInput from "$lib/components/labels/LabelInput.svelte";
   import AliasInput from "$lib/components/labels/AliasInput.svelte";
+  import ConnectionEditor from "$lib/components/connections/ConnectionEditor.svelte";
   import { regenerationService } from "$lib/services/RegenerationService.svelte";
   import { isEntityVisible, type Entity } from "schema";
   import { discoveryPolicyStore } from "$lib/stores/ui/discovery-policy.svelte";
+
+  let editingConnectionTarget = $state<string | null>(null);
 
   let {
     entity,
@@ -339,57 +342,93 @@
         {#if allConnections.length > 0}
           <div class="space-y-2">
             {#each allConnections as conn (conn.key)}
-              <div
-                class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
-              >
-                <button
-                  onclick={() => onNavigate(conn.id)}
-                  class="flex-1 min-w-0 flex items-center gap-3 text-left"
-                >
-                  <span
-                    class="w-1.5 h-1.5 rounded-full shrink-0 {conn.isOutbound
-                      ? 'bg-theme-primary'
-                      : 'bg-blue-500'}"
-                  ></span>
-                  <div class="flex-1 min-w-0">
-                    <div
-                      class="text-xs text-theme-muted uppercase tracking-widest font-header"
-                    >
-                      {conn.label}
-                    </div>
-                    <div
-                      class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"
-                    >
-                      {conn.title}
-                    </div>
-                  </div>
-                </button>
-
-                {#if !vault.isGuest}
-                  <button
-                    onclick={() => {
-                      const entityId = entity?.id;
-                      if (!entityId) return;
-                      if (conn.isOutbound) {
-                        vault.removeConnection(entityId, conn.id, conn.type);
-                      } else {
-                        vault.removeConnection(conn.id, entityId, conn.type);
-                      }
+              {#if editingConnectionTarget === conn.id && conn.isOutbound}
+                <div class="p-1">
+                  <ConnectionEditor
+                    sourceId={entity?.id || ""}
+                    connection={{
+                      target: conn.id,
+                      type: conn.type,
+                      label: conn.label || "",
                     }}
-                    class="text-theme-muted hover:text-theme-danger transition p-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0"
-                    aria-label="Delete connection"
-                    title="Delete connection"
+                    onSave={() => (editingConnectionTarget = null)}
+                    onCancel={() => (editingConnectionTarget = null)}
+                  />
+                </div>
+              {:else}
+                <div
+                  class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
+                >
+                  <button
+                    onclick={() => onNavigate(conn.id)}
+                    class="flex-1 min-w-0 flex items-center gap-3 text-left"
                   >
-                    <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+                    <span
+                      class="w-1.5 h-1.5 rounded-full shrink-0 {conn.isOutbound
+                        ? 'bg-theme-primary'
+                        : 'bg-blue-500'}"
+                    ></span>
+                    <div class="flex-1 min-w-0">
+                      <div
+                        class="text-xs text-theme-muted uppercase tracking-widest font-header"
+                      >
+                        {conn.label}
+                      </div>
+                      <div
+                        class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"
+                      >
+                        {conn.title}
+                      </div>
+                    </div>
                   </button>
-                {/if}
 
-                <button
-                  onclick={() => onNavigate(conn.id)}
-                  class="icon-[lucide--chevron-right] w-4 h-4 text-theme-muted group-hover:text-theme-primary group-focus-within:text-theme-primary focus-visible:text-theme-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition shrink-0"
-                  aria-label="Navigate to {conn.title}"
-                ></button>
-              </div>
+                  {#if !vault.isGuest}
+                    <div class="flex items-center gap-1">
+                      {#if conn.isOutbound}
+                        <button
+                          onclick={() => (editingConnectionTarget = conn.id)}
+                          class="text-theme-muted hover:text-theme-primary transition p-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0"
+                          aria-label="Edit connection"
+                          title="Edit connection"
+                        >
+                          <span class="icon-[lucide--pencil] w-3.5 h-3.5"
+                          ></span>
+                        </button>
+                      {/if}
+                      <button
+                        onclick={() => {
+                          const entityId = entity?.id;
+                          if (!entityId) return;
+                          if (conn.isOutbound) {
+                            vault.removeConnection(
+                              entityId,
+                              conn.id,
+                              conn.type,
+                            );
+                          } else {
+                            vault.removeConnection(
+                              conn.id,
+                              entityId,
+                              conn.type,
+                            );
+                          }
+                        }}
+                        class="text-theme-muted hover:text-theme-danger transition p-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0"
+                        aria-label="Delete connection"
+                        title="Delete connection"
+                      >
+                        <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+                      </button>
+                    </div>
+                  {/if}
+
+                  <button
+                    onclick={() => onNavigate(conn.id)}
+                    class="icon-[lucide--chevron-right] w-4 h-4 text-theme-muted group-hover:text-theme-primary group-focus-within:text-theme-primary focus-visible:text-theme-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition shrink-0"
+                    aria-label="Navigate to {conn.title}"
+                  ></button>
+                </div>
+              {/if}
             {/each}
           </div>
         {:else}

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -34,7 +34,8 @@
   interface ConnectionListItem {
     id: string;
     key: string;
-    label: string;
+    displayLabel: string;
+    rawLabel?: string;
     title: string;
     type: string;
     isOutbound: boolean;
@@ -62,7 +63,8 @@
         result.push({
           id: c.target,
           key: `${c.target}-out-${c.type}-${i}`,
-          label: c.label || c.type,
+          displayLabel: c.label || c.type,
+          rawLabel: c.label,
           title: vault.entities[c.target]?.title || c.target,
           type: c.type,
           isOutbound: true,
@@ -78,7 +80,8 @@
         result.push({
           id: item.sourceId,
           key: `${item.sourceId}-in-${item.connection.type}-${i}`,
-          label: item.connection.label || item.connection.type,
+          displayLabel: item.connection.label || item.connection.type,
+          rawLabel: item.connection.label,
           title: vault.entities[item.sourceId]?.title || item.sourceId,
           type: item.connection.type,
           isOutbound: false,
@@ -349,7 +352,7 @@
                     connection={{
                       target: conn.id,
                       type: conn.type,
-                      label: conn.label || "",
+                      label: conn.rawLabel || "",
                     }}
                     onSave={() => (editingConnectionTarget = null)}
                     onCancel={() => (editingConnectionTarget = null)}
@@ -373,7 +376,7 @@
                       <div
                         class="text-xs text-theme-muted uppercase tracking-widest font-header"
                       >
-                        {conn.label}
+                        {conn.displayLabel}
                       </div>
                       <div
                         class="text-sm font-bold text-theme-text group-hover:text-theme-primary truncate transition font-body"
@@ -444,6 +447,7 @@
     {#if editState.isEditing && !vault.isGuest}
       <div class="mt-6 pt-6 border-t border-theme-border">
         <button
+          type="button"
           onclick={onDelete}
           class="w-full border border-red-900/30 text-red-800 hover:text-red-500 hover:border-red-600 hover:bg-red-950/30 text-xs font-bold px-4 py-2 rounded tracking-widest transition flex items-center justify-center gap-2"
         >

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -360,6 +360,7 @@
                   class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
                 >
                   <button
+                    type="button"
                     onclick={() => onNavigate(conn.id)}
                     class="flex-1 min-w-0 flex items-center gap-3 text-left"
                   >
@@ -386,6 +387,7 @@
                     <div class="flex items-center gap-1">
                       {#if conn.isOutbound}
                         <button
+                          type="button"
                           onclick={() => (editingConnectionTarget = conn.id)}
                           class="text-theme-muted hover:text-theme-primary transition p-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 shrink-0"
                           aria-label="Edit connection"
@@ -396,6 +398,7 @@
                         </button>
                       {/if}
                       <button
+                        type="button"
                         onclick={() => {
                           const entityId = entity?.id;
                           if (!entityId) return;
@@ -423,6 +426,7 @@
                   {/if}
 
                   <button
+                    type="button"
                     onclick={() => onNavigate(conn.id)}
                     class="icon-[lucide--chevron-right] w-4 h-4 text-theme-muted group-hover:text-theme-primary group-focus-within:text-theme-primary focus-visible:text-theme-primary opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition shrink-0"
                     aria-label="Navigate to {conn.title}"

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -193,6 +193,45 @@
       return;
     }
 
+    if (isEditing) {
+      const activeEl = document.activeElement;
+      const isInput =
+        activeEl?.tagName === "INPUT" || activeEl?.tagName === "SELECT";
+      const isTextarea = activeEl?.tagName === "TEXTAREA";
+
+      if (e.key === "Enter" && isInput) {
+        const input = activeEl as HTMLInputElement;
+        if (
+          input.placeholder?.toLowerCase().includes("alias") &&
+          input.value.trim() !== ""
+        ) {
+          return;
+        }
+        if (
+          input.placeholder?.toLowerCase().includes("label") &&
+          input.value.trim() !== ""
+        ) {
+          return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        await saveChanges();
+        return;
+      }
+
+      if (e.key === "Escape" && (isInput || isTextarea)) {
+        if (activeEl?.getAttribute("aria-expanded") === "true") {
+          return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        cancelEditing();
+        return;
+      }
+    }
+
     if (
       document.activeElement?.tagName === "INPUT" ||
       document.activeElement?.tagName === "TEXTAREA" ||

--- a/apps/web/src/lib/components/zen/ZenView.svelte
+++ b/apps/web/src/lib/components/zen/ZenView.svelte
@@ -200,16 +200,9 @@
       const isTextarea = activeEl?.tagName === "TEXTAREA";
 
       if (e.key === "Enter" && isInput) {
-        const input = activeEl as HTMLInputElement;
         if (
-          input.placeholder?.toLowerCase().includes("alias") &&
-          input.value.trim() !== ""
-        ) {
-          return;
-        }
-        if (
-          input.placeholder?.toLowerCase().includes("label") &&
-          input.value.trim() !== ""
+          activeEl.closest('[data-shortcuts="ignore"]') ||
+          activeEl.closest('[role="combobox"]')
         ) {
           return;
         }
@@ -222,6 +215,9 @@
 
       if (e.key === "Escape" && (isInput || isTextarea)) {
         if (activeEl?.getAttribute("aria-expanded") === "true") {
+          return;
+        }
+        if (activeEl.closest('[data-shortcuts="ignore"]')) {
           return;
         }
 


### PR DESCRIPTION
Implements UI connection editing in Zen Mode and adds Enter (to save) and Escape (to cancel) keyboard shortcuts to editing fields. Closes #924.