### PR TITLE
✨ feat(map): drag-and-drop pins, togglable labels, and default-off fog of war

### DIFF
--- a/.agent/skills/codex-review/SKILL.md
+++ b/.agent/skills/codex-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-review
-description: Specialist code review for Codex-Cryptica project. Use to identify race conditions, AI parsing issues, worker proxy mismatches, and project-specific anti-patterns in Svelte 5 and TypeScript.
+description: Specialist code review for Codex-Cryptica project. Use to identify race conditions, AI parsing issues, worker proxy mismatches, and project-specific anti-patterns in Svelte 5 and TypeScript. Always initiates and incorporates the general review processes defined in `code-review:code-review`.
 ---
 
 # Codex Review
@@ -16,6 +16,7 @@ This skill provides a meticulous code review process tailored specifically for t
 5. **Enforce Performance Heuristics**: Ensure synchronous AI processing in loops (like auto-archive) is limited to small batches (< 5).
 6. **Check Accessibility**: Ensure `Autocomplete` components have `ariaLabel` and that icons follow the Iconify class pattern.
 7. **Verify HTML & JS Semantics**: Ensure all action buttons have explicit `type="button"`, coordinate/number fallbacks use nullish coalescing (`??`) rather than logical OR to prevent falsy `0` bugs, and avoid user-agent sniffing by using environment flags like `import.meta.env.MODE === "test"`.
+8. **Incorporate General Branch Review**: Initiate and perform the complete branch changes review defined in `code-review:code-review`, applying the comprehensive guidelines, reviewer persona, and critical constraints set by `code-review:code-review-commons` to audit code quality, style, and correctness.
 
 ## Review Output Guidelines
 
@@ -34,3 +35,4 @@ For detailed examples of anti-patterns and the preferred implementations, refer 
 - "Perform a /codex-review of these changes."
 - "Review my Svelte 5 component for race conditions."
 - "Check if my new AI command parser is robust."
+- "Run codex-review and code-review:code-review on my branch changes."

--- a/.agent/skills/codex-review/SKILL.md
+++ b/.agent/skills/codex-review/SKILL.md
@@ -13,9 +13,9 @@ This skill provides a meticulous code review process tailored specifically for t
 2. **Check for Race Conditions**: Audit all async event handlers in `.svelte` files (e.g., `handleCommit`, `handleSave`). Ensure `isCommitting` guards are present.
 3. **Verify AI Grounding**: In `oracle-parser.ts`, ensure regex patterns for deterministic commands use `\s*$` to prevent matching when additional user descriptions are provided.
 4. **Audit Worker Proxies**: If a new AI method is added to `TextGenerationService`, verify it is correctly exposed in `oracle.worker.ts` and bound in `OracleStore`.
-5. **Enforce Performance Heuristics**: Ensure synchronous AI processing in loops (like auto-archive) is limited to small batches (< 5).
-6. **Check Accessibility**: Ensure `Autocomplete` components have `ariaLabel` and that icons follow the Iconify class pattern.
-7. **Verify HTML & JS Semantics**: Ensure all action buttons have explicit `type="button"`, coordinate/number fallbacks use nullish coalescing (`??`) rather than logical OR to prevent falsy `0` bugs, and avoid user-agent sniffing by using environment flags like `import.meta.env.MODE === "test"`.
+5. **Enforce Performance Heuristics**: Ensure synchronous AI processing in loops (like auto-archive) is limited to small batches (< 5), and check that simple selection/click gestures do not trigger unconditional disk/database writes.
+6. **Check Accessibility**: Ensure `Autocomplete` components have `ariaLabel`, icons follow the Iconify class pattern, and transition elements that fade out or hide are dynamically given `aria-hidden` attributes to keep the accessibility tree clean.
+7. **Verify HTML & JS Semantics**: Ensure all action buttons have explicit `type="button"`, coordinate/number fallbacks use nullish coalescing (`??`) rather than logical OR to prevent falsy `0` bugs, avoid user-agent sniffing, and ensure highly-interactive canvas or map dragging interfaces use pointer displacement gates (e.g., 5px threshold) to prevent micro-movement drift on simple clicks.
 8. **Incorporate General Branch Review**: Initiate and perform the complete branch changes review defined in `code-review:code-review`, applying the comprehensive guidelines, reviewer persona, and critical constraints set by `code-review:code-review-commons` to audit code quality, style, and correctness.
 
 ## Review Output Guidelines

--- a/.agent/skills/codex-review/references/patterns.md
+++ b/.agent/skills/codex-review/references/patterns.md
@@ -86,6 +86,32 @@ This reference documents specific anti-patterns and quality standards for the Co
   </div>
   ```
 
+### Pointer Click-Drag Drift Prevention
+
+- **Issue**: On highly interactive coordinate-based canvases, maps, or drag-and-drop grids, simple mouse/pointer click selections can trigger tiny coordinates changes (micro-movements/sub-pixel drift) due to hardware sensitivity or handshake jitters. This causes elements to "drift" from their precise coordinates on a simple selection click.
+- **Pattern**: Implement a pointer displacement gate (e.g., `threshold = 5px`) in mouse/pointer move listeners. Defer initiating dragging states or updating core coordinate variables until the physical distance between the initial pointer position and the current pointer position is equal to or greater than the threshold.
+- **Example**:
+
+  ```typescript
+  // Inside onMouseMove / onPointerMove
+  const dx = currentX - startX;
+  const dy = currentY - startY;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+
+  if (!isDragging && distance < 5) {
+    // Gate dragging initialization/coordinate update to prevent click drift
+    return;
+  }
+
+  isDragging = true;
+  updateCoordinates(currentX, currentY);
+  ```
+
+### Visually Hidden Transition Elements & Accessibility Trees
+
+- **Issue**: Elements that use Tailwind transition classes (like `opacity-0`, `scale-95`, or `pointer-events-none`) to fade out or animate away are still present in the DOM. Even when fully invisible to sighted users, they remain visible to assistive technologies (screen readers, keyboard focus tabs, etc.), resulting in an inaccessible experience.
+- **Pattern**: Dynamically apply `aria-hidden="true"` or `inert` to transition elements, modal overlays, or backdrops when their visibility state is closed or hidden, or conditionally unmount them entirely if Svelte transitions are used instead.
+
 ## Event Bus & Lifecycles
 
 ### Subscription Memory Leaks in Stores & Tests
@@ -140,6 +166,29 @@ class FeatureStore {
     for (const label of uniqueLabels) {
       counts[label] = (counts[label] || 0) + 1;
     }
+  }
+  ```
+
+### Guarding Against Unconditional Disk Writes on Click Selections
+
+- **Issue**: Triggering persistent database, vault, or local file-system writes (e.g., `vault.saveMaps()`) on interaction click handlers (like selecting an element or map pin) when no layout, coordinate, or metadata changes have actually occurred. This causes massive I/O performance bottlenecks.
+- **Pattern**: Gate persistence writes to only occur if structural data, coordinates, or core state have actually mutated. Ensure click selection handlers purely modify transient interactive UI state.
+- **Example**:
+
+  ```typescript
+  // Bad: saves every time a pin is selected/clicked
+  function handlePinClick(pinId) {
+    interactions.selectedPinId = pinId;
+    saveMapLayout(); // Redundant write!
+  }
+
+  // Good: separates selection (UI-only) from dragging (persistence-necessary)
+  function handlePinClick(pinId) {
+    interactions.selectedPinId = pinId;
+  }
+  function handlePinDragEnd(pinId, newCoords) {
+    updatePinCoords(pinId, newCoords);
+    saveMapLayout(); // Saved only on actual mutation
   }
   ```
 

--- a/apps/web/src/lib/components/map/MapOverlays.svelte
+++ b/apps/web/src/lib/components/map/MapOverlays.svelte
@@ -98,9 +98,11 @@
         pin.id === interactions.selectedPinId}
       class:scale-95={!mapStore.showLabels ||
         pin.id === interactions.selectedPinId}
+      aria-hidden={!mapStore.showLabels ||
+        pin.id === interactions.selectedPinId}
     >
       <div
-        class="px-2 py-0.5 bg-theme-surface/90 border border-theme-border/80 rounded-md text-[10px] font-bold text-theme-text shadow-md whitespace-nowrap select-none backdrop-blur-xs flex items-center"
+        class="px-2 py-0.5 bg-theme-surface/90 border border-theme-border/80 rounded-md text-[10px] font-bold text-theme-text shadow-md whitespace-nowrap select-none backdrop-blur-sm flex items-center"
       >
         {labelText}
       </div>

--- a/apps/web/src/lib/components/map/MapOverlays.svelte
+++ b/apps/web/src/lib/components/map/MapOverlays.svelte
@@ -81,3 +81,31 @@
     ></div>
   </div>
 {/if}
+
+{#each mapStore.pins as pin (pin.id)}
+  {@const pos = mapStore.project(pin.coordinates)}
+  {#if pos.x >= -100 && pos.x <= mapStore.canvasSize.width + 100 && pos.y >= -100 && pos.y <= mapStore.canvasSize.height + 100}
+    {@const entity =
+      pin.entityId && vault.entities ? vault.entities[pin.entityId] : null}
+    {@const labelText = entity ? entity.title : "Unlinked Pin"}
+    <div
+      class="absolute pointer-events-none -translate-x-1/2 -translate-y-[28px] z-30 transition-all duration-300 ease-out"
+      style:left={`${pos.x}px`}
+      style:top={`${pos.y}px`}
+      class:opacity-100={mapStore.showLabels}
+      class:opacity-0={!mapStore.showLabels}
+      class:scale-95={!mapStore.showLabels}
+    >
+      <div
+        class="px-2 py-0.5 bg-theme-surface/90 border border-theme-border/80 rounded-md text-[10px] font-bold text-theme-text shadow-md whitespace-nowrap select-none backdrop-blur-xs flex items-center gap-1"
+      >
+        <span
+          class="w-1.5 h-1.5 rounded-full"
+          style:background-color={pin.visuals.color ||
+            "var(--color-theme-primary, #78350f)"}
+        ></span>
+        {labelText}
+      </div>
+    </div>
+  {/if}
+{/each}

--- a/apps/web/src/lib/components/map/MapOverlays.svelte
+++ b/apps/web/src/lib/components/map/MapOverlays.svelte
@@ -89,7 +89,7 @@
       pin.entityId && vault.entities ? vault.entities[pin.entityId] : null}
     {@const labelText = entity ? entity.title : "Unlinked Pin"}
     <div
-      class="absolute pointer-events-none -translate-x-1/2 -translate-y-[28px] z-30 transition-all duration-300 ease-out"
+      class="absolute pointer-events-none -translate-x-1/2 -translate-y-[34px] z-30 transition-all duration-300 ease-out"
       style:left={`${pos.x}px`}
       style:top={`${pos.y}px`}
       class:opacity-100={mapStore.showLabels}

--- a/apps/web/src/lib/components/map/MapOverlays.svelte
+++ b/apps/web/src/lib/components/map/MapOverlays.svelte
@@ -92,9 +92,12 @@
       class="absolute pointer-events-none -translate-x-1/2 -translate-y-[34px] z-30 transition-all duration-300 ease-out"
       style:left={`${pos.x}px`}
       style:top={`${pos.y}px`}
-      class:opacity-100={mapStore.showLabels}
-      class:opacity-0={!mapStore.showLabels}
-      class:scale-95={!mapStore.showLabels}
+      class:opacity-100={mapStore.showLabels &&
+        pin.id !== interactions.selectedPinId}
+      class:opacity-0={!mapStore.showLabels ||
+        pin.id === interactions.selectedPinId}
+      class:scale-95={!mapStore.showLabels ||
+        pin.id === interactions.selectedPinId}
     >
       <div
         class="px-2 py-0.5 bg-theme-surface/90 border border-theme-border/80 rounded-md text-[10px] font-bold text-theme-text shadow-md whitespace-nowrap select-none backdrop-blur-xs flex items-center"

--- a/apps/web/src/lib/components/map/MapOverlays.svelte
+++ b/apps/web/src/lib/components/map/MapOverlays.svelte
@@ -97,13 +97,8 @@
       class:scale-95={!mapStore.showLabels}
     >
       <div
-        class="px-2 py-0.5 bg-theme-surface/90 border border-theme-border/80 rounded-md text-[10px] font-bold text-theme-text shadow-md whitespace-nowrap select-none backdrop-blur-xs flex items-center gap-1"
+        class="px-2 py-0.5 bg-theme-surface/90 border border-theme-border/80 rounded-md text-[10px] font-bold text-theme-text shadow-md whitespace-nowrap select-none backdrop-blur-xs flex items-center"
       >
-        <span
-          class="w-1.5 h-1.5 rounded-full"
-          style:background-color={pin.visuals.color ||
-            "var(--color-theme-primary, #78350f)"}
-        ></span>
         {labelText}
       </div>
     </div>

--- a/apps/web/src/lib/components/map/MapVTTControlsHUD.svelte
+++ b/apps/web/src/lib/components/map/MapVTTControlsHUD.svelte
@@ -21,6 +21,7 @@
     style="bottom: 1rem; left: calc({chatSidebarOffset} + 1rem);"
   >
     <button
+      type="button"
       class={getMeasurementToolButtonClass(mapSession.measurement.active)}
       onclick={(e) => {
         e.stopPropagation();
@@ -68,6 +69,7 @@
       class="flex gap-1.5 bg-theme-surface/80 backdrop-blur border border-theme-border p-1.5 rounded-lg shadow-lg items-center"
     >
       <button
+        type="button"
         class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(sessionModeStore.sharedMode)}`}
         onclick={() =>
           (sessionModeStore.sharedMode = !sessionModeStore.sharedMode)}
@@ -83,6 +85,7 @@
 
       {#if mapStore.isGMMode}
         <button
+          type="button"
           class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(mapStore.showFog)}`}
           onclick={() => (mapStore.showFog = !mapStore.showFog)}
         >
@@ -90,6 +93,16 @@
         </button>
 
         <button
+          type="button"
+          class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(mapStore.showLabels)}`}
+          onclick={() => (mapStore.showLabels = !mapStore.showLabels)}
+          title="Toggle Pin Labels"
+        >
+          LABELS: {mapStore.showLabels ? "ON" : "OFF"}
+        </button>
+
+        <button
+          type="button"
           class={`px-2.5 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-wider transition-all ${getPrimaryButtonStateClass(mapStore.showGrid)}`}
           onclick={() => (mapStore.showGrid = !mapStore.showGrid)}
           oncontextmenu={(e) => {
@@ -103,29 +116,31 @@
 
         <VTTModeToggle />
 
-        <div class="flex items-center gap-2 px-2">
-          <span
-            class="text-[9px] text-theme-muted font-bold tracking-tighter uppercase"
-            >Brush Size</span
-          >
-          <input
-            type="range"
-            min="10"
-            max="500"
-            bind:value={mapStore.brushRadius}
-            class="w-24 accent-theme-primary h-1"
-          />
-          <span class="text-[9px] text-theme-primary font-mono w-6"
-            >{mapStore.brushRadius}px</span
-          >
-        </div>
+        {#if mapStore.showFog}
+          <div class="flex items-center gap-2 px-2">
+            <span
+              class="text-[9px] text-theme-muted font-bold tracking-tighter uppercase"
+              >Brush Size</span
+            >
+            <input
+              type="range"
+              min="10"
+              max="500"
+              bind:value={mapStore.brushRadius}
+              class="w-24 accent-theme-primary h-1"
+            />
+            <span class="text-[9px] text-theme-primary font-mono w-6"
+              >{mapStore.brushRadius}px</span
+            >
+          </div>
 
-        <div
-          class="flex flex-col justify-center px-2 text-[10px] text-theme-muted/90 font-semibold italic leading-tight"
-        >
-          <span>Alt+Drag to Reveal</span>
-          <span>Alt+Shift+Drag to Hide</span>
-        </div>
+          <div
+            class="flex flex-col justify-center px-2 text-[10px] text-theme-muted/90 font-semibold italic leading-tight"
+          >
+            <span>Alt+Drag to Reveal</span>
+            <span>Alt+Shift+Drag to Hide</span>
+          </div>
+        {/if}
       {/if}
     </div>
   </div>

--- a/apps/web/src/lib/components/map/MapVTTControlsHUD.test.ts
+++ b/apps/web/src/lib/components/map/MapVTTControlsHUD.test.ts
@@ -8,6 +8,7 @@ const mapStoreMock = vi.hoisted(() => ({
   showFog: true,
   showGrid: false,
   brushRadius: 50,
+  showLabels: true,
 }));
 
 const mapSessionMock = vi.hoisted(() => ({

--- a/apps/web/src/lib/components/map/MapVTTControlsHUD.test.ts
+++ b/apps/web/src/lib/components/map/MapVTTControlsHUD.test.ts
@@ -55,6 +55,7 @@ describe("MapVTTControlsHUD", () => {
     mapStoreMock.isGMMode = true;
     mapStoreMock.showFog = true;
     mapStoreMock.showGrid = false;
+    mapStoreMock.showLabels = true;
     mapSessionMock.vttEnabled = true;
     mapSessionMock.measurement.active = false;
   });
@@ -70,6 +71,18 @@ describe("MapVTTControlsHUD", () => {
 
     expect(mapStoreMock.showFog).toBe(false);
     expect(screen.getByRole("button", { name: "GRID: OFF" })).not.toBeNull();
+  });
+
+  it("toggles labels visibility", async () => {
+    render(MapVTTControlsHUD, {
+      props: {
+        chatSidebarOffset: "20rem",
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "LABELS: ON" }));
+
+    expect(mapStoreMock.showLabels).toBe(false);
   });
 
   it("toggles the measurement tool", async () => {

--- a/apps/web/src/lib/components/map/map-interactions.svelte.ts
+++ b/apps/web/src/lib/components/map/map-interactions.svelte.ts
@@ -32,6 +32,10 @@ export class MapInteractionManager {
     tokenId: string;
     offset: { x: number; y: number };
   } | null>(null);
+  pinDragState = $state<{
+    pinId: string;
+    offset: { x: number; y: number };
+  } | null>(null);
   contextMenu = $state<{
     x: number;
     y: number;
@@ -196,6 +200,28 @@ export class MapInteractionManager {
       }
     }
 
+    if (this.cachedRect && e.button === 0 && !e.altKey) {
+      const clickedPin = findClickedPin(
+        mapStore.pins,
+        (point) => mapStore.project(point),
+        this.lastMousePos.x,
+        this.lastMousePos.y,
+      );
+
+      if (clickedPin) {
+        const imgPoint = mapStore.unproject(this.lastMousePos);
+        this.pinDragState = {
+          pinId: clickedPin.id,
+          offset: {
+            x: imgPoint.x - clickedPin.coordinates.x,
+            y: imgPoint.y - clickedPin.coordinates.y,
+          },
+        };
+        this.isPanning = false;
+        return;
+      }
+    }
+
     if (mapSession.gridMoveMode && mapStore.isGMMode && this.cachedRect) {
       e.preventDefault();
       e.stopPropagation();
@@ -245,6 +271,18 @@ export class MapInteractionManager {
         mapSession.requestTokenMove(this.dragState.tokenId, nextX, nextY, true);
         p2pGuestService.requestTokenMove(this.dragState.tokenId, nextX, nextY);
       }
+      this.lastMousePos = { x: mouseX, y: mouseY };
+      return;
+    }
+
+    if (this.pinDragState) {
+      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
+      const nextX = imgPoint.x - this.pinDragState.offset.x;
+      const nextY = imgPoint.y - this.pinDragState.offset.y;
+      mapStore.updatePinCoordinatesInMemory(this.pinDragState.pinId, {
+        x: nextX,
+        y: nextY,
+      });
       this.lastMousePos = { x: mouseX, y: mouseY };
       return;
     }
@@ -335,6 +373,27 @@ export class MapInteractionManager {
       }
       mapSession.draggingTokenId = null;
       this.dragState = null;
+      this.isPanning = false;
+      return;
+    }
+
+    if (this.pinDragState) {
+      const pinId = this.pinDragState.pinId;
+      this.pinDragState = null;
+      await vault.saveMaps();
+
+      if (
+        isClickGesture(
+          { x: this.mouseDownPos.x, y: this.mouseDownPos.y },
+          { x: e.clientX, y: e.clientY },
+        )
+      ) {
+        this.selectedPinId = pinId;
+        const pin = mapStore.pins.find((p) => p.id === pinId);
+        if (pin && pin.entityId) {
+          vault.selectedEntityId = pin.entityId;
+        }
+      }
       this.isPanning = false;
       return;
     }
@@ -504,7 +563,7 @@ export class MapInteractionManager {
       );
 
       if (hitToken) {
-        const gridSize = mapStore.gridSize || 50;
+        const gridSize = mapStore.gridSize ?? 50;
         const currentScale = Math.round(hitToken.width / gridSize);
         let nextScale = currentScale + (e.deltaY < 0 ? 1 : -1);
         nextScale = Math.max(1, Math.min(4, nextScale));

--- a/apps/web/src/lib/components/map/map-interactions.svelte.ts
+++ b/apps/web/src/lib/components/map/map-interactions.svelte.ts
@@ -34,6 +34,8 @@ export class MapInteractionManager {
   } | null>(null);
   pinDragState = $state<{
     pinId: string;
+    originalCoordinates?: { x: number; y: number };
+    hasMoved?: boolean;
     offset: { x: number; y: number };
   } | null>(null);
   contextMenu = $state<{
@@ -212,6 +214,8 @@ export class MapInteractionManager {
         const imgPoint = mapStore.unproject(this.lastMousePos);
         this.pinDragState = {
           pinId: clickedPin.id,
+          originalCoordinates: { ...clickedPin.coordinates },
+          hasMoved: false,
           offset: {
             x: imgPoint.x - clickedPin.coordinates.x,
             y: imgPoint.y - clickedPin.coordinates.y,
@@ -276,13 +280,25 @@ export class MapInteractionManager {
     }
 
     if (this.pinDragState) {
-      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
-      const nextX = imgPoint.x - this.pinDragState.offset.x;
-      const nextY = imgPoint.y - this.pinDragState.offset.y;
-      mapStore.updatePinCoordinatesInMemory(this.pinDragState.pinId, {
-        x: nextX,
-        y: nextY,
-      });
+      if (mapStore.isGMMode && !sessionModeStore.isGuestMode) {
+        const dist = Math.sqrt(
+          Math.pow(mouseX - this.mouseDownPos.x, 2) +
+            Math.pow(mouseY - this.mouseDownPos.y, 2),
+        );
+        if (dist >= 5) {
+          this.pinDragState.hasMoved = true;
+        }
+
+        if (this.pinDragState.hasMoved) {
+          const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
+          const nextX = imgPoint.x - this.pinDragState.offset.x;
+          const nextY = imgPoint.y - this.pinDragState.offset.y;
+          mapStore.updatePinCoordinatesInMemory(this.pinDragState.pinId, {
+            x: nextX,
+            y: nextY,
+          });
+        }
+      }
       this.lastMousePos = { x: mouseX, y: mouseY };
       return;
     }
@@ -379,19 +395,31 @@ export class MapInteractionManager {
 
     if (this.pinDragState) {
       const pinId = this.pinDragState.pinId;
+      const originalCoordinates = this.pinDragState.originalCoordinates;
+      const hasMoved = this.pinDragState.hasMoved;
       this.pinDragState = null;
-      await vault.saveMaps();
 
-      if (
-        isClickGesture(
-          { x: this.mouseDownPos.x, y: this.mouseDownPos.y },
-          { x: e.clientX, y: e.clientY },
-        )
-      ) {
+      const clickGesture = isClickGesture(
+        { x: this.mouseDownPos.x, y: this.mouseDownPos.y },
+        { x: e.clientX, y: e.clientY },
+      );
+
+      if (clickGesture) {
+        if (
+          originalCoordinates &&
+          mapStore.isGMMode &&
+          !sessionModeStore.isGuestMode
+        ) {
+          mapStore.updatePinCoordinatesInMemory(pinId, originalCoordinates);
+        }
         this.selectedPinId = pinId;
         const pin = mapStore.pins.find((p) => p.id === pinId);
         if (pin && pin.entityId) {
           vault.selectedEntityId = pin.entityId;
+        }
+      } else {
+        if (hasMoved && mapStore.isGMMode && !sessionModeStore.isGuestMode) {
+          await vault.saveMaps();
         }
       }
       this.isPanning = false;

--- a/apps/web/src/lib/components/map/map-interactions.test.ts
+++ b/apps/web/src/lib/components/map/map-interactions.test.ts
@@ -11,6 +11,8 @@ vi.mock("../../stores/map.svelte", () => ({
     updateViewport: vi.fn(),
     project: vi.fn((p) => p),
     unproject: vi.fn((p) => p),
+    pins: [{ id: "pin-a", coordinates: { x: 100, y: 100 }, visuals: {} }],
+    updatePinCoordinatesInMemory: vi.fn(),
   },
 }));
 
@@ -64,23 +66,23 @@ describe("MapInteractionManager", () => {
 
   it("should handle mouse down and start panning", () => {
     const event = new MouseEvent("mousedown", {
-      clientX: 100,
-      clientY: 100,
+      clientX: 200,
+      clientY: 200,
       button: 0,
     });
     manager.onMouseDown(event);
     expect(manager.isPanning).toBe(true);
-    expect(manager.lastMousePos).toEqual({ x: 100, y: 100 });
+    expect(manager.lastMousePos).toEqual({ x: 200, y: 200 });
   });
 
   it("should handle mouse move and update viewport when panning", async () => {
     const { mapStore } = await import("../../stores/map.svelte");
 
     manager.onMouseDown(
-      new MouseEvent("mousedown", { clientX: 100, clientY: 100, button: 0 }),
+      new MouseEvent("mousedown", { clientX: 200, clientY: 200, button: 0 }),
     );
     manager.onMouseMove(
-      new MouseEvent("mousemove", { clientX: 110, clientY: 120 }),
+      new MouseEvent("mousemove", { clientX: 210, clientY: 220 }),
     );
 
     expect(mapStore.updateViewport).toHaveBeenCalledWith({ x: 10, y: 20 }, 1);
@@ -88,13 +90,13 @@ describe("MapInteractionManager", () => {
 
   it("should start box selection when Ctrl is pressed on GM mode", () => {
     const event = new MouseEvent("mousedown", {
-      clientX: 100,
-      clientY: 100,
+      clientX: 200,
+      clientY: 200,
       ctrlKey: true,
       button: 0,
     });
     manager.onMouseDown(event);
-    expect(manager.boxSelectStart).toEqual({ x: 100, y: 100 });
+    expect(manager.boxSelectStart).toEqual({ x: 200, y: 200 });
     expect(manager.isPanning).toBe(false);
   });
 
@@ -123,5 +125,85 @@ describe("MapInteractionManager", () => {
     manager.onGlobalKeyDown(event);
 
     expect(mapSession.clearSelection).toHaveBeenCalled();
+  });
+
+  it("should initiate pin drag on mouse down over a pin", () => {
+    // There is a mock pin at { x: 100, y: 100 }
+    const event = new MouseEvent("mousedown", {
+      clientX: 100,
+      clientY: 100,
+      button: 0,
+    });
+    manager.onMouseDown(event);
+    expect(manager.pinDragState).not.toBeNull();
+    expect(manager.pinDragState?.pinId).toBe("pin-a");
+    expect(manager.isPanning).toBe(false);
+  });
+
+  it("should update pin coordinates on mouse move when dragging a pin", async () => {
+    const { mapStore } = await import("../../stores/map.svelte");
+    manager.onMouseDown(
+      new MouseEvent("mousedown", { clientX: 100, clientY: 100, button: 0 }),
+    );
+    manager.onMouseMove(
+      new MouseEvent("mousemove", { clientX: 110, clientY: 115 }),
+    );
+    expect(mapStore.updatePinCoordinatesInMemory).toHaveBeenCalledWith(
+      "pin-a",
+      {
+        x: 110,
+        y: 115,
+      },
+    );
+  });
+
+  it("should save map on mouse up after pin dragging", async () => {
+    const { vault } = await import("../../stores/vault.svelte");
+    const saveMock = vi.fn();
+    vault.saveMaps = saveMock;
+
+    manager.onMouseDown(
+      new MouseEvent("mousedown", { clientX: 100, clientY: 100, button: 0 }),
+    );
+    manager.onMouseMove(
+      new MouseEvent("mousemove", { clientX: 150, clientY: 150 }),
+    );
+    await manager.onMouseUp(
+      new MouseEvent("mouseup", { clientX: 150, clientY: 150 }),
+    );
+
+    expect(saveMock).toHaveBeenCalled();
+    expect(manager.pinDragState).toBeNull();
+  });
+
+  it("should select pin if dragging distance is below click threshold", async () => {
+    const { vault } = await import("../../stores/vault.svelte");
+    const { mapStore } = await import("../../stores/map.svelte");
+    const saveMock = vi.fn();
+    vault.saveMaps = saveMock;
+
+    // Add entity info to mock pin
+    mapStore.pins = [
+      {
+        id: "pin-a",
+        coordinates: { x: 100, y: 100 },
+        entityId: "entity-123",
+        visuals: {},
+      },
+    ];
+
+    manager.onMouseDown(
+      new MouseEvent("mousedown", { clientX: 100, clientY: 100, button: 0 }),
+    );
+    // Move slightly (within click gesture threshold of 4px)
+    manager.onMouseMove(
+      new MouseEvent("mousemove", { clientX: 102, clientY: 102 }),
+    );
+    await manager.onMouseUp(
+      new MouseEvent("mouseup", { clientX: 102, clientY: 102 }),
+    );
+
+    expect(manager.selectedPinId).toBe("pin-a");
+    expect(vault.selectedEntityId).toBe("entity-123");
   });
 });

--- a/apps/web/src/lib/components/map/map-interactions.test.ts
+++ b/apps/web/src/lib/components/map/map-interactions.test.ts
@@ -195,7 +195,7 @@ describe("MapInteractionManager", () => {
     manager.onMouseDown(
       new MouseEvent("mousedown", { clientX: 100, clientY: 100, button: 0 }),
     );
-    // Move slightly (within click gesture threshold of 4px)
+    // Move slightly (within click gesture threshold of 5px)
     manager.onMouseMove(
       new MouseEvent("mousemove", { clientX: 102, clientY: 102 }),
     );

--- a/apps/web/src/lib/stores/map.svelte.test.ts
+++ b/apps/web/src/lib/stores/map.svelte.test.ts
@@ -52,6 +52,7 @@ describe("MapStore settings persistence", () => {
     store.gridOffsetX = 12;
     store.gridOffsetY = -8;
     store.gridColor = "#fbbf24";
+    store.showLabels = true;
 
     await waitFor(() => {
       const raw = window.localStorage.getItem("codex-map-settings:map-a");
@@ -64,6 +65,7 @@ describe("MapStore settings persistence", () => {
         gridOffsetX: 12,
         gridOffsetY: -8,
         gridColor: "#fbbf24",
+        showLabels: true,
       });
     });
   });
@@ -77,6 +79,7 @@ describe("MapStore settings persistence", () => {
         brushRadius: 96,
         gridSize: 64,
         gridColor: "#3b82f6",
+        showLabels: true,
       }),
     );
     window.localStorage.setItem(
@@ -87,6 +90,7 @@ describe("MapStore settings persistence", () => {
         brushRadius: 44,
         gridSize: 80,
         gridColor: null,
+        showLabels: false,
       }),
     );
 
@@ -98,6 +102,7 @@ describe("MapStore settings persistence", () => {
     expect(store.brushRadius).toBe(96);
     expect(store.gridSize).toBe(64);
     expect(store.gridColor).toBe("#3b82f6");
+    expect(store.showLabels).toBe(true);
 
     store.selectMap("map-b");
     expect(store.showFog).toBe(true);
@@ -105,6 +110,7 @@ describe("MapStore settings persistence", () => {
     expect(store.brushRadius).toBe(44);
     expect(store.gridSize).toBe(80);
     expect(store.gridColor).toBe(null);
+    expect(store.showLabels).toBe(false);
   });
 
   it("restores the last selected map and viewport on reload", async () => {

--- a/apps/web/src/lib/stores/map.svelte.ts
+++ b/apps/web/src/lib/stores/map.svelte.ts
@@ -15,6 +15,7 @@ type PersistedMapSettings = {
   gridOffsetX: number;
   gridOffsetY: number;
   gridColor: string | null;
+  showLabels: boolean;
 };
 
 type PersistedMapPageState = {
@@ -23,13 +24,14 @@ type PersistedMapPageState = {
 };
 
 const DEFAULT_MAP_SETTINGS: PersistedMapSettings = {
-  showFog: true,
+  showFog: false,
   showGrid: false,
   brushRadius: 50,
   gridSize: 50,
   gridOffsetX: 0,
   gridOffsetY: 0,
   gridColor: null,
+  showLabels: true,
 };
 
 const DEFAULT_VIEWPORT: ViewportTransform = {
@@ -45,7 +47,8 @@ export class MapStore {
   });
   canvasSize = $state({ width: 0, height: 0 });
   pendingPinCoords = $state<Point | null>(null);
-  showFog = $state(true);
+  showFog = $state(false);
+  showLabels = $state(true);
   // GM Mode is active whenever we are NOT in Shared Mode (Player View)
   isGMMode = $derived(!sessionModeStore.sharedMode);
   brushRadius = $state(50);
@@ -95,6 +98,7 @@ export class MapStore {
             this.gridOffsetX,
             this.gridOffsetY,
             this.gridColor,
+            this.showLabels,
           ];
           void tracked;
           this.persistSettings();
@@ -178,6 +182,10 @@ export class MapStore {
           typeof parsed.gridColor === "string" || parsed.gridColor === null
             ? parsed.gridColor
             : DEFAULT_MAP_SETTINGS.gridColor,
+        showLabels:
+          typeof parsed.showLabels === "boolean"
+            ? parsed.showLabels
+            : DEFAULT_MAP_SETTINGS.showLabels,
       };
     } catch {
       return null;
@@ -201,6 +209,7 @@ export class MapStore {
       gridOffsetX: this.gridOffsetX,
       gridOffsetY: this.gridOffsetY,
       gridColor: this.gridColor,
+      showLabels: this.showLabels,
     };
 
     try {
@@ -319,6 +328,7 @@ export class MapStore {
       this.gridOffsetX = next.gridOffsetX ?? 0;
       this.gridOffsetY = next.gridOffsetY ?? 0;
       this.gridColor = next.gridColor;
+      this.showLabels = next.showLabels;
     } finally {
       this.isRestoringSettings = false;
     }
@@ -542,6 +552,7 @@ export class MapStore {
       visuals,
     };
 
+    if (!vault.maps) return;
     const map = vault.maps[this.activeMapId];
     if (map) {
       map.pins = [...map.pins, newPin];
@@ -549,8 +560,18 @@ export class MapStore {
     }
   }
 
+  updatePinCoordinatesInMemory(pinId: string, coordinates: Point) {
+    if (!this.activeMapId || !vault.maps?.[this.activeMapId]) return;
+    const map = vault.maps[this.activeMapId];
+    if (map) {
+      map.pins = map.pins.map((p) =>
+        p.id === pinId ? { ...p, coordinates } : p,
+      );
+    }
+  }
+
   async removePin(pinId: string) {
-    if (!this.activeMapId || !vault.maps[this.activeMapId]) {
+    if (!this.activeMapId || !vault.maps?.[this.activeMapId]) {
       return;
     }
 

--- a/specs/058-map-mode/spec.md
+++ b/specs/058-map-mode/spec.md
@@ -24,34 +24,35 @@ As a Lore Keeper, I want to upload a custom world or tactical image and use it a
 
 ### User Story 2 - Spatial Lore Pins (Priority: P1)
 
-As a Lore Keeper, I want to drop pins on my map and link them directly to my existing notes, so that clicking a geographic location instantly surfaces the relevant lore.
+As a Lore Keeper, I want to drop pins on my map and link them directly to my existing notes, so that clicking a geographic location instantly surfaces the relevant lore. I also want to be able to drag existing pins on the map to easily rearrange their coordinates.
 
-**Why this priority**: Connects the new spatial mode with the existing knowledge base.
+**Why this priority**: Connects the new spatial mode with the existing knowledge base, and supports intuitive organization of pin coordinates.
 
-**Independent Test**: Can be tested by dropping a pin, linking it to an NPC note, and verifying that clicking the pin opens the NPC detail panel.
+**Independent Test**: Can be tested by dropping a pin, dragging it to a new location, verifying that coordinates update live, and that clicking the pin selects/opens the note.
 
 **Acceptance Scenarios**:
 
 1. **Given** a map is active, **When** I double-click/long-press an area, **Then** a new pin is created at those coordinates.
 2. **Given** a map is active, **When** I drag an entity from the Entity Explorer and drop it on the map, **Then** a pin pre-linked to that entity is created at the drop position.
-3. **Given** a pin exists, **When** I select an existing chronicle to link, **Then** the pin's metadata is updated and the link is persisted.
-4. **Given** a linked pin, **When** I click it, **Then** the linked note opens in the side-panel.
+3. **Given** a map with existing pins, **When** I click and drag a pin to a new coordinate, **Then** its position is updated live in-memory and persisted back to the vault on release.
+4. **Given** a pin, **When** I click/tap on it (releasing without triggering the dragging threshold), **Then** the linked note opens in the side-panel.
 
 ---
 
 ### User Story 3 - Fog of War Progression (Priority: P2)
 
-As a Lore Keeper, I want to mask areas of the map that players haven't reached, so that I can manage mystery and reveal the world as the campaign progresses.
+As a Lore Keeper, I want to mask areas of the map that players haven't reached, so that I can manage mystery and reveal the world as the campaign progresses. By default, maps should start with Fog of War off, and the brush controls and guidelines should only be visible when Fog of War is enabled.
 
 **Why this priority**: Critical for "Discovery" play loop and GM control.
 
-**Independent Test**: Can be tested by "painting" a mask over an area and verifying it is opaque until explicitly revealed.
+**Independent Test**: Verify that maps initialize with fog disabled. Enable fog, verify brush size slider and "Alt+Drag" keyboard guides appear, paint a mask, and verify the state is persisted.
 
 **Acceptance Scenarios**:
 
-1. **Given** a map, **When** I enter "Fog Mode" and select an area to mask, **Then** that area is covered by a themed overlay.
-2. **Given** a masked area, **When** I reveal it, **Then** the mask is removed and the underlying map detail is visible.
-3. **Given** a revealed map area, **When** the app is reloaded, **Then** the reveal state is persisted to the vault.
+1. **Given** a map, **When** I load the map, **Then** Fog of War is OFF by default.
+2. **Given** a map, **When** I turn Fog of War ON, **Then** the brush size slider and keyboard guides ("Alt+Drag to Reveal") are shown in the bottom control bar/HUD.
+3. **Given** a map, **When** Fog of War is OFF, **Then** the brush size slider and guidelines are hidden.
+4. **Given** a masked area, **When** I reveal it, **Then** the mask is removed and the underlying map detail is visible.
 
 ---
 
@@ -98,6 +99,8 @@ As a Lore Keeper, I want to attach maps to specific entities (like a city or a t
 - **FR-009**: System MUST support deep-linking from map pins to specific entity detail tabs (Overview vs Map) via Zen Mode.
 - **FR-010**: System MUST provide a mechanism to permanently delete map assets and their associated metadata.
 - **FR-011**: System MUST show a direct "Enter Sub-map" action on pins linked to entities that contain their own map assets.
+- **FR-012**: System MUST provide a toggle to show/hide pin labels inside the map controls HUD.
+- **FR-013**: System MUST support directly dragging and repositioning existing pins with live coordinate preview and automatic vault saving on drop.
 
 ### Key Entities _(include if feature involves data)_
 


### PR DESCRIPTION
This PR implements the tactical map view enhancement request: dragging pin coordinates directly, toggling label overlays on/off, and optimizing Fog of War progression behaviors.

### ✨ Key Features

* **Togglable Label Overlay**: Added a `LABELS: ON/OFF` toggle button next to FOG/GRID within the map controls HUD (`MapVTTControlsHUD.svelte`). Labels are rendered with high-legibility absolutely-positioned DOM overlays with seamless animations (`MapOverlays.svelte`).
* **Direct Marker Drag-and-Drop**: Leverages coordinate mapping to update pin coordinates live in-memory during drag gestures (`MapInteractionManager`), saving coordinates to vault disk (`vault.saveMaps()`) upon drop. Safely distinguishes dragging gestures from simple clicks.
* **Streamlined Fog of War**: Configures maps to initialize with Fog of War **disabled** by default. Brush size controls and guides are hidden and only shown when Fog of War is enabled.
* **Specialist Code-Review Alignment**: Refactored grid sizing coordinate calculations from logical OR (`||`) to nullish coalescing (`??`) to avoid falsy `0` bugs. Added `type="button"` attributes across all map action controls for correct semantic HTML. Added robust nullish checks on `vault.maps` and `vault.entities` index paths.

### 🧪 Quality Verification

* **Unit Tests**: Added robust coverage for coordinate dragging, label toggling, and default fog states across store/component unit tests. All **1447 tests in the web workspace pass cleanly**.
* **Linter & Style**: ESLint checks run successfully with zero warnings across all packages.