### PR TITLE
:memo: docs: update help articles, blog posts, and terms to use save/load directional terminology

### DIFF
--- a/apps/web/src/lib/content/blog/comprehensive-help-guide.md
+++ b/apps/web/src/lib/content/blog/comprehensive-help-guide.md
@@ -27,16 +27,16 @@ Codex Cryptica is built on **Local-First** principles. This means your data is s
 
 ## 2. Multi-Device Synchronization
 
-While your data is local, you can easily access it across different machines by using **Local Folder Synchronization.**
+While your data is local, you can easily access it across different machines by using **Local Folder Integration.**
 
 ### Setting up a Cloud Mirror:
 
 1.  **Install a Cloud Client:** Install a service like **Google Drive for Desktop**, **Dropbox**, or **iCloud** on your computer.
-2.  **Sync to a Local Folder:** In Codex, go to **Settings > Archive** and click **Sync to Folder**.
+2.  **Link to a Local Folder:** In Codex, click the **SAVE TO FOLDER** button in the bottom-left sidebar (or the Save icon in the Vault Selector).
 3.  **Choose your Cloud Directory:** Select a folder inside your Google Drive or Dropbox directory.
-4.  **Automatic Updates:** Codex will now keep your internal archives mirrored to that folder, and your OS will handle the cloud sync automatically.
+4.  **Automatic Updates:** Codex will now keep your internal archives mirrored to that folder, and your OS will handle the cloud mirroring automatically.
 
-To open your world on a second device, simply use the **Open Folder** button in the Archive Selector and choose that same synced directory.
+To open your world on a second device, simply use the **Open Folder** button in the Vault Selector and choose that same synced directory.
 
 ## 3. Working with the Lore Oracle
 
@@ -56,6 +56,6 @@ The Knowledge Graph and Spatial Maps provide a bird's-eye view of your campaign.
 
 - **Keep it Modular:** Use many small entities instead of a few massive ones. This helps both you and the AI find information faster.
 - **Use Labels:** Categorize your lore with custom labels to filter the graph and keep your notes organized.
-- **Regular Syncs:** Click the **Sync** button at the end of each session to ensure your local backup is up to date.
+- **Regular Saves:** Click the **SAVE TO FOLDER** button at the end of each session to ensure your local backup is up to date.
 
 Happy world-building!

--- a/apps/web/src/lib/content/blog/gdrive-cloud-sync.md
+++ b/apps/web/src/lib/content/blog/gdrive-cloud-sync.md
@@ -42,7 +42,7 @@ When you pull from Drive, Codex doesn't re-download everything. It compares what
 
 ## Import from Drive on any device
 
-Already backed up your vault on another machine? Open **Settings → Cloud Sync**, click **Browse Drive**, and Codex lists every vault subfolder it finds in your `CodexCryptica/` folder. One click and the differential pull kicks off — you're back up to speed without copying a single file by hand.
+Already backed up your vault on another machine? Open Settings, choose the **Vault** tab, scroll to the **Cloud Sync** section, and click **Browse Drive**. Codex will list every vault subfolder it finds in your `CodexCryptica/` folder. One click and the differential pull kicks off — you're back up to speed without copying a single file by hand.
 
 ## Share a vault with your co-GM
 
@@ -58,7 +58,7 @@ The first join uses a slightly broader Drive scope so Codex can read a folder it
 
 ## Try it now
 
-Head to **Settings → Cloud Sync** and click **Connect Google Drive**. The first time you connect you'll go through a standard Google OAuth flow — takes about thirty seconds.
+Head to Settings, select the **Vault** tab, scroll to the **Cloud Sync** section, and click **Connect Google Drive**. The first time you connect you'll go through a standard Google OAuth flow — takes about thirty seconds.
 
 If you run into anything, the [help article](/help/gdrive-cloud-sync) has a step-by-step walkthrough.
 

--- a/apps/web/src/lib/content/help/gdrive-cloud-sync.md
+++ b/apps/web/src/lib/content/help/gdrive-cloud-sync.md
@@ -11,7 +11,7 @@ Codex Cryptica can back up your vault to your personal Google Drive and restore 
 
 ## Connect Your Vault
 
-1. Open **Settings → Cloud Sync**.
+1. Open Settings, choose the **Vault** tab, and scroll to the **Cloud Sync** section.
 2. Click **Connect Google Drive** and sign in when Google prompts you.
 3. Codex creates a `CodexCryptica/` folder on your Drive (if it doesn't exist) and a subfolder named after your vault inside it. The folder ID is saved locally so future syncs know where to go.
 
@@ -27,7 +27,7 @@ Once connected you'll see two buttons:
 
 If you have vaults already stored in your `CodexCryptica/` Drive folder (from another device), you can load them without setting them up from scratch:
 
-1. In **Settings → Cloud Sync**, click **Browse Drive**.
+1. In the **Vault** settings tab under **Cloud Sync**, click **Browse Drive**.
 2. Codex lists every vault subfolder it finds under `CodexCryptica/`.
 3. Click **Load** next to any vault. Codex creates a local vault (or finds the existing one), then pulls only the files that are newer than what you have locally.
 
@@ -36,7 +36,7 @@ If you have vaults already stored in your `CodexCryptica/` Drive folder (from an
 If your GM has shared their Drive vault folder with you, you can connect to it directly:
 
 1. Ask your GM to share the Drive folder and copy the share link (it looks like `https://drive.google.com/drive/folders/…`).
-2. In **Settings → Cloud Sync**, paste the link into the **Join a Shared Vault** field and click **Join**.
+2. In the **Vault** settings tab under **Cloud Sync**, paste the link into the **Join a Shared Vault** field and click **Join**.
 3. Google will ask you to grant read access to the shared folder. Once approved, Codex imports the vault locally and you can pull updates any time with **Load from Drive**.
 
 > [!NOTE]

--- a/apps/web/src/lib/content/help/offline-sync.md
+++ b/apps/web/src/lib/content/help/offline-sync.md
@@ -1,11 +1,11 @@
 ---
 id: offline-sync
-title: Offline Support & Synchronization
+title: Offline Support & Local Folders
 tags: [technical, sync, privacy]
 rank: 16
 ---
 
-# Offline Support & Synchronization
+# Offline Support & Local Folders
 
 Codex Cryptica is designed as a **local-first** application. This means your data always lives on your device first, ensuring you can continue building your world even without an internet connection.
 
@@ -17,7 +17,7 @@ By default, all your campaign data is stored in the **Origin Private File System
 - **Speed:** Reading and writing thousands of chronicles is near-instant.
 - **Persistence:** Your work is saved automatically as you type.
 
-## Synchronization with Local Folders
+## Saving & Loading with Local Folders
 
 You can mirror your internal archives with any folder on your computer. This enables several powerful workflows:
 
@@ -25,15 +25,14 @@ You can mirror your internal archives with any folder on your computer. This ena
 2.  **External Editing:** Use your favorite Markdown editor (like Obsidian or VS Code) to edit your chronicles while Codex is closed.
 3.  **Cloud Mirroring:** By selecting a folder managed by a cloud provider (like Google Drive, Dropbox, or iCloud), you can achieve multi-device synchronization using your OS's built-in support.
 
-### How to set up Cloud Sync (via OS)
+### How to set up Cloud Mirroring (via OS)
 
-To sync your world across multiple devices using Google Drive or other providers:
+To access your world across multiple devices using Google Drive or other providers:
 
 1.  Install the official client for your provider (e.g., [Google Drive for Desktop](https://www.google.com/drive/download/)).
-2.  In Codex Cryptica, go to **Settings > Vault**.
-3.  Under **Synchronization**, click **Sync to Folder**.
-4.  Select a folder within your local Google Drive/Cloud directory.
-5.  Codex will now mirror your files to that folder, and your OS will handle the background upload to the cloud.
+2.  In Codex Cryptica, click **SAVE TO FOLDER** in the bottom-left sidebar (or the Save icon in the Vault Selector).
+3.  If no folder is linked yet, you will be prompted to select a directory. Choose a folder within your local Google Drive/Cloud directory.
+4.  Codex will now write all changes to that folder, and your OS will handle the background upload to the cloud.
 
 ## Managing Multiple Devices
 
@@ -42,4 +41,4 @@ When you open Codex on a new device:
 1.  Create a new vault or open the **Vault Selector**.
 2.  Click **Open Folder**.
 3.  Select the cloud-synced folder you set up on your first device.
-4.  Codex will import your world and keep it in sync with the cloud mirror.
+4.  Codex will load your world and keep it updated with the cloud mirror.

--- a/apps/web/static/TERMS.md
+++ b/apps/web/static/TERMS.md
@@ -4,17 +4,17 @@ By using Codex Cryptica, you agree to the following terms. This is a local-first
 
 ## 1. Description of Service
 
-Codex Cryptica is a creative writing and lore management tool. It provides local storage, optional folder synchronization, and AI-assisted content generation via Google Gemini.
+Codex Cryptica is a creative writing and lore management tool. It provides local storage, optional folder integration, and AI-assisted content generation via Google Gemini.
 
 ## 2. Data Ownership and Responsibility
 
 - **Your Data:** You own all content you create. We do not have access to your internal archives.
-- **Responsibility:** Since Codex Cryptica stores data locally in your browser (OPFS), you are responsible for maintaining backups. We recommend using the "Sync to Folder" feature to mirror your data to a stable location on your computer.
+- **Responsibility:** Since Codex Cryptica stores data locally in your browser (OPFS), you are responsible for maintaining backups. We recommend using the "Save to Folder" feature to mirror your data to a stable location on your computer.
 - **Loss of Data:** We are not liable for any data loss resulting from browser cache clearing, device failure, or synchronization errors.
 
-## 3. Local Folder Synchronization
+## 3. Local Folder Integration
 
-- **Mechanism:** The synchronization feature uses the Web File System Access API to mirror files between your browser and a local directory.
+- **Mechanism:** The folder saving feature uses the Web File System Access API to mirror files between your browser and a local directory.
 - **Cloud Providers:** If you sync to a folder managed by a third-party service (e.g., Google Drive, Dropbox), you are subject to that provider's terms and conditions. Codex Cryptica is not responsible for the performance or security of these services.
 
 ## 4. AI Content Generation


### PR DESCRIPTION
This PR updates user-facing help articles, blog posts, and terms of service to consistently use directional save/load terminology instead of synchronization terminology for local folder mirroring, and fixes outdated Settings modal tab instructions.