### PR TITLE
🧪 test: add comprehensive test coverage for local-first failure modes and date bounds

### DIFF
--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -401,6 +401,8 @@ export class SyncStore {
       () => this.checkForConflicts(),
     );
 
+    if (this.deps.activeVaultId() !== vaultIdAtStart) return;
+
     if (this._status !== "error") {
       const { updateLastSavedToFolder } = await import("./registry");
       await updateLastSavedToFolder(vaultIdAtStart);
@@ -466,6 +468,8 @@ export class SyncStore {
       },
       () => this.checkForConflicts(),
     );
+
+    if (this.deps.activeVaultId() !== vaultIdAtStart) return;
 
     if (this._status !== "error") {
       appEventBus.emit({

--- a/apps/web/src/lib/stores/vault/sync-store.test.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.test.ts
@@ -3,6 +3,8 @@ import { createMockOpfs } from "../../../tests/mocks/storage";
 import { cacheService } from "../../services/cache.svelte";
 import { SyncStore } from "./sync-store.svelte";
 import { notificationStore } from "$lib/stores/ui/notification.svelte";
+import { appEventBus } from "@codex/events";
+import { vaultEventBus } from "./events.svelte";
 
 vi.hoisted(() => {
   (global as any).$state = (v: any) => v;
@@ -510,6 +512,197 @@ describe("SyncStore", () => {
       await testStore.loadFromFolder();
       expect(pullSpy).toHaveBeenCalled();
       expect(flushPendingSavesSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Failure Modes & Race Conditions", () => {
+    it("US2: loadFromFolder sets needs-permission on permission denial", async () => {
+      const mockFolderHandle = {
+        queryPermission: vi.fn().mockResolvedValue("prompt"),
+        requestPermission: vi.fn().mockResolvedValue("denied"),
+      };
+      const pullSpy = vi.fn();
+
+      const storeWithMockFolder = new SyncStore({
+        activeVaultId: () => "vault-1",
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue({
+          pull: pullSpy,
+        } as any),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi
+          .fn()
+          .mockResolvedValue(mockFolderHandle as any),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await storeWithMockFolder.loadFromFolder();
+
+      expect(mockFolderHandle.queryPermission).toHaveBeenCalled();
+      expect(mockFolderHandle.requestPermission).toHaveBeenCalled();
+      expect(pullSpy).not.toHaveBeenCalled();
+      expect(storeWithMockFolder.status).toBe("needs-permission");
+      expect(storeWithMockFolder.errorMessage).toBe(
+        "Permission denied for local folder.",
+      );
+    });
+
+    it("aborts loadFiles early and does not emit completion events if vault is switched during loading", async () => {
+      let resolveLoadFiles: () => void = () => {};
+      const loadFilesPromise = new Promise<void>((resolve) => {
+        resolveLoadFiles = resolve;
+      });
+      repository.loadFiles.mockReturnValue(loadFilesPromise);
+
+      let activeVault = "vault-1";
+      const testStore = new SyncStore({
+        activeVaultId: () => activeVault,
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue(null),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi.fn().mockResolvedValue(null),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const vaultOpeningSpy = vi.spyOn(vaultEventBus, "emit");
+
+      // Start loadFiles (which waits on loadFilesPromise)
+      const runLoad = testStore.loadFiles(false);
+
+      expect(testStore.status).toBe("loading");
+
+      // Mid-execution: Switch vault ID
+      activeVault = "vault-2";
+
+      // Resolve the loadFiles promise
+      resolveLoadFiles();
+      await runLoad;
+
+      // Verify that loadMaps and updateEntityCount were NOT called for vault-1
+      expect(testStore.deps.loadMaps).not.toHaveBeenCalled();
+      expect(testStore.deps.updateEntityCount).not.toHaveBeenCalled();
+
+      // Verify that SYNC_COMPLETE was NOT emitted for vault-1
+      const syncCompleteEmitted = vaultOpeningSpy.mock.calls.some(
+        (call) =>
+          call[0].type === "SYNC_COMPLETE" && call[0].vaultId === "vault-1",
+      );
+      expect(syncCompleteEmitted).toBe(false);
+    });
+
+    it("aborts saveToFolder early and does not update registry or emit complete event if vault is switched during execution", async () => {
+      const mockFolderHandle = {
+        queryPermission: vi.fn().mockResolvedValue("granted"),
+      };
+
+      let resolvePush: (value: any) => void = () => {};
+      const pushPromise = new Promise<void>((resolve) => {
+        resolvePush = resolve;
+      });
+
+      const pushSpy = vi.fn().mockReturnValue(pushPromise);
+      let activeVault = "vault-1";
+
+      const testStore = new SyncStore({
+        activeVaultId: () => activeVault,
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue({
+          push: pushSpy,
+        } as any),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi
+          .fn()
+          .mockResolvedValue(mockFolderHandle as any),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const appEventEmitSpy = vi.spyOn(appEventBus, "emit");
+
+      const runSave = testStore.saveToFolder();
+
+      // Switch vault ID mid-save
+      activeVault = "vault-2";
+
+      resolvePush(undefined);
+      await runSave;
+
+      // Verify that SYNC:LOCAL_PUSH_COMPLETE was NOT emitted for vault-1
+      const pushCompleteEmitted = appEventEmitSpy.mock.calls.some(
+        (call) =>
+          call[0].type === "SYNC:LOCAL_PUSH_COMPLETE" &&
+          call[0].payload?.vaultId === "vault-1",
+      );
+      expect(pushCompleteEmitted).toBe(false);
+
+      // Verify status was not set to "saved" for the new or old vault
+      expect(testStore.status).not.toBe("saved");
+    });
+
+    it("aborts loadFromFolder early and does not loadFiles or emit complete event if vault is switched during execution", async () => {
+      const mockFolderHandle = {
+        queryPermission: vi.fn().mockResolvedValue("granted"),
+      };
+
+      let resolvePull: (value: any) => void = () => {};
+      const pullPromise = new Promise<void>((resolve) => {
+        resolvePull = resolve;
+      });
+
+      const pullSpy = vi.fn().mockReturnValue(pullPromise);
+      let activeVault = "vault-1";
+
+      const testStore = new SyncStore({
+        activeVaultId: () => activeVault,
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue({
+          pull: pullSpy,
+        } as any),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi
+          .fn()
+          .mockResolvedValue(mockFolderHandle as any),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const appEventEmitSpy = vi.spyOn(appEventBus, "emit");
+      const loadFilesSpy = vi
+        .spyOn(testStore, "loadFiles")
+        .mockResolvedValue(undefined);
+
+      const runLoad = testStore.loadFromFolder();
+
+      // Switch vault ID mid-load
+      activeVault = "vault-2";
+
+      resolvePull(undefined);
+      await runLoad;
+
+      // Verify that SYNC:LOCAL_PULL_COMPLETE was NOT emitted for vault-1
+      const pullCompleteEmitted = appEventEmitSpy.mock.calls.some(
+        (call) =>
+          call[0].type === "SYNC:LOCAL_PULL_COMPLETE" &&
+          call[0].payload?.vaultId === "vault-1",
+      );
+      expect(pullCompleteEmitted).toBe(false);
+
+      // Verify loadFiles was NOT called on the store
+      expect(loadFilesSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/chronology-engine/src/engine.ts
+++ b/packages/chronology-engine/src/engine.ts
@@ -68,7 +68,12 @@ export class CalendarEngine {
     date: TemporalMetadata | DateSelection,
     configOrSnapshot: WorldCalendar | CalendarSnapshot,
   ): boolean {
-    if (date.year === undefined || date.year === null) return false;
+    if (
+      date.year === undefined ||
+      date.year === null ||
+      !Number.isSafeInteger(date.year)
+    )
+      return false;
 
     const config = getConfig(configOrSnapshot);
     const months = this.getMonths(config);
@@ -85,7 +90,12 @@ export class CalendarEngine {
       }
 
       if (date.precision === "day") {
-        if (!date.unitId || date.day === undefined) return false;
+        if (
+          !date.unitId ||
+          date.day === undefined ||
+          !Number.isSafeInteger(date.day)
+        )
+          return false;
         const month = months.find((m) => m.id === date.unitId);
         if (!month) return false;
         return date.day >= 1 && date.day <= month.days;
@@ -103,10 +113,15 @@ export class CalendarEngine {
     // Legacy TemporalMetadata shape
     const legacyDate = date as TemporalMetadata;
     if (legacyDate.month !== undefined) {
-      if (legacyDate.month < 1 || legacyDate.month > months.length)
+      if (
+        !Number.isSafeInteger(legacyDate.month) ||
+        legacyDate.month < 1 ||
+        legacyDate.month > months.length
+      )
         return false;
 
       if (legacyDate.day !== undefined) {
+        if (!Number.isSafeInteger(legacyDate.day)) return false;
         const monthDays = months[legacyDate.month - 1].days;
         if (legacyDate.day < 1 || legacyDate.day > monthDays) return false;
       }

--- a/packages/chronology-engine/src/engine.ts
+++ b/packages/chronology-engine/src/engine.ts
@@ -65,10 +65,11 @@ export class CalendarEngine {
    * Validate if a date structure is valid under the given calendar rules.
    */
   isValid(
-    date: TemporalMetadata | DateSelection,
+    date: TemporalMetadata | DateSelection | null | undefined,
     configOrSnapshot: WorldCalendar | CalendarSnapshot,
   ): boolean {
     if (
+      !date ||
       date.year === undefined ||
       date.year === null ||
       !Number.isSafeInteger(date.year)

--- a/packages/chronology-engine/tests/engine.test.ts
+++ b/packages/chronology-engine/tests/engine.test.ts
@@ -485,4 +485,102 @@ describe("CalendarEngine", () => {
       expect(parseDirectDateInput("12.5.01.2024", DEFAULT_CALENDAR)).toBeNull();
     });
   });
+
+  describe("Invalid/Extreme Date Values Validation", () => {
+    it("should reject non-integer / floating-point years, months, and days", () => {
+      // Float year in DateSelection
+      expect(
+        calendarEngine.isValid(
+          { precision: "year", year: 2024.5 },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+      // Float year in legacy format
+      expect(calendarEngine.isValid({ year: 2024.5 }, DEFAULT_CALENDAR)).toBe(
+        false,
+      );
+      // Float month in legacy format
+      expect(
+        calendarEngine.isValid({ year: 2024, month: 1.5 }, DEFAULT_CALENDAR),
+      ).toBe(false);
+      // Float day in DateSelection
+      expect(
+        calendarEngine.isValid(
+          { precision: "day", year: 2024, unitId: "january", day: 15.5 },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+      // Float day in legacy format
+      expect(
+        calendarEngine.isValid(
+          { year: 2024, month: 1, day: 15.5 },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+    });
+
+    it("should reject non-safe-integer/overflow years, months, and days", () => {
+      const hugeNumber = Number.MAX_SAFE_INTEGER + 10;
+      expect(
+        calendarEngine.isValid({ year: hugeNumber }, DEFAULT_CALENDAR),
+      ).toBe(false);
+      expect(
+        calendarEngine.isValid(
+          { precision: "year", year: hugeNumber },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+      expect(
+        calendarEngine.isValid(
+          { year: 2024, month: hugeNumber },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+      expect(
+        calendarEngine.isValid(
+          { precision: "day", year: 2024, unitId: "january", day: hugeNumber },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+    });
+
+    it("should reject NaN, Infinity, and non-numeric year/month/day values", () => {
+      expect(
+        calendarEngine.isValid({ year: Number.NaN }, DEFAULT_CALENDAR),
+      ).toBe(false);
+      expect(
+        calendarEngine.isValid(
+          { year: Number.POSITIVE_INFINITY },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+      expect(
+        calendarEngine.isValid(
+          { year: 2024, month: Number.NaN },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+      expect(
+        calendarEngine.isValid(
+          { precision: "day", year: 2024, unitId: "january", day: Number.NaN },
+          DEFAULT_CALENDAR,
+        ),
+      ).toBe(false);
+    });
+
+    it("should parseDirectDateInput with negative, float and extreme inputs correctly", () => {
+      // Float parts should return null
+      expect(parseDirectDateInput("12.5/01/2024", DEFAULT_CALENDAR)).toBeNull();
+      expect(parseDirectDateInput("12/1.5/2024", DEFAULT_CALENDAR)).toBeNull();
+      expect(parseDirectDateInput("12/01/2024.5", DEFAULT_CALENDAR)).toBeNull();
+
+      // Extreme values should return null
+      expect(
+        parseDirectDateInput("12019999999999999999", DEFAULT_CALENDAR),
+      ).toBeNull();
+      expect(
+        parseDirectDateInput("99999999999999990112", DEFAULT_CALENDAR),
+      ).toBeNull();
+    });
+  });
 });

--- a/packages/chronology-engine/tests/engine.test.ts
+++ b/packages/chronology-engine/tests/engine.test.ts
@@ -566,6 +566,8 @@ describe("CalendarEngine", () => {
           DEFAULT_CALENDAR,
         ),
       ).toBe(false);
+      expect(calendarEngine.isValid(null, DEFAULT_CALENDAR)).toBe(false);
+      expect(calendarEngine.isValid(undefined, DEFAULT_CALENDAR)).toBe(false);
     });
 
     it("should parseDirectDateInput with negative, float and extreme inputs correctly", () => {

--- a/packages/vault-engine/src/sync-coordinator.test.ts
+++ b/packages/vault-engine/src/sync-coordinator.test.ts
@@ -263,5 +263,38 @@ describe("SyncCoordinator", () => {
 
       expect(mockEngine.sync).not.toHaveBeenCalled();
     });
+
+    it("should handle AbortError thrown during sync and revert status to idle", async () => {
+      mockIO.getLocalHandle.mockResolvedValue({
+        values: () => ({ next: vi.fn().mockResolvedValue({}) }),
+        queryPermission: vi.fn().mockResolvedValue("granted"),
+      } as any);
+
+      const abortError = new Error("aborted");
+      abortError.name = "AbortError";
+      mockEngine.sync.mockRejectedValue(abortError);
+
+      const onStateChange = vi.fn();
+
+      await coordinator.syncWithLocalFolder(
+        "v1",
+        {} as any,
+        "pull",
+        {},
+        vi.fn().mockResolvedValue(undefined),
+        onStateChange,
+        vi.fn(),
+      );
+
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "loading", syncType: "local" }),
+      );
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "idle", syncType: null }),
+      );
+      expect(onStateChange).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: "error" }),
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #934. Adds comprehensive unit test coverage and code validation hardening for local-first failure modes, stale guards, and calendar dates.