### PR TITLE
⚡️ perf: fix search indexing bottlenecks + post-review safety fixes (closes #933)

### DIFF
--- a/apps/web/src/lib/services/search.svelte.test.ts
+++ b/apps/web/src/lib/services/search.svelte.test.ts
@@ -303,6 +303,24 @@ describe("SearchService — BATCH_UPDATED patch filtering", () => {
     expect(sentEntries).toHaveLength(1);
     expect(sentEntries[0].id).toBe("e-pf-9");
   });
+
+  it("re-indexes when patch only changes metadata (fans into keywords field)", async () => {
+    // Regression for review finding C1: metadata was absent from SEARCH_FIELDS,
+    // so custom-property changes would silently skip re-indexing.
+    const { api, eventBus } = makeService();
+    emitVaultEvent(eventBus, VAULT_EVENTS.VAULT_OPENING, {}, "vault-1");
+    await flush();
+
+    emitVaultEvent(eventBus, VAULT_EVENTS.BATCH_UPDATED, {
+      entities: [makeEntity("e-meta-1")],
+      patches: { "e-meta-1": { metadata: { chapter: "Act 2" } } },
+    });
+    await flush();
+
+    // metadata values are fanned into the FlexSearch `keywords` field via
+    // mapToSearchEntry — must trigger a re-index.
+    expect(api.addBatch).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/services/search.svelte.test.ts
+++ b/apps/web/src/lib/services/search.svelte.test.ts
@@ -193,6 +193,119 @@ describe("SearchService — BATCH_CREATED", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: BATCH_CREATED — non-progressive path uses addBatch only (issue #933)
+// ---------------------------------------------------------------------------
+describe("SearchService — BATCH_CREATED non-progressive path", () => {
+  it("calls addBatch but NOT addBatchProgressive for non-progressive indexing", async () => {
+    const { api, eventBus } = makeService();
+    emitVaultEvent(eventBus, VAULT_EVENTS.VAULT_OPENING, {}, "vault-1");
+    await flush();
+
+    emitVaultEvent(eventBus, VAULT_EVENTS.BATCH_CREATED, {
+      entities: [makeEntity("e-np-1")],
+    });
+    await flush();
+
+    // Fix #4: single API call — addBatch only, no addBatchProgressive.
+    expect(api.addBatch).toHaveBeenCalledTimes(1);
+    expect(api.addBatchProgressive).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: BATCH_UPDATED — patch-field filtering (issue #933)
+// ---------------------------------------------------------------------------
+describe("SearchService — BATCH_UPDATED patch filtering", () => {
+  it("skips all entities when patches only contain non-search fields", async () => {
+    const { api, eventBus } = makeService();
+    emitVaultEvent(eventBus, VAULT_EVENTS.VAULT_OPENING, {}, "vault-1");
+    await flush();
+
+    emitVaultEvent(eventBus, VAULT_EVENTS.BATCH_UPDATED, {
+      entities: [makeEntity("e-pf-1"), makeEntity("e-pf-2")],
+      patches: {
+        "e-pf-1": { connections: [] },
+        "e-pf-2": { connections: [] },
+      },
+    });
+    await flush();
+
+    // Fix #3: zero re-index work for connection-only patches.
+    expect(api.addBatch).not.toHaveBeenCalled();
+  });
+
+  it("indexes only the entities whose patch touches a search field", async () => {
+    const { api, eventBus } = makeService();
+    emitVaultEvent(eventBus, VAULT_EVENTS.VAULT_OPENING, {}, "vault-1");
+    await flush();
+
+    emitVaultEvent(eventBus, VAULT_EVENTS.BATCH_UPDATED, {
+      entities: [makeEntity("e-pf-3"), makeEntity("e-pf-4")],
+      patches: {
+        "e-pf-3": { title: "Updated Title" }, // search-relevant
+        "e-pf-4": { connections: [] }, // not search-relevant
+      },
+    });
+    await flush();
+
+    expect(api.addBatch).toHaveBeenCalledTimes(1);
+    const sentEntries = api.addBatch.mock.calls[0][0] as any[];
+    expect(sentEntries).toHaveLength(1);
+    expect(sentEntries[0].id).toBe("e-pf-3");
+  });
+
+  it("re-indexes all entities when patches object is absent", async () => {
+    const { api, eventBus } = makeService();
+    emitVaultEvent(eventBus, VAULT_EVENTS.VAULT_OPENING, {}, "vault-1");
+    await flush();
+
+    emitVaultEvent(eventBus, VAULT_EVENTS.BATCH_UPDATED, {
+      entities: [makeEntity("e-pf-5"), makeEntity("e-pf-6")],
+      // no patches key at all — conservative fallback: re-index everything
+    });
+    await flush();
+
+    expect(api.addBatch).toHaveBeenCalledTimes(1);
+    expect(api.addBatch.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it("indexes entities whose patch includes content or lore", async () => {
+    const { api, eventBus } = makeService();
+    emitVaultEvent(eventBus, VAULT_EVENTS.VAULT_OPENING, {}, "vault-1");
+    await flush();
+
+    emitVaultEvent(eventBus, VAULT_EVENTS.BATCH_UPDATED, {
+      entities: [makeEntity("e-pf-7")],
+      patches: { "e-pf-7": { content: "new body text" } },
+    });
+    await flush();
+
+    expect(api.addBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("indexes entities with no patch entry conservatively", async () => {
+    // patches exists but doesn't include every entity ID
+    const { api, eventBus } = makeService();
+    emitVaultEvent(eventBus, VAULT_EVENTS.VAULT_OPENING, {}, "vault-1");
+    await flush();
+
+    emitVaultEvent(eventBus, VAULT_EVENTS.BATCH_UPDATED, {
+      entities: [makeEntity("e-pf-8"), makeEntity("e-pf-9")],
+      patches: {
+        "e-pf-8": { connections: [] }, // not search-relevant
+        // e-pf-9 has no patch entry → re-index conservatively
+      },
+    });
+    await flush();
+
+    expect(api.addBatch).toHaveBeenCalledTimes(1);
+    const sentEntries = api.addBatch.mock.calls[0][0] as any[];
+    expect(sentEntries).toHaveLength(1);
+    expect(sentEntries[0].id).toBe("e-pf-9");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: ENTITY_UPDATED — connection-only patch must NOT trigger indexing
 // ---------------------------------------------------------------------------
 describe("SearchService — ENTITY_UPDATED with connection-only patch", () => {

--- a/apps/web/src/lib/services/search.svelte.ts
+++ b/apps/web/src/lib/services/search.svelte.ts
@@ -217,8 +217,30 @@ export class SearchService {
 
             case VAULT_EVENTS.BATCH_UPDATED: {
               const entities = this.normalizeEntities(event.payload.entities);
-              if (entities.length > 0) {
-                await this.indexBatch(entities);
+              if (entities.length === 0) break;
+
+              // Fix #3: Skip re-indexing when only non-search metadata changed.
+              // Check each entity's patch; only queue those that touched a
+              // field FlexSearch actually indexes.
+              const patches: Record<string, Record<string, unknown>> = event
+                .payload.patches ?? {};
+              const SEARCH_FIELDS = [
+                "title",
+                "aliases",
+                "content",
+                "tags",
+                "labels",
+                "lore",
+              ] as const;
+              const entitiesToIndex = entities.filter((e: any) => {
+                const patch = patches[e.id];
+                // No patch entry for this entity → re-index conservatively.
+                if (!patch) return true;
+                return SEARCH_FIELDS.some((field) => field in patch);
+              });
+
+              if (entitiesToIndex.length > 0) {
+                await this.indexBatch(entitiesToIndex);
               }
               break;
             }
@@ -754,7 +776,8 @@ export class SearchService {
     source: "metadata" | "retry",
     options: { markReady?: boolean; saveOnReady?: boolean } = {},
   ) {
-    const api = await this.ensureWorker();
+    // Fix #1: Don't resolve the worker twice. indexBatch (and this.clear)
+    // each call ensureWorker() themselves; no separate resolution needed here.
     const runId = this.createRunId(vaultId);
     const markReady = options.markReady ?? true;
     const saveOnReady = options.saveOnReady ?? true;
@@ -775,7 +798,7 @@ export class SearchService {
     });
 
     try {
-      await api.clear();
+      await this.clear();
       await this.indexBatch(entities, {
         runId,
         vaultId,
@@ -834,46 +857,46 @@ export class SearchService {
           chunkEntries.push(entry);
         }
         const cleanChunkEntries = $state.snapshot(chunkEntries);
-        if (context && !this.isActiveRun(context.vaultId, context.runId)) {
-          return;
-        }
-        const result: ProgressiveBatchResult = context
-          ? await api.addBatchProgressive(cleanChunkEntries, {
+
+        if (context) {
+          // Fix #2 + #4: Progressive path — single API call, no redundant
+          // fake-result construction. Guard stale runs before every chunk.
+          if (!this.isActiveRun(context.vaultId, context.runId)) return;
+          const result: ProgressiveBatchResult = await api.addBatchProgressive(
+            cleanChunkEntries,
+            {
               runId: context.runId,
               vaultId: context.vaultId,
               batchIndex: Math.floor(i / INDEX_BATCH_SIZE),
               indexedBefore: this.progress.indexedCount,
               totalCount: context.totalCount,
-            })
-          : {
-              runId: "legacy",
-              vaultId: this.activeVaultId ?? "legacy",
-              acceptedCount: cleanChunkEntries.length,
-              failedIds: [],
-            };
-
-        if (!context) {
+            },
+          );
+          if (this.isActiveRun(result.vaultId, result.runId)) {
+            const indexedCount =
+              this.progress.indexedCount + result.acceptedCount;
+            this.emitProgress({
+              status: "partial",
+              vaultId: result.vaultId,
+              runId: result.runId,
+              indexedCount,
+              totalCount: context.totalCount,
+              isPartial: true,
+              canRetry: false,
+              message:
+                context.totalCount === null
+                  ? "Search is still indexing."
+                  : `Search is still indexing (${indexedCount}/${context.totalCount}).`,
+              error:
+                result.failedIds.length > 0
+                  ? `Failed to index ${result.failedIds.length} records.`
+                  : null,
+            });
+          }
+        } else {
+          // Non-progressive path: fire-and-forget batch with no progress
+          // tracking. No fake ProgressiveBatchResult construction needed.
           await api.addBatch(cleanChunkEntries);
-        } else if (this.isActiveRun(result.vaultId, result.runId)) {
-          const indexedCount =
-            this.progress.indexedCount + result.acceptedCount;
-          this.emitProgress({
-            status: "partial",
-            vaultId: result.vaultId,
-            runId: result.runId,
-            indexedCount,
-            totalCount: context.totalCount,
-            isPartial: true,
-            canRetry: false,
-            message:
-              context.totalCount === null
-                ? "Search is still indexing."
-                : `Search is still indexing (${indexedCount}/${context.totalCount}).`,
-            error:
-              result.failedIds.length > 0
-                ? `Failed to index ${result.failedIds.length} records.`
-                : null,
-          });
         }
         await this.delay(0);
       }

--- a/apps/web/src/lib/services/search.svelte.ts
+++ b/apps/web/src/lib/services/search.svelte.ts
@@ -14,6 +14,19 @@ import { VAULT_EVENTS } from "@codex/vault-engine";
 import { quickNoteStore } from "../stores/quicknote.svelte";
 
 const INDEX_BATCH_SIZE = 100;
+
+// Fields that FlexSearch indexes — used by the BATCH_UPDATED handler to skip
+// re-indexing when none of an entity's searchable fields changed.
+// Keep in sync with mapToSearchEntry().
+const BATCH_UPDATED_SEARCH_FIELDS = new Set([
+  "title",
+  "aliases",
+  "content",
+  "tags",
+  "labels",
+  "lore",
+  "metadata", // fanned into the `keywords` field via Object.values(entity.metadata)
+]);
 const READY_PROGRESS: SearchIndexProgress = {
   status: "idle",
   vaultId: null,
@@ -224,19 +237,13 @@ export class SearchService {
               // field FlexSearch actually indexes.
               const patches: Record<string, Record<string, unknown>> = event
                 .payload.patches ?? {};
-              const SEARCH_FIELDS = [
-                "title",
-                "aliases",
-                "content",
-                "tags",
-                "labels",
-                "lore",
-              ] as const;
               const entitiesToIndex = entities.filter((e: any) => {
                 const patch = patches[e.id];
                 // No patch entry for this entity → re-index conservatively.
                 if (!patch) return true;
-                return SEARCH_FIELDS.some((field) => field in patch);
+                return Object.keys(patch).some((k) =>
+                  BATCH_UPDATED_SEARCH_FIELDS.has(k),
+                );
               });
 
               if (entitiesToIndex.length > 0) {
@@ -781,7 +788,9 @@ export class SearchService {
     const runId = this.createRunId(vaultId);
     const markReady = options.markReady ?? true;
     const saveOnReady = options.saveOnReady ?? true;
-    this.pendingRetryEntities = entities;
+    // Fix C7: pendingRetryEntities is set AFTER clear() succeeds so that a
+    // failed clear() (e.g. worker torn down) does not overwrite a valid prior
+    // retry list with the new (possibly different) entities array.
     this.emitProgress({
       status: "rebuilding",
       vaultId,
@@ -799,6 +808,7 @@ export class SearchService {
 
     try {
       await this.clear();
+      this.pendingRetryEntities = entities;
       await this.indexBatch(entities, {
         runId,
         vaultId,

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -130,8 +130,10 @@ export class SyncStore {
     }
   }
 
-  private isStale(vaultIdAtStart: string, signal: AbortSignal): boolean {
-    return this.deps.activeVaultId() !== vaultIdAtStart || signal.aborted;
+  private isStale(vaultIdAtStart: string, signal?: AbortSignal): boolean {
+    return (
+      this.deps.activeVaultId() !== vaultIdAtStart || (signal?.aborted ?? false)
+    );
   }
 
   async loadFiles(skipSyncIfWarm = true) {
@@ -385,41 +387,50 @@ export class SyncStore {
 
     this.failedFiles = [];
 
-    await syncCoordinator.push(
-      vaultIdAtStart,
-      opfsHandle,
-      this.deps.repository.entities,
-      () => this.waitForSaves(),
-      (state) => {
-        if (this.deps.activeVaultId() === vaultIdAtStart) {
-          this.setStatus(state.status);
-          this.syncType = state.syncType;
-          if (state.errorMessage) this.errorMessage = state.errorMessage;
-          if (state.failedFiles) this.failedFiles = state.failedFiles;
-        }
-      },
-      () => this.checkForConflicts(),
-    );
+    try {
+      await syncCoordinator.push(
+        vaultIdAtStart,
+        opfsHandle,
+        this.deps.repository.entities,
+        () => this.waitForSaves(),
+        (state) => {
+          if (this.deps.activeVaultId() === vaultIdAtStart) {
+            this.setStatus(state.status);
+            this.syncType = state.syncType;
+            if (state.errorMessage) this.errorMessage = state.errorMessage;
+            if (state.failedFiles) this.failedFiles = state.failedFiles;
+          }
+        },
+        () => this.checkForConflicts(),
+      );
 
-    if (this.deps.activeVaultId() !== vaultIdAtStart) return;
+      if (this.isStale(vaultIdAtStart)) return;
 
-    if (this._status !== "error") {
-      const { updateLastSavedToFolder } = await import("./registry");
-      await updateLastSavedToFolder(vaultIdAtStart);
+      if (this._status !== "error") {
+        const { updateLastSavedToFolder } = await import("./registry");
+        await updateLastSavedToFolder(vaultIdAtStart);
 
-      appEventBus.emit({
-        type: "SYNC:LOCAL_PUSH_COMPLETE",
-        domain: "sync",
-        payload: { vaultId: vaultIdAtStart },
-        metadata: { timestamp: Date.now(), vaultId: vaultIdAtStart },
-      });
+        appEventBus.emit({
+          type: "SYNC:LOCAL_PUSH_COMPLETE",
+          domain: "sync",
+          payload: { vaultId: vaultIdAtStart },
+          metadata: { timestamp: Date.now(), vaultId: vaultIdAtStart },
+        });
 
-      this.setStatus("saved");
-      this.savedTimer = setTimeout(() => {
-        if (this._status === "saved") {
-          this.setStatus("idle");
-        }
-      }, 3000);
+        this.setStatus("saved");
+        this.savedTimer = setTimeout(() => {
+          if (this._status === "saved") {
+            this.setStatus("idle");
+          }
+        }, 3000);
+      }
+    } finally {
+      // Fix C4: if vault switched mid-save the onStateChange vault-ID guard
+      // suppresses the coordinator's final idle transition, leaving _status
+      // stuck at "saving"/"loading". Reset it so the UI doesn't freeze.
+      if (this._status === "saving" || this._status === "loading") {
+        this.setStatus("idle");
+      }
     }
   }
 
@@ -453,45 +464,55 @@ export class SyncStore {
 
     this.failedFiles = [];
 
-    await syncCoordinator.pull(
-      vaultIdAtStart,
-      opfsHandle,
-      this.deps.repository.entities,
-      () => this.waitForSaves(),
-      (state) => {
-        if (this.deps.activeVaultId() === vaultIdAtStart) {
-          this.setStatus(state.status);
-          this.syncType = state.syncType;
-          if (state.errorMessage) this.errorMessage = state.errorMessage;
-          if (state.failedFiles) this.failedFiles = state.failedFiles;
-        }
-      },
-      () => this.checkForConflicts(),
-    );
+    try {
+      await syncCoordinator.pull(
+        vaultIdAtStart,
+        opfsHandle,
+        this.deps.repository.entities,
+        () => this.waitForSaves(),
+        (state) => {
+          if (this.deps.activeVaultId() === vaultIdAtStart) {
+            this.setStatus(state.status);
+            this.syncType = state.syncType;
+            if (state.errorMessage) this.errorMessage = state.errorMessage;
+            if (state.failedFiles) this.failedFiles = state.failedFiles;
+          }
+        },
+        () => this.checkForConflicts(),
+      );
 
-    if (this.deps.activeVaultId() !== vaultIdAtStart) return;
+      if (this.isStale(vaultIdAtStart)) return;
 
-    if (this._status !== "error") {
-      appEventBus.emit({
-        type: "SYNC:LOCAL_PULL_COMPLETE",
-        domain: "sync",
-        payload: { vaultId: vaultIdAtStart },
-        metadata: { timestamp: Date.now(), vaultId: vaultIdAtStart },
-      });
+      if (this._status !== "error") {
+        appEventBus.emit({
+          type: "SYNC:LOCAL_PULL_COMPLETE",
+          domain: "sync",
+          payload: { vaultId: vaultIdAtStart },
+          metadata: { timestamp: Date.now(), vaultId: vaultIdAtStart },
+        });
 
-      await this.loadFiles();
+        await this.loadFiles();
+      }
+    } finally {
+      // Fix C4: mirror of saveToFolder — reset stuck transitional status
+      // if vault switched while the pull was in flight.
+      if (this._status === "saving" || this._status === "loading") {
+        this.setStatus("idle");
+      }
     }
   }
 
   async cleanupConflictFiles(signal?: AbortSignal) {
     const activeVaultId = this.deps.activeVaultId();
     if (!activeVaultId) return;
+    const vaultIdAtStart = activeVaultId;
 
     const syncCoordinator = await this.deps.getSyncCoordinator();
     if (!syncCoordinator) return;
 
     const opfsHandle = await this.deps.getActiveVaultHandle();
-    if (!opfsHandle || signal?.aborted) return;
+    // Fix C8: guard vault switch that may have occurred during the awaits above.
+    if (!opfsHandle || this.isStale(vaultIdAtStart, signal)) return;
 
     await syncCoordinator.cleanupConflictFiles(
       activeVaultId,

--- a/apps/web/src/lib/stores/vault/sync-store.test.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.test.ts
@@ -704,5 +704,115 @@ describe("SyncStore", () => {
       // Verify loadFiles was NOT called on the store
       expect(loadFilesSpy).not.toHaveBeenCalled();
     });
+
+    it("resets status to idle after vault-switch during saveToFolder (no frozen save spinner)", async () => {
+      // Regression for review finding C4: onStateChange vault-ID guard
+      // suppresses the final idle transition when vault switches mid-push,
+      // leaving _status stuck at "saving" indefinitely.
+      const mockFolderHandle = {
+        queryPermission: vi.fn().mockResolvedValue("granted"),
+      };
+
+      let resolvePush: (value: any) => void = () => {};
+      let capturedOnStateChange: ((state: any) => void) | null = null;
+
+      const pushSpy = vi
+        .fn()
+        .mockImplementation(
+          (_vaultId, _opfs, _entities, _waitFn, onStateChange) => {
+            capturedOnStateChange = onStateChange;
+            return new Promise((resolve) => {
+              resolvePush = resolve;
+            });
+          },
+        );
+
+      let activeVault = "vault-1";
+      const testStore = new SyncStore({
+        activeVaultId: () => activeVault,
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue({ push: pushSpy } as any),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi
+          .fn()
+          .mockResolvedValue(mockFolderHandle as any),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const runSave = testStore.saveToFolder();
+
+      // Flush setup awaits so pushSpy (and therefore capturedOnStateChange)
+      // is populated before we try to invoke the callback.
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Coordinator fires "saving" while vault still matches.
+      capturedOnStateChange?.({ status: "saving", syncType: "local" });
+      expect(testStore.status).toBe("saving");
+
+      // Vault switches — coordinator's final "idle" callback will be suppressed.
+      activeVault = "vault-2";
+
+      resolvePush(undefined);
+      await runSave;
+
+      // The finally block must have cleared the frozen status.
+      expect(testStore.status).toBe("idle");
+    });
+
+    it("resets status to idle after vault-switch during loadFromFolder (no frozen load spinner)", async () => {
+      // Regression for review finding C4: same race on the pull side.
+      const mockFolderHandle = {
+        queryPermission: vi.fn().mockResolvedValue("granted"),
+      };
+
+      let resolvePull: (value: any) => void = () => {};
+      let capturedOnStateChange: ((state: any) => void) | null = null;
+
+      const pullSpy = vi
+        .fn()
+        .mockImplementation(
+          (_vaultId, _opfs, _entities, _waitFn, onStateChange) => {
+            capturedOnStateChange = onStateChange;
+            return new Promise((resolve) => {
+              resolvePull = resolve;
+            });
+          },
+        );
+
+      let activeVault = "vault-1";
+      const testStore = new SyncStore({
+        activeVaultId: () => activeVault,
+        activeVaultRecord: () => mockVaultRecord,
+        repository: repository as any,
+        getSyncCoordinator: vi.fn().mockResolvedValue({ pull: pullSpy } as any),
+        getActiveVaultHandle: vi.fn().mockResolvedValue(opfsHandle),
+        getActiveFolderHandle: vi
+          .fn()
+          .mockResolvedValue(mockFolderHandle as any),
+        ensureServicesInitialized: vi.fn().mockResolvedValue(undefined),
+        loadMaps: vi.fn().mockResolvedValue(undefined),
+        loadCanvases: vi.fn().mockResolvedValue(undefined),
+        updateEntityCount: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const runLoad = testStore.loadFromFolder();
+
+      // Flush setup awaits so pullSpy is called and capturedOnStateChange set.
+      await new Promise((r) => setTimeout(r, 0));
+
+      capturedOnStateChange?.({ status: "loading", syncType: "local" });
+      expect(testStore.status).toBe("loading");
+
+      activeVault = "vault-2";
+
+      resolvePull(undefined);
+      await runLoad;
+
+      expect(testStore.status).toBe("idle");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes four performance bottlenecks in `SearchService` (issue #933) plus five correctness issues caught by a post-PR code review.

---

## Issue #933 — Search Indexing Performance

**Fix 1 — Resolve service once per bulk operation**
`rebuildFromEntities()` no longer calls `ensureWorker()` separately; it delegates to `this.clear()` (which calls it internally), removing a redundant round-trip.

**Fix 2 + 4 — Eliminate dead-code path in `indexBatch`**
Replaced the ternary-that-constructs-a-fake-`ProgressiveBatchResult` + trailing `if(!context)` guard with a clean `if/else`:
- context present → `api.addBatchProgressive` (progress-tracked)
- context absent → `api.addBatch` (fire-and-forget, no fake object)

**Fix 3 — Skip re-indexing on non-search metadata changes**
`BATCH_UPDATED` now cross-references `event.payload.patches` against `BATCH_UPDATED_SEARCH_FIELDS` (title, aliases, content, tags, labels, lore, metadata). Entities whose patch touches none of those fields are skipped. Entities with no patch entry are re-indexed conservatively.

---

## Post-review fixes

| Finding | Fix |
|---|---|
| **C4** `_status` frozen after vault switch in save/load | `try/finally` in `saveToFolder` + `loadFromFolder` resets stuck "saving"/"loading" to "idle" |
| **C1** `metadata` missing from batch-update search filter | Added `"metadata"` to `BATCH_UPDATED_SEARCH_FIELDS`; hoisted to module scope as a `Set` |
| **C8** `cleanupConflictFiles` had no stale-vault guard | Added `isStale(vaultIdAtStart, signal)` check after async handle lookups |
| **C7** `pendingRetryEntities` mutated before failable await | Moved assignment inside `try` block, after `clear()` succeeds |
| **C12** `isStale()` required non-optional `AbortSignal` | Made `signal?: AbortSignal` optional; inline vault guards now use `this.isStale()` |

---

## Tests

- **+5** tests for the issue #933 changes (batch-filter coverage, non-progressive path)
- **+3** tests for review findings (metadata re-index regression, frozen-status regression ×2)

All 75 affected tests pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)