### PR TITLE
[codex] Migrate pure package tests to Bun

### DIFF
--- a/docs/proposals/bun-native-test-migration-blueprint.md
+++ b/docs/proposals/bun-native-test-migration-blueprint.md
@@ -1,0 +1,101 @@
+# Bun Native Test Migration Blueprint
+
+This blueprint tracks a staged migration from Vitest to native `bun test` for packages that are safe to run without Vite, Svelte transforms, or browser-heavy test harnesses.
+
+The first local compatibility probe was run on 2026-05-27 with Bun 1.3.14:
+
+```text
+bun test packages
+548 pass, 186 fail, 2 errors, 734 tests, 2.86s
+```
+
+That result confirms the migration should be incremental. Some packages run cleanly under Bun today, while others depend on Svelte rune transforms, Vitest-only helper APIs, browser globals, DOM/canvas APIs, or package-specific mocks.
+
+## Phase 1 Scope
+
+Move only the packages that passed local `bun test` probes without code changes:
+
+| Package                      | Probe Result    | Phase 1 Action                  |
+| :--------------------------- | :-------------- | :------------------------------ |
+| `packages/chronology-engine` | 39 pass, 0 fail | Set `test` script to `bun test` |
+| `packages/dice-engine`       | 18 pass, 0 fail | Set `test` script to `bun test` |
+| `packages/editor-core`       | 41 pass, 0 fail | Set `test` script to `bun test` |
+| `packages/schema`            | 47 pass, 0 fail | Set `test` script to `bun test` |
+
+Keep `test:coverage` on Vitest during phase 1. Bun-native coverage can be evaluated separately after the basic runner migration is stable.
+
+## Phase 2 Complete
+
+Move the next pure TypeScript package after fixing Bun-compatible test assertions:
+
+| Package                  | Probe Result    | Phase 2 Action                  |
+| :----------------------- | :-------------- | :------------------------------ |
+| `packages/search-engine` | 45 pass, 0 fail | Set `test` script to `bun test` |
+
+Phase 2 kept `test:coverage` on Vitest. The package tests still import Vitest test helpers so the existing coverage command continues to work, but the default package test command now runs through Bun.
+
+The required test changes were limited to runner compatibility:
+
+- Added an explicit `beforeEach` import in `tests/smoke.test.ts`.
+- Replaced `await expect(promise).resolves.not.toThrow()` patterns with direct `await` calls followed by concrete state assertions.
+
+## Phase 3 Scope
+
+Move two small packages after replacing Vitest-only helper APIs with runner-compatible test setup:
+
+| Package             | Probe Result    | Phase 3 Action                  |
+| :------------------ | :-------------- | :------------------------------ |
+| `packages/proposer` | 22 pass, 0 fail | Set `test` script to `bun test` |
+| `packages/events`   | 13 pass, 0 fail | Set `test` script to `bun test` |
+
+Phase 3 also keeps `test:coverage` on Vitest for both packages.
+
+The required test changes were limited to compatibility:
+
+- Replaced `vi.mocked(GoogleGenerativeAI)` in `packages/proposer` with direct prototype assignment through a small `useMockModel` helper.
+- Replaced `vi.stubGlobal` / `vi.unstubAllGlobals` in `packages/events` with explicit `globalThis.BroadcastChannel` save and restore logic.
+
+## Phase 4 Scope
+
+Move the largest remaining pure-package candidate after replacing fake-timer-dependent retry tests with injected retry delays:
+
+| Package                | Probe Result    | Phase 4 Action                  |
+| :--------------------- | :-------------- | :------------------------------ |
+| `packages/sync-engine` | 82 pass, 0 fail | Set `test` script to `bun test` |
+
+Phase 4 keeps `test:coverage` on Vitest.
+
+The required changes were focused on dependency injection and test-runner compatibility:
+
+- Added optional wait/delay injection to `FileSystemBackend` and `GDriveBackend`, preserving real `setTimeout` delays by default.
+- Updated retry tests to inject a resolved wait function instead of relying on `vi.runAllTimersAsync` or `vi.advanceTimersByTimeAsync`.
+- Replaced a `vi.mocked(...)` call in `OpfsBackend` tests with a direct typed mock function cast.
+- Replaced one `await expect(promise).resolves.not.toThrow()` with direct `await`.
+
+## Deferred Packages
+
+These packages should stay on Vitest until their failure modes are handled explicitly:
+
+| Package                  | Current Bun Failure Mode                                           | Recommendation                                                          |
+| :----------------------- | :----------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| `packages/canvas-engine` | Svelte rune globals such as `$state` are not transformed by Bun    | Keep on Vitest unless the Svelte-stateful code is split from pure logic |
+| `packages/graph-engine`  | `vi.stubGlobal`, DOM, worker, and Cytoscape-style test assumptions | Keep on Vitest for now                                                  |
+| `packages/importer`      | Missing browser APIs such as `FileReader` and `DOMMatrix`          | Add targeted polyfills or keep on Vitest                                |
+| `packages/map-engine`    | Canvas renderer tests need canvas/browser mocks                    | Keep on Vitest until a Bun canvas harness exists                        |
+| `packages/oracle-engine` | Svelte rune globals, browser globals, and Vitest-only helpers      | Keep on Vitest                                                          |
+| `packages/vault-engine`  | Svelte rune globals such as `$state` are not transformed by Bun    | Keep on Vitest unless pure repository logic is separated                |
+
+## Migration Rules
+
+- Migrate package-by-package only after `bun test <package>` passes locally.
+- Do not classify packages containing `.svelte.ts` rune code as pure TypeScript unless their tests avoid the rune-backed modules or use a working transform.
+- Keep browser, DOM, canvas, worker, and IndexedDB-heavy tests on Vitest until Bun-specific preload/polyfill requirements are documented and verified.
+- Prefer explicit imports from `vitest` or `bun:test`; avoid relying on runner globals in package tests.
+- Update this document with measured pass/fail results before expanding the Bun-native scope.
+
+## Follow-Up Work
+
+1. Evaluate `packages/importer`; it may be viable with targeted browser API polyfills, but it is no longer a low-risk pure runner switch.
+2. Evaluate `packages/map-engine` only after deciding on a Bun-compatible canvas test harness.
+3. Split Svelte rune-backed stores from pure logic in `canvas-engine`, `oracle-engine`, and `vault-engine` before considering migration.
+4. Re-run `bun test packages` after each package migration and record the result here.

--- a/docs/proposals/bun-native-test-migration-blueprint.md
+++ b/docs/proposals/bun-native-test-migration-blueprint.md
@@ -72,6 +72,17 @@ The required changes were focused on dependency injection and test-runner compat
 - Replaced a `vi.mocked(...)` call in `OpfsBackend` tests with a direct typed mock function cast.
 - Replaced one `await expect(promise).resolves.not.toThrow()` with direct `await`.
 
+## Current Boundary
+
+Phases 1 through 4 cover the low-risk pure-package migration for this PR. There are no remaining obvious default `test` script switches that should be folded into the same change without introducing broader harness work.
+
+That does not mean Bun-native testing is exhausted. Further improvements should be tracked as follow-up work:
+
+- Audit deferred packages that may only be blocked by small Vitest compatibility assumptions.
+- Keep `test:coverage` on Vitest until Bun coverage can replace the current package coverage workflow cleanly.
+- Improve timing and reporting notes so future migrations compare package counts and runtime consistently.
+- Treat `apps/web` as a separate migration problem because Svelte, browser, and DOM-heavy tests need a dedicated harness strategy.
+
 ## Deferred Packages
 
 These packages should stay on Vitest until their failure modes are handled explicitly:

--- a/packages/chronology-engine/package.json
+++ b/packages/chronology-engine/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/dice-engine/package.json
+++ b/packages/dice-engine/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\"",
     "typecheck": "tsc --noEmit --project tsconfig.test.json"

--- a/packages/events/tests/CrossTabBroadcaster.test.ts
+++ b/packages/events/tests/CrossTabBroadcaster.test.ts
@@ -22,17 +22,23 @@ class MockBroadcastChannel {
 describe("CrossTabBroadcaster", () => {
   let bus: AppEventBus;
   let broadcaster: CrossTabBroadcaster;
+  let originalBroadcastChannel: typeof globalThis.BroadcastChannel | undefined;
 
   beforeEach(() => {
     MockBroadcastChannel.instances = [];
-    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
+    originalBroadcastChannel = globalThis.BroadcastChannel;
+    globalThis.BroadcastChannel = MockBroadcastChannel as any;
     bus = new AppEventBus();
     broadcaster = new CrossTabBroadcaster(bus);
   });
 
   afterEach(() => {
-    broadcaster.destroy();
-    vi.unstubAllGlobals();
+    broadcaster?.destroy();
+    if (originalBroadcastChannel === undefined) {
+      delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+    } else {
+      globalThis.BroadcastChannel = originalBroadcastChannel;
+    }
   });
 
   it("broadcasts local sync events as JSON strings", () => {

--- a/packages/proposer/package.json
+++ b/packages/proposer/package.json
@@ -7,7 +7,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/proposer/tests/service.test.ts
+++ b/packages/proposer/tests/service.test.ts
@@ -4,6 +4,12 @@ import { ProposerService } from "../src/service";
 import "fake-indexeddb/auto";
 import { openDB } from "idb";
 
+function useMockModel(generateContent: ReturnType<typeof vi.fn>): void {
+  (GoogleGenerativeAI as any).prototype.getGenerativeModel = vi
+    .fn()
+    .mockReturnValue({ generateContent });
+}
+
 vi.mock("@google/generative-ai", () => {
   const generateContent = vi.fn().mockResolvedValue({
     response: {
@@ -75,10 +81,7 @@ describe("ProposerService", () => {
           ]),
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
 
     const dbName = `test-db-${crypto.randomUUID()}`;
     service = new ProposerService(dbName, 1);
@@ -321,10 +324,7 @@ describe("ProposerService", () => {
           ]),
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const proposals = await service.analyzeEntity(
       "fake-key",
       "gemini-1.5-flash",
@@ -352,10 +352,7 @@ describe("ProposerService", () => {
           ]),
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const proposals = await service.analyzeEntity(
       "fake-key",
       "gemini-1.5-flash",
@@ -379,10 +376,7 @@ describe("ProposerService", () => {
           }),
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const proposal = await service.generateConnectionProposal(
       "key",
       "model",
@@ -401,10 +395,7 @@ describe("ProposerService", () => {
         text: () => "Invalid JSON",
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const proposal = await service.generateConnectionProposal(
       "key",
       "model",
@@ -429,10 +420,7 @@ describe("ProposerService", () => {
           }),
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const intent = await service.parseConnectionIntent(
       "key",
       "model",
@@ -449,10 +437,7 @@ describe("ProposerService", () => {
         text: () => "Garbage",
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const intent = await service.parseConnectionIntent("key", "model", "input");
     expect(intent.sourceName).toBe("");
     expect(intent.targetName).toBe("");
@@ -468,10 +453,7 @@ describe("ProposerService", () => {
           }),
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const intent = await service.parseMergeIntent(
       "key",
       "model",
@@ -487,10 +469,7 @@ describe("ProposerService", () => {
         text: () => "Garbage",
       },
     });
-    const mockModel = { generateContent };
-    vi.mocked(GoogleGenerativeAI).prototype.getGenerativeModel = vi
-      .fn()
-      .mockReturnValue(mockModel);
+    useMockModel(generateContent);
     const intent = await service.parseMergeIntent("key", "model", "input");
     expect(intent.sourceName).toBe("");
     expect(intent.targetName).toBe("");

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/search-engine/package.json
+++ b/packages/search-engine/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/search-engine/tests/search-engine-advanced.test.ts
+++ b/packages/search-engine/tests/search-engine-advanced.test.ts
@@ -89,8 +89,8 @@ describe("SearchEngine – setLogger", () => {
     engine.setLogger(() => {
       throw new Error("logger exploded");
     });
-    // Should not propagate the error
-    await expect(engine.add(makeEntry("safe"))).resolves.not.toThrow();
+    await engine.add(makeEntry("safe"));
+    expect(engine.docCount).toBe(1);
   });
 });
 
@@ -137,7 +137,8 @@ describe("SearchEngine – setChangeCallback", () => {
     throwingEngine.setChangeCallback(() => {
       throw new Error("callback exploded");
     });
-    await expect(throwingEngine.add(makeEntry("safe2"))).resolves.not.toThrow();
+    await throwingEngine.add(makeEntry("safe2"));
+    expect(throwingEngine.docCount).toBe(1);
   });
 });
 
@@ -275,7 +276,8 @@ describe("SearchEngine – error-path guards", () => {
   it("remove resolves without throwing when index is null", async () => {
     const engine = new SearchEngine();
     (engine as any).index = null;
-    await expect(engine.remove("ghost")).resolves.not.toThrow();
+    await engine.remove("ghost");
+    expect(engine.docCount).toBe(0);
   });
 
   it("exportIndex returns {} when index is null", async () => {
@@ -292,7 +294,7 @@ describe("SearchEngine – importIndex", () => {
   it("handles payload without _docIds without throwing", async () => {
     const engine = new SearchEngine();
     await engine.clear();
-    await expect(engine.importIndex({})).resolves.not.toThrow();
+    await engine.importIndex({});
     // docCount stays 0 because no _docIds were present
     expect(engine.docCount).toBe(0);
   });

--- a/packages/search-engine/tests/smoke.test.ts
+++ b/packages/search-engine/tests/smoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { SearchEngine } from "../src";
 import type { SearchEntry } from "schema";
 

--- a/packages/sync-engine/package.json
+++ b/packages/sync-engine/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/sync-engine/src/FileSystemBackend.test.ts
+++ b/packages/sync-engine/src/FileSystemBackend.test.ts
@@ -18,7 +18,10 @@ describe("FileSystemBackend", () => {
       }),
     };
 
-    backend = new FileSystemBackend(mockRootHandle);
+    backend = new FileSystemBackend(
+      mockRootHandle,
+      vi.fn().mockResolvedValue(undefined),
+    );
   });
 
   describe("scan", () => {
@@ -193,17 +196,11 @@ describe("FileSystemBackend", () => {
         .mockRejectedValueOnce(error)
         .mockResolvedValue(mockFile);
 
-      // We need to mock setTimeout or it will take a while
-      vi.useFakeTimers();
       const uploadPromise = backend.upload("test.md", new Blob(["data"]));
-
-      // Wait for the retry timer
-      await vi.runAllTimersAsync();
 
       const result = await uploadPromise;
       expect(result.path).toBe("test.md");
       expect(mockRootHandle.getFileHandle).toHaveBeenCalledTimes(3); // 1st try (fail), 2nd try (success), 3rd try (final verification)
-      vi.useRealTimers();
     });
 
     it("should abort on write failure", async () => {
@@ -228,21 +225,12 @@ describe("FileSystemBackend", () => {
       error.name = "NotFoundError";
       mockRootHandle.getFileHandle.mockRejectedValue(error);
 
-      vi.useFakeTimers();
       const uploadPromise = backend.upload("test.md", new Blob(["data"]));
 
       // Catch it early to avoid unhandled rejection in Vitest
       uploadPromise.catch(() => {});
 
-      // Wait for all retries (3 tries total)
-      // 1st attempt fails immediately
-      await vi.advanceTimersByTimeAsync(1000); // 1st retry delay
-      // 2nd attempt fails
-      await vi.advanceTimersByTimeAsync(2000); // 2nd retry delay
-      // 3rd attempt fails and rethrows original error
-
       await expect(uploadPromise).rejects.toThrow("Not found");
-      vi.useRealTimers();
     });
 
     it("should handle Directory NotFoundError in resolveFileHandle", async () => {

--- a/packages/sync-engine/src/FileSystemBackend.ts
+++ b/packages/sync-engine/src/FileSystemBackend.ts
@@ -1,7 +1,11 @@
 import { type ISyncBackend, type FileMetadata } from "./types";
 
 export class FileSystemBackend implements ISyncBackend {
-  constructor(private handle: FileSystemDirectoryHandle) {}
+  constructor(
+    private handle: FileSystemDirectoryHandle,
+    private readonly wait = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms)),
+  ) {}
 
   async scan(_vaultId: string): Promise<{ files: FileMetadata[] }> {
     const results: FileMetadata[] = [];
@@ -124,7 +128,7 @@ export class FileSystemBackend implements ISyncBackend {
             `[FileSystemBackend] Refreshing root and retrying ${path}... (${retries - 1} left)`,
           );
           retries--;
-          await new Promise((resolve) => setTimeout(resolve, delay));
+          await this.wait(delay);
           delay *= 2;
           continue;
         }

--- a/packages/sync-engine/src/GDriveBackend.test.ts
+++ b/packages/sync-engine/src/GDriveBackend.test.ts
@@ -13,7 +13,11 @@ describe("GDriveBackend", () => {
       getAccessToken: vi.fn().mockResolvedValue("test-token"),
       signOut: vi.fn().mockResolvedValue(undefined),
     };
-    backend = new GDriveBackend(mockAuthService, vaultId);
+    backend = new GDriveBackend(
+      mockAuthService,
+      vaultId,
+      vi.fn().mockResolvedValue(undefined),
+    );
     backend.setVaultFolderId(folderId);
 
     // Mock global fetch
@@ -38,7 +42,7 @@ describe("GDriveBackend", () => {
           Promise.resolve({ id: folderId, name: "Vault", trashed: false }),
       });
 
-      await expect(backend.connect()).resolves.not.toThrow();
+      await backend.connect();
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining(`/files/${folderId}`),
         expect.any(Object),
@@ -233,8 +237,6 @@ describe("GDriveBackend", () => {
     });
 
     it("should retry once on 500 Internal Server Error", async () => {
-      vi.useFakeTimers();
-
       (global.fetch as any)
         .mockResolvedValueOnce({ ok: false, status: 500 })
         .mockResolvedValueOnce({
@@ -242,17 +244,8 @@ describe("GDriveBackend", () => {
           json: () => Promise.resolve({ id: folderId }),
         });
 
-      const fetchPromise = backend.connect();
-
-      // First call happens immediately
-      await vi.advanceTimersByTimeAsync(0);
-
-      // Wait for backoff
-      await vi.advanceTimersByTimeAsync(500);
-
-      await fetchPromise;
+      await backend.connect();
       expect(global.fetch).toHaveBeenCalledTimes(2);
-      vi.useRealTimers();
     });
   });
 });

--- a/packages/sync-engine/src/GDriveBackend.ts
+++ b/packages/sync-engine/src/GDriveBackend.ts
@@ -31,6 +31,8 @@ export class GDriveBackend implements ISyncBackend {
   constructor(
     private readonly authService: IGDriveAuthService,
     private readonly vaultId: string,
+    private readonly wait = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms)),
   ) {}
 
   /**
@@ -233,7 +235,7 @@ export class GDriveBackend implements ISyncBackend {
         retryCount < 1
       ) {
         // Transient error, wait 500ms and retry once
-        await new Promise((resolve) => setTimeout(resolve, 500));
+        await this.wait(500);
         return this.driveFetch(endpoint, options, isFullUrl, retryCount + 1);
       }
 

--- a/packages/sync-engine/tests/unit/OpfsBackend.test.ts
+++ b/packages/sync-engine/tests/unit/OpfsBackend.test.ts
@@ -23,7 +23,9 @@ describe("OpfsBackend", () => {
 
   it("reuses cached hashes when file metadata is unchanged", async () => {
     const alpha = makeBlob("alpha", 100);
-    vi.mocked(registry.getOpfsStatesByVault).mockResolvedValue([
+    (
+      registry.getOpfsStatesByVault as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([
       {
         vaultId: "vault-1",
         filePath: "notes/alpha.md",


### PR DESCRIPTION
## Summary

Migrates the low-risk pure TypeScript package test scripts from Vitest to native `bun test` and records the measured phased migration plan in a new blueprint document.

Moved these package default `test` scripts to Bun:
- `chronology-engine`
- `dice-engine`
- `editor-core`
- `schema`
- `search-engine`
- `events`
- `proposer`
- `sync-engine`

Compatibility changes are limited to tests and retry-delay dependency injection:
- Replaced Bun-incompatible Vitest helper usage such as `vi.mocked`, `vi.stubGlobal`, and fake timer async helpers.
- Added optional wait injection to sync backends so retry tests stay deterministic without changing production defaults.
- Kept `test:coverage` on Vitest for migrated packages.

## Validation

- `bun run --filter @codex/sync-engine test`
- `bun run --filter @codex/sync-engine test:coverage`
- `bun run --filter @codex/sync-engine lint`
- `bun run test` passed before commit
- Pre-push hook passed:
  - `bun run --filter '*' lint -- --cache --cache-strategy content`
  - `BUN_NUM_THREADS=2 bun run --filter '*' test -- --changed`
