### PR TITLE
🧪 test: implement phases 5–7 of Bun test migration

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+watch = false
+preload = ["./tests/bun-preload.ts"]

--- a/docs/proposals/bun-native-test-deferred-audit.md
+++ b/docs/proposals/bun-native-test-deferred-audit.md
@@ -1,0 +1,184 @@
+# Bun Native Test Migration — Deferred Package Audit
+
+This document records the follow-up audit of the six packages deferred in
+[bun-native-test-migration-blueprint.md](./bun-native-test-migration-blueprint.md).
+The probe was run on 2026-05-28 with Bun 1.3.14.
+
+## Probe Results
+
+| Package                  | Pass | Fail | Primary failure modes                                                                     |
+| :----------------------- | ---: | ---: | :---------------------------------------------------------------------------------------- |
+| `packages/canvas-engine` |    0 |   10 | `$state is not defined` — all 10 tests instantiate `CanvasStore`                          |
+| `packages/graph-engine`  |   73 |   29 | `vi.stubGlobal`/`vi.unstubAllGlobals` (19), Cytoscape mock (10)                           |
+| `packages/importer`      |   40 |   10 | `FileReader is not defined` (5), `DOMMatrix is not defined` (4), assert type mismatch (1) |
+| `packages/map-engine`    |    3 |   16 | `document is not defined` (16) + `vi.unstubAllGlobals`                                    |
+| `packages/oracle-engine` |  102 |   82 | `vi.stubGlobal`/`vi.unstubAllGlobals` (68), `$state` (14)                                 |
+| `packages/vault-engine`  |   56 |   16 | `$state is not defined` — all 16 `VaultRepository` tests                                  |
+
+**Current total across the six packages:** 274 pass, 167 fail.
+**Projected total after all proposed phases:** 441 pass, ~10 fail (map-engine renderer deferred).
+
+## Failure Mode Analysis
+
+### `$state is not defined`
+
+Svelte 5 runes are used as class field initializers in `.svelte.ts` files
+(`store.svelte.ts`, `repository.svelte.ts`, `oracle-settings.svelte.ts`).
+Bun runs TypeScript without a Svelte transform, so `$state` is an undefined global.
+Affected packages: `canvas-engine`, `vault-engine`, `oracle-engine`.
+
+### `vi.stubGlobal` / `vi.unstubAllGlobals` not a function
+
+`bun:test`'s Vitest compatibility shim does not implement `vi.stubGlobal` or
+`vi.unstubAllGlobals`. All test files that call these methods fail at the
+`beforeEach`/`afterEach` hook, which cascades every test in the suite.
+Affected packages: `graph-engine`, `map-engine`, `oracle-engine`.
+
+The fix is the same save/restore pattern established in Phase 3
+(`packages/events`):
+
+```ts
+// Before (Vitest-only)
+beforeEach(() => {
+  vi.stubGlobal("BroadcastChannel", MockBC);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// After (bun-compatible)
+const original = globalThis.BroadcastChannel;
+beforeEach(() => {
+  (globalThis as any).BroadcastChannel = MockBC;
+});
+afterEach(() => {
+  (globalThis as any).BroadcastChannel = original;
+});
+```
+
+### Missing browser APIs — `FileReader`, `DOMMatrix`
+
+`packages/importer` uses `FileReader` inside parser source code and `DOMMatrix`
+in test helpers. Both are standard browser globals absent from Bun's runtime.
+A minimal preload shim is sufficient; no production code changes are needed.
+
+### `document is not defined`
+
+`packages/map-engine` renderer tests call `document.createElement` to build a
+canvas mock. Bun provides no DOM environment. Addressing this requires either
+a full DOM preload (e.g. `happy-dom`) or a Bun-compatible canvas test harness
+strategy — neither of which is settled yet.
+
+### Cytoscape mock — `node.connectedEdges is not a function`
+
+`packages/graph-engine` `useGraphSync.ts.test.ts` constructs a Cytoscape mock
+that does not implement `connectedEdges`. Under Vitest, module-level mocking
+(or Vitest's `vi.stubGlobal("Worker")` setup) masked this gap. Without that
+wrapper the mock is used directly and the missing method surfaces. The fix is
+to add `connectedEdges` to the stub object, but it requires manual inspection
+of the mock to confirm the full API surface needed.
+
+## Proposed Phases
+
+### Phase 5 — `importer`: browser API polyfills
+
+Add a test preload file (`packages/importer/tests/setup.ts`) with minimal
+`FileReader` and `DOMMatrix` shims, wired via `bunfig.toml` `preload`.
+
+- `FileReader` wraps Bun's `Blob.text()` / `arrayBuffer()` into the callback
+  contract the parsers expect.
+- `DOMMatrix` exposes the constructor so tests can instantiate it without
+  calling any geometric methods.
+
+Expected result: **40 → 50 pass** (all 10 blocked tests clear).
+Risk: low — shims are test-only; no production code touched.
+
+### Phase 6 — `oracle-engine` + `graph-engine`: replace `vi.stubGlobal`
+
+Apply the globalThis save/restore pattern to every test file that calls
+`vi.stubGlobal` or `vi.unstubAllGlobals`.
+
+**`oracle-engine` files:**
+
+- `src/chat-history.test.ts` — stubs `BroadcastChannel`
+- `src/undo-redo.test.ts` — stubs `BroadcastChannel`
+- `src/oracle-executor.test.ts` — stubs `navigator`
+- `src/executors/chat-executor.test.ts` — stubs `BroadcastChannel`
+- `src/executors/visualization-executor.test.ts` — stubs `URL`
+
+**`graph-engine` files:**
+
+- `src/LayoutManager.test.ts` — stubs `Worker`
+
+Expected result: oracle-engine **102 → ~170 pass**; graph-engine **73 → 92 pass**.
+Risk: low — identical to the Phase 3 approach that passed for `packages/events`.
+
+### Phase 7 — `vault-engine`, `oracle-engine`, `canvas-engine`: `$state` preload shim
+
+Add a per-package preload (or a shared one under `packages/`) that defines the
+Svelte 5 rune globals as passthrough functions:
+
+```ts
+// preload-svelte-runes.ts  (test-only, not shipped)
+(globalThis as any).$state = (init: unknown) => init;
+(globalThis as any).$derived = (fn: () => unknown) => fn();
+(globalThis as any).$effect = () => {};
+```
+
+At runtime `entities = $state({})` becomes `entities = {}`, which is the
+correct initial value. Tests for `VaultRepository`, `OracleSettingsService`,
+and `CanvasStore` exercise business logic (load, save, setters, getters) and
+do not assert on reactive binding behaviour, so the shim is sufficient.
+
+Expected result: vault-engine **56 → 72 pass**; oracle-engine **~170 → 184 pass**;
+canvas-engine **0 → 10 pass**.
+Risk: medium — the shim hides reactivity regressions. Acceptable for unit
+tests of business logic; document this limitation in the preload file.
+
+### Phase 8 — `graph-engine`: fix Cytoscape mock (`connectedEdges`)
+
+Inspect `useGraphSync.ts.test.ts` to identify the full Cytoscape node API
+surface used by the mock, then add the missing `connectedEdges` method.
+
+Expected result: graph-engine **92 → 102 pass** (all 29 failures cleared).
+Risk: medium — need to confirm the mock covers all code paths before
+expanding; do not reuse the Vitest `stubGlobal` shortcut.
+
+This phase should be scoped as a separate ticket after Phase 6 lands, so that
+the `vi.stubGlobal` conversion does not block the mock investigation.
+
+### Phase 9 — `map-engine`: DOM harness strategy (deferred)
+
+The 16 failing renderer tests need a real `document` object and a
+canvas-capable environment. Options:
+
+- Load `happy-dom` as a Bun preload — adds a full DOM; interaction with
+  canvas mock APIs is untested.
+- Keep renderer tests on Vitest — consistent with the blueprint rule that
+  canvas/browser-heavy tests stay on Vitest until a strategy is documented.
+
+**Recommendation:** keep on Vitest. Revisit only after a Bun canvas/DOM
+harness decision is made for `apps/web`. The 3 currently-passing map-engine
+tests remain green in the interim.
+
+## Migration Rules (additions to blueprint)
+
+- A `$state` preload shim is acceptable for packages where `.svelte.ts` files
+  hold only business logic reactive state (counters, maps, primitive flags).
+  Do not use a shim for packages whose tests assert on reactive update
+  propagation.
+- Replace every `vi.stubGlobal` / `vi.unstubAllGlobals` call with the
+  globalThis save/restore pattern before switching a package's `test` script
+  to `bun test`. Do not leave mixed `vi.stubGlobal` in a Bun-native package.
+- Record the pass/fail count for each package here after each phase lands.
+
+## Pass/Fail Log
+
+| Phase | Package         | Before | After    | Date       |
+| :---- | :-------------- | :----- | :------- | :--------- |
+| audit | `canvas-engine` | —      | 0 / 10   | 2026-05-28 |
+| audit | `graph-engine`  | —      | 73 / 29  | 2026-05-28 |
+| audit | `importer`      | —      | 40 / 10  | 2026-05-28 |
+| audit | `map-engine`    | —      | 3 / 16   | 2026-05-28 |
+| audit | `oracle-engine` | —      | 102 / 82 | 2026-05-28 |
+| audit | `vault-engine`  | —      | 56 / 16  | 2026-05-28 |

--- a/docs/proposals/bun-native-test-migration-blueprint.md
+++ b/docs/proposals/bun-native-test-migration-blueprint.md
@@ -98,3 +98,10 @@ Based on benchmarks of Svelte-related business logic, migrating **800+ of your 1
 
 - **95%+ Reduction in TDD Latency**: Your logic unit-tests will complete before your editor finishes autosaving.
 - **Smarter Resource Usage**: Bun avoids spawning dozens of heavy Node.js runtime instances across your Turborepo workspace.
+
+## Follow-Up Work
+
+A full probe of all six deferred packages (canvas-engine, graph-engine, importer,
+map-engine, oracle-engine, vault-engine) was run on 2026-05-28. Findings, proposed
+phases (5–9), and a per-package pass/fail log are in
+[bun-native-test-deferred-audit.md](./bun-native-test-deferred-audit.md).

--- a/packages/canvas-engine/bunfig.toml
+++ b/packages/canvas-engine/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+watch = false
+preload = ["../../tests/bun-preload.ts"]

--- a/packages/canvas-engine/package.json
+++ b/packages/canvas-engine/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/graph-engine/bunfig.toml
+++ b/packages/graph-engine/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+watch = false
+preload = ["../../tests/bun-preload.ts"]

--- a/packages/graph-engine/package.json
+++ b/packages/graph-engine/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -435,32 +435,34 @@ describe("LayoutManager", () => {
 
   it("should stop redraw even when the fit animation completion is missed", async () => {
     const originalSetTimeout = globalThis.setTimeout;
-    (globalThis as any).setTimeout = (cb: () => void, ms: number) => {
-      if (ms === 1200) {
-        return originalSetTimeout(cb, 5);
-      }
-      return originalSetTimeout(cb, ms);
-    };
+    try {
+      (globalThis as any).setTimeout = (cb: () => void, ms: number) => {
+        if (ms === 1200) {
+          return originalSetTimeout(cb, 5);
+        }
+        return originalSetTimeout(cb, ms);
+      };
 
-    mockCy.animate.mockImplementation(() => {});
-    const onLayoutStop = vi.fn();
+      mockCy.animate.mockImplementation(() => {});
+      const onLayoutStop = vi.fn();
 
-    await layoutManager.apply({
-      timelineMode: false,
-      timelineAxis: "x",
-      timelineScale: 1,
-      orbitMode: false,
-      centralNodeId: null,
-      stableLayout: false,
-      isGuest: false,
-      onLayoutStop,
-    });
+      await layoutManager.apply({
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: false,
+        isGuest: false,
+        onLayoutStop,
+      });
 
-    expect(onLayoutStop).not.toHaveBeenCalled();
-    await new Promise((resolve) => originalSetTimeout(resolve, 10));
-    expect(onLayoutStop).toHaveBeenCalledTimes(1);
-
-    globalThis.setTimeout = originalSetTimeout;
+      expect(onLayoutStop).not.toHaveBeenCalled();
+      await new Promise((resolve) => originalSetTimeout(resolve, 10));
+      expect(onLayoutStop).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
   });
 
   it("should stop redraw if the worker errors", async () => {
@@ -485,35 +487,37 @@ describe("LayoutManager", () => {
 
   it("should stop redraw if the worker never replies", async () => {
     const originalSetTimeout = globalThis.setTimeout;
-    (globalThis as any).setTimeout = (cb: () => void, ms: number) => {
-      if (ms === 15000) {
-        return originalSetTimeout(cb, 5);
-      }
-      return originalSetTimeout(cb, ms);
-    };
+    try {
+      (globalThis as any).setTimeout = (cb: () => void, ms: number) => {
+        if (ms === 15000) {
+          return originalSetTimeout(cb, 5);
+        }
+        return originalSetTimeout(cb, ms);
+      };
 
-    (globalThis as any).Worker = SilentWorker as any;
-    layoutManager = new LayoutManager(mockCy as unknown as Core);
-    const onLayoutStop = vi.fn();
+      (globalThis as any).Worker = SilentWorker as any;
+      layoutManager = new LayoutManager(mockCy as unknown as Core);
+      const onLayoutStop = vi.fn();
 
-    const applyPromise = layoutManager.apply({
-      timelineMode: false,
-      timelineAxis: "x",
-      timelineScale: 1,
-      orbitMode: false,
-      centralNodeId: null,
-      stableLayout: false,
-      isGuest: false,
-      onLayoutStop,
-    });
+      const applyPromise = layoutManager.apply({
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: false,
+        isGuest: false,
+        onLayoutStop,
+      });
 
-    await new Promise((resolve) => originalSetTimeout(resolve, 10));
-    await applyPromise;
+      await new Promise((resolve) => originalSetTimeout(resolve, 10));
+      await applyPromise;
 
-    expect(mockCy.animate).not.toHaveBeenCalled();
-    expect(onLayoutStop).toHaveBeenCalledTimes(1);
-
-    globalThis.setTimeout = originalSetTimeout;
+      expect(mockCy.animate).not.toHaveBeenCalled();
+      expect(onLayoutStop).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
   });
 
   it("should stop redraw when an in-flight worker is stopped", async () => {

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalWorker = globalThis.Worker;
 import {
   getLayoutCollisionSize,
   LayoutManager,
@@ -85,7 +87,7 @@ describe("LayoutManager", () => {
 
   beforeEach(() => {
     capturedPostMessage = null;
-    vi.stubGlobal("Worker", FakeWorker);
+    (globalThis as any).Worker = FakeWorker as any;
 
     const emptyCollection: any = {
       nonempty: vi.fn().mockReturnValue(false),
@@ -130,7 +132,7 @@ describe("LayoutManager", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    vi.unstubAllGlobals();
+    (globalThis as any).Worker = originalWorker;
   });
 
   it("should initialize with a cy instance", () => {
@@ -432,7 +434,14 @@ describe("LayoutManager", () => {
   });
 
   it("should stop redraw even when the fit animation completion is missed", async () => {
-    vi.useFakeTimers();
+    const originalSetTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (cb: () => void, ms: number) => {
+      if (ms === 1200) {
+        return originalSetTimeout(cb, 5);
+      }
+      return originalSetTimeout(cb, ms);
+    };
+
     mockCy.animate.mockImplementation(() => {});
     const onLayoutStop = vi.fn();
 
@@ -448,12 +457,14 @@ describe("LayoutManager", () => {
     });
 
     expect(onLayoutStop).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(1200);
+    await new Promise((resolve) => originalSetTimeout(resolve, 10));
     expect(onLayoutStop).toHaveBeenCalledTimes(1);
+
+    globalThis.setTimeout = originalSetTimeout;
   });
 
   it("should stop redraw if the worker errors", async () => {
-    vi.stubGlobal("Worker", ErrorWorker);
+    (globalThis as any).Worker = ErrorWorker as any;
     layoutManager = new LayoutManager(mockCy as unknown as Core);
     const onLayoutStop = vi.fn();
 
@@ -473,8 +484,15 @@ describe("LayoutManager", () => {
   });
 
   it("should stop redraw if the worker never replies", async () => {
-    vi.useFakeTimers();
-    vi.stubGlobal("Worker", SilentWorker);
+    const originalSetTimeout = globalThis.setTimeout;
+    (globalThis as any).setTimeout = (cb: () => void, ms: number) => {
+      if (ms === 15000) {
+        return originalSetTimeout(cb, 5);
+      }
+      return originalSetTimeout(cb, ms);
+    };
+
+    (globalThis as any).Worker = SilentWorker as any;
     layoutManager = new LayoutManager(mockCy as unknown as Core);
     const onLayoutStop = vi.fn();
 
@@ -489,15 +507,17 @@ describe("LayoutManager", () => {
       onLayoutStop,
     });
 
-    await vi.advanceTimersByTimeAsync(15000);
+    await new Promise((resolve) => originalSetTimeout(resolve, 10));
     await applyPromise;
 
     expect(mockCy.animate).not.toHaveBeenCalled();
     expect(onLayoutStop).toHaveBeenCalledTimes(1);
+
+    globalThis.setTimeout = originalSetTimeout;
   });
 
   it("should stop redraw when an in-flight worker is stopped", async () => {
-    vi.stubGlobal("Worker", SilentWorker);
+    (globalThis as any).Worker = SilentWorker as any;
     layoutManager = new LayoutManager(mockCy as unknown as Core);
     const onLayoutStop = vi.fn();
 
@@ -579,7 +599,7 @@ describe("LayoutManager", () => {
         });
       }
     }
-    vi.stubGlobal("Worker", FormatWorker);
+    (globalThis as any).Worker = FormatWorker as any;
     layoutManager = new LayoutManager(mockCy as unknown as Core);
 
     await layoutManager.apply({

--- a/packages/graph-engine/src/index.test.ts
+++ b/packages/graph-engine/src/index.test.ts
@@ -1,32 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { initGraph } from "./index";
-import cytoscape from "cytoscape";
-
-vi.mock("cytoscape", () => {
-  const mockCy = vi.fn(() => ({
-    on: vi.fn(),
-    off: vi.fn(),
-  }));
-  (mockCy as any).use = vi.fn();
-  return {
-    default: mockCy,
-  };
-});
 
 describe("initGraph adaptive zoom", () => {
   it("should calculate higher minZoom for small graphs", async () => {
-    await initGraph({
-      container: document.createElement("div"),
+    const cy = await initGraph({
+      headless: true,
       elements: [
         { group: "nodes", data: { id: "1" } },
         { group: "nodes", data: { id: "2" } },
       ],
     });
 
-    const callArgs = (cytoscape as any).mock.calls[0][0];
     // nodeCount = 2
     // minZoom = max(0.05, 0.3 - 2 * 0.0005) = 0.299
-    expect(callArgs.minZoom).toBeCloseTo(0.299, 3);
+    expect(cy.minZoom()).toBeCloseTo(0.299, 3);
   });
 
   it("should calculate lower minZoom for large graphs", async () => {
@@ -35,15 +22,14 @@ describe("initGraph adaptive zoom", () => {
       data: { id: i.toString() },
     }));
 
-    await initGraph({
-      container: document.createElement("div"),
+    const cy = await initGraph({
+      headless: true,
       elements: manyNodes as any,
     });
 
-    const callArgs = (cytoscape as any).mock.calls[1][0];
     // nodeCount = 1000
     // minZoom = max(0.01, 0.3 - 1000 * 0.0005) = max(0.01, -0.2) = 0.01
-    expect(callArgs.minZoom).toBe(0.01);
+    expect(cy.minZoom()).toBe(0.01);
   });
 
   it("should use a constant maxZoom of 9.0", async () => {
@@ -52,25 +38,21 @@ describe("initGraph adaptive zoom", () => {
       data: { id: i.toString() },
     }));
 
-    await initGraph({
-      container: document.createElement("div"),
+    const cy = await initGraph({
+      headless: true,
       elements: manyNodes as any,
     });
 
-    const callArgs = (cytoscape as any).mock.calls[2][0];
     // maxZoom is now constant 9.0
-    expect(callArgs.maxZoom).toBe(9.0);
+    expect(cy.maxZoom()).toBe(9.0);
   });
 
   it("should configure wheelSensitivity to 1.0 for smoother scrolling", async () => {
-    await initGraph({
-      container: document.createElement("div"),
+    const cy = await initGraph({
+      headless: true,
       elements: [],
     });
 
-    const callArgs = (cytoscape as any).mock.calls[
-      (cytoscape as any).mock.calls.length - 1
-    ][0];
-    expect(callArgs.wheelSensitivity).toBe(1.0);
+    expect((cy as any)._private?.options?.wheelSensitivity).toBe(1.0);
   });
 });

--- a/packages/graph-engine/src/sync/ImageManager.test.ts
+++ b/packages/graph-engine/src/sync/ImageManager.test.ts
@@ -1,6 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GraphImageManager } from "./ImageManager";
 
+async function waitFor(assertion: () => void, options = { timeout: 1000 }) {
+  const start = Date.now();
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (e) {
+      if (Date.now() - start > options.timeout) {
+        throw e;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+}
+
 describe("GraphImageManager", () => {
   let mockCy: any;
   let mockNode: any;
@@ -42,12 +57,9 @@ describe("GraphImageManager", () => {
     });
 
     // Wait for the async processing in ImageManager
-    await vi.waitFor(
-      () => {
-        expect(mockStyle.update).toHaveBeenCalled();
-      },
-      { timeout: 1000 },
-    );
+    await waitFor(() => {
+      expect(mockStyle.update).toHaveBeenCalled();
+    });
 
     expect(mockNode.data).toHaveBeenCalledWith("resolvedImage", "blob:url");
   });
@@ -66,9 +78,7 @@ describe("GraphImageManager", () => {
 
     manager.sync({ showImages: true, resolveImageUrl, releaseImageUrl });
 
-    await vi.waitFor(() => expect(mockStyle.update).toHaveBeenCalled(), {
-      timeout: 1000,
-    });
+    await waitFor(() => expect(mockStyle.update).toHaveBeenCalled());
 
     // Setup node for being "resolved" for the clear step
     mockNode.data.mockImplementation((key: string) => {
@@ -91,15 +101,9 @@ describe("GraphImageManager", () => {
 
     manager.sync({ showImages: true, resolveImageUrl, releaseImageUrl });
 
-    await vi.waitFor(
-      () => {
-        expect(resolveImageUrl).toHaveBeenCalledTimes(2);
-        expect(mockNode.data).toHaveBeenCalledWith(
-          "resolvedImage",
-          "blob:url2",
-        );
-      },
-      { timeout: 1000 },
-    );
+    await waitFor(() => {
+      expect(resolveImageUrl).toHaveBeenCalledTimes(2);
+      expect(mockNode.data).toHaveBeenCalledWith("resolvedImage", "blob:url2");
+    });
   });
 });

--- a/packages/importer/bunfig.toml
+++ b/packages/importer/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+watch = false
+preload = ["../../tests/bun-preload.ts"]

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/importer/tests/import-integration.spec.ts
+++ b/packages/importer/tests/import-integration.spec.ts
@@ -22,7 +22,7 @@ describe("Import Integration", () => {
         id: "test-id",
         suggestedTitle: item.title,
         suggestedType: item.type,
-        content: item.content,
+        content: item.content || item.lore || item.chronicle || "",
         frontmatter: item.frontmatter,
         detectedLinks: item.detectedLinks,
         suggestedFilename: item.title.toLowerCase().replace(/ /g, "-"),

--- a/packages/importer/tests/import-integration.spec.ts
+++ b/packages/importer/tests/import-integration.spec.ts
@@ -22,7 +22,9 @@ describe("Import Integration", () => {
         id: "test-id",
         suggestedTitle: item.title,
         suggestedType: item.type,
-        content: item.content || item.lore || item.chronicle || "",
+        content:
+          item.content ||
+          `${item.chronicle || ""}\n\n${item.lore || ""}`.trim(),
         frontmatter: item.frontmatter,
         detectedLinks: item.detectedLinks,
         suggestedFilename: item.title.toLowerCase().replace(/ /g, "-"),

--- a/packages/oracle-engine/bunfig.toml
+++ b/packages/oracle-engine/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+watch = false
+preload = ["../../tests/bun-preload.ts"]

--- a/packages/oracle-engine/package.json
+++ b/packages/oracle-engine/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/packages/oracle-engine/src/chat-history.test.ts
+++ b/packages/oracle-engine/src/chat-history.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChatHistoryService } from "./chat-history.svelte";
 
+const originalBroadcastChannel = globalThis.BroadcastChannel;
+const originalURL = globalThis.URL;
+
 describe("ChatHistoryService", () => {
   let service: ChatHistoryService;
   let mockDB: any;
 
   beforeEach(() => {
-    vi.stubGlobal(
-      "BroadcastChannel",
-      vi.fn().mockImplementation(
-        class {
-          postMessage = vi.fn();
-          onmessage = null;
-        } as any,
-      ),
-    );
+    (globalThis as any).BroadcastChannel = vi.fn().mockImplementation(
+      class {
+        postMessage = vi.fn();
+        onmessage = null;
+      } as any,
+    ) as any;
 
     service = new ChatHistoryService();
     mockDB = {
@@ -24,6 +24,11 @@ describe("ChatHistoryService", () => {
         delete: vi.fn().mockResolvedValue(undefined),
       },
     };
+  });
+
+  afterEach(() => {
+    (globalThis as any).BroadcastChannel = originalBroadcastChannel;
+    (globalThis as any).URL = originalURL;
   });
 
   it("should initialize with empty messages", async () => {
@@ -49,7 +54,10 @@ describe("ChatHistoryService", () => {
   });
 
   it("should initialize and restore blob URLs", async () => {
-    vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "restored-url") });
+    (globalThis as any).URL = {
+      createObjectURL: vi.fn(() => "restored-url"),
+      revokeObjectURL: originalURL?.revokeObjectURL,
+    } as any;
     mockDB.appSettings.get.mockResolvedValue({
       value: [
         { id: "1", role: "assistant", imageBlob: new Blob([]), content: "img" },
@@ -57,17 +65,20 @@ describe("ChatHistoryService", () => {
     });
     await service.init(mockDB, "vault-1");
     expect(service.messages[0].imageUrl).toBe("restored-url");
-    vi.unstubAllGlobals();
+    (globalThis as any).URL = originalURL;
   });
 
   it("should handle removeMessage with blob URL", async () => {
-    vi.stubGlobal("URL", { revokeObjectURL: vi.fn() });
+    (globalThis as any).URL = {
+      revokeObjectURL: vi.fn(),
+      createObjectURL: originalURL?.createObjectURL,
+    } as any;
     await service.init(mockDB, "vault-1");
     const msg = { id: "1", role: "assistant", imageUrl: "blob:123" } as any;
     await service.addMessage(msg);
     await service.removeMessage("1");
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:123");
-    vi.unstubAllGlobals();
+    (globalThis as any).URL = originalURL;
   });
 
   it("should strip blob URLs when saving to DB", async () => {
@@ -106,11 +117,14 @@ describe("ChatHistoryService", () => {
     });
 
     // Should not throw - errors are silently caught
-    await expect(service.addMessage({ id: "1" } as any)).resolves.not.toThrow();
+    await service.addMessage({ id: "1" } as any);
   });
 
   it("should revoke blob URLs on destroy", async () => {
-    vi.stubGlobal("URL", { revokeObjectURL: vi.fn() });
+    (globalThis as any).URL = {
+      revokeObjectURL: vi.fn(),
+      createObjectURL: originalURL?.createObjectURL,
+    } as any;
     await service.init(mockDB, "vault-1");
 
     const msg = { id: "1", role: "assistant", imageUrl: "blob:test123" } as any;
@@ -119,7 +133,7 @@ describe("ChatHistoryService", () => {
     service.destroy();
 
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test123");
-    vi.unstubAllGlobals();
+    (globalThis as any).URL = originalURL;
   });
 
   it("should handle destroy with no blob URLs", async () => {
@@ -202,10 +216,10 @@ describe("ChatHistoryService", () => {
     });
 
     it("should revoke blob URLs from the old vault on switch", async () => {
-      vi.stubGlobal("URL", {
+      (globalThis as any).URL = {
         revokeObjectURL: vi.fn(),
         createObjectURL: vi.fn(() => "new-url"),
-      });
+      } as any;
 
       await service.init(mockDB, "vault-1");
       service.messages = [
@@ -221,7 +235,7 @@ describe("ChatHistoryService", () => {
       await service.switchVault("vault-2");
 
       expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:old");
-      vi.unstubAllGlobals();
+      (globalThis as any).URL = originalURL;
     });
 
     it("should only apply results from the last concurrent switch call", async () => {

--- a/packages/oracle-engine/src/executors/chat-executor.test.ts
+++ b/packages/oracle-engine/src/executors/chat-executor.test.ts
@@ -1,10 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ChatExecutor } from "./chat-executor";
+
+const originalNavigator = globalThis.navigator;
+const originalURL = globalThis.URL;
 
 describe("ChatExecutor", () => {
   beforeEach(() => {
-    vi.stubGlobal("navigator", { onLine: true });
-    vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "url") });
+    (globalThis as any).navigator = { onLine: true } as any;
+    (globalThis as any).URL = {
+      createObjectURL: vi.fn(() => "url"),
+      revokeObjectURL: originalURL?.revokeObjectURL,
+    } as any;
+  });
+
+  afterEach(() => {
+    (globalThis as any).navigator = originalNavigator;
+    (globalThis as any).URL = originalURL;
   });
 
   it("should handle simple chat queries", async () => {
@@ -79,7 +90,7 @@ describe("ChatExecutor", () => {
   });
 
   it("should handle offline mode", async () => {
-    vi.stubGlobal("navigator", { onLine: false });
+    (globalThis as any).navigator = { onLine: false } as any;
     const executor = new ChatExecutor();
     const addMessage = vi.fn();
 

--- a/packages/oracle-engine/src/executors/visualization-executor.test.ts
+++ b/packages/oracle-engine/src/executors/visualization-executor.test.ts
@@ -1,9 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { VisualizationExecutor } from "./visualization-executor";
+
+const originalURL = globalThis.URL;
 
 describe("VisualizationExecutor", () => {
   beforeEach(() => {
-    vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob-url") });
+    (globalThis as any).URL = {
+      createObjectURL: vi.fn(() => "blob-url"),
+      revokeObjectURL: originalURL?.revokeObjectURL,
+    } as any;
+  });
+
+  afterEach(() => {
+    (globalThis as any).URL = originalURL;
   });
 
   it("should draw an entity in demo mode", async () => {

--- a/packages/oracle-engine/src/oracle-executor.test.ts
+++ b/packages/oracle-engine/src/oracle-executor.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { OracleActionExecutor } from "./oracle-executor";
 
+const originalNavigator = globalThis.navigator;
+const originalURL = globalThis.URL;
+
 describe("OracleActionExecutor - Detailed", () => {
   let executor: OracleActionExecutor;
   let mockContext: any;
@@ -8,7 +11,7 @@ describe("OracleActionExecutor - Detailed", () => {
   let mockDraftingEngine: any;
 
   beforeEach(() => {
-    vi.stubGlobal("navigator", { onLine: true });
+    (globalThis as any).navigator = { onLine: true } as any;
 
     mockGenerator = {
       identifyPrimaryEntity: vi
@@ -101,7 +104,8 @@ describe("OracleActionExecutor - Detailed", () => {
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    (globalThis as any).navigator = originalNavigator;
+    (globalThis as any).URL = originalURL;
   });
 
   describe("executeCreate", () => {
@@ -556,7 +560,7 @@ describe("OracleActionExecutor - Detailed", () => {
 
   describe("executeChat", () => {
     it("should handle offline mode", async () => {
-      vi.stubGlobal("navigator", { onLine: false });
+      (globalThis as any).navigator = { onLine: false } as any;
 
       await executor.execute(
         {
@@ -573,7 +577,8 @@ describe("OracleActionExecutor - Detailed", () => {
         }),
       );
 
-      vi.unstubAllGlobals();
+      (globalThis as any).navigator = originalNavigator;
+      (globalThis as any).URL = originalURL;
     });
 
     it("should handle disabled AI intent", async () => {
@@ -590,7 +595,10 @@ describe("OracleActionExecutor - Detailed", () => {
 
     it("should handle image intent", async () => {
       mockContext.effectiveApiKey = "key";
-      vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob-url") });
+      (globalThis as any).URL = {
+        createObjectURL: vi.fn(() => "blob-url"),
+        revokeObjectURL: originalURL?.revokeObjectURL,
+      } as any;
 
       await executor.execute(
         { type: "chat", query: "/draw orc", isAIIntent: true },
@@ -598,7 +606,7 @@ describe("OracleActionExecutor - Detailed", () => {
       );
 
       expect(mockContext.chatHistory.setMessages).toHaveBeenCalled();
-      vi.unstubAllGlobals();
+      (globalThis as any).URL = originalURL;
     });
 
     it("should NOT proactively trigger plot analysis for conversational queries", async () => {
@@ -1022,7 +1030,14 @@ describe("OracleActionExecutor - Detailed", () => {
 
   describe("drawing", () => {
     beforeEach(() => {
-      vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "url") });
+      (globalThis as any).URL = {
+        createObjectURL: vi.fn(() => "url"),
+        revokeObjectURL: originalURL?.revokeObjectURL,
+      } as any;
+    });
+
+    afterEach(() => {
+      (globalThis as any).URL = originalURL;
     });
 
     it("should draw entity in demo mode", async () => {

--- a/packages/oracle-engine/src/undo-redo.test.ts
+++ b/packages/oracle-engine/src/undo-redo.test.ts
@@ -1,20 +1,23 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { UndoRedoService } from "./undo-redo.svelte";
+
+const originalBroadcastChannel = globalThis.BroadcastChannel;
 
 describe("UndoRedoService", () => {
   let service: UndoRedoService;
 
   beforeEach(() => {
-    vi.stubGlobal(
-      "BroadcastChannel",
-      vi.fn().mockImplementation(
-        class {
-          postMessage = vi.fn();
-          onmessage = null;
-        } as any,
-      ),
-    );
+    (globalThis as any).BroadcastChannel = vi.fn().mockImplementation(
+      class {
+        postMessage = vi.fn();
+        onmessage = null;
+      } as any,
+    ) as any;
     service = new UndoRedoService();
+  });
+
+  afterEach(() => {
+    (globalThis as any).BroadcastChannel = originalBroadcastChannel;
   });
 
   it("should push undo actions and clear redo stack", async () => {

--- a/packages/vault-engine/bunfig.toml
+++ b/packages/vault-engine/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+watch = false
+preload = ["../../tests/bun-preload.ts"]

--- a/packages/vault-engine/package.json
+++ b/packages/vault-engine/package.json
@@ -6,7 +6,7 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "vitest run",
+    "test": "bun test",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },

--- a/tests/bun-preload.ts
+++ b/tests/bun-preload.ts
@@ -1,0 +1,116 @@
+/**
+ * Bun Test Preload - Environment Polyfills and Svelte 5 Rune Shims
+ */
+
+// 1. FileReader Shim (needed for packages/importer)
+if (typeof globalThis.FileReader === "undefined") {
+  class MockFileReader extends EventTarget {
+    onload: ((this: MockFileReader, ev: ProgressEvent) => any) | null = null;
+    onerror: ((this: MockFileReader, ev: ProgressEvent) => any) | null = null;
+    result: string | ArrayBuffer | null = null;
+
+    readAsText(blob: Blob) {
+      blob
+        .text()
+        .then((text) => {
+          this.result = text;
+          const event = new Event("load") as ProgressEvent;
+          Object.defineProperty(event, "target", {
+            value: this,
+            writable: false,
+          });
+          if (this.onload) this.onload(event);
+        })
+        .catch((_err) => {
+          const event = new Event("error") as ProgressEvent;
+          Object.defineProperty(event, "target", {
+            value: this,
+            writable: false,
+          });
+          if (this.onerror) this.onerror(event);
+        });
+    }
+
+    readAsArrayBuffer(blob: Blob) {
+      blob
+        .arrayBuffer()
+        .then((buf) => {
+          this.result = buf;
+          const event = new Event("load") as ProgressEvent;
+          Object.defineProperty(event, "target", {
+            value: this,
+            writable: false,
+          });
+          if (this.onload) this.onload(event);
+        })
+        .catch((_err) => {
+          const event = new Event("error") as ProgressEvent;
+          Object.defineProperty(event, "target", {
+            value: this,
+            writable: false,
+          });
+          if (this.onerror) this.onerror(event);
+        });
+    }
+  }
+
+  (globalThis as any).FileReader = MockFileReader;
+}
+
+// 2. DOMMatrix Shim (needed for pdfjs-dist in packages/importer tests)
+if (typeof globalThis.DOMMatrix === "undefined") {
+  class MockDOMMatrix {
+    a = 1;
+    b = 0;
+    c = 0;
+    d = 1;
+    e = 0;
+    f = 0;
+    m11 = 1;
+    m12 = 0;
+    m13 = 0;
+    m14 = 0;
+    m21 = 0;
+    m22 = 1;
+    m23 = 0;
+    m24 = 0;
+    m31 = 0;
+    m32 = 0;
+    m33 = 1;
+    m34 = 0;
+    m41 = 0;
+    m42 = 0;
+    m43 = 0;
+    m44 = 1;
+    is2D = true;
+    isIdentity = true;
+  }
+
+  (globalThis as any).DOMMatrix = MockDOMMatrix;
+}
+
+// 3. Svelte 5 Runes Shim (needed for vault-engine, canvas-engine, oracle-engine)
+const stateShim = (init: unknown) => init;
+(stateShim as any).snapshot = (init: unknown) => init;
+
+(globalThis as any).$state = stateShim;
+(globalThis as any).$derived = (fn: () => unknown) =>
+  typeof fn === "function" ? fn() : fn;
+(globalThis as any).$derived.by = (fn: () => unknown) => fn();
+(globalThis as any).$effect = () => {};
+(globalThis as any).$effect.pre = () => {};
+(globalThis as any).$effect.active = () => false;
+(globalThis as any).$effect.root = (fn: () => unknown) => fn();
+(globalThis as any).$props = () => ({});
+(globalThis as any).$bindable = () => {};
+(globalThis as any).$inspect = () => {};
+
+// 4. Minimal DOM document Shim (needed for packages/graph-engine and others)
+if (typeof globalThis.document === "undefined") {
+  (globalThis as any).document = {
+    createElement: () => ({
+      appendChild: () => {},
+      style: {},
+    }),
+  } as any;
+}

--- a/tests/bun-preload.ts
+++ b/tests/bun-preload.ts
@@ -90,6 +90,12 @@ if (typeof globalThis.DOMMatrix === "undefined") {
 }
 
 // 3. Svelte 5 Runes Shim (needed for vault-engine, canvas-engine, oracle-engine)
+// NOTE: These shims are simplified for unit tests running outside Svelte compiler transforms.
+// Limitations:
+// - `$derived` expects expressions wrapped by the Svelte compiler in production, but here it acts as a passthrough or immediate function evaluator.
+// - `$effect.active` always returns false.
+// - `$effect.root` evaluates the function immediately and does not return the actual teardown function.
+// - Re-assigning or replacing `$derived` in other tests might break the attached `.by` helper.
 const stateShim = (init: unknown) => init;
 (stateShim as any).snapshot = (init: unknown) => init;
 


### PR DESCRIPTION
Closes #952. Switched importer, oracle-engine, graph-engine, vault-engine, and canvas-engine to bun test, resolving all global stubs and adding preloads for browser APIs and Svelte 5 runes.