### PR TITLE
:zap: perf(vtt): replace Math.max spread with imperative loop for token zIndex

### DIFF
--- a/apps/web/src/lib/stores/vtt/vtt-token-manager.svelte.ts
+++ b/apps/web/src/lib/stores/vtt/vtt-token-manager.svelte.ts
@@ -463,17 +463,22 @@ export class VTTTokenManager {
 
     const mapStore = this.deps.getMapStore();
     const offset = mapStore.gridSize || 50;
+    // ⚡ Bolt Optimization: Use imperative loop instead of ...allTokens.map to find max zIndex
+    // to avoid intermediate array allocation and spread operator overhead.
+    let maxZ = source.zIndex;
+    for (const token of this.allTokens) {
+      if (token.zIndex > maxZ) {
+        maxZ = token.zIndex;
+      }
+    }
+
     const clone: Token = {
       ...source,
       id: crypto.randomUUID(),
       name: this.getClonedTokenName(source.name),
       x: source.x + offset,
       y: source.y + offset,
-      zIndex:
-        Math.max(
-          ...this.allTokens.map((token) => token.zIndex),
-          source.zIndex,
-        ) + 1,
+      zIndex: maxZ + 1,
     };
 
     this.tokens = {


### PR DESCRIPTION
## Summary

Replaces `Math.max(...this.allTokens.map(t => t.zIndex))` with a single imperative loop in `vtt-token-manager.svelte.ts`.

## Why

- The original iterated the array twice (`.map` + spread) and allocated an intermediate array
- Spreading large arrays onto `Math.max` can throw `RangeError: Maximum call stack size exceeded` for encounters with many tokens
- The imperative loop is O(n), allocation-free, and safe at any scale

Clean cherry-pick of the Jules change from #961 onto a fresh branch off `staging`.

Closes #961