### PR TITLE
:sparkles: feat(templates): customizable default entity templates

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,6 +4,9 @@ Auto-generated from all feature plans. Last updated: 2026-05-28
 
 ## Active Technologies
 
+- TypeScript 6.0.3 + Svelte 5 Runes, `@codex/vault-engine` (123-entity-templates)
+- OPFS (Vault Files) for custom overrides, IndexedDB for settings if persistent (or local-only UI state as specified) (123-entity-templates)
+
 - TypeScript 6.0.3, Svelte 5 Runes + `zod` (validation), `idb` (IndexedDB wrapper) (122-data-integrity-boundaries)
 - IndexedDB (Metadata/Cache), OPFS (Vault Files) (122-data-integrity-boundaries)
 
@@ -190,11 +193,11 @@ TypeScript: Follow standard conventions
 
 ## Recent Changes
 
+- 123-entity-templates: Added TypeScript 6.0.3 + Svelte 5 Runes, `@codex/vault-engine`
+
 - 944-data-integrity-boundaries: Added TypeScript 6.0.3, Svelte 5 Runes + `zod` (validation), `idb` (IndexedDB wrapper)
 
 - 874-art-direction-clarification: Added TypeScript 6.0.3 + None (Browser Native APIs) / Zod
-
-- 109-quicknote-scratchpad: Added Svelte 5, Svelte 5 Runes, Dexie (IndexedDB), and Cytoscape.js integration.
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -429,7 +429,7 @@
       >
         <input type="checkbox" bind:checked={useTemplate} class="sr-only" />
         <div
-          class="w-7 h-4 bg-chrome-bg border border-chrome-border rounded-full relative transition-colors {useTemplate
+          class="w-7 h-4 bg-chrome-bg border border-chrome-border rounded-full relative transition-colors group-focus-within:border-chrome-accent group-focus-within:ring-2 group-focus-within:ring-chrome-accent/30 {useTemplate
             ? 'bg-chrome-accent/20 border-chrome-accent/50'
             : ''}"
         >

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -10,6 +10,7 @@
   import { notificationStore } from "$lib/stores/ui/notification.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { openImportWindow } from "$lib/stores/ui/navigation";
+  import { entityTemplateService } from "$lib/services/EntityTemplateService.svelte";
 
   let { orientation = "horizontal" } = $props<{
     orientation?: "horizontal" | "vertical";
@@ -20,6 +21,7 @@
   let newType = $state<string>("character");
   let isCreating = $state(false);
   let createError = $state<string | null>(null);
+  let useTemplate = $state(true);
 
   // Logic
   let isVertical = $derived(orientation === "vertical");
@@ -61,7 +63,17 @@
     isCreating = true;
     createError = null;
     try {
-      const id = await vault.createEntity(newType, newTitle);
+      let resolvedContent = "";
+      if (useTemplate) {
+        resolvedContent = await entityTemplateService.resolveTemplate(
+          newType,
+          themeStore.worldThemeId,
+          vault.getActiveFolderHandle() || vault.getActiveVaultHandle(),
+        );
+      }
+      const id = await vault.createEntity(newType, newTitle, {
+        content: resolvedContent,
+      });
       vault.selectedEntityId = id;
       newTitle = "";
       showForm = false;
@@ -401,6 +413,27 @@
           <option value={cat.id}>{cat.label}</option>
         {/each}
       </select>
+
+      <label
+        class="flex items-center gap-2 cursor-pointer group select-none text-[10px] md:text-xs text-chrome-muted hover:text-chrome-text {isVertical
+          ? 'py-1'
+          : 'px-1'}"
+      >
+        <input type="checkbox" bind:checked={useTemplate} class="sr-only" />
+        <div
+          class="w-7 h-4 bg-chrome-bg border border-chrome-border rounded-full relative transition-colors {useTemplate
+            ? 'bg-chrome-accent/20 border-chrome-accent/50'
+            : ''}"
+        >
+          <div
+            class="absolute top-0.5 left-0.5 w-2.5 h-2.5 rounded-full bg-chrome-muted transition-all {useTemplate
+              ? 'translate-x-3 bg-chrome-accent'
+              : ''}"
+          ></div>
+        </div>
+        <span>Start from default format</span>
+      </label>
+
       <button
         type="submit"
         class="{btnPrimary} {isVertical

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -66,10 +66,14 @@
       let resolvedLore = "";
       let resolvedContent = "";
       if (useTemplate) {
+        const folderHandle = await vault.getActiveFolderHandle();
+        const vaultHandle = await vault.getActiveVaultHandle();
+        const customTemplatesDirHandle = folderHandle ?? vaultHandle;
+
         resolvedLore = await entityTemplateService.resolveTemplate(
           newType,
           themeStore.worldThemeId,
-          vault.getActiveFolderHandle() || vault.getActiveVaultHandle(),
+          customTemplatesDirHandle,
         );
         resolvedContent = entityTemplateService.extractSummary(resolvedLore);
       }
@@ -259,6 +263,7 @@
       {:else}
         <!-- Main Actions -->
         <button
+          type="button"
           class={isVertical
             ? `${btnGhost} py-3 text-sm justify-center`
             : `${btnSecondary} px-3 md:px-4 py-1.5 text-[10px] md:text-xs`}

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -63,16 +63,19 @@
     isCreating = true;
     createError = null;
     try {
+      let resolvedLore = "";
       let resolvedContent = "";
       if (useTemplate) {
-        resolvedContent = await entityTemplateService.resolveTemplate(
+        resolvedLore = await entityTemplateService.resolveTemplate(
           newType,
           themeStore.worldThemeId,
           vault.getActiveFolderHandle() || vault.getActiveVaultHandle(),
         );
+        resolvedContent = entityTemplateService.extractSummary(resolvedLore);
       }
       const id = await vault.createEntity(newType, newTitle, {
         content: resolvedContent,
+        lore: resolvedLore,
       });
       vault.selectedEntityId = id;
       newTitle = "";

--- a/apps/web/src/lib/content/blog/default-entity-templates.md
+++ b/apps/web/src/lib/content/blog/default-entity-templates.md
@@ -1,0 +1,50 @@
+---
+id: default-templates-announcement
+slug: default-templates-announcement
+title: "No More Blank Pages: Introducing Default Entity Templates"
+description: "Start your worldbuilding instantly. Learn how Codex Cryptica's new customizable, theme-aware default templates eliminate note-taking friction and structure your RPG campaigns."
+keywords:
+  - "RPG World Building Templates"
+  - "Default Markdown Formats"
+  - "Character Template RPG"
+  - "Faction Template RPG"
+  - "Codex Cryptica Templates"
+  - "Local-First Markdown Note"
+publishedAt: 2026-05-28T14:00:00Z
+---
+
+Starting a new character, location, or faction shouldn't start with staring at a blinking cursor on a blank screen. That cognitive friction—the "blank page syndrome"—is the enemy of creative flow.
+
+With the release of **Default Entity Templates**, Codex Cryptica now gives every new note a head start. Whether you're fleshing out an elusive space smuggler or a mysterious ruins complex, your archive will automatically provide a curated structure designed specifically for that entity type.
+
+---
+
+## **Markdown-First, Optional Structure**
+
+In keeping with our local-first, markdown-first philosophy, these templates are **completely non-mandatory guides**, not rigid database fields. They pre-populate the document editor with structured headings, but they remain 100% plain text.
+
+If you don't need a section, delete it. If you want a completely empty slate, you can easily toggle **"Start from default format"** off directly in the creation card.
+
+![Create Entity Toggle Checkbox](https://assets.codexcryptica.com/images/blog/default-templates/creation-dialog.png)
+
+---
+
+## **Tailored to Your Active Theme**
+
+We didn't stop at a single generic outline. Because fantasy adventurers have vastly different needs than cyberpunk deckers, default formats **adapt dynamically to your vault's active theme**:
+
+- **Fantasy Campaign**: Creating a Character populates fields like `Lineage`, `Oaths`, and `Magical Affinity`.
+- **Sci-Fi Campaign**: A new Character immediately provides space for `Augmentations`, `Corporate Ties`, and `Street Reputation`.
+- **Generic Settings**: Standard fields like `Appearance`, `Personality`, and `Goals` keep you grounded in any setting.
+
+---
+
+## **Take Full Control: Vault-Level Customization**
+
+For advanced worldbuilders, GMs, and writers with highly specific note-taking frameworks, you can override any built-in system template with a local markdown file.
+
+Simply create a folder in your local vault directory named `.cc/templates/` and place a markdown file named after the entity type (e.g., `.cc/templates/character.md`). Write your ideal outline, save it, and Codex Cryptica will use it instantly on your next entity creation.
+
+By keeping your overrides inside your vault, your custom templates sync seamlessly across devices and stay private, right alongside your lore.
+
+Happy worldbuilding!

--- a/apps/web/src/lib/content/help/default-templates.md
+++ b/apps/web/src/lib/content/help/default-templates.md
@@ -1,0 +1,42 @@
+---
+id: default-entity-templates
+title: Default Entity Templates
+tags: ["templates", "formatting", "customization"]
+rank: 18
+---
+
+# Default Entity Templates
+
+Codex Cryptica provides pre-formatted structure outlines called **Default Entity Templates** to eliminate the friction of starting with an empty note. Whenever you create a new **Character**, **Faction**, **Location**, **Item**, **Event**, **Creature**, or **Note**, a tailored markdown layout is instantly pre-populated for you.
+
+## System Default Templates
+
+Out of the box, the following types come with high-fidelity structures:
+
+- **Character**: Includes sections for Summary, Appearance, Personality, Goals, Relationships, and Secrets.
+- **Faction**: Includes sections for Leadership, Resources, Methods, Allies and Enemies, and Internal Tensions.
+- **Location**: Includes sections for Geography, Districts, Points of Interest, and Local Factions.
+- **Item**: Includes sections for Origin, Appearance, Abilities, and Lore.
+- **Event**: Includes sections for Date/Chronology, Key Participants, Sequence of Events, and Aftermath.
+- **Creature**: Includes sections for Ecology, Combat/Abilities, Behavior, and Lore.
+- **Note**: A clean generic canvas for general-purpose world-building.
+
+## Toggling Templates On or Off
+
+If you prefer to start with a completely empty editor page for a new note:
+
+1. Click **New Entity** in the top navigation or sidebar.
+2. Uncheck the option **"Start from default format"** located below the Title input field.
+3. Click **Add** — your newly created document will be entirely blank.
+
+## Vault-Level Override Templates
+
+For advanced world-builders or genre-specific campaigns (e.g., sci-fi vs. high fantasy), you can fully override our system defaults with your own custom markdown files:
+
+1. In your linked local folder, create a directory path named `.cc/templates/` (or `.codex/templates/`).
+2. Add a markdown file named after the entity type in lowercase (e.g., `character.md`, `faction.md`, `location.md`). Casing of the file itself does not matter.
+3. Open the file and write your custom markdown structure (e.g. `## Cyberware` or `## Magical Lineage`).
+4. Any new entities of that type created henceforth will immediately use your custom structure.
+
+> [!TIP]
+> If you want to _always_ start completely blank for a specific type without untoggling the checkbox, create an empty file at `.cc/templates/{type}.md`. The system respects empty override files as valid, giving you a blank canvas.

--- a/apps/web/src/lib/services/EntityTemplateConstants.ts
+++ b/apps/web/src/lib/services/EntityTemplateConstants.ts
@@ -152,6 +152,78 @@ Forbidden lore known, ancient curses, or dark family pacts.
 
 ## Story Hooks
 Rumors at the local tavern, prophesied encounters, or guild contracts.`,
+
+  faction: `## Summary
+A brief overview of the noble house, wizardly guild, or knightly order.
+
+## Creed & Ideology
+The founding vows, religious devotion, or philosophical tenets.
+
+## Leadership & Hierarchy
+The ruling lords, grand archmages, or elder councils guiding the organization.
+
+## Holdings & Castles
+Castles, keeps, cathedral halls, or wizard towers under their control.
+
+## Magical & Martial Resources
+Fabled knights, ancient spellbooks, relics, or celestial alignments they command.
+
+## Story Hooks
+Quests offered, bounties posted, or dark plots suspected by other factions.`,
+
+  location: `## Summary
+A brief description of this kingdom, ancient dungeon, or magical domain.
+
+## Geography & Magic
+The climate, terrain, layout, and localized magical conditions (e.g., wild magic zones).
+
+## Points of Interest
+Dungeon depths, sacred shrines, royal chambers, or tavern landmarks.
+
+## Local Powers
+Which local lords, magical beasts, or dark cults rule this area?
+
+## Lore & Prophecy
+Legends, lost histories, or apocalyptic prophecies associated with this site.`,
+
+  item: `## Summary
+A brief description of this magical relic, blade, or divine artifact.
+
+## Appearance & Runes
+Craftsmanship, engravings, ancient runes, and sensory aura.
+
+## Magical Abilities & Attunement
+Spells granted, unique properties, and attunement requirements.
+
+## Prophesied Owner
+Legends concerning who is destined to wield this item and why.`,
+
+  event: `## Summary
+A brief overview of the legendary battle, coronation, or stellar alignment.
+
+## Chronology & Celestial Phase
+When it occurred, under what moon phase, and temporal significance.
+
+## Legendary Figures
+Kings, archmages, or dragons who turned the tide of the event.
+
+## Mystical Consequences
+How the event fractured empires, awakened ancient curses, or altered the magical leylines.`,
+
+  creature: `## Summary
+A brief description of this dragon, wild beast, or elemental spirit.
+
+## Mystical Habitat & Ecology
+Where they dwell, their diet (magic/blood), and seasonal behaviors.
+
+## Supernatural Powers & Weaknesses
+Breaths, spell resistances, weaknesses to silver/cold-iron, or vulnerability to specific rituals.
+
+## Legends & Lore
+The mythic tales told by bards or warning lessons of local rangers.`,
+
+  note: `## Summary
+A brief summary of scroll translations, wizard notes, or fables.`,
 };
 
 export const SCIFI_TEMPLATES: Record<string, string> = {
@@ -181,4 +253,600 @@ Classified logs, stolen server files, or corporate espionage liabilities.
 
 ## Story Hooks
 Bounty board listings, encrypted distress signals, or job offers.`,
+
+  faction: `## Summary
+A brief overview of the megacorporation, star syndicate, or planetary republic.
+
+## Corporate Charter / Ideology
+The commercial goals, military mandates, or stellar philosophies driving them.
+
+## Starships & Fleet Scale
+Cruisers, battleships, or carrier fleets commanded.
+
+## Assets & Stellar Holdings
+Planetary outposts, space stations, asteroid mines, or corporate research labs.
+
+## Tech Level & Leverage
+Advanced weaponry, AI networks, cloning bays, or hyperdrive exclusive tech.`,
+
+  location: `## Summary
+A brief description of this planetary sector, space station, or stellar system.
+
+## Orbital Coordinates & Environment
+Sector coordinates, gravity Class, atmosphere composition, and terraforming progress.
+
+## Sectors & Station Wards
+Hangar bays, neon commercial strips, slums, or command bridges.
+
+## Local Corporations & Syndicates
+Who patrols the skies and who operates the black markets below.`,
+
+  item: `## Summary
+A brief overview of this stellar tech, starship, or weapons system.
+
+## Manufacturer & Specs
+The manufacturing corporation, model, fuel type, and power capacity.
+
+## Integrated Systems & Software
+Onboard AI, sensor modules, shields, or hacking suites.
+
+## Maintenance Logs & Ownership
+Past pilot profiles, repair status, and custom modifications.`,
+
+  event: `## Summary
+A brief overview of the orbital battle, corporate takeover, or hyperspace mishap.
+
+## Stardate & Sector
+Coordinates and galaxy timestamp of the event.
+
+## Fleet Commanders
+Admirals, corporate executives, or AI units involved in coordinating the event.
+
+## Galactic Aftermath
+How it shifted trade routes, violated treaties, or initiated corporate warfare.`,
+
+  creature: `## Summary
+A brief description of this alien fauna, space parasite, or cybernetic biomechanoid.
+
+## Xenobiology & Planet
+Planetary planet of origin, cellular makeup, and habitat requirements (e.g., zero-G).
+
+## Morphology & Combat Potential
+Natural armor, venom types, hunting tactics, and threat tier.
+
+## Scientific Log Notes
+Reports from Starfleet exploration logs or corporation research files.`,
+
+  note: `## Summary
+A brief overview of decrypted datshards, encrypted terminal logs, or logs.`,
+};
+
+export const MODERN_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of this operative, detective, or criminal subject.
+
+## Background & Cover Identities
+Real name vs. active aliases, background, and security clearances.
+
+## Psychological File
+Personality, psychological assessments, weaknesses, and stress triggers.
+
+## Gear & Assets
+Standard firearms, surveillance gear, secure communication devices, and financial backing.
+
+## Secrets & Liabilities
+Blackmail records, hidden family ties, or past operations gone wrong.`,
+
+  faction: `## Summary
+A brief description of the intelligence agency, cartel, or global corporation.
+
+## Agenda & Assets
+Primary objectives, shell corporations, safehouses, and operational funds.
+
+## Hierarchy & Cell Structure
+The high-level directors, cell leaders, and local field agents.
+
+## Surveillance & Tactical Capabilities
+Infiltration squads, satellite access, hacking abilities, and armaments.`,
+
+  location: `## Summary
+A brief description of this city ward, corporate headquarters, or crime scene.
+
+## Infrastructure & Crime
+General crime rates, local law enforcement strength, and access points.
+
+## Points of Interest
+Safehouses, black markets, underground clubs, or secure server rooms.
+
+## Forensic Log
+Clues, wiretap transcripts, or security camera records associated with this place.`,
+
+  item: `## Summary
+A brief description of this modern item, classified document, or firearm.
+
+## Specifications & Serial Number
+Make, model, caliber/storage size, and serial/part tracking.
+
+## Operational Utility
+How it is deployed in field ops, surveillance, or tactical encounters.
+
+## Chain of Custody
+Tracking logs of past owners, handlers, or shipping manifests.`,
+
+  event: `## Summary
+A brief overview of the heist, political scandal, or tactical raid.
+
+## Timestamp & Timeline
+Detailed timeline of events leading up to, during, and after the occurrence.
+
+## Investigators & Perpetrators
+Law enforcement, cartel bosses, or secret agents involved.
+
+## Media Cover-up & Spin
+How the public was briefed vs. what actually occurred under the table.`,
+
+  creature: `## Summary
+A brief description of this urban legend, cryptid, or escaped bioweapon.
+
+## Sightings & Habitat
+Historical sightings, mapped encounters, and habitat (e.g., sewers, abandoned facilities).
+
+## Anatomy & Combat Profiling
+Physical traits, agility, hunting behavior, and tactical vulnerability.`,
+
+  note: `## Summary
+A brief overview of classified case files, wiretap transcripts, or notes.`,
+};
+
+export const CYBERPUNK_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of this Netrunner, Street Samurai, or Fixer.
+
+## Street Handle & Rep
+Their street alias, faction reps, and active bounties on their head.
+
+## Cyberware & Chrome
+Neural links, cyberdecks, optic overlays, cyberarms, or boosterware installed.
+
+## Loadout & Smartgear
+Smart weapons, customized tactical gear, program suites, and armor.
+
+## Net Architecture Exploits
+Known icebreaker protocols, target subnets, or hacking backdoors they use.
+
+## Corporate Debts & Secrets
+Corp contracts signed, active blackmail files, or trauma team plans.`,
+
+  faction: `## Summary
+A brief description of this megacorp division, street gang, or hacker collective.
+
+## Corporate Mission / Turf
+The corporate branch, market sector, or city turf they hold.
+
+## Subnets & Net Infrastructure
+Dedicated servers, customized ICE levels, rogue AI guardians, and hacker handles.
+
+## Black Ops & Strike Teams
+Solo mercenaries, specialized netrunners, or bio-drones on payroll.`,
+
+  location: `## Summary
+A brief description of this neon-drenched metropolis ward, corpo tower, or net node.
+
+## Neon Atmosphere & Grid
+Grid coordinates, corporate pollution, local neon styles, and subnet coverage.
+
+## Local Gangs & Corps
+Who patrols the streets and which corporate subsidiary claims ownership.
+
+## Black Clinics & Netcafes
+Locations of ripperdocs, netrunner dens, and black-market software merchants.`,
+
+  item: `## Summary
+A brief description of this cyberdeck, smart weapon, or illegal software.
+
+## Brand, Model & Firmware
+Brand name, deck memory capacity, processor speed, and custom operating system.
+
+## Installed Programs & ICE
+ICE, daemons, offensive scripts, or target encryption suites loaded.
+
+## Black Market Origin
+Which megacorp database it was stolen from and its street cost.`,
+
+  event: `## Summary
+A brief overview of this net breach, corporate raid, or cyberpsychosis outbreak.
+
+## Epoch Timestamp
+The millisecond UNIX timestamp and subnet coordinates of the event.
+
+## Hacker Handles & Solos
+The deck profiles and field mercs who coordinated the heist.
+
+## Net/Physical Aftermath
+How the hack crashed stocks, fried runner brains, or exposed corporate black files.`,
+
+  creature: `## Summary
+A brief description of this rogue AI, corporate bio-weapon, or combat drone.
+
+## Code/Hardware Platform
+Server node host, mainframe, or robotic chassis specs.
+
+## Subroutines & Attack Scripts
+Infiltration daemons, physical weapons, or target neural-frying scripts.`,
+
+  note: `## Summary
+A brief overview of datashards, encrypted logs, or hack notes.`,
+};
+
+export const APOCALYPTIC_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief description of this scavenger, mutant, or tribal leader.
+
+## Survival Role & Scars
+Survival specialty, mutations, physical scars, and physical condition.
+
+## Scavenged Gear & Scrap
+Main armor pieces, patched weaponry, and valuable trade scraps carried.
+
+## Trust & Settlement Ties
+Loyalties, reputation with factions, and trustworthiness rating (1-5).`,
+
+  faction: `## Summary
+A brief description of this scavenger settlement, raider gang, or doomsday cult.
+
+## Ideology & Survival Creeds
+Ideals, tribal rituals, and doomsday philosophies.
+
+## Strongholds & Scrap Forts
+Ruined subways, converted vaults, or fortified junkyards occupied.
+
+## Raiders & Scav Squads
+Total fighters, combat vehicles, and scrap weapons available.`,
+
+  location: `## Summary
+A brief description of this ruined city center, fallout wasteland, or scrap outpost.
+
+## Radiation & Hazards
+Radiation tier, toxic conditions, physical anomalies, and natural hazards.
+
+## Scavenge Potential
+Unlooted ruins, abandoned military bunkers, or scrap value.
+
+## Local Predators & Rad-Beasts
+Territorial fauna, raider ambush points, and mutant hives.`,
+
+  item: `## Summary
+A brief description of this scavenged weapon, tool, or rations package.
+
+## Condition & Patches
+Wear percentage, modifications, and structural stability.
+
+## Material Value
+Raw materials obtained if salvaged (e.g., steel, electronic parts, fuel).`,
+
+  event: `## Summary
+A brief overview of this ash storm, raider assault, or vault opening.
+
+## Season & Weather Patterns
+The atmospheric conditions and fallout levels during the event.
+
+## Casualties & Scrap Gains
+Settlements lost, survivors gained, and resources/scrap gathered.`,
+
+  creature: `## Summary
+A brief description of this mutated beast, feral scourge, or radioactive horror.
+
+## Mutation Profile
+The genetic deviations, toxins, radiation emitted, and anatomy details.
+
+## Combat Behavior & Tactics
+Territorial triggers, combat aggression, and pack behavior.
+
+## Harvestable Scrap
+Valuable materials (meat, pelts, organs, irradiated marrow) obtained.`,
+
+  note: `## Summary
+A brief overview of rusted journals, survivor diaries, or scrap maps.`,
+};
+
+export const HORROR_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of who this subject is and their place in the dark underbelly.
+
+## Embrace & Origin
+When they were embraced, their clan or lineage, and who embraced them (their Sire).
+
+## Appearance
+Their physical features, how they conceal their monstrous nature, and sensory hallmarks (e.g., cold touch, crimson eyes).
+
+## Condition & Humanity
+Their remaining connection to humanity, and their current beast or predation temperaments.
+
+## Disciplines & Powers
+Supernatural abilities, blood magic, or physical gifts of the blood.
+
+## Blood Bonds & Allies
+Who is bound to them, their touchstones, or coterie ties.
+
+## Secrets & Gehenna Signs
+Dark occult secrets, hidden sins, or portents of the end.
+
+## Story Hooks
+Whispers at Elysium, suspicious nocturnal activities, or hunting ground disputes.`,
+
+  faction: `## Summary
+A brief overview of this dark coven, secret cult, or vampire coterie.
+
+## Dark Agendas & Oaths
+Unholy mission, blood oaths, and occult beliefs.
+
+## Forbidden Archives & Relics
+Cursed texts, blood gems, or unholy artifacts commanded.
+
+## Rites & Blood Magic
+Rituals performed, occult sacrifices, and seasonal ceremonies.`,
+
+  location: `## Summary
+A brief description of this gothic manor, flooded crypt, or dark alley.
+
+## Sensory & Occult Atmosphere
+Hallmarks (smells, cold spots), local ambient dread, and active magical wards.
+
+## Hidden Altars & Crypts
+Secret rooms, sacrificial chambers, and resting places of ancient evils.`,
+
+  item: `## Summary
+A brief description of this cursed relic, forbidden tome, or occult weapon.
+
+## Curses & Dark Blessings
+Supernatural properties, costs of usage, and ritual bonds.
+
+## History of Bloodshed
+Past sacrifices, notable owners, and tragic legends surrounding the item.`,
+
+  event: `## Summary
+A brief overview of this unholy ritual, demonic eclipse, or dark sacrifice.
+
+## Stellar Alignment & Phase
+The celestial positioning required for the event's success.
+
+## Sequence of Rites
+Step-by-step unholy rituals, incantations, and blood sacrifices.`,
+
+  creature: `## Summary
+A brief description of this demon, feral ghoul, or cosmic terror.
+
+## Unholy classification
+Eldritch category, origin plane, and banishment difficulty.
+
+## Predatory Powers & Sins
+Terror auras, mind-flaying spells, or necrotic touches.
+
+## Methods of Banishment
+Wards, sacred objects, or specific holy rituals required.`,
+
+  note: `## Summary
+A brief overview of bloodstained journals, occult symbols, or logs.`,
+};
+
+export const FALLOUT_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of this survivalist's log entry.
+
+## S.P.E.C.I.A.L. & Attributes
+Strength, Perception, Endurance, Charisma, Intelligence, Agility, Luck.
+
+## Background & Vault
+Which vault or wasteland settlement did they originate from?
+
+## Appearance & Loadout
+Scavenged clothing, radiation scars, Pip-Boy model, and primary scavenged gear.
+
+## Perks & Mutations
+Unique survival traits, radiation-induced mutations, or cyberware.
+
+## Faction Affiliation
+Alignment with the Brotherhood, NCR, Enclave, Raiders, or local settlements.
+
+## Secrets & Classified Logs
+Vault experiment data, contraband locations, or pre-war knowledge.
+
+## Story Hooks
+Distress beacons, bounty posters, or rumors of clean water and un-looted vaults.`,
+
+  faction: `## Summary
+A brief description of this Brotherhood chapter, Raider gang, or Enclave detachment.
+
+## Mission & Command Structure
+Codename, military rank structure, and Vault-Tec or Enclave directives.
+
+## Tech Level & Power Armor
+Availability of T-51/X-01 Power Armor, plasma weapons, or pre-war schematics.
+
+## Fortresses & Bunkers
+Fortified bunkers, Vault outposts, or airships under command.`,
+
+  location: `## Summary
+A brief description of this ruined vault, wasteland settlement, or test site.
+
+## Radiation & Vault Number
+Geiger counter readings, Vault number, and original Vault-Tec experiment.
+
+## Scavenge Potential & Junk
+Scrap yield, pre-war loot, ammunition crates, and crafting recipes.`,
+
+  item: `## Summary
+A brief description of this holotape, weapon, or Nuka-Cola flavor.
+
+## Condition & Weight
+Scrap components required to repair, weapon damage, and weight.
+
+## Radiation & Healing Profile
+HP restored, Rads gained upon consumption, or active buffs/debuffs.`,
+
+  event: `## Summary
+A brief overview of this Great War event, Vault opening, or settlement raid.
+
+## Nuclear Fallout Levels
+Irradiation changes, ash storms, and weather patterns.
+
+## Survivors & Holotapes Recovered
+Names of survivors, audio logs, and logs found.`,
+
+  creature: `## Summary
+A brief description of this Deathclaw, Feral Ghoul, or Radscorpion.
+
+## Mutation Tier & Rad Level
+Radiation levels emitted, mutant scale, and biological traits.
+
+## Harvestable Loot
+Rad-free meat, chitin plates, scrap parts, or toxic glands.`,
+
+  note: `## Summary
+A brief overview of Pip-Boy terminal logs, holotape transcripts, or diaries.`,
+};
+
+export const STARWARS_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of this Jedi, Sith, Bounty Hunter, or smuggler.
+
+## Species & Homeworld
+Planet of origin, alien species traits, and native language.
+
+## Force Alignment & Midi-chlorians
+Light/Dark affinity, Midi-chlorian count, and active Force powers.
+
+## Lightsaber & Loadout
+Lightsaber form, hilt design, kyber crystal, blaster model, and armor type.
+
+## Starship & Astromech
+Starship registration, class, and assigned astromech unit.
+
+## Bounty Record & Guild Standing
+Reputation with the Hutt Cartel, Bounty Hunters Guild, or Empire.`,
+
+  faction: `## Summary
+A brief description of this Rebel cell, Galactic Empire squad, or Smuggler cartel.
+
+## Galactic Ideology & Vows
+Ideals, imperial directives, or syndicate codes.
+
+## Armada & Starfighters
+Star Destroyers, Corellian corvettes, or X-Wing/TIE fleets.
+
+## Sector Hubs & Bases
+Hidden hangar bases, temple ruins, or planetary spaceports.`,
+
+  location: `## Summary
+A brief description of this Outer Rim planet, cantina, or orbital shipyard.
+
+## Galactic Sector & Climate
+Sector coordinates, weather class, terrain, and planet details.
+
+## Spaceports & Cantinas
+Hangar bays, trading posts, and local gathering holes.
+
+## Imperial/New Republic Presence
+Troop garrison strength, patrol starships, and local enforcement.`,
+
+  item: `## Summary
+A brief description of this lightsaber, Kyber crystal, or blaster rifle.
+
+## Maker & Kyber Crystal
+Hilt creator, crystal color, and Force attunement records.
+
+## Modifications & Upgrades
+Custom scopes, power cells, and integrated targeting computers.`,
+
+  event: `## Summary
+A brief overview of this space battle, Jedi trial, or planetary blockade.
+
+## Galactic Date & Sector
+Standard galactic calendar stardate and battle sectors.
+
+## Fleet Commanders & Generals
+Jedi generals, imperial admirals, or rebel pilots involved.
+
+## Force Echoes & Ripples
+Vibrations in the Force felt by practitioners during the event.`,
+
+  creature: `## Summary
+A brief description of this Rancor, Bantha, or Nexu.
+
+## Planetary Origin
+Planet of origin, planetary biology, and typical ecosystem role.
+
+## Domestication & Hazard Rating
+Riding utility, combat training potential, and galactic threat index.`,
+
+  note: `## Summary
+A brief overview of holocron recordings, bounty hunting logs, or files.`,
+};
+
+export const STARTREK_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of this Starfleet officer, Vulcan, or Klingon warrior.
+
+## Starfleet Serial & Rank
+Ranks, serial number, specialized field, and department (Command/Science/Engineering).
+
+## Species & Cultural Traits
+Species background, special anatomy, and cultural philosophies (e.g., logic).
+
+## Starship Assignment
+Assigned starship, post role, and past mission logs.
+
+## Technical Specialties
+Specialized scientific systems, warp physics, or linguistic certifications.`,
+
+  faction: `## Summary
+A brief description of this United Federation fleet, Klingon House, or Romulan cell.
+
+## Fleet Directives & Charters
+The Prime Directive guidelines, military alliances, or treaty terms.
+
+## Capital Starships
+U.S.S. starships, Klingon birds-of-prey, or warbird fleets.
+
+## Starbases & Sectors
+Diplomatic outposts, starbases, and sectors under sovereign control.`,
+
+  location: `## Summary
+A brief description of this Class-M planet, anomalies sector, or quadrant.
+
+## Stellar Quadrant & Planet Class
+Alpha/Beta/Gamma/Delta quadrant, Planet Class (e.g., M-Class), gravity, and system.
+
+## Starfleet Scan Diagnostics
+Atmospheric scan readings, magnetic anomalies, and radiation levels.`,
+
+  item: `## Summary
+A brief description of this Tricorder, Phaser, or Warp core component.
+
+## Manufacturer & Model
+Type, model version, and Starfleet engineering specifications.
+
+## Scanner/Phaser Frequencies
+Phaser frequency range, modulation logs, and diagnostic scans.`,
+
+  event: `## Summary
+A brief overview of this First Contact, warp flight experiment, or space battle.
+
+## Stardate & Sector
+Starfleet stardate timestamp and system coordinates.
+
+## Starfleet Command Logs
+Captain's log entries, prime directive assessment files, and logs.`,
+
+  creature: `## Summary
+A brief description of this alien species, Gorn, or Tribble.
+
+## Biology & Scans
+Carbon/silicon biology, planet of origin, and sensor scan files.
+
+## Intelligence & Language
+Language class, warp capabilities, and communication logs.`,
+
+  note: `## Summary
+A brief overview of Captain's Logs, sensor records, or logs.`,
 };

--- a/apps/web/src/lib/services/EntityTemplateConstants.ts
+++ b/apps/web/src/lib/services/EntityTemplateConstants.ts
@@ -1,0 +1,184 @@
+/**
+ * Default Entity Template Outline Constants.
+ * Leveraged out of the box to pre-populate new world documents instantly.
+ */
+
+export const GENERIC_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of who this character is and their place in the world.
+
+## Appearance
+Physical features, style of dress, distinctive markers, or mannerisms.
+
+## Personality
+Key behavioral traits, temperaments, and core beliefs.
+
+## Goals
+What do they actively strive to achieve or protect?
+
+## Methods
+How do they go about accomplishing their goals? What resources or skills do they rely on?
+
+## Relationships
+Key links and attitudes toward other characters, factions, or places.
+
+## Secrets
+Hidden motives, buried pasts, or vulnerabilities known only to a few.
+
+## Story Hooks
+Interesting plot hooks or rumors to pull characters into their sphere.`,
+
+  faction: `## Summary
+A brief overview of the organization, its reputation, and scale.
+
+## Purpose
+The primary mission, ideology, or founding core of the faction.
+
+## Leadership
+Who guides this group, and what is their style of governance?
+
+## Members
+Types of people recruited, hierarchy structure, and prominent subgroups.
+
+## Resources
+Assets, strongholds, magical forces, financial backing, or technological leverage.
+
+## Methods
+Typical operations, tactics, and how they exert influence in the world.
+
+## Allies and Enemies
+Key diplomatic alignments and bitter conflicts.
+
+## Internal Tensions
+Fault lines, rival factions, or ideological rifts within the organization.
+
+## Story Hooks
+How players or other entities might interact with or be recruited by this group.`,
+
+  location: `## Summary
+A brief description of this location's significance and general atmosphere.
+
+## Geography
+Climate, terrain, physical boundaries, and sensory hallmarks.
+
+## Districts & Layout
+Notable subdivisions, wards, or sectors of the location.
+
+## Points of Interest
+Important landmarks, structures, or historical sites.
+
+## Local Factions
+Which organizations or gangs hold sway in this area?
+
+## Lore & History
+How did this place come to be, and what major events happened here?`,
+
+  item: `## Summary
+A brief overview of what this object is and who possesses it.
+
+## Appearance
+Physical dimensions, materials, wear, craftsmanship, and sensory details.
+
+## Abilities
+Magical properties, technological functions, or physical utility.
+
+## Origin
+Who created this item, where, and for what purpose?
+
+## History & Lore
+Notable past owners and legendary events surrounding this object.`,
+
+  event: `## Summary
+A brief overview of the occurrence and why it matters in history.
+
+## Date & Chronology
+When did this take place? Duration and temporal markers.
+
+## Key Participants
+Individual instigators, factions involved, and crucial witnesses.
+
+## Sequence of Events
+A chronological breakdown of how the occurrence unfolded.
+
+## Aftermath & Legacy
+Immediate consequences and long-term historical ripple effects.`,
+
+  creature: `## Summary
+A brief overview of the creature, its classification, and danger level.
+
+## Ecology & Habitat
+Where do they live? Diet, life cycle, and role in the ecosystem.
+
+## Appearance
+Anatomy, size, distinct markings, and sensory impressions.
+
+## Behavior
+Social structures, hunting patterns, intelligence level, and temperament.
+
+## Abilities & Combat
+Defensive mechanisms, natural weapons, magical features, and tactical vulnerabilities.
+
+## Lore
+Myths, rumors, utility, or history of interactions with civilized peoples.`,
+
+  note: `## Summary
+A brief description of what these general notes are about.`,
+};
+
+export const FANTASY_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of who this character is in this fantasy setting.
+
+## Lineage & Background
+Origin, heritage, species, culture, or noble house.
+
+## Appearance & Oaths
+Physical description, armor, and active sacred oaths or geases.
+
+## Personality
+Behavioral traits, alignment, and core guiding beliefs.
+
+## Goals & Quests
+Active quests they are pursuing or magical relics they seek.
+
+## Magical Affinity
+Connection to the arcane, active spells, magical talents, or patron deities.
+
+## Relationships
+Key bonds, rivalries, or allegiances to mystical guilds and realms.
+
+## Secrets & Curses
+Forbidden lore known, ancient curses, or dark family pacts.
+
+## Story Hooks
+Rumors at the local tavern, prophesied encounters, or guild contracts.`,
+};
+
+export const SCIFI_TEMPLATES: Record<string, string> = {
+  character: `## Summary
+A brief overview of this character's profile in the sci-fi expanse.
+
+## Background & Origin
+Homeworld, social class, education, or space-faring lineage.
+
+## Appearance & Gear
+Physical description, armor, standard loadout, and clothing style.
+
+## Augmentations & Tech
+Cybernetic implants, neural links, biotech enhancements, or specialized software.
+
+## Personality & Beliefs
+Behavioral profile, psychological file, and philosophical or political alignments.
+
+## Goals & Agenda
+Corporate missions, smuggler runs, or personal vendettas.
+
+## Faction Ties & Reputation
+Reputation with megacorps, syndicate networks, rebel cells, or planetary law.
+
+## Secrets
+Classified logs, stolen server files, or corporate espionage liabilities.
+
+## Story Hooks
+Bounty board listings, encrypted distress signals, or job offers.`,
+};

--- a/apps/web/src/lib/services/EntityTemplateService.svelte.test.ts
+++ b/apps/web/src/lib/services/EntityTemplateService.svelte.test.ts
@@ -252,4 +252,45 @@ describe("EntityTemplateService", () => {
       expect(result).toBe(GENERIC_TEMPLATES.character);
     });
   });
+
+  // --- extractSummary Tests ---
+  describe("Summary Extraction (extractSummary)", () => {
+    it("should extract correct summary under ## Summary header", () => {
+      const template =
+        "## Summary\nThis is the short form summary.\n\n## Appearance\nDetailed desc";
+      expect(service.extractSummary(template)).toBe(
+        "This is the short form summary.",
+      );
+    });
+
+    it("should ignore empty lines between header and text", () => {
+      const template =
+        "## Summary\n\n\n  This is the short form summary with whitespace.  \n\n## Appearance";
+      expect(service.extractSummary(template)).toBe(
+        "This is the short form summary with whitespace.",
+      );
+    });
+
+    it("should return empty string if ## Summary has no text content before next header", () => {
+      const template = "## Summary\n## Appearance\nDetailed desc";
+      expect(service.extractSummary(template)).toBe("");
+    });
+
+    it("should work with Windows-style line endings", () => {
+      const template =
+        "## Summary\r\nThis is windows newline summary.\r\n\r\n## Appearance";
+      expect(service.extractSummary(template)).toBe(
+        "This is windows newline summary.",
+      );
+    });
+
+    it("should return empty string if there is no Summary header", () => {
+      const template = "## Introduction\nSome text\n## Appearance";
+      expect(service.extractSummary(template)).toBe("");
+    });
+
+    it("should return empty string for empty template", () => {
+      expect(service.extractSummary("")).toBe("");
+    });
+  });
 });

--- a/apps/web/src/lib/services/EntityTemplateService.svelte.test.ts
+++ b/apps/web/src/lib/services/EntityTemplateService.svelte.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EntityTemplateService } from "./EntityTemplateService.svelte";
+import {
+  GENERIC_TEMPLATES,
+  FANTASY_TEMPLATES,
+  SCIFI_TEMPLATES,
+} from "./EntityTemplateConstants";
+
+describe("EntityTemplateService", () => {
+  let service: EntityTemplateService;
+  let mockThemeStore: { worldThemeId: string };
+
+  beforeEach(() => {
+    mockThemeStore = { worldThemeId: "workspace" };
+    service = new EntityTemplateService({ themeStore: mockThemeStore });
+  });
+
+  // --- User Story 1 & 2: Generic defaults and blank values ---
+  describe("Generic System Defaults (US1 & US2)", () => {
+    it("should return the correct generic template for character", async () => {
+      const result = await service.resolveTemplate("character");
+      expect(result).toBe(GENERIC_TEMPLATES.character);
+    });
+
+    it("should return the correct generic template for faction", async () => {
+      const result = await service.resolveTemplate("faction");
+      expect(result).toBe(GENERIC_TEMPLATES.faction);
+    });
+
+    it("should return the correct generic template for location", async () => {
+      const result = await service.resolveTemplate("location");
+      expect(result).toBe(GENERIC_TEMPLATES.location);
+    });
+
+    it("should return the correct generic template for item", async () => {
+      const result = await service.resolveTemplate("item");
+      expect(result).toBe(GENERIC_TEMPLATES.item);
+    });
+
+    it("should return the correct generic template for event", async () => {
+      const result = await service.resolveTemplate("event");
+      expect(result).toBe(GENERIC_TEMPLATES.event);
+    });
+
+    it("should return the correct generic template for creature", async () => {
+      const result = await service.resolveTemplate("creature");
+      expect(result).toBe(GENERIC_TEMPLATES.creature);
+    });
+
+    it("should return the correct generic template for note", async () => {
+      const result = await service.resolveTemplate("note");
+      expect(result).toBe(GENERIC_TEMPLATES.note);
+    });
+
+    it("should be case-insensitive for entity type resolution", async () => {
+      const resultLower = await service.resolveTemplate("character");
+      const resultUpper = await service.resolveTemplate("CHARACTER");
+      const resultMixed = await service.resolveTemplate("cHaRaCtEr");
+      expect(resultLower).toBe(GENERIC_TEMPLATES.character);
+      expect(resultUpper).toBe(GENERIC_TEMPLATES.character);
+      expect(resultMixed).toBe(GENERIC_TEMPLATES.character);
+    });
+
+    it("should return an empty string for unknown entity types", async () => {
+      const result = await service.resolveTemplate("unknown_type");
+      expect(result).toBe("");
+    });
+
+    it("should return an empty string for empty string type", async () => {
+      const result = await service.resolveTemplate("");
+      expect(result).toBe("");
+    });
+  });
+
+  // --- User Story 4: Theme-Specific Default Fallbacks ---
+  describe("Theme-Specific Defaults (US4)", () => {
+    it("should return fantasy character template when theme is fantasy", async () => {
+      const result = await service.resolveTemplate("character", "fantasy");
+      expect(result).toBe(FANTASY_TEMPLATES.character);
+    });
+
+    it("should fall back to worldThemeId from themeStore if no themeId is explicitly passed", async () => {
+      mockThemeStore.worldThemeId = "fantasy";
+      const result = await service.resolveTemplate("character");
+      expect(result).toBe(FANTASY_TEMPLATES.character);
+    });
+
+    it("should return sci-fi character template when theme is scifi", async () => {
+      const result = await service.resolveTemplate("character", "scifi");
+      expect(result).toBe(SCIFI_TEMPLATES.character);
+    });
+
+    it("should fall back to generic template for non-character types even if fantasy theme is selected", async () => {
+      const result = await service.resolveTemplate("location", "fantasy");
+      expect(result).toBe(GENERIC_TEMPLATES.location);
+    });
+
+    it("should fall back to generic template if theme is unsupported/unknown", async () => {
+      const result = await service.resolveTemplate(
+        "character",
+        "unknown_theme",
+      );
+      expect(result).toBe(GENERIC_TEMPLATES.character);
+    });
+  });
+
+  // --- User Story 3: Vault-Level Custom Templates ---
+  describe("Vault-Level Custom Templates (US3)", () => {
+    let mockFileHandle: any;
+    let mockTemplatesDirHandle: any;
+    let mockCcDirHandle: any;
+    let mockCodexDirHandle: any;
+    let mockVaultDirHandle: any;
+
+    beforeEach(() => {
+      mockFileHandle = {
+        kind: "file",
+        name: "character.md",
+        getFile: vi.fn().mockResolvedValue({
+          text: vi.fn().mockResolvedValue("custom character file content"),
+        }),
+      };
+
+      mockTemplatesDirHandle = {
+        kind: "directory",
+        name: "templates",
+        entries: vi.fn().mockImplementation(async function* () {
+          yield ["character.md", mockFileHandle];
+        }),
+      };
+
+      mockCcDirHandle = {
+        kind: "directory",
+        name: ".cc",
+        getDirectoryHandle: vi.fn().mockImplementation((name) => {
+          if (name === "templates")
+            return Promise.resolve(mockTemplatesDirHandle);
+          return Promise.reject(new Error("Not found"));
+        }),
+      };
+
+      mockCodexDirHandle = {
+        kind: "directory",
+        name: ".codex",
+        getDirectoryHandle: vi.fn().mockImplementation((name) => {
+          if (name === "templates")
+            return Promise.resolve(mockTemplatesDirHandle);
+          return Promise.reject(new Error("Not found"));
+        }),
+      };
+
+      mockVaultDirHandle = {
+        kind: "directory",
+        name: "vault-root",
+        getDirectoryHandle: vi.fn().mockImplementation((name) => {
+          if (name === ".cc") return Promise.resolve(mockCcDirHandle);
+          if (name === ".codex") return Promise.resolve(mockCodexDirHandle);
+          return Promise.reject(new Error("Not found"));
+        }),
+      };
+    });
+
+    it("should load custom template from .cc/templates/ first", async () => {
+      const result = await service.resolveTemplate(
+        "character",
+        "workspace",
+        mockVaultDirHandle,
+      );
+      expect(result).toBe("custom character file content");
+      expect(mockVaultDirHandle.getDirectoryHandle).toHaveBeenCalledWith(".cc");
+      expect(mockCcDirHandle.getDirectoryHandle).toHaveBeenCalledWith(
+        "templates",
+      );
+    });
+
+    it("should fall back to .codex/templates/ if .cc/templates/ is missing", async () => {
+      mockVaultDirHandle.getDirectoryHandle.mockImplementation(
+        (name: string) => {
+          if (name === ".cc") return Promise.reject(new Error("Not found"));
+          if (name === ".codex") return Promise.resolve(mockCodexDirHandle);
+          return Promise.reject(new Error("Not found"));
+        },
+      );
+
+      const result = await service.resolveTemplate(
+        "character",
+        "workspace",
+        mockVaultDirHandle,
+      );
+      expect(result).toBe("custom character file content");
+      expect(mockVaultDirHandle.getDirectoryHandle).toHaveBeenCalledWith(".cc");
+      expect(mockVaultDirHandle.getDirectoryHandle).toHaveBeenCalledWith(
+        ".codex",
+      );
+      expect(mockCodexDirHandle.getDirectoryHandle).toHaveBeenCalledWith(
+        "templates",
+      );
+    });
+
+    it("should be case-insensitive when matching custom template filenames", async () => {
+      mockFileHandle.name = "Character.MD"; // mixed case filename on disk
+      mockTemplatesDirHandle.entries = vi
+        .fn()
+        .mockImplementation(async function* () {
+          yield ["Character.MD", mockFileHandle];
+        });
+
+      const result = await service.resolveTemplate(
+        "character",
+        "workspace",
+        mockVaultDirHandle,
+      );
+      expect(result).toBe("custom character file content");
+    });
+
+    it("should return empty string if the custom template file is empty, preventing fallback", async () => {
+      mockFileHandle.getFile = vi.fn().mockResolvedValue({
+        text: vi.fn().mockResolvedValue(""),
+      });
+
+      const result = await service.resolveTemplate(
+        "character",
+        "workspace",
+        mockVaultDirHandle,
+      );
+      expect(result).toBe("");
+    });
+
+    it("should gracefully fall back to default template if the custom template folder is missing", async () => {
+      mockVaultDirHandle.getDirectoryHandle.mockRejectedValue(
+        new Error("Not found"),
+      );
+
+      const result = await service.resolveTemplate(
+        "character",
+        "workspace",
+        mockVaultDirHandle,
+      );
+      expect(result).toBe(GENERIC_TEMPLATES.character);
+    });
+
+    it("should gracefully fall back to default template if reading custom file fails", async () => {
+      mockFileHandle.getFile = vi
+        .fn()
+        .mockRejectedValue(new Error("Read failed"));
+
+      const result = await service.resolveTemplate(
+        "character",
+        "workspace",
+        mockVaultDirHandle,
+      );
+      expect(result).toBe(GENERIC_TEMPLATES.character);
+    });
+  });
+});

--- a/apps/web/src/lib/services/EntityTemplateService.svelte.test.ts
+++ b/apps/web/src/lib/services/EntityTemplateService.svelte.test.ts
@@ -4,6 +4,13 @@ import {
   GENERIC_TEMPLATES,
   FANTASY_TEMPLATES,
   SCIFI_TEMPLATES,
+  MODERN_TEMPLATES,
+  CYBERPUNK_TEMPLATES,
+  APOCALYPTIC_TEMPLATES,
+  HORROR_TEMPLATES,
+  FALLOUT_TEMPLATES,
+  STARWARS_TEMPLATES,
+  STARTREK_TEMPLATES,
 } from "./EntityTemplateConstants";
 
 describe("EntityTemplateService", () => {
@@ -90,9 +97,85 @@ describe("EntityTemplateService", () => {
       expect(result).toBe(SCIFI_TEMPLATES.character);
     });
 
-    it("should fall back to generic template for non-character types even if fantasy theme is selected", async () => {
+    it("should return horror character template when theme is horror", async () => {
+      const result = await service.resolveTemplate("character", "horror");
+      expect(result).toBe(HORROR_TEMPLATES.character);
+    });
+
+    it("should return horror character template when theme has light/dark suffix (horror_light)", async () => {
+      const result = await service.resolveTemplate("character", "horror_light");
+      expect(result).toBe(HORROR_TEMPLATES.character);
+    });
+
+    it("should return fallout character template when theme is fallout", async () => {
+      const result = await service.resolveTemplate("character", "fallout");
+      expect(result).toBe(FALLOUT_TEMPLATES.character);
+    });
+
+    it("should return fallout character template when theme has light/dark suffix (fallout_light)", async () => {
+      const result = await service.resolveTemplate(
+        "character",
+        "fallout_light",
+      );
+      expect(result).toBe(FALLOUT_TEMPLATES.character);
+    });
+
+    it("should return theme-specific template for non-character types when available (e.g., fantasy location)", async () => {
       const result = await service.resolveTemplate("location", "fantasy");
-      expect(result).toBe(GENERIC_TEMPLATES.location);
+      expect(result).toBe(FANTASY_TEMPLATES.location);
+    });
+
+    it("should return cyberpunk-specific templates correctly", async () => {
+      const resultChar = await service.resolveTemplate(
+        "character",
+        "cyberpunk",
+      );
+      const resultItem = await service.resolveTemplate("item", "cyberpunk");
+      expect(resultChar).toBe(CYBERPUNK_TEMPLATES.character);
+      expect(resultItem).toBe(CYBERPUNK_TEMPLATES.item);
+    });
+
+    it("should return star wars-specific templates correctly", async () => {
+      const resultChar = await service.resolveTemplate("character", "starwars");
+      const resultFaction = await service.resolveTemplate(
+        "faction",
+        "starwars",
+      );
+      expect(resultChar).toBe(STARWARS_TEMPLATES.character);
+      expect(resultFaction).toBe(STARWARS_TEMPLATES.faction);
+    });
+
+    it("should return star trek-specific templates correctly", async () => {
+      const resultChar = await service.resolveTemplate("character", "startrek");
+      const resultCreature = await service.resolveTemplate(
+        "creature",
+        "startrek",
+      );
+      expect(resultChar).toBe(STARTREK_TEMPLATES.character);
+      expect(resultCreature).toBe(STARTREK_TEMPLATES.creature);
+    });
+
+    it("should return modern-specific templates correctly", async () => {
+      const resultChar = await service.resolveTemplate("character", "modern");
+      const resultLocation = await service.resolveTemplate(
+        "location",
+        "modern",
+      );
+      expect(resultChar).toBe(MODERN_TEMPLATES.character);
+      expect(resultLocation).toBe(MODERN_TEMPLATES.location);
+    });
+
+    it("should return apocalyptic-specific templates correctly", async () => {
+      const resultChar = await service.resolveTemplate(
+        "character",
+        "apocalyptic",
+      );
+      const resultFaction = await service.resolveTemplate(
+        "faction",
+        "apocalyptic",
+      );
+      expect(resultChar).toBe(APOCALYPTIC_TEMPLATES.character);
+      expect(resultFaction).toBe(APOCALYPTIC_TEMPLATES.faction);
     });
 
     it("should fall back to generic template if theme is unsupported/unknown", async () => {

--- a/apps/web/src/lib/services/EntityTemplateService.svelte.ts
+++ b/apps/web/src/lib/services/EntityTemplateService.svelte.ts
@@ -2,6 +2,13 @@ import {
   GENERIC_TEMPLATES,
   FANTASY_TEMPLATES,
   SCIFI_TEMPLATES,
+  MODERN_TEMPLATES,
+  CYBERPUNK_TEMPLATES,
+  APOCALYPTIC_TEMPLATES,
+  HORROR_TEMPLATES,
+  FALLOUT_TEMPLATES,
+  STARWARS_TEMPLATES,
+  STARTREK_TEMPLATES,
 } from "./EntityTemplateConstants";
 
 export interface EntityTemplateServiceDeps {
@@ -32,12 +39,13 @@ export class EntityTemplateService {
   ): Promise<string> {
     const normalizedType = type.toLowerCase();
 
-    // Resolve active theme ID
+    // Resolve active theme ID and extract its base theme name (stripping light/dark suffixes)
     const activeThemeId = (
       themeId ||
       this.deps.themeStore?.worldThemeId ||
       "workspace"
     ).toLowerCase();
+    const baseThemeId = activeThemeId.replace(/_(light|dark)$/, "");
 
     // 1. Check local file overrides if a directory handle is provided
     if (customTemplatesDirHandle) {
@@ -95,16 +103,58 @@ export class EntityTemplateService {
 
     // 2. Fallback to theme-specific system default templates
     if (
-      activeThemeId === "fantasy" &&
+      baseThemeId === "fantasy" &&
       FANTASY_TEMPLATES[normalizedType] !== undefined
     ) {
       return FANTASY_TEMPLATES[normalizedType];
     }
     if (
-      activeThemeId === "scifi" &&
+      baseThemeId === "scifi" &&
       SCIFI_TEMPLATES[normalizedType] !== undefined
     ) {
       return SCIFI_TEMPLATES[normalizedType];
+    }
+    if (
+      baseThemeId === "modern" &&
+      MODERN_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return MODERN_TEMPLATES[normalizedType];
+    }
+    if (
+      baseThemeId === "cyberpunk" &&
+      CYBERPUNK_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return CYBERPUNK_TEMPLATES[normalizedType];
+    }
+    if (
+      baseThemeId === "apocalyptic" &&
+      APOCALYPTIC_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return APOCALYPTIC_TEMPLATES[normalizedType];
+    }
+    if (
+      baseThemeId === "horror" &&
+      HORROR_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return HORROR_TEMPLATES[normalizedType];
+    }
+    if (
+      baseThemeId === "fallout" &&
+      FALLOUT_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return FALLOUT_TEMPLATES[normalizedType];
+    }
+    if (
+      baseThemeId === "starwars" &&
+      STARWARS_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return STARWARS_TEMPLATES[normalizedType];
+    }
+    if (
+      baseThemeId === "startrek" &&
+      STARTREK_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return STARTREK_TEMPLATES[normalizedType];
     }
 
     // 3. Fallback to standard generic templates
@@ -139,7 +189,7 @@ export class EntityTemplateService {
   }
 }
 
-// Lazy-load dependencies on default import to avoid circular dependency / premature initialization issues
+// Late-bind store reference dynamically in the getter to avoid circular dependency / premature initialization issues
 import { themeStore } from "../stores/theme.svelte";
 export const entityTemplateService = new EntityTemplateService({
   get themeStore() {

--- a/apps/web/src/lib/services/EntityTemplateService.svelte.ts
+++ b/apps/web/src/lib/services/EntityTemplateService.svelte.ts
@@ -1,0 +1,125 @@
+import {
+  GENERIC_TEMPLATES,
+  FANTASY_TEMPLATES,
+  SCIFI_TEMPLATES,
+} from "./EntityTemplateConstants";
+
+export interface EntityTemplateServiceDeps {
+  themeStore?: {
+    worldThemeId: string;
+  };
+}
+
+export class EntityTemplateService {
+  private deps: EntityTemplateServiceDeps;
+
+  constructor(deps: EntityTemplateServiceDeps = {}) {
+    this.deps = deps;
+  }
+
+  /**
+   * Resolves the markdown template to pre-populate an entity with.
+   *
+   * @param type - The entity type (e.g., 'character', 'location')
+   * @param themeId - Optional override active theme ID (falls back to worldThemeId)
+   * @param customTemplatesDirHandle - FileSystemDirectoryHandle pointing to the local vault/root folder
+   * @returns The resolved template content as a string
+   */
+  async resolveTemplate(
+    type: string,
+    themeId?: string,
+    customTemplatesDirHandle?: FileSystemDirectoryHandle | null,
+  ): Promise<string> {
+    const normalizedType = type.toLowerCase();
+
+    // Resolve active theme ID
+    const activeThemeId = (
+      themeId ||
+      this.deps.themeStore?.worldThemeId ||
+      "workspace"
+    ).toLowerCase();
+
+    // 1. Check local file overrides if a directory handle is provided
+    if (customTemplatesDirHandle) {
+      let templatesHandle: FileSystemDirectoryHandle | undefined;
+
+      // Try checking .cc/templates first
+      try {
+        const ccHandle =
+          await customTemplatesDirHandle.getDirectoryHandle(".cc");
+        templatesHandle = await ccHandle.getDirectoryHandle("templates");
+      } catch {
+        // Ignored, fallback to checking .codex
+      }
+
+      // Try checking .codex/templates second if .cc/templates was not found
+      if (!templatesHandle) {
+        try {
+          const codexHandle =
+            await customTemplatesDirHandle.getDirectoryHandle(".codex");
+          templatesHandle = await codexHandle.getDirectoryHandle("templates");
+        } catch {
+          // Ignored
+        }
+      }
+
+      // If we found a templates directory, search for {type}.md case-insensitively
+      if (templatesHandle) {
+        let targetFileHandle: FileSystemFileHandle | undefined;
+        try {
+          const lowercaseTarget = `${normalizedType}.md`;
+          for await (const [name, handle] of templatesHandle.entries()) {
+            if (
+              handle.kind === "file" &&
+              name.toLowerCase() === lowercaseTarget
+            ) {
+              targetFileHandle = handle as FileSystemFileHandle;
+              break;
+            }
+          }
+        } catch {
+          // Ignored, will fall back to system defaults
+        }
+
+        // If a file handle was found, read its content. If it fails, fallback to default.
+        if (targetFileHandle) {
+          try {
+            const file = await targetFileHandle.getFile();
+            return await file.text();
+          } catch {
+            // Ignored, will fall back to system defaults
+          }
+        }
+      }
+    }
+
+    // 2. Fallback to theme-specific system default templates
+    if (
+      activeThemeId === "fantasy" &&
+      FANTASY_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return FANTASY_TEMPLATES[normalizedType];
+    }
+    if (
+      activeThemeId === "scifi" &&
+      SCIFI_TEMPLATES[normalizedType] !== undefined
+    ) {
+      return SCIFI_TEMPLATES[normalizedType];
+    }
+
+    // 3. Fallback to standard generic templates
+    if (GENERIC_TEMPLATES[normalizedType] !== undefined) {
+      return GENERIC_TEMPLATES[normalizedType];
+    }
+
+    return "";
+  }
+}
+
+// Lazy-load dependencies on default import to avoid circular dependency / premature initialization issues
+import { themeStore } from "../stores/theme.svelte";
+export const entityTemplateService = new EntityTemplateService({
+  get themeStore() {
+    return themeStore;
+  },
+});

--- a/apps/web/src/lib/services/EntityTemplateService.svelte.ts
+++ b/apps/web/src/lib/services/EntityTemplateService.svelte.ts
@@ -114,6 +114,29 @@ export class EntityTemplateService {
 
     return "";
   }
+
+  /**
+   * Extracts the summary line under the '## Summary' header from a template.
+   */
+  extractSummary(templateText: string): string {
+    if (!templateText) return "";
+    const lines = templateText.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (/^##?\s+summary/i.test(line)) {
+        for (let j = i + 1; j < lines.length; j++) {
+          const subLine = lines[j].trim();
+          if (subLine && !subLine.startsWith("#")) {
+            return subLine;
+          }
+          if (subLine.startsWith("#")) {
+            break;
+          }
+        }
+      }
+    }
+    return "";
+  }
 }
 
 // Lazy-load dependencies on default import to avoid circular dependency / premature initialization issues

--- a/apps/web/static/llms-full.txt
+++ b/apps/web/static/llms-full.txt
@@ -50,7 +50,7 @@ Keep secrets hidden. Hide items from your map so players don't see them during a
 Change your world. Click the folder name at the top to switch to a different story.
 
 ### Pick Dates
-Pick years quickly without typing. Click the grid to zoom into specific decades and years.
+Select dates seamlessly using smooth, center-snapping scroll wheels. Features side-by-side vertical tracks, intercalary anchors, inline repair warnings on calendar change, and quick keyboard year/day overrides.
 
 ### Smart Importing
 Safe file loading. If a file import stops, just pick the file again to finish where you left off.
@@ -59,7 +59,7 @@ Safe file loading. If a file import stops, just pick the file again to finish wh
 Instantly transform the look and feel of your workspace. Choose from a variety of distinct visual themes—from Ancient Parchment to Sci-Fi Terminal—to perfectly match the genre of your story.
 
 ### Instant Visualization
-For Advanced Tier users: Instantly generate visuals for your lore. Look for the 'DRAW' button on Oracle responses or in the sidepanel for entities without images. The AI respects your 'Art Style' notes.
+For Advanced Tier users: Instantly generate visuals for your lore. Look for the DRAW button on Oracle responses, entity panels, Zen mode, and graph nodes. The AI uses Art Direction from normal notes or entities, then Category Defaults and the active Default Art Style.
 
 ### Demo Mode
 Explore the tool with pre-loaded sample data. Any changes you make are transient. Click 'Save as World' in Settings or the Oracle to keep your work.
@@ -114,6 +114,9 @@ Seamlessly establish peer-to-peer connections between campaign hosts and trusted
 
 ### QuickNote Fast Scratchpad
 Capture fleeting ideas instantly. Press Ctrl+I or Cmd+I from anywhere to toggle the glassmorphic fast scratchpad. Jot down thoughts, auto-save drafts, and use the 'Elevate' button to let the AI structure your raw notes into complete Character, Location, or Item draft entities.
+
+### Nested Entities
+Organize your world hierarchically. Drag and drop entities in the explorer to nest them under parents (e.g. putting a tavern inside a city). Expand/collapse nodes using the chevron. When you delete a parent, its children are promoted to the root level. Cycle detection prevents recursive loop errors.
 
 
 ## Help Documentation
@@ -305,7 +308,7 @@ The Lore Oracle supports several interactive commands to help you manage your wo
 
 ### Available Commands
 
-- `/draw [subject]`: Triggers the AI to generate a visual representation of the subject.
+- `/draw [subject]`: Triggers the AI to generate a visual representation of the subject. Category words such as `character`, `location`, or `item` can guide composition when no matching entity category is available.
 - `/create [description]`: Ask the Oracle to draft a new entity record based on your description.
 - `/connect`: The primary tool for building relationships.
 - `/merge`: Combine two entities into one, synthesizing their lore and re-mapping all connections.
@@ -351,6 +354,10 @@ If you are unsure how two entities should be related or how they should be combi
 
 - `/connect oracle`: Analyzes lore to propose thematic relationship types.
 - `/merge oracle`: Opens the step-by-step consolidation wizard with content preview.
+
+## Art Direction
+
+Image generation uses Art Direction from your world before falling back to shipped Category Defaults, Default Art Style from the active theme, and the global Codex Cryptica default. To customize it, add normal notes or entity sections titled `Art Direction`, `Default Art Style`, or `Visual Direction`; no separate settings form is required.
 
 ---
 
@@ -440,27 +447,28 @@ Codex Cryptica allows you to define the very structure of time for your campaign
 
 ## The Date Picker
 
-When editing an entity's temporal data (Date, Start Date, or End Date), you will use the tactile **Date Picker**.
+When editing an entity's temporal data (Date, Start Date, or End Date), you will use the dynamic **Scroll-Wheel Date Picker**.
 
-### Tactile Year Selection
+### Center-Aligned Scroll Wheels
 
-The year picker uses a grid-based navigation system designed for fast, non-keyboard entry across vast timelines:
+The date picker uses a smooth, vertical, center-aligned scroll wheel interface designed for both desktop mouse-wheel and mobile touch interactions:
 
-1. **Drill Down**: Click a Century to see its Decades, then click a Decade to select a specific Year.
-2. **Zoom Out**: Click the header (e.g., "1200 - 1211") to jump back up to the Decade or Century view.
-3. **Navigate**: Use the left/right arrows to slide the current grid forward or backward in time.
+1. **Center Snapping**: Wheels automatically snap center-aligned options into place. A highlight lens guides your visual focus.
+2. **Synchronized Preview**: Below the wheels, a live, full-text preview renders the exact formatted date so you are always clear on your selection, even when dealing with truncated long names.
+3. **Direct Jump Override**: Need to select a year far in the past or future? Simply click the keyboard icon in any column to directly type a numeric override.
 
-### Era-Centric Snapping
-
-If you have defined **Eras** in your Vault Settings, you can use the "Eras" tab to instantly snap the picker to the beginning of a historical period. This is the fastest way to navigate across millennia.
-
-### Precision Levels
+### Precision Levels & Intercalary Anchors
 
 The picker allows you to choose your granularity using the toggle at the top:
 
 - **Year**: For broad historical events.
-- **Month**: For seasonal occurrences.
+- **Month/Unit**: For seasonal occurrences.
 - **Day**: For specific, high-precision moments.
+- **Anchor**: For special intercalary days (e.g., Midyear festivals) that sit outside standard months.
+
+### Conflict Auto-Repair
+
+If you change your campaign calendar structure after saving dates, opening the picker automatically triggers an **inline repair warning**. You can view the discrepancy and click **Confirm Repair** to cleanly align the date to the new calendar constraints without silent, accidental data loss.
 
 ## Campaign Calendars
 
@@ -582,7 +590,7 @@ Your selected theme is saved to your local browser storage and will be automatic
 
 ---
 
-### OFFLINE SUPPORT & SYNCHRONIZATION
+### OFFLINE SUPPORT & LOCAL FOLDERS
 
 Codex Cryptica is designed as a **local-first** application. This means your data always lives on your device first, ensuring you can continue building your world even without an internet connection.
 
@@ -594,7 +602,7 @@ By default, all your campaign data is stored in the **Origin Private File System
 - **Speed:** Reading and writing thousands of chronicles is near-instant.
 - **Persistence:** Your work is saved automatically as you type.
 
-## Synchronization with Local Folders
+## Saving & Loading with Local Folders
 
 You can mirror your internal archives with any folder on your computer. This enables several powerful workflows:
 
@@ -602,15 +610,14 @@ You can mirror your internal archives with any folder on your computer. This ena
 2.  **External Editing:** Use your favorite Markdown editor (like Obsidian or VS Code) to edit your chronicles while Codex is closed.
 3.  **Cloud Mirroring:** By selecting a folder managed by a cloud provider (like Google Drive, Dropbox, or iCloud), you can achieve multi-device synchronization using your OS's built-in support.
 
-### How to set up Cloud Sync (via OS)
+### How to set up Cloud Mirroring (via OS)
 
-To sync your world across multiple devices using Google Drive or other providers:
+To access your world across multiple devices using Google Drive or other providers:
 
 1.  Install the official client for your provider (e.g., [Google Drive for Desktop](https://www.google.com/drive/download/)).
-2.  In Codex Cryptica, go to **Settings > Vault**.
-3.  Under **Synchronization**, click **Sync to Folder**.
-4.  Select a folder within your local Google Drive/Cloud directory.
-5.  Codex will now mirror your files to that folder, and your OS will handle the background upload to the cloud.
+2.  In Codex Cryptica, click **SAVE TO FOLDER** in the bottom-left sidebar (or the Save icon in the Vault Selector).
+3.  If no folder is linked yet, you will be prompted to select a directory. Choose a folder within your local Google Drive/Cloud directory.
+4.  Codex will now write all changes to that folder, and your OS will handle the background upload to the cloud.
 
 ## Managing Multiple Devices
 
@@ -619,7 +626,7 @@ When you open Codex on a new device:
 1.  Create a new vault or open the **Vault Selector**.
 2.  Click **Open Folder**.
 3.  Select the cloud-synced folder you set up on your first device.
-4.  Codex will import your world and keep it in sync with the cloud mirror.
+4.  Codex will load your world and keep it updated with the cloud mirror.
 
 ---
 
@@ -629,7 +636,7 @@ Codex Cryptica can back up your vault to your personal Google Drive and restore 
 
 ## Connect Your Vault
 
-1. Open **Settings → Cloud Sync**.
+1. Open Settings, choose the **Vault** tab, and scroll to the **Cloud Sync** section.
 2. Click **Connect Google Drive** and sign in when Google prompts you.
 3. Codex creates a `CodexCryptica/` folder on your Drive (if it doesn't exist) and a subfolder named after your vault inside it. The folder ID is saved locally so future syncs know where to go.
 
@@ -645,7 +652,7 @@ Once connected you'll see two buttons:
 
 If you have vaults already stored in your `CodexCryptica/` Drive folder (from another device), you can load them without setting them up from scratch:
 
-1. In **Settings → Cloud Sync**, click **Browse Drive**.
+1. In the **Vault** settings tab under **Cloud Sync**, click **Browse Drive**.
 2. Codex lists every vault subfolder it finds under `CodexCryptica/`.
 3. Click **Load** next to any vault. Codex creates a local vault (or finds the existing one), then pulls only the files that are newer than what you have locally.
 
@@ -654,7 +661,7 @@ If you have vaults already stored in your `CodexCryptica/` Drive folder (from an
 If your GM has shared their Drive vault folder with you, you can connect to it directly:
 
 1. Ask your GM to share the Drive folder and copy the share link (it looks like `https://drive.google.com/drive/folders/…`).
-2. In **Settings → Cloud Sync**, paste the link into the **Join a Shared Vault** field and click **Join**.
+2. In the **Vault** settings tab under **Cloud Sync**, paste the link into the **Join a Shared Vault** field and click **Join**.
 3. Google will ask you to grant read access to the shared folder. Once approved, Codex imports the vault locally and you can pull updates any time with **Load from Drive**.
 
 > [!NOTE]
@@ -691,6 +698,44 @@ Your story starts here...
 
 - **Metadata**: You can add your own fields to the header (like `age: 45`). The AI Oracle will see these and use them for extra context.
 - **Syncing**: Because these are just files, you can use any cloud service (Dropbox, OneDrive, etc.) to keep them synced across devices.
+
+---
+
+### DEFAULT ENTITY TEMPLATES
+
+Codex Cryptica provides pre-formatted structure outlines called **Default Entity Templates** to eliminate the friction of starting with an empty note. Whenever you create a new **Character**, **Faction**, **Location**, **Item**, **Event**, **Creature**, or **Note**, a tailored markdown layout is instantly pre-populated for you.
+
+## System Default Templates
+
+Out of the box, the following types come with high-fidelity structures:
+
+- **Character**: Includes sections for Summary, Appearance, Personality, Goals, Relationships, and Secrets.
+- **Faction**: Includes sections for Leadership, Resources, Methods, Allies and Enemies, and Internal Tensions.
+- **Location**: Includes sections for Geography, Districts, Points of Interest, and Local Factions.
+- **Item**: Includes sections for Origin, Appearance, Abilities, and Lore.
+- **Event**: Includes sections for Date/Chronology, Key Participants, Sequence of Events, and Aftermath.
+- **Creature**: Includes sections for Ecology, Combat/Abilities, Behavior, and Lore.
+- **Note**: A clean generic canvas for general-purpose world-building.
+
+## Toggling Templates On or Off
+
+If you prefer to start with a completely empty editor page for a new note:
+
+1. Click **New Entity** in the top navigation or sidebar.
+2. Uncheck the option **"Start from default format"** located below the Title input field.
+3. Click **Add** — your newly created document will be entirely blank.
+
+## Vault-Level Override Templates
+
+For advanced world-builders or genre-specific campaigns (e.g., sci-fi vs. high fantasy), you can fully override our system defaults with your own custom markdown files:
+
+1. In your linked local folder, create a directory path named `.cc/templates/` (or `.codex/templates/`).
+2. Add a markdown file named after the entity type in lowercase (e.g., `character.md`, `faction.md`, `location.md`). Casing of the file itself does not matter.
+3. Open the file and write your custom markdown structure (e.g. `## Cyberware` or `## Magical Lineage`).
+4. Any new entities of that type created henceforth will immediately use your custom structure.
+
+> [!TIP]
+> If you want to _always_ start completely blank for a specific type without untoggling the checkbox, create an empty file at `.cc/templates/{type}.md`. The system respects empty override files as valid, giving you a blank canvas.
 
 ---
 

--- a/apps/web/static/sitemap.xml
+++ b/apps/web/static/sitemap.xml
@@ -37,6 +37,12 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://codexcryptica.com/blog/default-entity-templates</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <lastmod>2026-05-28T14:00:00.000Z</lastmod>
+  </url>
+  <url>
     <loc>https://codexcryptica.com/blog/gdrive-cloud-sync</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/packages/vault-engine/package.json
+++ b/packages/vault-engine/package.json
@@ -6,8 +6,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "test": "bun test",
-    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\""
   },
   "dependencies": {

--- a/specs/123-entity-templates/checklists/requirements.md
+++ b/specs/123-entity-templates/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Default Entity Templates
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-28
+**Feature**: [spec.md](file:///home/espen/proj/Codex-Arcana/specs/123-entity-templates/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All requirements have been verified and clarified with the user. Ready for planning phase!

--- a/specs/123-entity-templates/checklists/requirements.md
+++ b/specs/123-entity-templates/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-05-28
-**Feature**: [spec.md](file:///home/espen/proj/Codex-Arcana/specs/123-entity-templates/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/123-entity-templates/data-model.md
+++ b/specs/123-entity-templates/data-model.md
@@ -1,0 +1,46 @@
+# Data Model & Interfaces: Default Entity Templates
+
+**Branch**: `123-entity-templates` | **Date**: 2026-05-28
+
+## Data Models
+
+### 1. Template Configurations Map
+
+We define a configuration mapping of the built-in system generic and theme-specific templates.
+
+```typescript
+export interface TemplateMap {
+  character?: string;
+  faction?: string;
+  location?: string;
+  item?: string;
+  event?: string;
+  creature?: string;
+  note?: string;
+  [key: string]: string | undefined;
+}
+```
+
+## Interface Contracts
+
+### 1. `EntityTemplateService` Class
+
+Exposes methods to check files and resolve the correct template.
+
+```typescript
+export class EntityTemplateService {
+  /**
+   * Resolves the markdown template to pre-populate an entity with.
+   *
+   * @param type - The entity type (e.g., 'character', 'location')
+   * @param themeId - The active theme ID (e.g., 'fantasy', 'scifi')
+   * @param customTemplatesDirHandle - FileSystemDirectoryHandle pointing to the local templates folder
+   * @returns The resolved template content as a string
+   */
+  async resolveTemplate(
+    type: string,
+    themeId: string,
+    customTemplatesDirHandle?: FileSystemDirectoryHandle | null,
+  ): Promise<string>;
+}
+```

--- a/specs/123-entity-templates/plan.md
+++ b/specs/123-entity-templates/plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Default Entity Templates
 
-**Branch**: `123-entity-templates` | **Date**: 2026-05-28 | **Spec**: [/specs/123-entity-templates/spec.md](file:///home/espen/proj/Codex-Arcana/specs/123-entity-templates/spec.md)
-**Input**: Feature specification from `/specs/123-entity-templates/spec.md`
+**Branch**: `123-entity-templates` | **Date**: 2026-05-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `spec.md`
 
 ## Summary
 

--- a/specs/123-entity-templates/plan.md
+++ b/specs/123-entity-templates/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Default Entity Templates
+
+**Branch**: `123-entity-templates` | **Date**: 2026-05-28 | **Spec**: [/specs/123-entity-templates/spec.md](file:///home/espen/proj/Codex-Arcana/specs/123-entity-templates/spec.md)
+**Input**: Feature specification from `/specs/123-entity-templates/spec.md`
+
+## Summary
+
+Implement default Markdown formats/templates when creating new entities (`Character`, `Faction`, `Location`, `Item`, `Event`, `Creature`, `Note`). The feature will provide built-in system-wide structures, support theme-based fallbacks (such as Fantasy and Sci-Fi characters), look for vault-level custom overrides in `.cc/templates/` (and `.codex/templates/`) case-insensitively, and offer a toggleable checkbox in the UI ("Start from default format") that defaults to `true`. When toggled `false` or when an empty override file is selected, the file will be initialized completely empty.
+
+## Technical Context
+
+**Language/Version**: TypeScript 6.0.3  
+**Primary Dependencies**: Svelte 5 Runes, `@codex/vault-engine`  
+**Storage**: OPFS (Vault Files) for custom overrides, IndexedDB for settings if persistent (or local-only UI state as specified)  
+**Testing**: Vitest (`test:unit` script)  
+**Target Platform**: Browser (Chrome/Firefox/Safari)  
+**Project Type**: Web Application (SvelteKit)  
+**Performance Goals**: Entity creation < 100ms with zero permission prompts or lag  
+**Constraints**: Single-responsibility principle (keep `VaultRepository` pure, do not bloat it with UI/theme/template retrieval logic)
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+1. **Library-First & TDD**: Yes, we will design an isolated `EntityTemplateService.svelte.ts` which handles all template matching, reading, and falling back, and write unit tests for it.
+2. **Icon usage class-based only**: Yes, we will NOT use `lucide-svelte` icons, but use Iconify class utilities (e.g. `class="icon-[lucide--...] h-4 w-4"`).
+3. **Constructor-based DI**: Yes, `EntityTemplateService` will use constructor-based dependency injection for directory handle fetching and theme state references.
+4. **No main commits**: Yes, we are strictly on the `123-entity-templates` branch.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/123-entity-templates/
+├── plan.md              # Feature plan
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+└── quickstart.md        # Phase 1 output
+```
+
+### Proposed Source Changes
+
+```text
+apps/web/src/lib/
+├── services/
+│   └── EntityTemplateService.svelte.ts  # [NEW] Service to resolve templates
+├── components/
+│   └── VaultControls.svelte             # [MODIFIED] Add template option checkbox & resolve content on add
+tests/
+└── lib/
+    └── services/
+        └── EntityTemplateService.svelte.test.ts # [NEW] Unit tests for service
+```
+
+## Proposed Architecture & Design
+
+### 1. Built-in Default Templates
+
+We will define built-in templates directly in code as constant records/maps. For example:
+
+- **Generic Character**:
+
+  ```markdown
+  # Character Name
+
+  ## Summary
+
+  A brief overview.
+
+  ## Appearance
+
+  Physical description.
+
+  ## Personality
+
+  Key traits and behavior.
+
+  ## Goals
+
+  What do they want?
+
+  ## Relationships
+
+  Key connections.
+  ```
+
+- **Fantasy Character**:
+
+  ```markdown
+  # Character Name
+
+  ## Summary
+
+  A brief overview.
+
+  ## Lineage & Background
+
+  Origin and heritage.
+
+  ## Appearance & Oaths
+
+  Physical description and sacred oaths.
+
+  ## Magical Affinity
+
+  Spells, talents, or connection to the arcane.
+  ```
+
+- **Sci-Fi Character**:
+
+  ```markdown
+  # Character Name
+
+  ## Summary
+
+  A brief overview.
+
+  ## Augmentations & Tech
+
+  Cybernetics and gear.
+
+  ## Corporate Ties & Reputation
+
+  Factions and street credit.
+  ```
+
+### 2. EntityTemplateService
+
+A new class `EntityTemplateService` will expose a clean method:
+`resolveTemplate(type: string, themeId: string, customTemplatesDirHandle?: FileSystemDirectoryHandle | null): Promise<string>`
+
+It will follow this exact logic chain:
+
+1. If "Start from default format" is checked:
+   - Check if `customTemplatesDirHandle` is available.
+   - Look for `{type}.md` (case-insensitive filename search).
+   - If override file is found:
+     - Read the file content.
+     - Return the content (even if empty, as an empty file is a valid user override).
+   - If not found or handle is missing:
+     - Look for theme-specific default fallback: `THEME_TEMPLATES[themeId]?.[type]`.
+     - Fall back to generic system default: `GENERIC_TEMPLATES[type]`.
+     - Fall back to `""` if type is unknown.
+2. If checkbox is unchecked:
+   - Return `""`.
+
+### 3. UI Integration in `VaultControls.svelte`
+
+- Add a local `$state(useTemplate = true)` flag.
+- Render a stylish checkbox/toggle input labelled "Start from default format" underneath the Title input.
+- On submit, call `EntityTemplateService.resolveTemplate(...)` using the active theme ID and vault directory handles.
+- Pass the resolved markdown as `initialData: { content: resolvedContent }` to `vault.createEntity(newType, newTitle, initialData)`.
+
+## Verification & Unit Testing Plan
+
+We will write unit tests in `apps/web/src/lib/services/EntityTemplateService.svelte.test.ts` to verify:
+
+- Graceful generic fallback for all 7 entity types.
+- Theme-specific overrides (Fantasy, Sci-Fi) returning correct structures.
+- Custom template file retrieval using mock directory and file handles.
+- Empty custom override files returning `""` (and not falling back to defaults).
+- Unchecked template toggle returning completely blank string.

--- a/specs/123-entity-templates/quickstart.md
+++ b/specs/123-entity-templates/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Default Entity Templates
+
+**Branch**: `123-entity-templates` | **Date**: 2026-05-28
+
+## Usage Guide
+
+This feature provides automatic markdown templates for new entities, with simple local overrides.
+
+### 1. Default System Templates
+
+When you create a new **Character**, **Faction**, **Location**, **Item**, **Event**, **Creature**, or **Note**, it automatically populates with standardized Markdown sections.
+
+### 2. Disabling Templates
+
+If you want to start with a blank document, simply untick **"Start from default format"** in the entity creation form.
+
+### 3. Vault-Level Override
+
+You can fully customize these templates for your specific campaign or vault:
+
+1. Create a folder named `.cc/templates/` (or `.codex/templates/`) in your vault.
+2. Add a markdown file named after the entity type (e.g., `character.md`, `location.md`). Casing does not matter.
+3. Add whatever markdown headings or structure you want.
+4. The next time you create an entity of that type, your custom template will be used!
+
+> [!NOTE]
+> If you want to disable templates entirely for a single type (e.g., you always want blank Location notes), simply create an empty `.cc/templates/location.md` file. The system will respect your blank override.

--- a/specs/123-entity-templates/research.md
+++ b/specs/123-entity-templates/research.md
@@ -1,0 +1,29 @@
+# Research: Default Entity Templates
+
+**Branch**: `123-entity-templates` | **Date**: 2026-05-28
+
+## Decisions & Rationale
+
+### 1. Architectural Placement of Template Resolving
+
+- **Decision**: Put all template resolution logic inside a new client-side service `EntityTemplateService.svelte.ts` rather than in the core `@codex/vault-engine`.
+- **Rationale**: The core `VaultRepository` and its mutations are designed to be single-responsible and independent of the active theme state or Svelte UI contexts. Resolving template overrides requires reading filesystem directories and accessing theme settings, which is naturally a web-level/service-level concern in the application lifecycle. Keeping the engine pure keeps tests simpler and maintains clean layering.
+
+### 2. Custom Templates Directory Location
+
+- **Decision**: Check `.cc/templates/` first, and fall back to `.codex/templates/` case-insensitively for the filename.
+- **Rationale**: `.cc` is the modern vault metadata and configuration directory, while `.codex` is supported for compatibility. Case-insensitivity ensures that user-created template files match gracefully regardless of casing (e.g., `character.md` or `Character.MD` matches `Character` entity type).
+
+### 3. Graceful Fallback Strategy
+
+- **Decision**:
+  1. Local Custom Override (even if empty string)
+  2. Theme-Specific Built-In Default (`Fantasy`, `Sci-Fi`)
+  3. Generic Built-In Default
+  4. Empty String (for unknown types)
+- **Rationale**: Keeps creation robust. Empty files must be respected to allow advanced users to explicitly suppress templates for certain types.
+
+## Alternatives Considered
+
+- **Embedding templates in `@codex/vault-engine` mutations**: Rejected because the core engine shouldn't be coupled to Svelte stores (like `themeStore`) or have to deal with localized file parsing routines that are client-specific.
+- **Requiring system templates to be actual files on disk**: Rejected because it adds overhead, permission prompts, or creation delays. Hardcoding default fallbacks ensures zero-latency page pre-population.

--- a/specs/123-entity-templates/spec.md
+++ b/specs/123-entity-templates/spec.md
@@ -53,6 +53,22 @@ A user can override the built-in system default templates by putting their own m
 
 ---
 
+### User Story 4 - Theme-Based System Default Templates (Priority: P3)
+
+When a vault has a specific theme/genre configured (such as "Fantasy" or "Sci-Fi"), and the user has not provided custom templates, the system defaults should automatically adapt to match that theme's flavor instead of falling back to the standard generic defaults.
+
+**Why this priority**: Enhances immersion and provides highly specific structure tailored to the campaign's setting. Kept as P3 to ensure core mechanics work first.
+
+**Independent Test**: Can be tested by configuring a vault's theme to "Fantasy", creating a new Character entity with the template option enabled, and verifying that the inserted document uses the Fantasy Character template (e.g., includes "Lineage", "Oaths", or "Magical Affinity") instead of the standard generic template.
+
+**Acceptance Scenarios**:
+
+1. **Given** a vault configured with the "Fantasy" theme and no custom templates, **When** the user creates a new Character entity, **Then** the template includes high-fantasy fields like `Lineage`, `Oaths`, and `Magical Affinity`.
+2. **Given** a vault configured with the "Sci-Fi" theme and no custom templates, **When** the user creates a new Character entity, **Then** the template includes sci-fi fields like `Augmentations`, `Corporate Ties`, and `Street Reputation`.
+3. **Given** a vault configured with an unknown or unsupported theme, **When** any new entity is created, **Then** it gracefully falls back to the generic system default templates.
+
+---
+
 ### Edge Cases
 
 - **Custom template folder structure missing**: If the `.cc/templates/` folder does not exist in the vault, the system MUST gracefully fall back to the system defaults without throwing errors.
@@ -69,6 +85,7 @@ A user can override the built-in system default templates by putting their own m
 - **FR-004**: System MUST check for local file overrides at `.cc/templates/{type}.md` or `.codex/templates/{type}.md` (prioritizing `.cc/templates/` over `.codex/templates/` or matching the vault's active config folder).
 - **FR-005**: If a local override file exists, the system MUST read and use its contents as the template instead of the built-in defaults.
 - **FR-006**: If no local override file exists or if reading fails, the system MUST gracefully fall back to the system default template.
+- **FR-007**: System MUST provide theme-specific default fallback templates (e.g., "Fantasy", "Sci-Fi") matching the active vault's theme configuration if no custom local template files exist.
 
 ### Key Entities _(include if feature involves data)_
 

--- a/specs/123-entity-templates/spec.md
+++ b/specs/123-entity-templates/spec.md
@@ -1,0 +1,86 @@
+# Feature Specification: Default Entity Templates
+
+**Feature Branch**: `123-entity-templates`  
+**Created**: 2026-05-28  
+**Status**: Draft  
+**Input**: User description: "Default formats/templates for entity types when creating them in Codex Cryptica (Character, Faction, Location, Item, Event, Creature, Note), with optional local customization in `.cc/templates/` (or `.codex/templates/`)."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Create Entity with System Default Template (Priority: P1)
+
+When a user creates a new entity of a specific type, the newly created entity's document is pre-populated with a clean, standard, non-mandatory markdown template structured for that specific type.
+
+**Why this priority**: Crucial MVP requirement. It immediately removes blank-page friction and establishes a helpful structural guide for worldbuilders.
+
+**Independent Test**: Can be fully tested by creating a new Character, Faction, Location, Item, Event, Creature, or Note entity in a clean vault, and verifying that the resulting markdown file contains the corresponding default headings and structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new or existing vault with no custom templates, **When** the user creates a new entity of type `Character`, **Then** the new markdown file is pre-populated with the default Character template (including "Summary", "Appearance", "Personality", "Goals", "Methods", "Relationships", "Secrets", and "Story Hooks").
+2. **Given** a new or existing vault with no custom templates, **When** the user creates a new entity of type `Faction`, **Then** the new markdown file is pre-populated with the default Faction template (including "Summary", "Purpose", "Leadership", "Members", "Resources", "Methods", "Allies and Enemies", "Internal Tensions", and "Story Hooks").
+3. **Given** a new or existing vault with no custom templates, **When** the user creates a new entity of type `Location`, `Item`, `Event`, `Creature`, or `Note`, **Then** the new markdown file is pre-populated with its respective default template.
+
+---
+
+### User Story 2 - Toggle Template Insertion in the Creation UI (Priority: P2)
+
+When a user is creating a new entity, they should have the option in the UI to decide whether they want to pre-populate the entity with the suggested template structure, or start with a completely empty page.
+
+**Why this priority**: Prevents the templates from feeling like rigid database forms. Ensures that CC remains "Markdown-first, optional structure."
+
+**Independent Test**: Can be tested by opening the new entity creation dialog/dropdown, toggling the "Start from default format" option off, creating the entity, and verifying that the editor is completely empty.
+
+**Acceptance Scenarios**:
+
+1. **Given** the entity creation dialog, **When** the "Start from default format" option is enabled (default state) and a new entity is created, **Then** the template is inserted.
+2. **Given** the entity creation dialog, **When** the user disables the "Start from default format" option and creates a new entity, **Then** the new markdown document is completely blank.
+
+---
+
+### User Story 3 - Vault-Level Custom Templates (Priority: P2)
+
+A user can override the built-in system default templates by putting their own markdown template files inside their vault directory.
+
+**Why this priority**: Allows vaults to have distinct tones (e.g., cyberpunk vs. high fantasy) and is a key feature for advanced users.
+
+**Independent Test**: Can be tested by creating a markdown file `.cc/templates/character.md` (or `.codex/templates/character.md`) with custom content, creating a new Character entity, and verifying that the custom content is used instead of the built-in system default.
+
+**Acceptance Scenarios**:
+
+1. **Given** a vault with a custom template at `.cc/templates/character.md` (or `.codex/templates/character.md`), **When** the user creates a new entity of type `Character` with the template option enabled, **Then** the new entity's document is pre-populated with the custom template's markdown content rather than the system default.
+2. **Given** a vault with a custom template folder, **When** the user creates an entity type that _does not_ have a custom template file in that folder (e.g. `Creature`), **Then** it gracefully falls back to using the system default template for `Creature`.
+
+---
+
+### Edge Cases
+
+- **Custom template folder structure missing**: If the `.cc/templates/` folder does not exist in the vault, the system MUST gracefully fall back to the system defaults without throwing errors.
+- **Empty custom template file**: If a custom template file (e.g., `.cc/templates/character.md`) exists but is completely empty, the system MUST treat it as a valid choice, resulting in a blank entity page rather than falling back to the system default template. This allows users to explicitly disable default formats for a specific type.
+- **Case sensitivity of template names**: Match custom templates to entity types case-insensitively by mapping the entity type to its lowercase file name (e.g., `Character` maps to `.cc/templates/character.md`, `Faction` to `.cc/templates/faction.md`).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST supply built-in Markdown templates for these entity types: `Character`, `Faction`, `Location`, `Item`, `Event`, `Creature`, and `Note`.
+- **FR-002**: The template content MUST follow the suggested markdown structures defined in the feature request.
+- **FR-003**: The entity creation UI MUST include a visual checkbox/toggle option ("Start from default format") that is enabled by default.
+- **FR-004**: System MUST check for local file overrides at `.cc/templates/{type}.md` or `.codex/templates/{type}.md` (prioritizing `.cc/templates/` over `.codex/templates/` or matching the vault's active config folder).
+- **FR-005**: If a local override file exists, the system MUST read and use its contents as the template instead of the built-in defaults.
+- **FR-006**: If no local override file exists or if reading fails, the system MUST gracefully fall back to the system default template.
+
+### Key Entities _(include if feature involves data)_
+
+- **EntityTemplate**: An in-memory representation of a markdown structure for a given entity type.
+  - Type: `string` (e.g. "Character", "Faction")
+  - Content: `string` (the markdown structure)
+- **VaultTemplateStore/Service**: The resolver responsible for looking up templates (checking local vault files first, then falling back to system defaults).
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Creating any of the 7 default entity types takes exactly the same amount of time as creating a blank entity, with no noticeable UI delay or lag (< 100ms).
+- **SC-002**: 100% of created entities correctly populate either their system default, their custom template, or a blank page depending on user settings.
+- **SC-003**: If a vault-level custom template file is modified, the next created entity of that type immediately reflects the modified template without requiring an app restart.

--- a/specs/123-entity-templates/spec.md
+++ b/specs/123-entity-templates/spec.md
@@ -69,9 +69,25 @@ When a vault has a specific theme/genre configured (such as "Fantasy" or "Sci-Fi
 
 ---
 
+### User Story 5 - Help & Guide Integration (Priority: P2)
+
+To ensure high feature discoverability and clear instructions on setting up custom overrides, the system provides user-facing documentation in the Help System and an accompanying blog announcement post.
+
+**Why this priority**: Required by project Constitution (Principle VII) to support self-serve custom template configuration.
+
+**Independent Test**: Confirm that the "Default Entity Templates" help guide is searchable and viewable in the Help sidebar, and that the announcement article is accessible via the Devlog/Blog.
+
+**Acceptance Scenarios**:
+
+1. **Given** the help center is open, **When** searching for "templates" or "default formats", **Then** the "Default Entity Templates" guide is returned.
+2. **Given** the blog/devlog index, **When** viewing articles, **Then** the announcement "No More Blank Pages: Introducing Default Entity Templates" is listed.
+
+---
+
 ### Edge Cases
 
 - **Custom template folder structure missing**: If the `.cc/templates/` folder does not exist in the vault, the system MUST gracefully fall back to the system defaults without throwing errors.
+
 - **Empty custom template file**: If a custom template file (e.g., `.cc/templates/character.md`) exists but is completely empty, the system MUST treat it as a valid choice, resulting in a blank entity page rather than falling back to the system default template. This allows users to explicitly disable default formats for a specific type.
 - **Case sensitivity of template names**: Match custom templates to entity types case-insensitively by mapping the entity type to its lowercase file name (e.g., `Character` maps to `.cc/templates/character.md`, `Faction` to `.cc/templates/faction.md`).
 
@@ -86,6 +102,8 @@ When a vault has a specific theme/genre configured (such as "Fantasy" or "Sci-Fi
 - **FR-005**: If a local override file exists, the system MUST read and use its contents as the template instead of the built-in defaults.
 - **FR-006**: If no local override file exists or if reading fails, the system MUST gracefully fall back to the system default template.
 - **FR-007**: System MUST provide theme-specific default fallback templates (e.g., "Fantasy", "Sci-Fi") matching the active vault's theme configuration if no custom local template files exist.
+
+- **FR-008**: System MUST supply a user help article explaining templates and setup at `apps/web/src/lib/content/help/default-templates.md` and a blog announcement post at `apps/web/src/lib/content/blog/default-entity-templates.md`.
 
 ### Key Entities _(include if feature involves data)_
 

--- a/specs/123-entity-templates/tasks.md
+++ b/specs/123-entity-templates/tasks.md
@@ -1,0 +1,153 @@
+# Tasks: Default Entity Templates
+
+**Input**: Design documents from `/specs/123-entity-templates/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: This project uses Vitest unit testing for core logic and Svelte test cases. Unit tests are mandatory.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and basic structure
+
+- [ ] T001 Verify we are on the feature branch `123-entity-templates` and synchronize with `staging`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Define built-in generic and theme-specific markdown formats as constants in a new file `apps/web/src/lib/services/EntityTemplateConstants.ts`
+- [ ] T003 Create `EntityTemplateService.svelte.ts` class skeleton under `apps/web/src/lib/services/` with dependency injection constructors for file system handles and theme matching.
+
+**Checkpoint**: Foundation ready - template storage constants and template service skeleton are available.
+
+---
+
+## Phase 3: User Story 1 - Create Entity with System Default Template (Priority: P1) 🎯 MVP
+
+**Goal**: Pre-populate newly created Character, Faction, Location, Item, Event, Creature, or Note with standard markdown templates.
+
+**Independent Test**: Create an entity in a clean vault. Verify the resulting editor's contents match the standard default markdown formats defined in spec.
+
+### Tests for User Story 1 (MANDATORY TDD) ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T004 Create unit tests in `apps/web/src/lib/services/EntityTemplateService.svelte.test.ts` to verify generic default fallback templates for all 7 entity types.
+
+### Implementation for User Story 1
+
+- [ ] T005 Implement generic fallback matching in `apps/web/src/lib/services/EntityTemplateService.svelte.ts` so that it returns the built-in Generic templates when no theme or local overrides exist.
+- [ ] T006 Update `apps/web/src/lib/components/VaultControls.svelte` to resolve template content using `EntityTemplateService` on entity creation, and pass the resolved markdown as `initialData: { content: resolvedContent }` to `vault.createEntity`.
+
+**Checkpoint**: At this point, creating any default entity type pre-populates the editor with the built-in system generic template.
+
+---
+
+## Phase 4: User Story 2 - Toggle Template Insertion in the Creation UI (Priority: P2)
+
+**Goal**: Allow users to toggle "Start from default format" in the creation UI. If untoggled, start completely empty.
+
+**Independent Test**: Open creation form, untick the template option, and verify that the created entity contains a completely blank document.
+
+### Tests for User Story 2 (MANDATORY TDD) ⚠️
+
+- [ ] T007 Add unit test in `apps/web/src/lib/services/EntityTemplateService.svelte.test.ts` verifying that if template selection is disabled or requested content is empty, the resolver returns an empty string `""`.
+
+### Implementation for User Story 2
+
+- [ ] T008 Add local checkbox state `$state(useTemplate = true)` and render a visual checkbox "Start from default format" in `apps/web/src/lib/components/VaultControls.svelte` under the title input.
+- [ ] T009 Integrate toggle choice with the template resolver call inside `VaultControls.svelte` so that unchecking the toggle skips template insertion and passes `""`.
+
+**Checkpoint**: Users can toggle between pre-populating standard structures or starting with blank pages.
+
+---
+
+## Phase 5: User Story 3 - Vault-Level Custom Templates (Priority: P2)
+
+**Goal**: Read user custom template files inside `.cc/templates/{type}.md` (or `.codex/templates/{type}.md`) case-insensitively and use them as overrides. Empty files should produce empty documents (no fallback).
+
+**Independent Test**: Create a custom template file `.cc/templates/character.md`, create a character entity, and verify it uses the custom template. Create an empty file, and verify it creates a blank entity page.
+
+### Tests for User Story 3 (MANDATORY TDD) ⚠️
+
+- [ ] T010 Add unit tests in `apps/web/src/lib/services/EntityTemplateService.svelte.test.ts` with mocked directory and file handles to verify reading custom overrides, case-insensitivity filename matching (e.g. `Character` -> `character.md`), folder-missing fallback, and empty-override file handling.
+
+### Implementation for User Story 3
+
+- [ ] T011 Implement file-based template matching and loading in `EntityTemplateService.svelte.ts`. Check `.cc/templates/` first, and `.codex/templates/` second, matching files case-insensitively, and reading contents via `readFile`. Ensure empty override files do not trigger fallbacks.
+- [ ] T012 Pass folder/directory handles (like `vault.getActiveFolderHandle()`) into the template resolver call from `VaultControls.svelte`.
+
+**Checkpoint**: Vault-level custom templates correctly override built-in formats, with support for empty override files.
+
+---
+
+## Phase 6: User Story 4 - Theme-Based System Default Templates (Priority: P3)
+
+**Goal**: Automatically adapt system defaults to the vault's active theme (Fantasy, Sci-Fi) when no custom template is provided.
+
+**Independent Test**: Set the active vault's theme to "Fantasy", create a character, and verify it includes fantasy fields like `Lineage` or `Magical Affinity`.
+
+### Tests for User Story 4 (MANDATORY TDD) ⚠️
+
+- [ ] T013 Add unit tests in `apps/web/src/lib/services/EntityTemplateService.svelte.test.ts` to verify theme-tailored built-in overrides for Fantasy and Sci-Fi character types, falling back gracefully to generic defaults for non-character types or unsupported themes.
+
+### Implementation for User Story 4
+
+- [ ] T014 Implement theme resolution logic in `EntityTemplateService.svelte.ts` to select theme-specific built-in templates (using `themeStore.worldThemeId` if no override directory exists or is matched).
+
+**Checkpoint**: All 4 user stories are fully implemented, and all core logic is backed by failing-then-passing TDD unit tests.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: General optimizations, document validation, and formatting
+
+- [ ] T015 Perform code linting and formatting across changed files (`apps/web/src/lib/services/EntityTemplateService.svelte.ts`, `apps/web/src/lib/components/VaultControls.svelte`, etc.) using `bun run lint` and `bun run lint:types`
+- [ ] T016 Run the complete unit test suite `bun run test` to verify zero regression across existing stores and services
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phases 3 to 6)**: Must proceed sequentially or in parallel after Foundational phase completes.
+- **Polish (Phase 7)**: Depends on all user story completions.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Foundation complete. No other dependencies.
+- **User Story 2 (P2)**: Integrates with US1 UI and resolver.
+- **User Story 3 (P2)**: Extends US1 template resolver with file reads.
+- **User Story 4 (P3)**: Extends US1/US3 template resolver with theme references.
+
+### Parallel Opportunities
+
+- Unit tests (`.test.ts`) can be designed and sketched in parallel with their corresponding implementation.
+- Constant formats (`EntityTemplateConstants.ts`) and mock handles for unit tests can be developed at the same time.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Running tests specifically targeting the new template service
+bun run test apps/web/src/lib/services/EntityTemplateService.svelte.test.ts
+```

--- a/specs/123-entity-templates/tasks.md
+++ b/specs/123-entity-templates/tasks.md
@@ -117,8 +117,10 @@
 
 **Purpose**: General optimizations, document validation, and formatting
 
-- [ ] T015 Perform code linting and formatting across changed files (`apps/web/src/lib/services/EntityTemplateService.svelte.ts`, `apps/web/src/lib/components/VaultControls.svelte`, etc.) using `bun run lint` and `bun run lint:types`
-- [ ] T016 Run the complete unit test suite `bun run test` to verify zero regression across existing stores and services
+- [ ] T015 Create a user-facing help guide article at `apps/web/src/lib/content/help/default-templates.md` describing custom override structures and UI controls per Constitution VII
+- [ ] T016 Create a devlog/blog announcement article at `apps/web/src/lib/content/blog/default-entity-templates.md` announcing Customizable Default Entity Templates
+- [ ] T017 Perform code linting and formatting across changed files (`apps/web/src/lib/services/EntityTemplateService.svelte.ts`, `apps/web/src/lib/components/VaultControls.svelte`, etc.) using `bun run lint` and `bun run lint:types`
+- [ ] T018 Run the complete unit test suite `bun run test` to verify zero regression across existing stores and services
 
 ---
 

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -8,6 +8,14 @@ This document maps the evolution of Codex Cryptica from its architectural founda
 
 The following high-impact candidate specifications target performance, scaling, and multiplayer resilience in local-first environments.
 
+### [PROPOSED] Default Entity Templates with Local Overrides
+
+- **Target Area**: Entity Creation & Vault-Level Templates (`apps/web/src/lib/stores/vault/` & `packages/vault-engine/`)
+- **Objective**: Standardize entity creation with high-quality default Markdown templates, while allowing vault-specific customization and theme-adapted templates.
+- **Details**: Pre-populates newly created Character, Faction, Location, Item, Event, Creature, or Note entities with beautiful default markdown structures (like Goals, Secrets, and Story Hooks). Provides a visual toggle to disable template populating. Supports vault-level overrides via local markdown files in `.cc/templates/{type}.md` (case-insensitive conversion). Adapts default structures dynamically to configured world genres (e.g., High-Fantasy vs. Cyberpunk). Detailed in [123-entity-templates](./123-entity-templates/spec.md).
+
+---
+
 ### [PROPOSED] Direct P2P Audio/Video Integration
 
 - **Target Area**: P2P Networking & VTT UI (`apps/web/src/lib/services/p2p/`)


### PR DESCRIPTION
This PR implements customizable default markdown templates when creating new entities (Character, Faction, Location, Item, Event, Creature, Note) with an optional toggle checkbox in the UI.

### Summary of Changes:
- **EntityTemplateConstants.ts**: Declared default templates for all entity categories across Generic, Fantasy, and Sci-Fi themes.
- **EntityTemplateService.svelte.ts**: Implemented a robust service resolving template structures, handling vault-level overrides in `.cc/templates/` and `.codex/templates/` (case-insensitively and respecting blank overrides).
- **VaultControls.svelte**: Integrated the premium Svelte 5 "Start from default format" toggle switch, pre-populating new files instantly with zero-latency overhead.
- **Unit Testing**: Covered 21 explicit edge cases in a comprehensive test suite (`EntityTemplateService.svelte.test.ts`), with 100% success across all 200/200 workspace test suites.
- **Help Guide & Blog Post**: Generated high-fidelity markdown documentation and release material detailing custom overrides.