### PR TITLE
[codex] Decompose MapInteractionManager

### DIFF
--- a/apps/web/src/lib/components/map/interactions/box-selection-handler.svelte.ts
+++ b/apps/web/src/lib/components/map/interactions/box-selection-handler.svelte.ts
@@ -1,0 +1,47 @@
+import type { Point } from "schema";
+import type { TokenSelectionManager } from "./token-selection-manager";
+
+export interface BoxSelectionDependencies {
+  isHostMode: () => boolean;
+  isVttEnabled: () => boolean;
+  tokenSelection: TokenSelectionManager;
+}
+
+export class BoxSelectionHandler {
+  start = $state<Point | null>(null);
+  end = $state<Point | null>(null);
+
+  constructor(private deps: BoxSelectionDependencies) {}
+
+  begin(point: Point, modifiers: { ctrlKey?: boolean; metaKey?: boolean }) {
+    if (
+      !this.deps.isHostMode() ||
+      !this.deps.isVttEnabled() ||
+      (!modifiers.ctrlKey && !modifiers.metaKey)
+    ) {
+      return false;
+    }
+
+    this.start = point;
+    this.end = point;
+    return true;
+  }
+
+  update(point: Point) {
+    if (!this.start) return false;
+    this.end = point;
+    return true;
+  }
+
+  commit() {
+    if (!this.start || !this.end) return false;
+    this.deps.tokenSelection.selectWithinBox(this.start, this.end);
+    this.clear();
+    return true;
+  }
+
+  clear() {
+    this.start = null;
+    this.end = null;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/box-selection-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/box-selection-handler.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BoxSelectionHandler } from "./box-selection-handler.svelte";
+
+describe("BoxSelectionHandler", () => {
+  let hostMode = true;
+  let vttEnabled = true;
+  let selectWithinBox: ReturnType<typeof vi.fn>;
+  let handler: BoxSelectionHandler;
+
+  beforeEach(() => {
+    hostMode = true;
+    vttEnabled = true;
+    selectWithinBox = vi.fn();
+    handler = new BoxSelectionHandler({
+      isHostMode: () => hostMode,
+      isVttEnabled: () => vttEnabled,
+      tokenSelection: { selectWithinBox } as any,
+    });
+  });
+
+  it("starts with ctrl or meta only in host VTT mode", () => {
+    expect(handler.begin({ x: 10, y: 20 }, {})).toBe(false);
+
+    expect(handler.begin({ x: 10, y: 20 }, { ctrlKey: true })).toBe(true);
+    expect(handler.start).toEqual({ x: 10, y: 20 });
+    expect(handler.end).toEqual({ x: 10, y: 20 });
+  });
+
+  it("does not start outside host VTT mode", () => {
+    hostMode = false;
+    expect(handler.begin({ x: 10, y: 20 }, { ctrlKey: true })).toBe(false);
+
+    hostMode = true;
+    vttEnabled = false;
+    expect(handler.begin({ x: 10, y: 20 }, { ctrlKey: true })).toBe(false);
+  });
+
+  it("updates and commits the selected rectangle", () => {
+    handler.begin({ x: 10, y: 20 }, { ctrlKey: true });
+    handler.update({ x: 100, y: 120 });
+
+    expect(handler.commit()).toBe(true);
+
+    expect(selectWithinBox).toHaveBeenCalledWith(
+      { x: 10, y: 20 },
+      { x: 100, y: 120 },
+    );
+    expect(handler.start).toBeNull();
+    expect(handler.end).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/context-menu-interaction-handler.svelte.ts
+++ b/apps/web/src/lib/components/map/interactions/context-menu-interaction-handler.svelte.ts
@@ -1,0 +1,41 @@
+import type { Point } from "schema";
+import type { TokenSelectionManager } from "./token-selection-manager";
+
+export interface MapContextMenuState {
+  x: number;
+  y: number;
+  imgX: number;
+  imgY: number;
+  tokenId?: string;
+}
+
+export interface ContextMenuInteractionDependencies {
+  isVttEnabled: () => boolean;
+  unproject: (point: Point) => Point;
+  tokenSelection: TokenSelectionManager;
+}
+
+export class ContextMenuInteractionHandler {
+  contextMenu = $state<MapContextMenuState | null>(null);
+
+  constructor(private deps: ContextMenuInteractionDependencies) {}
+
+  clear() {
+    this.contextMenu = null;
+  }
+
+  open(eventPoint: Point, viewportPoint: Point) {
+    if (!this.deps.isVttEnabled()) return false;
+
+    const hitToken = this.deps.tokenSelection.hitTest(viewportPoint);
+    const imgCoords = this.deps.unproject(viewportPoint);
+    this.contextMenu = {
+      x: eventPoint.x,
+      y: eventPoint.y,
+      imgX: imgCoords.x,
+      imgY: imgCoords.y,
+      tokenId: hitToken?.id,
+    };
+    return true;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/context-menu-interaction-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/context-menu-interaction-handler.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Token } from "../../../../types/vtt";
+import { ContextMenuInteractionHandler } from "./context-menu-interaction-handler.svelte";
+import { TokenSelectionManager } from "./token-selection-manager";
+
+function token(input: Partial<Token> & { id: string; x: number; y: number }) {
+  return {
+    entityId: null,
+    name: input.id,
+    width: 50,
+    height: 50,
+    rotation: 0,
+    zIndex: 0,
+    ownerPeerId: null,
+    ownerGuestName: null,
+    visibleTo: "all",
+    color: "#fff",
+    imageUrl: null,
+    statusEffects: [],
+    ...input,
+  } satisfies Token;
+}
+
+describe("ContextMenuInteractionHandler", () => {
+  let vttEnabled = true;
+  let handler: ContextMenuInteractionHandler;
+
+  beforeEach(() => {
+    const tokenSelection = new TokenSelectionManager({
+      getTokens: () => [token({ id: "token-a", x: 10, y: 10 })],
+      project: (point) => point,
+      getSelectedTokens: () => new Set(),
+      setSelection: vi.fn(),
+      addToSelection: vi.fn(),
+      removeFromSelection: vi.fn(),
+      setMultiSelection: vi.fn(),
+    });
+    vttEnabled = true;
+    handler = new ContextMenuInteractionHandler({
+      isVttEnabled: () => vttEnabled,
+      unproject: (point) => ({ x: point.x + 1, y: point.y + 2 }),
+      tokenSelection,
+    });
+  });
+
+  it("opens a context menu with image coordinates and token hit", () => {
+    expect(handler.open({ x: 300, y: 400 }, { x: 20, y: 20 })).toBe(true);
+
+    expect(handler.contextMenu).toEqual({
+      x: 300,
+      y: 400,
+      imgX: 21,
+      imgY: 22,
+      tokenId: "token-a",
+    });
+  });
+
+  it("does not open when VTT mode is disabled", () => {
+    vttEnabled = false;
+
+    expect(handler.open({ x: 300, y: 400 }, { x: 20, y: 20 })).toBe(false);
+
+    expect(handler.contextMenu).toBeNull();
+  });
+
+  it("clears the current context menu", () => {
+    handler.open({ x: 300, y: 400 }, { x: 20, y: 20 });
+
+    handler.clear();
+
+    expect(handler.contextMenu).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/creation-interaction-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/creation-interaction-handler.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CreationInteractionHandler } from "./creation-interaction-handler";
+
+describe("CreationInteractionHandler", () => {
+  let vttEnabled = true;
+  let canCreateTokens = true;
+  let setPendingTokenCoords: ReturnType<typeof vi.fn>;
+  let setPendingPinCoords: ReturnType<typeof vi.fn>;
+  let handler: CreationInteractionHandler;
+
+  beforeEach(() => {
+    vttEnabled = true;
+    canCreateTokens = true;
+    setPendingTokenCoords = vi.fn();
+    setPendingPinCoords = vi.fn();
+    handler = new CreationInteractionHandler({
+      unproject: (point) => ({ x: point.x + 1, y: point.y + 2 }),
+      isVttEnabled: () => vttEnabled,
+      canCreateTokens: () => canCreateTokens,
+      setPendingTokenCoords,
+      setPendingPinCoords,
+    });
+  });
+
+  it("sets pending token coordinates for VTT host mode", () => {
+    expect(handler.handleDoubleClick({ x: 10, y: 20 })).toBe(true);
+
+    expect(setPendingTokenCoords).toHaveBeenCalledWith({ x: 11, y: 22 });
+    expect(setPendingPinCoords).not.toHaveBeenCalled();
+  });
+
+  it("sets pending pin coordinates outside VTT mode", () => {
+    vttEnabled = false;
+
+    expect(handler.handleDoubleClick({ x: 10, y: 20 })).toBe(true);
+
+    expect(setPendingPinCoords).toHaveBeenCalledWith({ x: 11, y: 22 });
+    expect(setPendingTokenCoords).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for VTT non-host mode", () => {
+    canCreateTokens = false;
+
+    expect(handler.handleDoubleClick({ x: 10, y: 20 })).toBe(false);
+
+    expect(setPendingTokenCoords).not.toHaveBeenCalled();
+    expect(setPendingPinCoords).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/creation-interaction-handler.ts
+++ b/apps/web/src/lib/components/map/interactions/creation-interaction-handler.ts
@@ -1,0 +1,28 @@
+import type { Point } from "schema";
+
+export interface CreationInteractionDependencies {
+  unproject: (point: Point) => Point;
+  isVttEnabled: () => boolean;
+  canCreateTokens: () => boolean;
+  setPendingTokenCoords: (point: Point) => void;
+  setPendingPinCoords: (point: Point) => void;
+}
+
+export class CreationInteractionHandler {
+  constructor(private deps: CreationInteractionDependencies) {}
+
+  handleDoubleClick(viewportPoint: Point) {
+    const imgCoords = this.deps.unproject(viewportPoint);
+    if (this.deps.isVttEnabled() && this.deps.canCreateTokens()) {
+      this.deps.setPendingTokenCoords(imgCoords);
+      return true;
+    }
+
+    if (!this.deps.isVttEnabled()) {
+      this.deps.setPendingPinCoords(imgCoords);
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/fog-interaction-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/fog-interaction-handler.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FogInteractionHandler } from "./fog-interaction-handler";
+
+describe("FogInteractionHandler", () => {
+  let painter: any;
+  let canPaint = true;
+  let shouldBroadcast = true;
+  let broadcastFogSync: ReturnType<typeof vi.fn>;
+  let handler: FogInteractionHandler;
+
+  beforeEach(() => {
+    painter = {
+      isPainting: false,
+      begin: vi.fn(() => {
+        painter.isPainting = true;
+      }),
+      move: vi.fn(),
+      finish: vi.fn(async () => {
+        painter.isPainting = false;
+        return true;
+      }),
+    };
+    canPaint = true;
+    shouldBroadcast = true;
+    broadcastFogSync = vi.fn();
+    handler = new FogInteractionHandler({
+      painter,
+      canPaint: () => canPaint,
+      shouldBroadcastFogSync: () => shouldBroadcast,
+      broadcastFogSync,
+    });
+  });
+
+  it("starts painting only when allowed", () => {
+    canPaint = false;
+    expect(handler.begin({ x: 10, y: 20 }, false)).toBe(false);
+    expect(painter.begin).not.toHaveBeenCalled();
+
+    canPaint = true;
+    expect(handler.begin({ x: 10, y: 20 }, true)).toBe(true);
+    expect(painter.begin).toHaveBeenCalledWith({ x: 10, y: 20 }, true);
+  });
+
+  it("moves only while painting", () => {
+    expect(handler.move({ x: 30, y: 40 }, false)).toBe(false);
+
+    painter.isPainting = true;
+    expect(handler.move({ x: 30, y: 40 }, true)).toBe(true);
+    expect(painter.move).toHaveBeenCalledWith({ x: 30, y: 40 }, true);
+  });
+
+  it("finishes and broadcasts fog sync when required", async () => {
+    painter.isPainting = true;
+
+    expect(await handler.finish()).toBe(true);
+
+    expect(painter.finish).toHaveBeenCalled();
+    expect(broadcastFogSync).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/fog-interaction-handler.ts
+++ b/apps/web/src/lib/components/map/interactions/fog-interaction-handler.ts
@@ -1,0 +1,38 @@
+import type { Point } from "schema";
+import type { MapFogPainter } from "../map-fog-painter";
+
+export interface FogInteractionDependencies {
+  painter: MapFogPainter;
+  canPaint: () => boolean;
+  shouldBroadcastFogSync: () => boolean;
+  broadcastFogSync: () => unknown;
+}
+
+export class FogInteractionHandler {
+  constructor(private deps: FogInteractionDependencies) {}
+
+  get isPainting() {
+    return this.deps.painter.isPainting;
+  }
+
+  begin(point: Point, erase: boolean) {
+    if (!this.deps.canPaint()) return false;
+    this.deps.painter.begin(point, erase);
+    return true;
+  }
+
+  move(point: Point, erase: boolean) {
+    if (!this.deps.painter.isPainting) return false;
+    this.deps.painter.move(point, erase);
+    return true;
+  }
+
+  async finish() {
+    if (!this.deps.painter.isPainting) return false;
+    const finished = await this.deps.painter.finish();
+    if (finished && this.deps.shouldBroadcastFogSync()) {
+      void this.deps.broadcastFogSync();
+    }
+    return true;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/grid-interaction-handler.svelte.ts
+++ b/apps/web/src/lib/components/map/interactions/grid-interaction-handler.svelte.ts
@@ -1,0 +1,95 @@
+import type { Point, ViewportTransform } from "schema";
+
+export interface GridInteractionDependencies {
+  isGridMoveMode: () => boolean;
+  setGridMoveMode: (active: boolean) => void;
+  isGridFitMode: () => boolean;
+  setGridFitMode: (active: boolean) => void;
+  isHostMode: () => boolean;
+  getViewport: () => ViewportTransform;
+  getCanvasSize: () => { width: number; height: number };
+  getGridSize: () => number;
+  setGridSize: (gridSize: number) => void;
+  setGridOffset: (offset: Point) => void;
+  setShowGridSettings: (show: boolean) => void;
+  unproject: (point: Point) => Point;
+  clearNotification: () => void;
+}
+
+export class GridInteractionHandler {
+  gridFitStart = $state<Point | null>(null);
+  gridFitEnd = $state<Point | null>(null);
+
+  constructor(private deps: GridInteractionDependencies) {}
+
+  commitGridMove() {
+    if (!this.deps.isGridMoveMode()) return false;
+
+    const viewport = this.deps.getViewport();
+    const canvasSize = this.deps.getCanvasSize();
+    const gridSize = this.deps.getGridSize();
+    this.deps.setGridOffset({
+      x: -((viewport.pan.x + canvasSize.width / 2) / viewport.zoom) % gridSize,
+      y: -((viewport.pan.y + canvasSize.height / 2) / viewport.zoom) % gridSize,
+    });
+    this.deps.setGridMoveMode(false);
+    this.deps.clearNotification();
+    return true;
+  }
+
+  cancelGridMove() {
+    if (!this.deps.isGridMoveMode()) return false;
+    this.deps.setGridMoveMode(false);
+    this.deps.clearNotification();
+    return true;
+  }
+
+  cancelGridFit() {
+    if (!this.deps.isGridFitMode() && !this.gridFitStart) return false;
+    this.deps.setGridFitMode(false);
+    this.gridFitStart = null;
+    this.gridFitEnd = null;
+    return true;
+  }
+
+  shouldStartGridMove() {
+    return this.deps.isGridMoveMode() && this.deps.isHostMode();
+  }
+
+  startGridFit(point: Point) {
+    if (!this.deps.isGridFitMode() || !this.deps.isHostMode()) return false;
+    this.gridFitStart = point;
+    this.gridFitEnd = point;
+    return true;
+  }
+
+  updateGridFit(point: Point) {
+    if (!this.gridFitStart) return false;
+    this.gridFitEnd = point;
+    return true;
+  }
+
+  commitGridFit() {
+    if (!this.gridFitStart || !this.gridFitEnd) return false;
+
+    const startImg = this.deps.unproject(this.gridFitStart);
+    const endImg = this.deps.unproject(this.gridFitEnd);
+    const imgWidth = Math.abs(endImg.x - startImg.x);
+    const imgHeight = Math.abs(endImg.y - startImg.y);
+
+    if (imgWidth >= 5 || imgHeight >= 5) {
+      const cellSize = Math.round(Math.max(imgWidth, imgHeight));
+      this.deps.setGridSize(cellSize);
+      this.deps.setGridOffset({
+        x: -(Math.min(startImg.x, endImg.x) % cellSize),
+        y: -(Math.min(startImg.y, endImg.y) % cellSize),
+      });
+    }
+
+    this.gridFitStart = null;
+    this.gridFitEnd = null;
+    this.deps.setGridFitMode(false);
+    this.deps.setShowGridSettings(true);
+    return true;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/grid-interaction-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/grid-interaction-handler.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GridInteractionHandler } from "./grid-interaction-handler.svelte";
+
+describe("GridInteractionHandler", () => {
+  let gridMoveMode = false;
+  let gridFitMode = false;
+  let hostMode = true;
+  let gridSize = 50;
+  let gridOffset = { x: 0, y: 0 };
+  let showGridSettings = false;
+  let clearNotification: ReturnType<typeof vi.fn>;
+  let handler: GridInteractionHandler;
+
+  beforeEach(() => {
+    gridMoveMode = false;
+    gridFitMode = false;
+    hostMode = true;
+    gridSize = 50;
+    gridOffset = { x: 0, y: 0 };
+    showGridSettings = false;
+    clearNotification = vi.fn();
+    handler = new GridInteractionHandler({
+      isGridMoveMode: () => gridMoveMode,
+      setGridMoveMode: (active) => {
+        gridMoveMode = active;
+      },
+      isGridFitMode: () => gridFitMode,
+      setGridFitMode: (active) => {
+        gridFitMode = active;
+      },
+      isHostMode: () => hostMode,
+      getViewport: () => ({ pan: { x: 25, y: 75 }, zoom: 2 }),
+      getCanvasSize: () => ({ width: 800, height: 600 }),
+      getGridSize: () => gridSize,
+      setGridSize: (next) => {
+        gridSize = next;
+      },
+      setGridOffset: (offset) => {
+        gridOffset = offset;
+      },
+      setShowGridSettings: (show) => {
+        showGridSettings = show;
+      },
+      unproject: (point) => point,
+      clearNotification,
+    });
+  });
+
+  it("commits grid move offset and exits move mode", () => {
+    gridMoveMode = true;
+
+    expect(handler.commitGridMove()).toBe(true);
+
+    expect(gridOffset).toEqual({ x: -12.5, y: -37.5 });
+    expect(gridMoveMode).toBe(false);
+    expect(clearNotification).toHaveBeenCalled();
+  });
+
+  it("cancels grid fit and clears the fit rectangle", () => {
+    gridFitMode = true;
+    handler.startGridFit({ x: 10, y: 20 });
+
+    expect(handler.cancelGridFit()).toBe(true);
+
+    expect(gridFitMode).toBe(false);
+    expect(handler.gridFitStart).toBeNull();
+    expect(handler.gridFitEnd).toBeNull();
+  });
+
+  it("only starts grid fit for host mode while fit mode is active", () => {
+    gridFitMode = true;
+    hostMode = false;
+
+    expect(handler.startGridFit({ x: 10, y: 20 })).toBe(false);
+
+    hostMode = true;
+    expect(handler.startGridFit({ x: 10, y: 20 })).toBe(true);
+    expect(handler.gridFitStart).toEqual({ x: 10, y: 20 });
+  });
+
+  it("commits grid fit size and opens grid settings", () => {
+    gridFitMode = true;
+    handler.startGridFit({ x: 10, y: 20 });
+    handler.updateGridFit({ x: 80, y: 95 });
+
+    expect(handler.commitGridFit()).toBe(true);
+
+    expect(gridSize).toBe(75);
+    expect(gridOffset).toEqual({ x: -10, y: -20 });
+    expect(gridFitMode).toBe(false);
+    expect(showGridSettings).toBe(true);
+    expect(handler.gridFitStart).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/interaction-adapters.ts
+++ b/apps/web/src/lib/components/map/interactions/interaction-adapters.ts
@@ -1,0 +1,104 @@
+import { p2pGuestService } from "$lib/cloud-bridge/p2p/guest-service";
+import { p2pHost } from "$lib/cloud-bridge/p2p/host-service.svelte";
+import { mapSession } from "$lib/stores/map-session.svelte";
+import { mapStore } from "$lib/stores/map.svelte";
+import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
+import { vault } from "$lib/stores/vault.svelte";
+import { notificationStore } from "$lib/stores/ui/notification.svelte";
+import type { GridInteractionDependencies } from "./grid-interaction-handler.svelte";
+import type { MeasurementInteractionDependencies } from "./measurement-interaction-handler";
+import type { PinInteractionDependencies } from "./pin-interaction-handler";
+import type { TokenDragDependencies } from "./token-drag-handler";
+import type { TokenSelectionDependencies } from "./token-selection-manager";
+
+export function createTokenSelectionDependencies(): TokenSelectionDependencies {
+  return {
+    getTokens: () => mapSession.allTokens,
+    project: (point) => mapStore.project(point),
+    getSelectedTokens: () => mapSession.selectedTokens,
+    setSelection: (tokenId) => mapSession.setSelection(tokenId),
+    addToSelection: (tokenId) => mapSession.addToSelection(tokenId),
+    removeFromSelection: (tokenId) => mapSession.removeFromSelection(tokenId),
+    setMultiSelection: (tokenIds) => mapSession.setMultiSelection(tokenIds),
+  };
+}
+
+export function createTokenDragDependencies(): TokenDragDependencies {
+  return {
+    getTokens: () => mapSession.allTokens,
+    project: (point) => mapStore.project(point),
+    unproject: (point) => mapStore.unproject(point),
+    isHostMode: () => mapStore.isGMMode,
+    getPeerId: () => p2pGuestService.peerId,
+    canMoveToken: (tokenId, peerId, isHost) =>
+      mapSession.canMoveToken(tokenId, peerId, isHost),
+    moveToken: (tokenId, x, y) => mapSession.moveToken(tokenId, x, y),
+    requestTokenMove: (tokenId, x, y, persistent) =>
+      mapSession.requestTokenMove(tokenId, x, y, persistent),
+    sendTokenMoveRequest: (tokenId, x, y) =>
+      p2pGuestService.requestTokenMove(tokenId, x, y),
+    confirmTokenMove: (tokenId) => mapSession.confirmTokenMove(tokenId),
+    setDraggingTokenId: (tokenId) => {
+      mapSession.draggingTokenId = tokenId;
+    },
+  };
+}
+
+export function createPinInteractionDependencies(): PinInteractionDependencies {
+  return {
+    getPins: () => mapStore.pins,
+    project: (point) => mapStore.project(point),
+    unproject: (point) => mapStore.unproject(point),
+    canEditPins: () => mapStore.isGMMode && !sessionModeStore.isGuestMode,
+    updatePinCoordinates: (pinId, point) =>
+      mapStore.updatePinCoordinatesInMemory(pinId, point),
+    saveMaps: () => vault.saveMaps(),
+    selectEntity: (entityId) => {
+      vault.selectedEntityId = entityId;
+    },
+  };
+}
+
+export function createGridInteractionDependencies(): GridInteractionDependencies {
+  return {
+    isGridMoveMode: () => mapSession.gridMoveMode,
+    setGridMoveMode: (active) => {
+      mapSession.gridMoveMode = active;
+    },
+    isGridFitMode: () => mapSession.gridFitMode,
+    setGridFitMode: (active) => {
+      mapSession.gridFitMode = active;
+    },
+    isHostMode: () => mapStore.isGMMode,
+    getViewport: () => mapStore.viewport,
+    getCanvasSize: () => mapStore.canvasSize,
+    getGridSize: () => mapStore.gridSize,
+    setGridSize: (gridSize) => {
+      mapStore.gridSize = gridSize;
+    },
+    setGridOffset: (offset) => {
+      mapStore.gridOffsetX = offset.x;
+      mapStore.gridOffsetY = offset.y;
+    },
+    setShowGridSettings: (show) => {
+      mapSession.showGridSettings = show;
+    },
+    unproject: (point) => mapStore.unproject(point),
+    clearNotification: () => notificationStore.clearNotification(),
+  };
+}
+
+export function createMeasurementInteractionDependencies(): MeasurementInteractionDependencies {
+  return {
+    getMeasurement: () => mapSession.measurement,
+    unproject: (point) => mapStore.unproject(point),
+    setMeasurementStart: (start) => mapSession.setMeasurementStart(start),
+    setMeasurementEnd: (end, silent) =>
+      mapSession.setMeasurementEnd(end, silent),
+    setMeasurementLocked: (locked) => mapSession.setMeasurementLocked(locked),
+  };
+}
+
+export function broadcastActiveMapFogSync() {
+  return p2pHost.broadcastActiveMapFogSync();
+}

--- a/apps/web/src/lib/components/map/interactions/map-interaction-handler-factory.ts
+++ b/apps/web/src/lib/components/map/interactions/map-interaction-handler-factory.ts
@@ -1,0 +1,115 @@
+import { mapSession } from "$lib/stores/map-session.svelte";
+import { mapStore } from "$lib/stores/map.svelte";
+import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
+import type { MapFogPainter } from "../map-fog-painter";
+import { BoxSelectionHandler } from "./box-selection-handler.svelte";
+import { ContextMenuInteractionHandler } from "./context-menu-interaction-handler.svelte";
+import { CreationInteractionHandler } from "./creation-interaction-handler";
+import { FogInteractionHandler } from "./fog-interaction-handler";
+import { GridInteractionHandler } from "./grid-interaction-handler.svelte";
+import {
+  broadcastActiveMapFogSync,
+  createGridInteractionDependencies,
+  createMeasurementInteractionDependencies,
+  createPinInteractionDependencies,
+  createTokenDragDependencies,
+  createTokenSelectionDependencies,
+} from "./interaction-adapters";
+import { MeasurementInteractionHandler } from "./measurement-interaction-handler";
+import { PinInteractionHandler } from "./pin-interaction-handler";
+import { TokenDragHandler } from "./token-drag-handler";
+import { TokenResizeHandler } from "./token-resize-handler";
+import { TokenSelectionManager } from "./token-selection-manager";
+
+export interface MapInteractionHandlers {
+  tokenSelection: TokenSelectionManager;
+  tokenDrag: TokenDragHandler;
+  pinInteractions: PinInteractionHandler;
+  gridInteractions: GridInteractionHandler;
+  measurementInteractions: MeasurementInteractionHandler;
+  contextMenuInteractions: ContextMenuInteractionHandler;
+  tokenResize: TokenResizeHandler;
+  boxSelection: BoxSelectionHandler;
+  fogInteractions: FogInteractionHandler;
+  creationInteractions: CreationInteractionHandler;
+}
+
+export type MapInteractionHandlerOverrides = Partial<MapInteractionHandlers> & {
+  broadcastFogSync?: () => unknown;
+};
+
+export function createMapInteractionHandlers(
+  painter: MapFogPainter,
+  overrides: MapInteractionHandlerOverrides = {},
+): MapInteractionHandlers {
+  const tokenSelection =
+    overrides.tokenSelection ??
+    new TokenSelectionManager(createTokenSelectionDependencies());
+  const broadcastFogSync =
+    overrides.broadcastFogSync ?? broadcastActiveMapFogSync;
+
+  return {
+    tokenSelection,
+    tokenDrag:
+      overrides.tokenDrag ??
+      new TokenDragHandler(createTokenDragDependencies()),
+    pinInteractions:
+      overrides.pinInteractions ??
+      new PinInteractionHandler(createPinInteractionDependencies()),
+    gridInteractions:
+      overrides.gridInteractions ??
+      new GridInteractionHandler(createGridInteractionDependencies()),
+    measurementInteractions:
+      overrides.measurementInteractions ??
+      new MeasurementInteractionHandler(
+        createMeasurementInteractionDependencies(),
+      ),
+    contextMenuInteractions:
+      overrides.contextMenuInteractions ??
+      new ContextMenuInteractionHandler({
+        isVttEnabled: () => mapSession.vttEnabled,
+        unproject: (point) => mapStore.unproject(point),
+        tokenSelection,
+      }),
+    tokenResize:
+      overrides.tokenResize ??
+      new TokenResizeHandler({
+        tokenSelection,
+        getGridSize: () => mapStore.gridSize,
+        updateToken: (tokenId, updates) =>
+          mapSession.updateToken(tokenId, updates),
+      }),
+    boxSelection:
+      overrides.boxSelection ??
+      new BoxSelectionHandler({
+        isHostMode: () => mapStore.isGMMode,
+        isVttEnabled: () => mapSession.vttEnabled,
+        tokenSelection,
+      }),
+    fogInteractions:
+      overrides.fogInteractions ??
+      new FogInteractionHandler({
+        painter,
+        canPaint: () => mapStore.isGMMode,
+        shouldBroadcastFogSync: () =>
+          mapStore.isGMMode &&
+          !sessionModeStore.isGuestMode &&
+          mapSession.vttEnabled,
+        broadcastFogSync,
+      }),
+    creationInteractions:
+      overrides.creationInteractions ??
+      new CreationInteractionHandler({
+        unproject: (point) => mapStore.unproject(point),
+        isVttEnabled: () => mapSession.vttEnabled,
+        canCreateTokens: () =>
+          mapStore.isGMMode && !sessionModeStore.isGuestMode,
+        setPendingTokenCoords: (point) => {
+          mapSession.pendingTokenCoords = point;
+        },
+        setPendingPinCoords: (point) => {
+          mapStore.pendingPinCoords = point;
+        },
+      }),
+  };
+}

--- a/apps/web/src/lib/components/map/interactions/measurement-interaction-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/measurement-interaction-handler.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MeasurementState } from "../../../../types/vtt";
+import { MeasurementInteractionHandler } from "./measurement-interaction-handler";
+
+describe("MeasurementInteractionHandler", () => {
+  let measurement: MeasurementState;
+  let setMeasurementStart: ReturnType<typeof vi.fn>;
+  let setMeasurementEnd: ReturnType<typeof vi.fn>;
+  let setMeasurementLocked: ReturnType<typeof vi.fn>;
+  let handler: MeasurementInteractionHandler;
+
+  beforeEach(() => {
+    measurement = { active: false, start: null, end: null, locked: false };
+    setMeasurementStart = vi.fn((start) => {
+      measurement = { ...measurement, start };
+    });
+    setMeasurementEnd = vi.fn((end, silent) => {
+      void silent;
+      measurement = { ...measurement, end };
+    });
+    setMeasurementLocked = vi.fn((locked) => {
+      measurement = { ...measurement, locked };
+    });
+    handler = new MeasurementInteractionHandler({
+      getMeasurement: () => measurement,
+      unproject: (point) => ({ x: point.x + 1, y: point.y + 2 }),
+      setMeasurementStart,
+      setMeasurementEnd,
+      setMeasurementLocked,
+    });
+  });
+
+  it("updates live measurement end silently while active and unlocked", () => {
+    measurement = {
+      active: true,
+      start: { x: 0, y: 0 },
+      end: null,
+      locked: false,
+    };
+
+    expect(handler.updateLiveEnd({ x: 10, y: 20 })).toBe(true);
+
+    expect(setMeasurementEnd).toHaveBeenCalledWith({ x: 11, y: 22 }, true);
+  });
+
+  it("does not update live measurement end when locked", () => {
+    measurement = {
+      active: true,
+      start: { x: 0, y: 0 },
+      end: null,
+      locked: true,
+    };
+
+    expect(handler.updateLiveEnd({ x: 10, y: 20 })).toBe(false);
+
+    expect(setMeasurementEnd).not.toHaveBeenCalled();
+  });
+
+  it("starts, locks, then restarts measurement on repeated clicks", () => {
+    measurement = { active: true, start: null, end: null, locked: false };
+
+    expect(handler.handleClick({ x: 10, y: 20 })).toBe(true);
+    expect(setMeasurementStart).toHaveBeenLastCalledWith({ x: 11, y: 22 });
+
+    measurement = {
+      active: true,
+      start: { x: 11, y: 22 },
+      end: null,
+      locked: false,
+    };
+    handler.handleClick({ x: 30, y: 40 });
+    expect(setMeasurementEnd).toHaveBeenLastCalledWith({ x: 31, y: 42 });
+    expect(setMeasurementLocked).toHaveBeenLastCalledWith(true);
+
+    measurement = {
+      active: true,
+      start: { x: 11, y: 22 },
+      end: { x: 31, y: 42 },
+      locked: true,
+    };
+    handler.handleClick({ x: 50, y: 60 });
+    expect(setMeasurementStart).toHaveBeenLastCalledWith({ x: 51, y: 62 });
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/measurement-interaction-handler.ts
+++ b/apps/web/src/lib/components/map/interactions/measurement-interaction-handler.ts
@@ -1,0 +1,41 @@
+import type { Point } from "schema";
+import type { MeasurementState } from "../../../../types/vtt";
+
+export interface MeasurementInteractionDependencies {
+  getMeasurement: () => MeasurementState;
+  unproject: (point: Point) => Point;
+  setMeasurementStart: (start: Point | null) => void;
+  setMeasurementEnd: (end: Point | null, silent?: boolean) => void;
+  setMeasurementLocked: (locked: boolean) => void;
+}
+
+export class MeasurementInteractionHandler {
+  constructor(private deps: MeasurementInteractionDependencies) {}
+
+  updateLiveEnd(viewportPoint: Point) {
+    const measurement = this.deps.getMeasurement();
+    if (!measurement.active || !measurement.start || measurement.locked) {
+      return false;
+    }
+
+    this.deps.setMeasurementEnd(this.deps.unproject(viewportPoint), true);
+    return true;
+  }
+
+  handleClick(viewportPoint: Point) {
+    const measurement = this.deps.getMeasurement();
+    if (!measurement.active) return false;
+
+    const imgCoords = this.deps.unproject(viewportPoint);
+    if (!measurement.start) {
+      this.deps.setMeasurementStart(imgCoords);
+    } else if (!measurement.locked) {
+      this.deps.setMeasurementEnd(imgCoords);
+      this.deps.setMeasurementLocked(true);
+    } else {
+      this.deps.setMeasurementStart(imgCoords);
+    }
+
+    return true;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/pin-interaction-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/pin-interaction-handler.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MapPin } from "schema";
+import { PinInteractionHandler } from "./pin-interaction-handler";
+
+function pin(input: Partial<MapPin> & { id: string; x: number; y: number }) {
+  return {
+    id: input.id,
+    entityId: input.entityId,
+    coordinates: { x: input.x, y: input.y },
+    visuals: {},
+  } satisfies MapPin;
+}
+
+describe("PinInteractionHandler", () => {
+  let pins: MapPin[];
+  let canEdit = true;
+  let updatePinCoordinates: ReturnType<typeof vi.fn>;
+  let saveMaps: ReturnType<typeof vi.fn>;
+  let selectEntity: ReturnType<typeof vi.fn>;
+  let handler: PinInteractionHandler;
+
+  beforeEach(() => {
+    pins = [pin({ id: "pin-a", x: 100, y: 100, entityId: "entity-a" })];
+    canEdit = true;
+    updatePinCoordinates = vi.fn((pinId: string, point) => {
+      const target = pins.find((candidate) => candidate.id === pinId);
+      if (target) target.coordinates = point;
+    });
+    saveMaps = vi.fn().mockResolvedValue(undefined);
+    selectEntity = vi.fn();
+    handler = new PinInteractionHandler({
+      getPins: () => pins,
+      project: (point) => point,
+      unproject: (point) => point,
+      canEditPins: () => canEdit,
+      updatePinCoordinates,
+      saveMaps,
+      selectEntity,
+    });
+  });
+
+  it("selects a clicked pin and linked entity without saving maps", async () => {
+    expect(handler.begin({ x: 100, y: 100 })?.id).toBe("pin-a");
+
+    const result = await handler.end({ x: 100, y: 100 }, { x: 102, y: 102 });
+
+    expect(result).toEqual({ type: "selected", pinId: "pin-a" });
+    expect(selectEntity).toHaveBeenCalledWith("entity-a");
+    expect(saveMaps).not.toHaveBeenCalled();
+  });
+
+  it("selects a pin at a viewport point without starting a drag", () => {
+    const selected = handler.selectAt({ x: 100, y: 100 });
+
+    expect(selected?.id).toBe("pin-a");
+    expect(selectEntity).toHaveBeenCalledWith("entity-a");
+    expect(handler.dragState).toBeNull();
+  });
+
+  it("updates coordinates while dragging and saves on mouse up", async () => {
+    handler.begin({ x: 100, y: 100 });
+    handler.move({ x: 130, y: 135 }, { x: 100, y: 100 });
+
+    expect(updatePinCoordinates).toHaveBeenCalledWith("pin-a", {
+      x: 130,
+      y: 135,
+    });
+
+    const result = await handler.end({ x: 100, y: 100 }, { x: 130, y: 135 });
+
+    expect(result).toEqual({ type: "dragged", pinId: "pin-a" });
+    expect(saveMaps).toHaveBeenCalled();
+  });
+
+  it("restores original coordinates when movement stays within the click threshold", async () => {
+    handler.begin({ x: 100, y: 100 });
+    handler.move({ x: 102, y: 102 }, { x: 100, y: 100 });
+
+    await handler.end({ x: 100, y: 100 }, { x: 102, y: 102 });
+
+    expect(updatePinCoordinates).toHaveBeenCalledWith("pin-a", {
+      x: 100,
+      y: 100,
+    });
+    expect(saveMaps).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate or save pins when editing is disabled", async () => {
+    canEdit = false;
+
+    handler.begin({ x: 100, y: 100 });
+    handler.move({ x: 130, y: 135 }, { x: 100, y: 100 });
+    await handler.end({ x: 100, y: 100 }, { x: 130, y: 135 });
+
+    expect(updatePinCoordinates).not.toHaveBeenCalled();
+    expect(saveMaps).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/pin-interaction-handler.ts
+++ b/apps/web/src/lib/components/map/interactions/pin-interaction-handler.ts
@@ -1,0 +1,119 @@
+import type { MapPin, Point } from "schema";
+import { findClickedPin, isClickGesture } from "../map-view-helpers";
+
+export interface PinInteractionDependencies {
+  getPins: () => MapPin[];
+  project: (point: Point) => Point;
+  unproject: (point: Point) => Point;
+  canEditPins: () => boolean;
+  updatePinCoordinates: (pinId: string, point: Point) => void;
+  saveMaps: () => Promise<void>;
+  selectEntity: (entityId: string) => void;
+}
+
+export interface PinDragState {
+  pinId: string;
+  originalCoordinates?: Point;
+  hasMoved?: boolean;
+  offset: Point;
+}
+
+export type PinEndResult =
+  | { type: "none" }
+  | { type: "selected"; pinId: string }
+  | { type: "dragged"; pinId: string };
+
+export class PinInteractionHandler {
+  dragState: PinDragState | null = null;
+
+  constructor(private deps: PinInteractionDependencies) {}
+
+  begin(viewportPoint: Point) {
+    const clickedPin = findClickedPin(
+      this.deps.getPins(),
+      this.deps.project,
+      viewportPoint.x,
+      viewportPoint.y,
+    );
+
+    if (!clickedPin) return null;
+
+    const imgPoint = this.deps.unproject(viewportPoint);
+    this.dragState = {
+      pinId: clickedPin.id,
+      originalCoordinates: { ...clickedPin.coordinates },
+      hasMoved: false,
+      offset: {
+        x: imgPoint.x - clickedPin.coordinates.x,
+        y: imgPoint.y - clickedPin.coordinates.y,
+      },
+    };
+
+    return clickedPin;
+  }
+
+  selectAt(viewportPoint: Point) {
+    const clickedPin = findClickedPin(
+      this.deps.getPins(),
+      this.deps.project,
+      viewportPoint.x,
+      viewportPoint.y,
+    );
+
+    if (clickedPin?.entityId) {
+      this.deps.selectEntity(clickedPin.entityId);
+    }
+
+    return clickedPin;
+  }
+
+  move(viewportPoint: Point, mouseDownPoint: Point) {
+    if (!this.dragState) return false;
+
+    if (this.deps.canEditPins()) {
+      const dist = Math.hypot(
+        viewportPoint.x - mouseDownPoint.x,
+        viewportPoint.y - mouseDownPoint.y,
+      );
+      if (dist >= 5) {
+        this.dragState.hasMoved = true;
+      }
+
+      if (this.dragState.hasMoved) {
+        const imgPoint = this.deps.unproject(viewportPoint);
+        this.deps.updatePinCoordinates(this.dragState.pinId, {
+          x: imgPoint.x - this.dragState.offset.x,
+          y: imgPoint.y - this.dragState.offset.y,
+        });
+      }
+    }
+
+    return true;
+  }
+
+  async end(mouseDownPoint: Point, mouseUpPoint: Point): Promise<PinEndResult> {
+    if (!this.dragState) return { type: "none" };
+
+    const { pinId, originalCoordinates, hasMoved } = this.dragState;
+    this.dragState = null;
+
+    if (isClickGesture(mouseDownPoint, mouseUpPoint)) {
+      if (originalCoordinates && this.deps.canEditPins()) {
+        this.deps.updatePinCoordinates(pinId, originalCoordinates);
+      }
+
+      const pin = this.deps
+        .getPins()
+        .find((candidate) => candidate.id === pinId);
+      if (pin?.entityId) {
+        this.deps.selectEntity(pin.entityId);
+      }
+      return { type: "selected", pinId };
+    }
+
+    if (hasMoved && this.deps.canEditPins()) {
+      await this.deps.saveMaps();
+    }
+    return { type: "dragged", pinId };
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/token-drag-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/token-drag-handler.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Token } from "../../../../types/vtt";
+import { TokenDragHandler } from "./token-drag-handler";
+
+function token(input: Partial<Token> & { id: string; x: number; y: number }) {
+  return {
+    entityId: null,
+    name: input.id,
+    width: 50,
+    height: 50,
+    rotation: 0,
+    zIndex: 0,
+    ownerPeerId: null,
+    ownerGuestName: null,
+    visibleTo: "all",
+    color: "#fff",
+    imageUrl: null,
+    statusEffects: [],
+    ...input,
+  } satisfies Token;
+}
+
+describe("TokenDragHandler", () => {
+  const tokens = [token({ id: "token-a", x: 10, y: 20 })];
+  let isHost = true;
+  let canMoveToken: ReturnType<typeof vi.fn>;
+  let moveToken: ReturnType<typeof vi.fn>;
+  let requestTokenMove: ReturnType<typeof vi.fn>;
+  let sendTokenMoveRequest: ReturnType<typeof vi.fn>;
+  let confirmTokenMove: ReturnType<typeof vi.fn>;
+  let setDraggingTokenId: ReturnType<typeof vi.fn>;
+  let handler: TokenDragHandler;
+
+  beforeEach(() => {
+    isHost = true;
+    canMoveToken = vi.fn(() => true);
+    moveToken = vi.fn();
+    requestTokenMove = vi.fn();
+    sendTokenMoveRequest = vi.fn();
+    confirmTokenMove = vi.fn();
+    setDraggingTokenId = vi.fn();
+    handler = new TokenDragHandler({
+      getTokens: () => tokens,
+      project: (point) => point,
+      unproject: (point) => point,
+      isHostMode: () => isHost,
+      getPeerId: () => "peer-a",
+      canMoveToken,
+      moveToken,
+      requestTokenMove,
+      sendTokenMoveRequest,
+      confirmTokenMove,
+      setDraggingTokenId,
+    });
+  });
+
+  it("starts dragging a movable token and records the image-space offset", () => {
+    const hit = handler.begin({ x: 20, y: 30 });
+
+    expect(hit?.id).toBe("token-a");
+    expect(handler.dragState).toEqual({
+      tokenId: "token-a",
+      offset: { x: 10, y: 10 },
+    });
+    expect(setDraggingTokenId).toHaveBeenCalledWith("token-a");
+  });
+
+  it("does not start dragging when the token is not movable", () => {
+    canMoveToken.mockReturnValue(false);
+
+    const hit = handler.begin({ x: 20, y: 30 });
+
+    expect(hit).toBeNull();
+    expect(handler.dragState).toBeNull();
+    expect(setDraggingTokenId).not.toHaveBeenCalled();
+  });
+
+  it("moves host tokens directly", () => {
+    handler.begin({ x: 20, y: 30 });
+    handler.move({ x: 40, y: 60 });
+
+    expect(moveToken).toHaveBeenCalledWith("token-a", 30, 50);
+    expect(requestTokenMove).not.toHaveBeenCalled();
+    expect(sendTokenMoveRequest).not.toHaveBeenCalled();
+  });
+
+  it("optimistically moves guest tokens and sends a P2P request", () => {
+    isHost = false;
+
+    handler.begin({ x: 20, y: 30 });
+    handler.move({ x: 40, y: 60 });
+
+    expect(requestTokenMove).toHaveBeenCalledWith("token-a", 30, 50, true);
+    expect(sendTokenMoveRequest).toHaveBeenCalledWith("token-a", 30, 50);
+    expect(moveToken).not.toHaveBeenCalled();
+  });
+
+  it("confirms guest moves on drag end", () => {
+    isHost = false;
+
+    handler.begin({ x: 20, y: 30 });
+    expect(handler.end()).toBe(true);
+
+    expect(confirmTokenMove).toHaveBeenCalledWith("token-a");
+    expect(setDraggingTokenId).toHaveBeenLastCalledWith(null);
+    expect(handler.dragState).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/token-drag-handler.ts
+++ b/apps/web/src/lib/components/map/interactions/token-drag-handler.ts
@@ -1,0 +1,95 @@
+import type { Point } from "schema";
+import type { Token } from "../../../../types/vtt";
+import { hitTestToken } from "$lib/utils/vtt-helpers";
+
+export interface TokenDragDependencies {
+  getTokens: () => Token[];
+  project: (point: Point) => Point;
+  unproject: (point: Point) => Point;
+  isHostMode: () => boolean;
+  getPeerId: () => string | null;
+  canMoveToken: (
+    tokenId: string,
+    peerId: string | null,
+    isHost: boolean,
+  ) => boolean;
+  moveToken: (tokenId: string, x: number, y: number) => void;
+  requestTokenMove: (
+    tokenId: string,
+    x: number,
+    y: number,
+    persistent: boolean,
+  ) => void;
+  sendTokenMoveRequest: (tokenId: string, x: number, y: number) => void;
+  confirmTokenMove: (tokenId: string) => void;
+  setDraggingTokenId: (tokenId: string | null) => void;
+}
+
+export interface TokenDragState {
+  tokenId: string;
+  offset: Point;
+}
+
+export class TokenDragHandler {
+  dragState: TokenDragState | null = null;
+
+  constructor(private deps: TokenDragDependencies) {}
+
+  begin(viewportPoint: Point) {
+    const hitToken = hitTestToken(
+      this.deps.getTokens(),
+      this.deps.project,
+      viewportPoint.x,
+      viewportPoint.y,
+    );
+
+    if (
+      !hitToken ||
+      !this.deps.canMoveToken(
+        hitToken.id,
+        this.deps.getPeerId(),
+        this.deps.isHostMode(),
+      )
+    ) {
+      return null;
+    }
+
+    const imgPoint = this.deps.unproject(viewportPoint);
+    this.dragState = {
+      tokenId: hitToken.id,
+      offset: {
+        x: imgPoint.x - hitToken.x,
+        y: imgPoint.y - hitToken.y,
+      },
+    };
+    this.deps.setDraggingTokenId(hitToken.id);
+    return hitToken;
+  }
+
+  move(viewportPoint: Point) {
+    if (!this.dragState) return false;
+
+    const imgPoint = this.deps.unproject(viewportPoint);
+    const nextX = imgPoint.x - this.dragState.offset.x;
+    const nextY = imgPoint.y - this.dragState.offset.y;
+
+    if (this.deps.isHostMode()) {
+      this.deps.moveToken(this.dragState.tokenId, nextX, nextY);
+    } else {
+      this.deps.requestTokenMove(this.dragState.tokenId, nextX, nextY, true);
+      this.deps.sendTokenMoveRequest(this.dragState.tokenId, nextX, nextY);
+    }
+
+    return true;
+  }
+
+  end() {
+    if (!this.dragState) return false;
+    if (!this.deps.isHostMode()) {
+      this.deps.confirmTokenMove(this.dragState.tokenId);
+    }
+    this.deps.setDraggingTokenId(null);
+    this.dragState = null;
+    return true;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/token-resize-handler.test.ts
+++ b/apps/web/src/lib/components/map/interactions/token-resize-handler.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Token } from "../../../../types/vtt";
+import { TokenResizeHandler } from "./token-resize-handler";
+import { TokenSelectionManager } from "./token-selection-manager";
+
+function token(input: Partial<Token> & { id: string; x: number; y: number }) {
+  return {
+    entityId: null,
+    name: input.id,
+    width: 50,
+    height: 50,
+    rotation: 0,
+    zIndex: 0,
+    ownerPeerId: null,
+    ownerGuestName: null,
+    visibleTo: "all",
+    color: "#fff",
+    imageUrl: null,
+    statusEffects: [],
+    ...input,
+  } satisfies Token;
+}
+
+describe("TokenResizeHandler", () => {
+  let tokens: Token[];
+  let updateToken: ReturnType<typeof vi.fn>;
+  let handler: TokenResizeHandler;
+
+  beforeEach(() => {
+    tokens = [token({ id: "token-a", x: 10, y: 10, width: 50, height: 50 })];
+    updateToken = vi.fn();
+    const tokenSelection = new TokenSelectionManager({
+      getTokens: () => tokens,
+      project: (point) => point,
+      getSelectedTokens: () => new Set(),
+      setSelection: vi.fn(),
+      addToSelection: vi.fn(),
+      removeFromSelection: vi.fn(),
+      setMultiSelection: vi.fn(),
+    });
+    handler = new TokenResizeHandler({
+      tokenSelection,
+      getGridSize: () => 50,
+      updateToken,
+    });
+  });
+
+  it("resizes the token under the pointer by one grid step", () => {
+    expect(handler.resizeAt({ x: 20, y: 20 }, -100)).toBe(true);
+
+    expect(updateToken).toHaveBeenCalledWith("token-a", {
+      width: 100,
+      height: 100,
+    });
+  });
+
+  it("returns false when no token is under the pointer", () => {
+    expect(handler.resizeAt({ x: 500, y: 500 }, -100)).toBe(false);
+
+    expect(updateToken).not.toHaveBeenCalled();
+  });
+
+  it("does not update when the token is already at the minimum scale", () => {
+    expect(handler.resizeAt({ x: 20, y: 20 }, 100)).toBe(true);
+
+    expect(updateToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/token-resize-handler.ts
+++ b/apps/web/src/lib/components/map/interactions/token-resize-handler.ts
@@ -1,0 +1,34 @@
+import type { Point } from "schema";
+import type { TokenStateUpdateInput } from "../../../../types/vtt";
+import type { TokenSelectionManager } from "./token-selection-manager";
+
+export interface TokenResizeDependencies {
+  tokenSelection: TokenSelectionManager;
+  getGridSize: () => number;
+  updateToken: (tokenId: string, updates: TokenStateUpdateInput) => void;
+}
+
+export class TokenResizeHandler {
+  constructor(private deps: TokenResizeDependencies) {}
+
+  resizeAt(viewportPoint: Point, deltaY: number) {
+    const hitToken = this.deps.tokenSelection.hitTest(viewportPoint);
+    if (!hitToken) return false;
+
+    const gridSize = this.deps.getGridSize() || 50;
+    const currentScale = Math.round(hitToken.width / gridSize);
+    const nextScale = Math.max(
+      1,
+      Math.min(4, currentScale + (deltaY < 0 ? 1 : -1)),
+    );
+
+    if (nextScale !== currentScale) {
+      this.deps.updateToken(hitToken.id, {
+        width: nextScale * gridSize,
+        height: nextScale * gridSize,
+      });
+    }
+
+    return true;
+  }
+}

--- a/apps/web/src/lib/components/map/interactions/token-selection-manager.test.ts
+++ b/apps/web/src/lib/components/map/interactions/token-selection-manager.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Token } from "../../../../types/vtt";
+import { TokenSelectionManager } from "./token-selection-manager";
+
+function token(input: Partial<Token> & { id: string; x: number; y: number }) {
+  return {
+    entityId: null,
+    name: input.id,
+    width: 50,
+    height: 50,
+    rotation: 0,
+    zIndex: 0,
+    ownerPeerId: null,
+    ownerGuestName: null,
+    visibleTo: "all",
+    color: "#fff",
+    imageUrl: null,
+    statusEffects: [],
+    ...input,
+  } satisfies Token;
+}
+
+describe("TokenSelectionManager", () => {
+  const tokens = [
+    token({ id: "token-a", x: 10, y: 10, zIndex: 1 }),
+    token({ id: "token-b", x: 100, y: 100, zIndex: 2 }),
+  ];
+  let selectedTokens: Set<string>;
+  let setSelection: ReturnType<typeof vi.fn>;
+  let addToSelection: ReturnType<typeof vi.fn>;
+  let removeFromSelection: ReturnType<typeof vi.fn>;
+  let setMultiSelection: ReturnType<typeof vi.fn>;
+  let manager: TokenSelectionManager;
+
+  beforeEach(() => {
+    selectedTokens = new Set();
+    setSelection = vi.fn();
+    addToSelection = vi.fn((tokenId: string) => selectedTokens.add(tokenId));
+    removeFromSelection = vi.fn((tokenId: string) =>
+      selectedTokens.delete(tokenId),
+    );
+    setMultiSelection = vi.fn();
+    manager = new TokenSelectionManager({
+      getTokens: () => tokens,
+      project: (point) => point,
+      getSelectedTokens: () => selectedTokens,
+      setSelection,
+      addToSelection,
+      removeFromSelection,
+      setMultiSelection,
+    });
+  });
+
+  it("selects a token without modifiers", () => {
+    manager.applyModifierSelection("token-a", {});
+
+    expect(setSelection).toHaveBeenCalledWith("token-a");
+    expect(addToSelection).not.toHaveBeenCalled();
+    expect(removeFromSelection).not.toHaveBeenCalled();
+  });
+
+  it("adds a token with ctrl or meta without replacing selection", () => {
+    manager.applyModifierSelection("token-a", { ctrlKey: true });
+
+    expect(addToSelection).toHaveBeenCalledWith("token-a");
+    expect(setSelection).not.toHaveBeenCalled();
+  });
+
+  it("toggles a selected token off with shift", () => {
+    selectedTokens.add("token-a");
+
+    manager.applyModifierSelection("token-a", { shiftKey: true });
+
+    expect(removeFromSelection).toHaveBeenCalledWith("token-a");
+    expect(addToSelection).not.toHaveBeenCalled();
+  });
+
+  it("toggles an unselected token on with shift", () => {
+    manager.applyModifierSelection("token-a", { shiftKey: true });
+
+    expect(addToSelection).toHaveBeenCalledWith("token-a");
+    expect(removeFromSelection).not.toHaveBeenCalled();
+  });
+
+  it("selects tokens inside a box only when the box exceeds the area threshold", () => {
+    expect(manager.selectWithinBox({ x: 0, y: 0 }, { x: 5, y: 5 })).toBe(false);
+    expect(setMultiSelection).not.toHaveBeenCalled();
+
+    expect(manager.selectWithinBox({ x: 0, y: 0 }, { x: 120, y: 120 })).toBe(
+      true,
+    );
+    expect(setMultiSelection).toHaveBeenCalledWith(["token-a", "token-b"]);
+  });
+});

--- a/apps/web/src/lib/components/map/interactions/token-selection-manager.ts
+++ b/apps/web/src/lib/components/map/interactions/token-selection-manager.ts
@@ -1,0 +1,82 @@
+import type { Point } from "schema";
+import type { Token } from "../../../../types/vtt";
+import { hitTestToken } from "$lib/utils/vtt-helpers";
+
+export interface TokenSelectionDependencies {
+  getTokens: () => Token[];
+  project: (point: Point) => Point;
+  getSelectedTokens: () => ReadonlySet<string>;
+  setSelection: (tokenId: string | null) => void;
+  addToSelection: (tokenId: string) => void;
+  removeFromSelection: (tokenId: string) => void;
+  setMultiSelection: (tokenIds: string[]) => void;
+}
+
+export class TokenSelectionManager {
+  constructor(private deps: TokenSelectionDependencies) {}
+
+  hitTest(point: Point) {
+    return hitTestToken(
+      this.deps.getTokens(),
+      this.deps.project,
+      point.x,
+      point.y,
+    );
+  }
+
+  applyModifierSelection(
+    tokenId: string,
+    modifiers: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean },
+  ) {
+    if (modifiers.ctrlKey || modifiers.metaKey) {
+      this.deps.addToSelection(tokenId);
+      return;
+    }
+
+    if (modifiers.shiftKey) {
+      if (this.deps.getSelectedTokens().has(tokenId)) {
+        this.deps.removeFromSelection(tokenId);
+      } else {
+        this.deps.addToSelection(tokenId);
+      }
+      return;
+    }
+
+    this.deps.setSelection(tokenId);
+  }
+
+  selectToken(tokenId: string) {
+    this.deps.setSelection(tokenId);
+  }
+
+  clearSelection() {
+    this.deps.setSelection(null);
+  }
+
+  selectWithinBox(start: Point, end: Point, minArea = 100) {
+    const x1 = Math.min(start.x, end.x);
+    const y1 = Math.min(start.y, end.y);
+    const x2 = Math.max(start.x, end.x);
+    const y2 = Math.max(start.y, end.y);
+
+    if ((x2 - x1) * (y2 - y1) <= minArea) {
+      return false;
+    }
+
+    const selected: string[] = [];
+    for (const token of this.deps.getTokens()) {
+      const projected = this.deps.project({ x: token.x, y: token.y });
+      if (
+        projected.x >= x1 &&
+        projected.x <= x2 &&
+        projected.y >= y1 &&
+        projected.y <= y2
+      ) {
+        selected.push(token.id);
+      }
+    }
+
+    this.deps.setMultiSelection(selected);
+    return true;
+  }
+}

--- a/apps/web/src/lib/components/map/map-interactions.svelte.ts
+++ b/apps/web/src/lib/components/map/map-interactions.svelte.ts
@@ -1,50 +1,59 @@
 import { mapStore } from "../../stores/map.svelte";
 import { mapSession } from "../../stores/map-session.svelte";
-import { vault } from "../../stores/vault.svelte";
-import { p2pGuestService } from "../../cloud-bridge/p2p/guest-service";
-import { p2pHost } from "../../cloud-bridge/p2p/host-service.svelte";
-import { hitTestToken } from "$lib/utils/vtt-helpers";
 import {
-  findClickedPin,
   getKeyboardViewportUpdate,
   getZoomViewportUpdate,
   isClickGesture,
   shouldIgnoreMapKeyboardEvent,
 } from "./map-view-helpers";
 import type { MapFogPainter } from "./map-fog-painter";
-import { notificationStore } from "$lib/stores/ui/notification.svelte";
+import {
+  createMapInteractionHandlers,
+  type MapInteractionHandlerOverrides,
+  type MapInteractionHandlers,
+} from "./interactions/map-interaction-handler-factory";
 import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
 
 export class MapInteractionManager {
   painter: MapFogPainter;
   getContainer: () => HTMLElement | null;
+  tokenSelection!: MapInteractionHandlers["tokenSelection"];
+  tokenDrag!: MapInteractionHandlers["tokenDrag"];
+  pinInteractions!: MapInteractionHandlers["pinInteractions"];
+  gridInteractions!: MapInteractionHandlers["gridInteractions"];
+  measurementInteractions!: MapInteractionHandlers["measurementInteractions"];
+  contextMenuInteractions!: MapInteractionHandlers["contextMenuInteractions"];
+  tokenResize!: MapInteractionHandlers["tokenResize"];
+  boxSelection!: MapInteractionHandlers["boxSelection"];
+  fogInteractions!: MapInteractionHandlers["fogInteractions"];
+  creationInteractions!: MapInteractionHandlers["creationInteractions"];
 
   isPanning = $state(false);
   lastMousePos = $state({ x: 0, y: 0 });
   mouseDownPos = { x: 0, y: 0 };
   isAltPressed = $state(false);
   isPointerOver = $state(false);
-  gridFitStart = $state<{ x: number; y: number } | null>(null);
-  gridFitEnd = $state<{ x: number; y: number } | null>(null);
-  boxSelectStart = $state<{ x: number; y: number } | null>(null);
-  boxSelectEnd = $state<{ x: number; y: number } | null>(null);
-  dragState = $state<{
-    tokenId: string;
-    offset: { x: number; y: number };
-  } | null>(null);
-  pinDragState = $state<{
-    pinId: string;
-    originalCoordinates?: { x: number; y: number };
-    hasMoved?: boolean;
-    offset: { x: number; y: number };
-  } | null>(null);
-  contextMenu = $state<{
-    x: number;
-    y: number;
-    imgX: number;
-    imgY: number;
-    tokenId?: string;
-  } | null>(null);
+  get gridFitStart() {
+    return this.gridInteractions.gridFitStart;
+  }
+  get gridFitEnd() {
+    return this.gridInteractions.gridFitEnd;
+  }
+  get boxSelectStart() {
+    return this.boxSelection.start;
+  }
+  get boxSelectEnd() {
+    return this.boxSelection.end;
+  }
+  get pinDragState() {
+    return this.pinInteractions.dragState;
+  }
+  get contextMenu() {
+    return this.contextMenuInteractions.contextMenu;
+  }
+  set contextMenu(value) {
+    this.contextMenuInteractions.contextMenu = value;
+  }
   selectedPinId = $state<string | null>(null);
   mapAnnouncement = $state("");
 
@@ -54,12 +63,15 @@ export class MapInteractionManager {
 
   visualBrushRadius = $derived(mapStore.brushRadius * mapStore.viewport.zoom);
 
-  constructor(opts: {
-    painter: MapFogPainter;
-    getContainer: () => HTMLElement | null;
-  }) {
+  constructor(
+    opts: {
+      painter: MapFogPainter;
+      getContainer: () => HTMLElement | null;
+    } & MapInteractionHandlerOverrides,
+  ) {
     this.painter = opts.painter;
     this.getContainer = opts.getContainer;
+    Object.assign(this, createMapInteractionHandlers(this.painter, opts));
   }
 
   updateCachedRect() {
@@ -94,35 +106,19 @@ export class MapInteractionManager {
   };
 
   onGlobalKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Enter" && mapSession.gridMoveMode) {
+    if (event.key === "Enter" && this.gridInteractions.commitGridMove()) {
       event.preventDefault();
-      const viewport = mapStore.viewport;
-      const canvasSize = mapStore.canvasSize;
-      mapStore.gridOffsetX =
-        -((viewport.pan.x + canvasSize.width / 2) / viewport.zoom) %
-        mapStore.gridSize;
-      mapStore.gridOffsetY =
-        -((viewport.pan.y + canvasSize.height / 2) / viewport.zoom) %
-        mapStore.gridSize;
-      mapSession.gridMoveMode = false;
-      notificationStore.clearNotification();
       return;
     }
     if (event.key === "Escape") {
-      if (mapSession.gridMoveMode) {
-        mapSession.gridMoveMode = false;
-        notificationStore.clearNotification();
+      if (this.gridInteractions.cancelGridMove()) {
         return;
       }
-      if (mapSession.gridFitMode) {
-        mapSession.gridFitMode = false;
-        this.gridFitStart = null;
-        this.gridFitEnd = null;
+      if (this.gridInteractions.cancelGridFit()) {
         return;
       }
       if (this.boxSelectStart) {
-        this.boxSelectStart = null;
-        this.boxSelectEnd = null;
+        this.boxSelection.clear();
         return;
       }
       if (mapSession.selectedTokens.size > 1) {
@@ -137,7 +133,7 @@ export class MapInteractionManager {
   };
 
   onMouseDown = (e: MouseEvent) => {
-    this.contextMenu = null;
+    this.contextMenuInteractions.clear();
     this.updateCachedRect();
     if (this.cachedRect) {
       this.lastMousePos = {
@@ -148,104 +144,55 @@ export class MapInteractionManager {
     this.mouseDownPos = { x: e.clientX, y: e.clientY };
     this.isAltPressed = e.altKey;
 
-    if (
-      mapStore.isGMMode &&
-      (e.ctrlKey || e.metaKey) &&
-      mapSession.vttEnabled &&
-      this.cachedRect
-    ) {
+    if (this.cachedRect && this.boxSelection.begin(this.lastMousePos, e)) {
       e.preventDefault();
-      this.boxSelectStart = { x: this.lastMousePos.x, y: this.lastMousePos.y };
-      this.boxSelectEnd = this.boxSelectStart;
       this.isPanning = false;
       return;
     }
 
     if (mapSession.vttEnabled && this.cachedRect) {
-      const hitToken = hitTestToken(
-        mapSession.allTokens,
-        (point) => mapStore.project(point),
-        this.lastMousePos.x,
-        this.lastMousePos.y,
-      );
+      const hitToken = this.tokenDrag.begin(this.lastMousePos);
 
-      if (
-        hitToken &&
-        mapSession.canMoveToken(
-          hitToken.id,
-          p2pGuestService.peerId,
-          mapStore.isGMMode,
-        )
-      ) {
-        const imgPoint = mapStore.unproject(this.lastMousePos);
-        this.dragState = {
-          tokenId: hitToken.id,
-          offset: {
-            x: imgPoint.x - hitToken.x,
-            y: imgPoint.y - hitToken.y,
-          },
-        };
-        mapSession.draggingTokenId = hitToken.id;
-        if (e.ctrlKey || e.metaKey) {
-          mapSession.addToSelection(hitToken.id);
-        } else if (e.shiftKey) {
-          if (mapSession.selectedTokens.has(hitToken.id)) {
-            mapSession.removeFromSelection(hitToken.id);
-          } else {
-            mapSession.addToSelection(hitToken.id);
-          }
-        } else {
-          mapSession.setSelection(hitToken.id);
-        }
+      if (hitToken) {
+        this.tokenSelection.applyModifierSelection(hitToken.id, e);
         this.isPanning = false;
         return;
       }
     }
 
     if (this.cachedRect && e.button === 0 && !e.altKey) {
-      const clickedPin = findClickedPin(
-        mapStore.pins,
-        (point) => mapStore.project(point),
-        this.lastMousePos.x,
-        this.lastMousePos.y,
-      );
+      const clickedPin = this.pinInteractions.begin(this.lastMousePos);
 
       if (clickedPin) {
-        const imgPoint = mapStore.unproject(this.lastMousePos);
-        this.pinDragState = {
-          pinId: clickedPin.id,
-          originalCoordinates: { ...clickedPin.coordinates },
-          hasMoved: false,
-          offset: {
-            x: imgPoint.x - clickedPin.coordinates.x,
-            y: imgPoint.y - clickedPin.coordinates.y,
-          },
-        };
         this.isPanning = false;
         return;
       }
     }
 
-    if (mapSession.gridMoveMode && mapStore.isGMMode && this.cachedRect) {
+    if (this.cachedRect && this.gridInteractions.shouldStartGridMove()) {
       e.preventDefault();
       e.stopPropagation();
       this.isPanning = true;
       return;
     }
 
-    if (mapSession.gridFitMode && mapStore.isGMMode && this.cachedRect) {
+    if (
+      this.cachedRect &&
+      this.gridInteractions.startGridFit(this.lastMousePos)
+    ) {
       e.preventDefault();
       e.stopPropagation();
-      this.gridFitStart = { x: this.lastMousePos.x, y: this.lastMousePos.y };
-      this.gridFitEnd = this.gridFitStart;
       return;
     }
 
-    if (mapStore.isGMMode && e.altKey) {
-      this.painter.begin(
+    if (
+      e.altKey &&
+      this.fogInteractions.begin(
         { x: this.lastMousePos.x, y: this.lastMousePos.y },
         e.shiftKey || e.ctrlKey || e.metaKey,
-      );
+      )
+    ) {
+      return;
     } else if (e.button === 0) {
       this.isPanning = true;
     }
@@ -260,68 +207,45 @@ export class MapInteractionManager {
     this.isAltPressed = e.altKey;
 
     if (this.boxSelectStart) {
-      this.boxSelectEnd = { x: mouseX, y: mouseY };
+      this.boxSelection.update({ x: mouseX, y: mouseY });
       this.lastMousePos = { x: mouseX, y: mouseY };
       return;
     }
 
-    if (this.dragState) {
-      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
-      const nextX = imgPoint.x - this.dragState.offset.x;
-      const nextY = imgPoint.y - this.dragState.offset.y;
-      if (mapStore.isGMMode) {
-        mapSession.moveToken(this.dragState.tokenId, nextX, nextY);
-      } else {
-        mapSession.requestTokenMove(this.dragState.tokenId, nextX, nextY, true);
-        p2pGuestService.requestTokenMove(this.dragState.tokenId, nextX, nextY);
-      }
+    if (this.tokenDrag.dragState) {
+      this.tokenDrag.move({ x: mouseX, y: mouseY });
       this.lastMousePos = { x: mouseX, y: mouseY };
       return;
     }
 
     if (this.pinDragState) {
-      if (mapStore.isGMMode && !sessionModeStore.isGuestMode) {
-        const dist = Math.sqrt(
-          Math.pow(mouseX - this.mouseDownPos.x, 2) +
-            Math.pow(mouseY - this.mouseDownPos.y, 2),
-        );
-        if (dist >= 5) {
-          this.pinDragState.hasMoved = true;
-        }
-
-        if (this.pinDragState.hasMoved) {
-          const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
-          const nextX = imgPoint.x - this.pinDragState.offset.x;
-          const nextY = imgPoint.y - this.pinDragState.offset.y;
-          mapStore.updatePinCoordinatesInMemory(this.pinDragState.pinId, {
-            x: nextX,
-            y: nextY,
-          });
-        }
-      }
+      this.pinInteractions.move(
+        { x: mouseX, y: mouseY },
+        { x: this.mouseDownPos.x, y: this.mouseDownPos.y },
+      );
       this.lastMousePos = { x: mouseX, y: mouseY };
       return;
     }
 
     if (this.gridFitStart) {
-      this.gridFitEnd = { x: mouseX, y: mouseY };
+      this.gridInteractions.updateGridFit({ x: mouseX, y: mouseY });
       this.lastMousePos = { x: mouseX, y: mouseY };
       return;
     }
 
-    if (this.painter.isPainting) {
-      this.painter.move(
+    if (
+      this.fogInteractions.move(
         { x: mouseX, y: mouseY },
         e.shiftKey || e.ctrlKey || e.metaKey,
-      );
-    } else if (
-      mapSession.measurement.active &&
-      mapSession.measurement.start &&
-      !mapSession.measurement.locked
+      )
     ) {
-      const imgPoint = mapStore.unproject({ x: mouseX, y: mouseY });
-      mapSession.setMeasurementEnd(imgPoint, true);
-    } else if (this.isPanning && !this.isAltPressed) {
+      this.lastMousePos = { x: mouseX, y: mouseY };
+      return;
+    } else if (
+      !this.measurementInteractions.updateLiveEnd({ x: mouseX, y: mouseY }) &&
+      this.isPanning &&
+      !this.isAltPressed
+    ) {
       const dx = mouseX - this.lastMousePos.x;
       const dy = mouseY - this.lastMousePos.y;
       mapStore.updateViewport(
@@ -342,109 +266,32 @@ export class MapInteractionManager {
   };
 
   onMouseUp = async (e: MouseEvent) => {
-    if (this.painter.isPainting) {
-      const finished = await this.painter.finish();
-      if (
-        finished &&
-        mapStore.isGMMode &&
-        !sessionModeStore.isGuestMode &&
-        mapSession.vttEnabled
-      ) {
-        void p2pHost.broadcastActiveMapFogSync();
-      }
-    }
+    await this.fogInteractions.finish();
 
-    if (this.boxSelectStart && this.boxSelectEnd && this.cachedRect) {
-      const allTokens = mapSession.allTokens;
-      const x1 = Math.min(this.boxSelectStart.x, this.boxSelectEnd.x);
-      const y1 = Math.min(this.boxSelectStart.y, this.boxSelectEnd.y);
-      const x2 = Math.max(this.boxSelectStart.x, this.boxSelectEnd.x);
-      const y2 = Math.max(this.boxSelectStart.y, this.boxSelectEnd.y);
-      const minArea = 100;
-
-      if ((x2 - x1) * (y2 - y1) > minArea) {
-        const selected: string[] = [];
-        for (const token of allTokens) {
-          const projected = mapStore.project({ x: token.x, y: token.y });
-          if (
-            projected.x >= x1 &&
-            projected.x <= x2 &&
-            projected.y >= y1 &&
-            projected.y <= y2
-          ) {
-            selected.push(token.id);
-          }
-        }
-        mapSession.setMultiSelection(selected);
-      }
-
-      this.boxSelectStart = null;
-      this.boxSelectEnd = null;
+    if (this.boxSelection.commit()) {
       return;
     }
 
-    if (this.dragState) {
-      if (!mapStore.isGMMode) {
-        mapSession.confirmTokenMove(this.dragState.tokenId);
-      }
-      mapSession.draggingTokenId = null;
-      this.dragState = null;
+    if (this.tokenDrag.dragState) {
+      this.tokenDrag.end();
       this.isPanning = false;
       return;
     }
 
     if (this.pinDragState) {
-      const pinId = this.pinDragState.pinId;
-      const originalCoordinates = this.pinDragState.originalCoordinates;
-      const hasMoved = this.pinDragState.hasMoved;
-      this.pinDragState = null;
-
-      const clickGesture = isClickGesture(
+      const result = await this.pinInteractions.end(
         { x: this.mouseDownPos.x, y: this.mouseDownPos.y },
         { x: e.clientX, y: e.clientY },
       );
 
-      if (clickGesture) {
-        if (
-          originalCoordinates &&
-          mapStore.isGMMode &&
-          !sessionModeStore.isGuestMode
-        ) {
-          mapStore.updatePinCoordinatesInMemory(pinId, originalCoordinates);
-        }
-        this.selectedPinId = pinId;
-        const pin = mapStore.pins.find((p) => p.id === pinId);
-        if (pin && pin.entityId) {
-          vault.selectedEntityId = pin.entityId;
-        }
-      } else {
-        if (hasMoved && mapStore.isGMMode && !sessionModeStore.isGuestMode) {
-          await vault.saveMaps();
-        }
+      if (result.type === "selected") {
+        this.selectedPinId = result.pinId;
       }
       this.isPanning = false;
       return;
     }
 
-    if (this.gridFitStart && this.gridFitEnd && this.cachedRect) {
-      const startImg = mapStore.unproject(this.gridFitStart);
-      const endImg = mapStore.unproject(this.gridFitEnd);
-      const imgWidth = Math.abs(endImg.x - startImg.x);
-      const imgHeight = Math.abs(endImg.y - startImg.y);
-
-      if (imgWidth >= 5 || imgHeight >= 5) {
-        const cellSize = Math.round(Math.max(imgWidth, imgHeight));
-        mapStore.gridSize = cellSize;
-        const gridMinX = Math.min(startImg.x, endImg.x);
-        const gridMinY = Math.min(startImg.y, endImg.y);
-        mapStore.gridOffsetX = -(gridMinX % cellSize);
-        mapStore.gridOffsetY = -(gridMinY % cellSize);
-      }
-
-      this.gridFitStart = null;
-      this.gridFitEnd = null;
-      mapSession.gridFitMode = false;
-      mapSession.showGridSettings = true;
+    if (this.gridInteractions.commitGridFit()) {
       return;
     }
 
@@ -469,77 +316,43 @@ export class MapInteractionManager {
     const y = e.clientY - rect.top;
 
     if (mapSession.vttEnabled) {
-      const hitToken = hitTestToken(
-        mapSession.allTokens,
-        (point) => mapStore.project(point),
-        x,
-        y,
-      );
+      const hitToken = this.tokenSelection.hitTest({ x, y });
 
       if (hitToken) {
-        mapSession.setSelection(hitToken.id);
+        this.tokenSelection.selectToken(hitToken.id);
         this.selectedPinId = null;
         return;
       }
 
-      mapSession.setSelection(null);
-      if (mapSession.measurement.active) {
-        const imgCoords = mapStore.unproject({ x, y });
-        if (!mapSession.measurement.start) {
-          mapSession.setMeasurementStart(imgCoords);
-        } else if (!mapSession.measurement.locked) {
-          mapSession.setMeasurementEnd(imgCoords);
-          mapSession.setMeasurementLocked(true);
-        } else {
-          mapSession.setMeasurementStart(imgCoords);
-        }
-      }
+      this.tokenSelection.clearSelection();
+      this.measurementInteractions.handleClick({ x, y });
       return;
     }
 
-    const clickedPin = findClickedPin(
-      mapStore.pins,
-      (point) => mapStore.project(point),
-      x,
-      y,
-    );
+    const clickedPin = this.pinInteractions.selectAt({ x, y });
 
     if (clickedPin) {
       this.selectedPinId = clickedPin.id;
-      if (clickedPin.entityId) {
-        vault.selectedEntityId = clickedPin.entityId;
-      }
     } else {
       this.selectedPinId = null;
     }
   };
 
   onDoubleClick = (e: MouseEvent) => {
-    this.contextMenu = null;
+    this.contextMenuInteractions.clear();
     const el = this.getContainer();
     if (!el) return;
 
     const rect = el.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-
-    const imgCoords = mapStore.unproject({ x, y });
-    if (
-      mapSession.vttEnabled &&
-      mapStore.isGMMode &&
-      !sessionModeStore.isGuestMode
-    ) {
-      mapSession.pendingTokenCoords = imgCoords;
-    } else if (!mapSession.vttEnabled) {
-      mapStore.pendingPinCoords = imgCoords;
-    }
+    this.creationInteractions.handleDoubleClick({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    });
   };
 
   onContextMenu = (e: MouseEvent) => {
     if (this.gridFitStart) {
-      this.gridFitStart = null;
-      this.gridFitEnd = null;
-      mapSession.gridFitMode = false;
+      this.gridInteractions.cancelGridFit();
       return;
     }
 
@@ -551,21 +364,7 @@ export class MapInteractionManager {
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
 
-    const hitToken = hitTestToken(
-      mapSession.allTokens,
-      (point) => mapStore.project(point),
-      x,
-      y,
-    );
-
-    const imgCoords = mapStore.unproject({ x, y });
-    this.contextMenu = {
-      x: e.clientX,
-      y: e.clientY,
-      imgX: imgCoords.x,
-      imgY: imgCoords.y,
-      tokenId: hitToken?.id,
-    };
+    this.contextMenuInteractions.open({ x: e.clientX, y: e.clientY }, { x, y });
   };
 
   onWheel = (e: WheelEvent) => {
@@ -583,25 +382,7 @@ export class MapInteractionManager {
       const mouseX = e.clientX - rect.left;
       const mouseY = e.clientY - rect.top;
 
-      const hitToken = hitTestToken(
-        mapSession.allTokens,
-        (point) => mapStore.project(point),
-        mouseX,
-        mouseY,
-      );
-
-      if (hitToken) {
-        const gridSize = mapStore.gridSize ?? 50;
-        const currentScale = Math.round(hitToken.width / gridSize);
-        let nextScale = currentScale + (e.deltaY < 0 ? 1 : -1);
-        nextScale = Math.max(1, Math.min(4, nextScale));
-
-        if (nextScale !== currentScale) {
-          mapSession.updateToken(hitToken.id, {
-            width: nextScale * gridSize,
-            height: nextScale * gridSize,
-          });
-        }
+      if (this.tokenResize.resizeAt({ x: mouseX, y: mouseY }, e.deltaY)) {
         return;
       }
     }

--- a/docs/refactoring/MAP_INTERACTION_MANAGER_GODFILE_ANALYSIS.md
+++ b/docs/refactoring/MAP_INTERACTION_MANAGER_GODFILE_ANALYSIS.md
@@ -1,0 +1,498 @@
+# MapInteractionManager God-File Analysis
+
+**File:** `apps/web/src/lib/components/map/map-interactions.svelte.ts`  
+**Original Size:** 626 lines  
+**Post-refactor Size:** 407 lines  
+**Status:** In progress; first decomposition pass implemented  
+**Parent Issue:** [#943](https://github.com/eserlan/Codex-Cryptica/issues/943)
+
+## 1. Executive Summary
+
+`MapInteractionManager` was created during the first `MapView.svelte` decomposition to move interaction logic out of a 1,500+ line component. That extraction was successful, but the new class has become its own multi-responsibility coordinator. It now owns canvas gestures, VTT token selection, token drag state, pin editing, fog painting, grid fitting, measurement interactions, context menu hit testing, and direct calls into several stores and P2P services.
+
+The next refactor should not move logic back into Svelte components. It should split the interaction state machine into focused handlers with narrow injected dependencies, leaving `MapInteractionManager` as the event router and canvas gesture coordinator.
+
+## 0. Implementation Snapshot
+
+The branch `965-map-interaction-manager-decomposition` implements the first decomposition pass described by this analysis. The extracted handler set is broader than the initial token/pin proposal because several later candidates proved isolated enough to move safely in the same pass.
+
+Current structure:
+
+```text
+apps/web/src/lib/components/map/
+├── map-interactions.svelte.ts
+├── interactions/
+│   ├── box-selection-handler.svelte.ts
+│   ├── context-menu-interaction-handler.svelte.ts
+│   ├── creation-interaction-handler.ts
+│   ├── fog-interaction-handler.ts
+│   ├── grid-interaction-handler.svelte.ts
+│   ├── interaction-adapters.ts
+│   ├── map-interaction-handler-factory.ts
+│   ├── measurement-interaction-handler.ts
+│   ├── pin-interaction-handler.ts
+│   ├── token-drag-handler.ts
+│   ├── token-resize-handler.ts
+│   └── token-selection-manager.ts
+```
+
+Implemented extractions:
+
+- `TokenSelectionManager`: token hit testing, click selection, modifier selection, empty-selection clearing, and box selection commit.
+- `TokenDragHandler`: movable-token hit testing, drag offset, host movement, guest optimistic movement, P2P move request, and guest move confirmation.
+- `PinInteractionHandler`: pin hit testing, drag state, click-vs-drag handling, pin coordinate updates, map saves, and linked entity selection.
+- `GridInteractionHandler`: grid move commit/cancel, grid fit start/update/commit/cancel, grid size/offset writes, and grid settings reveal.
+- `MeasurementInteractionHandler`: live measurement endpoint updates and click-to-start/lock/restart measurement.
+- `ContextMenuInteractionHandler`: context-menu state, token hit lookup, and image coordinate calculation.
+- `TokenResizeHandler`: shift-wheel token resize hit testing and grid-step size updates.
+- `FogInteractionHandler`: fog paint begin/move/finish and conditional fog-sync broadcast.
+- `CreationInteractionHandler`: double-click token or pin creation coordinate routing.
+- `map-interaction-handler-factory.ts`: default handler composition and global-store adapters kept outside the manager constructor.
+
+Remaining `MapInteractionManager` responsibilities after this pass:
+
+- DOM event entry points.
+- container rect caching and viewport coordinate extraction.
+- interaction priority ordering across handlers.
+- panning, wheel zoom, keyboard viewport movement, and map announcements.
+- small compatibility getters consumed by `MapOverlays.svelte` and `MapView.svelte`.
+
+Verification for this pass:
+
+- `bun run --filter web test -- src/lib/components/map` passed with 21 files and 83 tests.
+- Targeted ESLint passed for `map-interactions.svelte.ts` and `apps/web/src/lib/components/map/interactions`.
+- Svelte autofixer passed for `map-interactions.svelte.ts`.
+
+## 2. Current Responsibilities
+
+### A. Canvas Gesture Coordination
+
+The class tracks pointer coordinates, cached container bounds, panning, wheel zoom, keyboard pan/zoom, pointer-over state, and ARIA announcements.
+
+Relevant code:
+
+- `cachedRect`, `lastMousePos`, `mouseDownPos`, `isPanning`, `isPointerOver`
+- `onKeyDown`, `onKeyUp`, `onMouseDown`, `onMouseMove`, `onMouseUp`, `onWheel`
+- `getKeyboardViewportUpdate`, `getZoomViewportUpdate`, `shouldIgnoreMapKeyboardEvent`
+
+This is the responsibility that should remain in `MapInteractionManager`.
+
+### B. VTT Token Selection
+
+The manager hit-tests tokens and directly mutates selection state:
+
+- click selection
+- empty-space deselection
+- `Ctrl`/`Meta` add-to-selection
+- `Shift` toggle selection
+- multi-token box selection
+- context-menu token lookup
+
+Relevant code:
+
+- `hitTestToken(mapSession.allTokens, ...)`
+- `mapSession.setSelection`
+- `mapSession.addToSelection`
+- `mapSession.removeFromSelection`
+- `mapSession.setMultiSelection`
+- `mapSession.clearSelection`
+
+This should be extracted into `TokenSelectionManager`.
+
+### C. VTT Token Dragging
+
+The manager owns drag state and coordinates host-vs-guest movement behavior:
+
+- permission check through `canMoveToken`
+- drag offset calculation
+- GM immediate token movement
+- guest optimistic movement
+- guest P2P movement request
+- guest move confirmation on mouse-up
+- setting and clearing `draggingTokenId`
+
+Relevant code:
+
+- `dragState`
+- `mapSession.canMoveToken(hitToken.id, p2pGuestService.peerId, mapStore.isGMMode)`
+- `mapSession.moveToken`
+- `mapSession.requestTokenMove`
+- `p2pGuestService.requestTokenMove`
+- `mapSession.confirmTokenMove`
+- `mapSession.draggingTokenId`
+
+This should be extracted into `TokenDragHandler`.
+
+### D. Pin Selection And Editing
+
+Pin interactions are unrelated to VTT token movement but share the same mouse handlers:
+
+- pin hit testing
+- pin drag state
+- click-vs-drag threshold
+- restoring original coordinates after click gestures
+- in-memory pin coordinate updates
+- map persistence through `vault.saveMaps`
+- entity focus through `vault.selectedEntityId`
+
+Relevant code:
+
+- `pinDragState`
+- `findClickedPin`
+- `mapStore.updatePinCoordinatesInMemory`
+- `vault.saveMaps`
+- `vault.selectedEntityId`
+
+This should be extracted after token handling, likely into `PinInteractionHandler`.
+
+### E. Fog Painting
+
+The class starts, moves, and finishes fog painting, then broadcasts fog sync when needed.
+
+Relevant code:
+
+- `this.painter.begin`
+- `this.painter.move`
+- `await this.painter.finish()`
+- `p2pHost.broadcastActiveMapFogSync`
+
+This can remain in the manager initially because it is canvas gesture behavior, but the P2P sync callback should be injected instead of imported directly.
+
+### F. Grid Tools
+
+The class owns grid move mode and grid fit mode:
+
+- Enter commits grid move
+- Escape cancels grid modes
+- mouse drag tracks grid fit bounds
+- mouse-up calculates grid size and offsets
+- grid settings panel is opened after fit
+
+Relevant code:
+
+- `gridFitStart`, `gridFitEnd`
+- `mapSession.gridMoveMode`
+- `mapSession.gridFitMode`
+- `mapSession.showGridSettings`
+- `mapStore.gridSize`, `gridOffsetX`, `gridOffsetY`
+- `notificationStore.clearNotification`
+
+This can stay in the manager for the first token-focused split, but it is a good later candidate for `GridInteractionHandler`.
+
+### G. Measurement Tool
+
+The manager updates active measurements during mouse move and click:
+
+- live measurement endpoint updates
+- first click starts measurement
+- second click locks measurement
+- third click restarts measurement
+
+Relevant code:
+
+- `mapSession.measurement`
+- `mapSession.setMeasurementStart`
+- `mapSession.setMeasurementEnd`
+- `mapSession.setMeasurementLocked`
+
+This is VTT tool behavior and can move to a later `MeasurementInteractionHandler` after token and pin extraction.
+
+## 3. Coupling Problems
+
+`MapInteractionManager` imports concrete global stores and services directly:
+
+- `mapStore`
+- `mapSession`
+- `vault`
+- `p2pGuestService`
+- `p2pHost`
+- `notificationStore`
+- `sessionModeStore`
+
+That makes unit tests depend on broad module mocks and makes the class hard to reuse for touch input or alternate pointer-event handling. The current tests mock whole stores instead of small behavior-specific interfaces, so a change in one map subsystem can break unrelated interaction tests.
+
+The refactor should introduce constructor-based dependencies and narrow adapters. This aligns with the project constitution and matches the direction already used in VTT managers.
+
+## 4. Proposed Architecture
+
+```text
+apps/web/src/lib/components/map/
+├── map-interactions.svelte.ts          # Thin event router and canvas gestures
+├── interactions/
+│   ├── box-selection-handler.svelte.ts # Reactive box-selection overlay state
+│   ├── context-menu-interaction-handler.svelte.ts
+│   ├── creation-interaction-handler.ts
+│   ├── fog-interaction-handler.ts
+│   ├── token-selection-manager.ts      # Token hit testing and selection rules
+│   ├── token-drag-handler.ts           # Token drag lifecycle and move requests
+│   ├── token-resize-handler.ts         # Shift-wheel token size changes
+│   ├── pin-interaction-handler.ts      # Pin click, drag, restore, save
+│   ├── grid-interaction-handler.svelte.ts
+│   ├── measurement-interaction-handler.ts
+│   ├── map-interaction-handler-factory.ts
+│   └── interaction-adapters.ts         # Narrow interfaces and default adapters
+```
+
+### `MapInteractionManager` Target Role
+
+The manager should keep:
+
+- DOM event entry points
+- container rect caching
+- viewport coordinate calculation
+- pan/zoom/keyboard viewport updates
+- interaction priority ordering
+- overlay state exposure needed by `MapOverlays.svelte`
+- delegating token, pin, grid, fog, and measurement work to focused handlers
+
+Target size: 250-350 lines remains the long-term goal. The first pass reduced the file to 407 lines while keeping pan/zoom and event ordering in place.
+
+### `TokenSelectionManager`
+
+Responsibilities:
+
+- hit-test token under viewport coordinates
+- select single token on click
+- deselect on empty VTT click
+- add/remove/toggle selection based on modifier keys
+- calculate tokens inside box-select rectangle
+- expose no Svelte global stores directly
+
+Proposed dependencies:
+
+```ts
+export interface TokenSelectionDependencies {
+  getTokens(): Token[];
+  project(point: Point): Point;
+  selectedTokens(): ReadonlySet<string>;
+  setSelection(tokenId: string | null): void;
+  addToSelection(tokenId: string): void;
+  removeFromSelection(tokenId: string): void;
+  setMultiSelection(tokenIds: string[]): void;
+}
+```
+
+### `TokenDragHandler`
+
+Responsibilities:
+
+- begin drag if token hit and caller can move it
+- calculate image-space offset
+- move host token directly
+- apply guest optimistic move and send P2P request
+- confirm guest movement on drag end
+- clear local drag state
+
+Proposed dependencies:
+
+```ts
+export interface TokenDragDependencies {
+  getTokens(): Token[];
+  project(point: Point): Point;
+  unproject(point: Point): Point;
+  isHostMode(): boolean;
+  getPeerId(): string | null;
+  canMoveToken(
+    tokenId: string,
+    peerId: string | null,
+    isHost: boolean,
+  ): boolean;
+  moveToken(tokenId: string, x: number, y: number): void;
+  requestTokenMove(
+    tokenId: string,
+    x: number,
+    y: number,
+    persistent: boolean,
+  ): void;
+  sendTokenMoveRequest(tokenId: string, x: number, y: number): void;
+  confirmTokenMove(tokenId: string): void;
+  setDraggingTokenId(tokenId: string | null): void;
+}
+```
+
+### `PinInteractionHandler`
+
+Responsibilities:
+
+- hit-test pin under viewport coordinates
+- begin pin drag
+- detect click-vs-drag threshold
+- update in-memory pin coordinates only for non-guest GMs
+- restore original coordinates on click gesture
+- persist maps only after a meaningful drag
+- focus linked entity on pin click
+
+Proposed dependencies:
+
+```ts
+export interface PinInteractionDependencies {
+  getPins(): MapPin[];
+  project(point: Point): Point;
+  unproject(point: Point): Point;
+  canEditPins(): boolean;
+  updatePinCoordinates(pinId: string, point: Point): void;
+  saveMaps(): Promise<void>;
+  selectEntity(entityId: string): void;
+}
+```
+
+## 5. Interaction Priority To Preserve
+
+The refactor must preserve the existing ordering in `onMouseDown`, `onMouseMove`, and `onMouseUp`. This ordering is user-visible.
+
+### Mouse Down Priority
+
+1. Clear context menu and cache container rect.
+2. Start box selection for GM + VTT + `Ctrl`/`Meta`.
+3. Start token drag when VTT is enabled and a movable token is hit.
+4. Start pin drag on left-click over pin when not holding Alt.
+5. Start grid move mode.
+6. Start grid fit mode.
+7. Start fog painting for GM + Alt.
+8. Fall back to panning for left-click.
+
+### Mouse Move Priority
+
+1. Update box selection bounds.
+2. Move dragged token.
+3. Move dragged pin.
+4. Update grid fit bounds.
+5. Move fog brush.
+6. Update active measurement endpoint.
+7. Pan viewport.
+
+### Mouse Up Priority
+
+1. Finish fog painting and broadcast sync.
+2. Commit box selection.
+3. End token drag and confirm guest move.
+4. End pin click/drag and save when needed.
+5. Commit grid fit.
+6. Treat a pan click as a map click.
+7. Clear panning.
+
+## 6. Testing Strategy
+
+The current `map-interactions.test.ts` covers panning, wheel zoom, box selection start, Escape multi-selection clearing, and basic pin drag behavior. Token behavior needs more focused coverage before extraction.
+
+### Add tests before extracting token handling
+
+- movable token mousedown starts drag, sets `draggingTokenId`, and applies normal selection
+- `Ctrl`/`Meta` on token mousedown adds to selection without replacing existing selection
+- `Shift` on selected token removes it from multi-selection
+- `Shift` on unselected token adds it to multi-selection
+- non-movable token does not start drag and falls through to map click/pan behavior
+- GM token drag calls `moveToken` with unprojected coordinates minus drag offset
+- guest token drag calls optimistic `requestTokenMove(..., true)` and outbound `requestTokenMove`
+- guest token mouse-up calls `confirmTokenMove`
+- box selection commits only when rectangle area exceeds the threshold
+- box selection ignores tiny click rectangles
+- clicking empty VTT space clears token selection
+
+### Add tests before extracting pin handling
+
+- pin click selects pin and linked entity without saving maps
+- pin drag below threshold restores original coordinates
+- pin drag above threshold updates in-memory coordinates and saves maps on mouse-up
+- guest mode cannot mutate pin coordinates or save maps
+- Alt-click over a pin starts fog painting instead of pin dragging
+
+### Add tests around interaction priority
+
+- token hit wins over pin hit when VTT mode is enabled and token is movable
+- box-select shortcut wins over token drag for GM `Ctrl`/`Meta`
+- active token drag suppresses panning
+- active pin drag suppresses panning
+- active grid fit suppresses panning
+
+## 7. Refactor Phases
+
+### Phase 1: Add narrow dependency adapters
+
+Introduce default adapters for map, session, vault, peer, notification, and mode dependencies while preserving the public constructor shape used by `MapView.svelte`.
+
+Deliverables:
+
+- `interaction-adapters.ts`
+- updated `MapInteractionManager` constructor dependencies
+- tests updated to use small fake adapters instead of broad `vi.mock` store modules
+
+### Phase 2: Extract `TokenSelectionManager`
+
+Move token hit testing and selection rules out of the main manager. Keep stateful overlay geometry in `MapInteractionManager`, but delegate the selected token calculation.
+
+Deliverables:
+
+- `token-selection-manager.ts`
+- focused unit tests for selection behavior
+- `MapInteractionManager` uses selection manager for click, modifier selection, context menu token lookup, and box selection
+
+### Phase 3: Extract `TokenDragHandler`
+
+Move token drag lifecycle out of the main manager.
+
+Deliverables:
+
+- `token-drag-handler.ts`
+- focused unit tests for GM and guest drag paths
+- `MapInteractionManager` keeps only event ordering and last pointer state
+
+### Phase 4: Extract `PinInteractionHandler`
+
+Move pin drag/click/persistence handling out of the main manager.
+
+Deliverables:
+
+- `pin-interaction-handler.ts`
+- focused tests for click, drag, restore, save, and guest restrictions
+- `selectedPinId` remains exposed by `MapInteractionManager` or moves behind a small pin state object consumed by `MapOverlays.svelte`
+
+### Phase 5: Extract grid and measurement handlers
+
+Implemented in the first pass because the behavior was isolated and had clear test seams.
+
+Deliverables:
+
+- `grid-interaction-handler.svelte.ts`
+- `measurement-interaction-handler.ts`
+- focused tests for grid move/fit and measurement live/click flows
+
+### Phase 6: Extract remaining isolated interaction helpers
+
+Implemented in the first pass after token, pin, grid, and measurement were stable.
+
+Deliverables:
+
+- `box-selection-handler.svelte.ts`
+- `context-menu-interaction-handler.svelte.ts`
+- `token-resize-handler.ts`
+- `fog-interaction-handler.ts`
+- `creation-interaction-handler.ts`
+- `map-interaction-handler-factory.ts`
+- focused tests for each handler
+
+## 8. Non-Goals
+
+- Do not change token persistence or VTT protocol semantics.
+- Do not change rendered map visuals.
+- Do not move interaction state back into `MapView.svelte`.
+- Do not replace mouse events with pointer events in the same PR. Pointer/touch support should come after the handlers are isolated.
+- Do not refactor `VTTTokenManager` at the same time; this analysis is scoped to `MapInteractionManager`.
+
+## 9. Acceptance Criteria
+
+- `MapInteractionManager` no longer imports `p2pGuestService`, `p2pHost`, or `vault` directly.
+- Token selection logic is unit-testable without Svelte store module mocks.
+- Token drag logic is unit-testable without a real peer session or full map session store.
+- Pin drag/click persistence behavior is unit-testable without the full vault store.
+- Existing map interaction tests still pass.
+- New tests cover both expected paths and at least one meaningful negative path for each extracted handler.
+- User-visible behavior for pan, zoom, grid fit, fog painting, token drag, token selection, pin click, and pin drag remains unchanged.
+
+## 10. Recommended Subtasks
+
+1. Create `TokenSelectionManager` and `TokenDragHandler` behind injected adapters.
+2. Move existing token selection and drag tests from broad manager mocks to focused handler tests.
+3. Extract `PinInteractionHandler` once token behavior is stable.
+4. Revisit `MapInteractionManager` size and decide whether grid and measurement need their own handlers.
+5. Update `docs/refactoring/MAP_VIEW_REFACTOR.md` with a short note that the original map refactor is complete and this document tracks the second-stage interaction split.

--- a/docs/refactoring/MAP_VIEW_REFACTOR.md
+++ b/docs/refactoring/MAP_VIEW_REFACTOR.md
@@ -90,3 +90,7 @@ To minimize risk and avoid breaking VTT interactions, this refactor should be ex
 ## Summary
 
 By executing this refactor, we successfully eliminated the largest god file in the project. `MapView.svelte` has been reduced from 1,536 lines to 328 lines, resulting in a cleaner UI hierarchy, easier testing for complex map gestures, and a more maintainable VTT environment.
+
+## Follow-up
+
+The extracted `MapInteractionManager` now carries the interaction-state complexity that previously lived inside `MapView.svelte`. Track the second-stage decomposition in [MAP_INTERACTION_MANAGER_GODFILE_ANALYSIS.md](./MAP_INTERACTION_MANAGER_GODFILE_ANALYSIS.md).


### PR DESCRIPTION
## Summary

Refactors `MapInteractionManager` into focused interaction handlers for token selection/dragging/resizing, pin interaction, grid fit/move, measurement, context menus, fog painting, double-click creation, and handler composition.

The main manager now keeps DOM event routing, coordinate extraction, interaction ordering, panning/zooming, keyboard viewport updates, and overlay compatibility getters.

## Why

Issue #965 tracks the MapInteractionManager portion of the broader god-file decomposition in #943. The class had grown into a multi-responsibility coordinator with direct access to stores, vault persistence, and P2P services. This isolates those behaviors behind narrower handlers and focused tests.

## Validation

- `bun run --filter web test -- src/lib/components/map`
- `bun run --filter web lint -- src/lib/components/map/map-interactions.svelte.ts src/lib/components/map/interactions`
- `npx @sveltejs/mcp svelte-autofixer apps/web/src/lib/components/map/map-interactions.svelte.ts --svelte-version 5`
- `bun run --filter web build`
- pre-push hook: `bun run --filter '*' lint -- --cache --cache-strategy content`
- pre-push hook: `BUN_NUM_THREADS=2 bun run --filter '*' test -- --changed`

## Notes

`apps/web/static/llms-full.txt` was regenerated during build but intentionally left out of this PR.
