### PR TITLE
:zap: perf(map): redraw MapCanvas on dirty instead of continuous rAF

### DIFF
--- a/apps/web/src/lib/components/map/MapCanvas.svelte
+++ b/apps/web/src/lib/components/map/MapCanvas.svelte
@@ -8,6 +8,10 @@
   import type { Point } from "schema";
   import type { PingState, Token } from "../../../types/vtt";
   import type { MapInteractionManager } from "./map-interactions.svelte";
+  import {
+    CanvasRedrawScheduler,
+    hasActivePings,
+  } from "./map-canvas-scheduler";
 
   interface EnrichedToken extends Token {
     label: string;
@@ -40,6 +44,8 @@
     valid: boolean;
   }
 
+  const PING_DURATION_MS = 3000;
+
   let {
     mapImage,
     maskCanvas,
@@ -62,7 +68,7 @@
 
   let canvas = $state<HTMLCanvasElement | null>(null);
   let container = $state<HTMLDivElement | null>(null);
-  let animationFrameId: number;
+  const scheduler = new CanvasRedrawScheduler(() => draw());
 
   const fogColor = $derived(
     `rgba(${hexToRgb(themeStore.activeTheme.tokens.secondary)}, ${mapStore.isGMMode ? 0.6 : 1.0})`,
@@ -89,215 +95,254 @@
       if (ctx) {
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       }
+      scheduler.request();
     }
   }
 
   function draw() {
-    if (canvas) {
-      renderMap({
-        canvas: canvas,
-        image: mapImage,
-        transform: mapStore.viewport,
-        canvasSize: mapStore.canvasSize,
-        pins: mapStore.pins,
-        maskCanvas: maskCanvas,
-        showFog: mapStore.showFog,
-        fogColor,
-        accentColor: themeStore.activeTheme.tokens.primary,
-        grid: {
-          type: mapStore.showGrid ? "square" : "none",
-          size: mapStore.gridSize,
-          color: gridColor,
-          opacity: 0.65,
-          offsetX: mapStore.gridOffsetX,
-          offsetY: mapStore.gridOffsetY,
-          fixed: mapSession.gridMoveMode && mapStore.isGMMode,
-        },
-        tokens: vttTokens,
-        measurement: vttMeasurement,
-      });
+    if (!canvas) return;
 
-      if (vttDragPreview) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          const point = mapStore.project({
-            x: vttDragPreview.x,
-            y: vttDragPreview.y,
+    renderMap({
+      canvas: canvas,
+      image: mapImage,
+      transform: mapStore.viewport,
+      canvasSize: mapStore.canvasSize,
+      pins: mapStore.pins,
+      maskCanvas: maskCanvas,
+      showFog: mapStore.showFog,
+      fogColor,
+      accentColor: themeStore.activeTheme.tokens.primary,
+      grid: {
+        type: mapStore.showGrid ? "square" : "none",
+        size: mapStore.gridSize,
+        color: gridColor,
+        opacity: 0.65,
+        offsetX: mapStore.gridOffsetX,
+        offsetY: mapStore.gridOffsetY,
+        fixed: mapSession.gridMoveMode && mapStore.isGMMode,
+      },
+      tokens: vttTokens,
+      measurement: vttMeasurement,
+    });
+
+    if (vttDragPreview) {
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        const point = mapStore.project({
+          x: vttDragPreview.x,
+          y: vttDragPreview.y,
+        });
+        const size = Math.max(
+          28,
+          (mapStore.gridSize || 50) * mapStore.viewport.zoom,
+        );
+        const radius = size / 2;
+        const stroke = vttDragPreview.valid
+          ? themeStore.activeTheme.tokens.primary
+          : "#ef4444";
+        const fill = vttDragPreview.valid
+          ? "rgba(16, 185, 129, 0.25)"
+          : "rgba(239, 68, 68, 0.25)";
+
+        ctx.save();
+        ctx.translate(point.x, point.y);
+        ctx.globalAlpha = 0.8;
+        ctx.fillStyle = fill;
+        ctx.strokeStyle = stroke;
+        ctx.lineWidth = 2;
+        ctx.setLineDash([6, 4]);
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.setLineDash([]);
+        ctx.beginPath();
+        ctx.arc(0, 0, 4, 0, Math.PI * 2);
+        ctx.fillStyle = stroke;
+        ctx.fill();
+
+        ctx.font = "600 12px sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "bottom";
+        ctx.fillStyle = stroke;
+        ctx.fillText(vttDragPreview.label, 0, -radius - 8);
+        ctx.restore();
+      }
+    }
+
+    if (vttPings.length > 0) {
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        const now = Date.now();
+        for (const ping of vttPings) {
+          const elapsed = now - ping.timestamp;
+          if (elapsed > PING_DURATION_MS) continue;
+
+          const progress = elapsed / PING_DURATION_MS;
+          const pingPoint = mapStore.project({
+            x: ping.x,
+            y: ping.y,
           });
-          const size = Math.max(
-            28,
-            (mapStore.gridSize || 50) * mapStore.viewport.zoom,
-          );
-          const radius = size / 2;
-          const stroke = vttDragPreview.valid
-            ? themeStore.activeTheme.tokens.primary
-            : "#ef4444";
-          const fill = vttDragPreview.valid
-            ? "rgba(16, 185, 129, 0.25)"
-            : "rgba(239, 68, 68, 0.25)";
 
           ctx.save();
-          ctx.translate(point.x, point.y);
-          ctx.globalAlpha = 0.8;
-          ctx.fillStyle = fill;
-          ctx.strokeStyle = stroke;
-          ctx.lineWidth = 2;
-          ctx.setLineDash([6, 4]);
+
+          const baseRadius = 25 * mapStore.viewport.zoom;
+          const expandRange = 40 * mapStore.viewport.zoom;
+          const radius = baseRadius + progress * expandRange;
+          const opacity = 1 - progress;
+
           ctx.beginPath();
-          ctx.arc(0, 0, radius, 0, Math.PI * 2);
-          ctx.fill();
+          ctx.arc(pingPoint.x, pingPoint.y, radius, 0, Math.PI * 2);
+          ctx.strokeStyle = ping.color;
+          ctx.globalAlpha = opacity;
+          ctx.lineWidth = 4 * (1 - progress) + 1;
+
+          ctx.shadowColor = ping.color;
+          ctx.shadowBlur = 10 * opacity;
           ctx.stroke();
 
-          ctx.setLineDash([]);
+          ctx.globalAlpha = opacity * 0.5;
           ctx.beginPath();
-          ctx.arc(0, 0, 4, 0, Math.PI * 2);
-          ctx.fillStyle = stroke;
-          ctx.fill();
-
-          ctx.font = "600 12px sans-serif";
-          ctx.textAlign = "center";
-          ctx.textBaseline = "bottom";
-          ctx.fillStyle = stroke;
-          ctx.fillText(vttDragPreview.label, 0, -radius - 8);
-          ctx.restore();
-        }
-      }
-
-      if (vttPings.length > 0) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          const now = Date.now();
-          const PING_DURATION = 3000;
-          for (const ping of vttPings) {
-            const elapsed = now - ping.timestamp;
-            if (elapsed > PING_DURATION) continue;
-
-            const progress = elapsed / PING_DURATION;
-            const pingPoint = mapStore.project({
-              x: ping.x,
-              y: ping.y,
-            });
-
-            ctx.save();
-
-            const baseRadius = 25 * mapStore.viewport.zoom;
-            const expandRange = 40 * mapStore.viewport.zoom;
-            const radius = baseRadius + progress * expandRange;
-            const opacity = 1 - progress;
-
-            ctx.beginPath();
-            ctx.arc(pingPoint.x, pingPoint.y, radius, 0, Math.PI * 2);
-            ctx.strokeStyle = ping.color;
-            ctx.globalAlpha = opacity;
-            ctx.lineWidth = 4 * (1 - progress) + 1;
-
-            ctx.shadowColor = ping.color;
-            ctx.shadowBlur = 10 * opacity;
-            ctx.stroke();
-
-            ctx.globalAlpha = opacity * 0.5;
-            ctx.beginPath();
-            ctx.arc(pingPoint.x, pingPoint.y, 3, 0, Math.PI * 2);
-            ctx.fillStyle = ping.color;
-            ctx.fill();
-
-            ctx.restore();
-          }
-        }
-      }
-
-      if (remoteMeasurement) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          const start = mapStore.project(remoteMeasurement.start);
-          const end = mapStore.project(remoteMeasurement.end);
-
-          ctx.save();
-          ctx.strokeStyle = remoteMeasurement.color;
-          ctx.lineWidth = 2;
-          ctx.setLineDash([8, 4]);
-          ctx.globalAlpha = 0.8;
-
-          ctx.beginPath();
-          ctx.moveTo(start.x, start.y);
-          ctx.lineTo(end.x, end.y);
-          ctx.stroke();
-
-          ctx.setLineDash([]);
-          ctx.beginPath();
-          ctx.arc(start.x, start.y, 5, 0, Math.PI * 2);
-          ctx.fillStyle = remoteMeasurement.color;
-          ctx.fill();
-
-          ctx.beginPath();
-          ctx.arc(end.x, end.y, 5, 0, Math.PI * 2);
-          ctx.fill();
-
-          const midX = (start.x + end.x) / 2;
-          const midY = (start.y + end.y) / 2;
-          ctx.font = "12px sans-serif";
-          ctx.fillStyle = remoteMeasurement.color;
-          ctx.textAlign = "center";
-          ctx.textBaseline = "bottom";
-          ctx.fillText(remoteMeasurement.label, midX, midY - 8);
-
-          ctx.restore();
-        }
-      }
-
-      if (
-        mapStore.isGMMode &&
-        interactions.isAltPressed &&
-        interactions.isPointerOver
-      ) {
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-          ctx.save();
-          const primaryRGB = hexToRgb(themeStore.activeTheme.tokens.primary);
-
-          ctx.beginPath();
-          ctx.arc(
-            interactions.lastMousePos.x,
-            interactions.lastMousePos.y,
-            interactions.visualBrushRadius,
-            0,
-            Math.PI * 2,
-          );
-          ctx.strokeStyle = `rgba(${primaryRGB}, 0.5)`;
-          ctx.lineWidth = 2;
-          ctx.stroke();
-
-          ctx.fillStyle = `rgba(${primaryRGB}, 0.1)`;
-          ctx.fill();
-
-          ctx.beginPath();
-          ctx.arc(
-            interactions.lastMousePos.x,
-            interactions.lastMousePos.y,
-            2,
-            0,
-            Math.PI * 2,
-          );
-          ctx.fillStyle = `rgba(${primaryRGB}, 0.5)`;
+          ctx.arc(pingPoint.x, pingPoint.y, 3, 0, Math.PI * 2);
+          ctx.fillStyle = ping.color;
           ctx.fill();
 
           ctx.restore();
         }
       }
     }
-    animationFrameId = requestAnimationFrame(draw);
+
+    if (remoteMeasurement) {
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        const start = mapStore.project(remoteMeasurement.start);
+        const end = mapStore.project(remoteMeasurement.end);
+
+        ctx.save();
+        ctx.strokeStyle = remoteMeasurement.color;
+        ctx.lineWidth = 2;
+        ctx.setLineDash([8, 4]);
+        ctx.globalAlpha = 0.8;
+
+        ctx.beginPath();
+        ctx.moveTo(start.x, start.y);
+        ctx.lineTo(end.x, end.y);
+        ctx.stroke();
+
+        ctx.setLineDash([]);
+        ctx.beginPath();
+        ctx.arc(start.x, start.y, 5, 0, Math.PI * 2);
+        ctx.fillStyle = remoteMeasurement.color;
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(end.x, end.y, 5, 0, Math.PI * 2);
+        ctx.fill();
+
+        const midX = (start.x + end.x) / 2;
+        const midY = (start.y + end.y) / 2;
+        ctx.font = "12px sans-serif";
+        ctx.fillStyle = remoteMeasurement.color;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "bottom";
+        ctx.fillText(remoteMeasurement.label, midX, midY - 8);
+
+        ctx.restore();
+      }
+    }
+
+    if (
+      mapStore.isGMMode &&
+      interactions.isAltPressed &&
+      interactions.isPointerOver
+    ) {
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        ctx.save();
+        const primaryRGB = hexToRgb(themeStore.activeTheme.tokens.primary);
+
+        ctx.beginPath();
+        ctx.arc(
+          interactions.lastMousePos.x,
+          interactions.lastMousePos.y,
+          interactions.visualBrushRadius,
+          0,
+          Math.PI * 2,
+        );
+        ctx.strokeStyle = `rgba(${primaryRGB}, 0.5)`;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+
+        ctx.fillStyle = `rgba(${primaryRGB}, 0.1)`;
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(
+          interactions.lastMousePos.x,
+          interactions.lastMousePos.y,
+          2,
+          0,
+          Math.PI * 2,
+        );
+        ctx.fillStyle = `rgba(${primaryRGB}, 0.5)`;
+        ctx.fill();
+
+        ctx.restore();
+      }
+    }
+
+    // Self-perpetuating rAF loop while any ping is still animating.
+    // Pings animate from a timestamp, so the visual changes even when no
+    // input does — without this we'd freeze mid-ping.
+    if (hasActivePings(vttPings, Date.now(), PING_DURATION_MS)) {
+      scheduler.request();
+    }
   }
+
+  // Trigger a redraw whenever any input that affects the canvas changes.
+  $effect(() => {
+    // Touch every reactive read to register dependencies. `void` keeps the
+    // expressions from being tree-shaken.
+    void canvas;
+    void mapImage;
+    void maskCanvas;
+    void mapStore.viewport;
+    void mapStore.canvasSize;
+    void mapStore.pins;
+    void mapStore.showFog;
+    void mapStore.isGMMode;
+    void mapStore.showGrid;
+    void mapStore.gridSize;
+    void mapStore.gridOffsetX;
+    void mapStore.gridOffsetY;
+    void mapStore.gridColor;
+    void mapSession.gridMoveMode;
+    void themeStore.activeTheme;
+    void vttTokens;
+    void vttMeasurement;
+    void remoteMeasurement;
+    void vttPings;
+    void vttDragPreview;
+    void fogColor;
+    void gridColor;
+    void interactions.isAltPressed;
+    void interactions.isPointerOver;
+    void interactions.lastMousePos.x;
+    void interactions.lastMousePos.y;
+    void interactions.visualBrushRadius;
+
+    scheduler.request();
+  });
 
   onMount(() => {
     setTimeout(handleResize, 10);
     const resizeObserver = new ResizeObserver(handleResize);
     if (container) resizeObserver.observe(container);
 
-    animationFrameId = requestAnimationFrame(draw);
-
     return () => {
       resizeObserver.disconnect();
-      cancelAnimationFrame(animationFrameId);
+      scheduler.dispose();
     };
   });
 </script>

--- a/apps/web/src/lib/components/map/MapCanvas.svelte
+++ b/apps/web/src/lib/components/map/MapCanvas.svelte
@@ -12,6 +12,7 @@
     CanvasRedrawScheduler,
     hasActivePings,
   } from "./map-canvas-scheduler";
+  import { PING_DURATION_MS } from "$lib/stores/vtt/vtt-measurement-manager.svelte";
 
   interface EnrichedToken extends Token {
     label: string;
@@ -43,8 +44,6 @@
     label: string;
     valid: boolean;
   }
-
-  const PING_DURATION_MS = 3000;
 
   let {
     mapImage,
@@ -177,7 +176,8 @@
         const now = Date.now();
         for (const ping of vttPings) {
           const elapsed = now - ping.timestamp;
-          if (elapsed > PING_DURATION_MS) continue;
+          // Use >= so this matches hasActivePings (elapsed < duration === active).
+          if (elapsed >= PING_DURATION_MS) continue;
 
           const progress = elapsed / PING_DURATION_MS;
           const pingPoint = mapStore.project({
@@ -302,8 +302,9 @@
 
   // Trigger a redraw whenever any input that affects the canvas changes.
   $effect(() => {
-    // Touch every reactive read to register dependencies. `void` keeps the
-    // expressions from being tree-shaken.
+    // Read each reactive value so Svelte 5 registers it as a dependency of
+    // this effect. `void` marks the read as intentionally unused so ESLint's
+    // no-unused-expressions rule lets it pass.
     void canvas;
     void mapImage;
     void maskCanvas;

--- a/apps/web/src/lib/components/map/map-canvas-scheduler.test.ts
+++ b/apps/web/src/lib/components/map/map-canvas-scheduler.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from "vitest";
+import { CanvasRedrawScheduler, hasActivePings } from "./map-canvas-scheduler";
+
+describe("CanvasRedrawScheduler", () => {
+  function makeFakeRaf() {
+    let nextId = 1;
+    const pending = new Map<number, FrameRequestCallback>();
+    const raf = vi.fn((cb: FrameRequestCallback) => {
+      const id = nextId++;
+      pending.set(id, cb);
+      return id;
+    });
+    const cancel = vi.fn((id: number) => {
+      pending.delete(id);
+    });
+    const tick = (timestamp = performance.now()) => {
+      const callbacks = Array.from(pending.values());
+      pending.clear();
+      for (const cb of callbacks) cb(timestamp);
+    };
+    return { raf, cancel, tick, pendingCount: () => pending.size };
+  }
+
+  it("schedules one frame for a single request()", () => {
+    const draw = vi.fn();
+    const { raf, cancel, tick } = makeFakeRaf();
+    const sched = new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    sched.request();
+    expect(raf).toHaveBeenCalledTimes(1);
+    expect(draw).not.toHaveBeenCalled();
+
+    tick();
+    expect(draw).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces multiple request() calls within the same frame", () => {
+    const draw = vi.fn();
+    const { raf, cancel, tick } = makeFakeRaf();
+    const sched = new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    sched.request();
+    sched.request();
+    sched.request();
+    sched.request();
+
+    expect(raf).toHaveBeenCalledTimes(1);
+    tick();
+    expect(draw).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a new frame after the previous one fires", () => {
+    const draw = vi.fn();
+    const { raf, cancel, tick } = makeFakeRaf();
+    const sched = new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    sched.request();
+    tick();
+    expect(draw).toHaveBeenCalledTimes(1);
+
+    sched.request();
+    tick();
+    expect(draw).toHaveBeenCalledTimes(2);
+    expect(raf).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not draw spontaneously when idle (no request() calls)", () => {
+    const draw = vi.fn();
+    const { raf, cancel, tick } = makeFakeRaf();
+    new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    // No request() — nothing should be scheduled.
+    expect(raf).not.toHaveBeenCalled();
+    tick(); // No-op because no pending frames.
+    expect(draw).not.toHaveBeenCalled();
+  });
+
+  it("exposes pending status", () => {
+    const draw = vi.fn();
+    const { raf, cancel, tick } = makeFakeRaf();
+    const sched = new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    expect(sched.pending).toBe(false);
+    sched.request();
+    expect(sched.pending).toBe(true);
+    tick();
+    expect(sched.pending).toBe(false);
+  });
+
+  it("dispose() cancels a pending frame", () => {
+    const draw = vi.fn();
+    const { raf, cancel, pendingCount } = makeFakeRaf();
+    const sched = new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    sched.request();
+    expect(pendingCount()).toBe(1);
+
+    sched.dispose();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(sched.pending).toBe(false);
+    expect(pendingCount()).toBe(0);
+  });
+
+  it("dispose() is a no-op when no frame is pending", () => {
+    const draw = vi.fn();
+    const { raf, cancel } = makeFakeRaf();
+    const sched = new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    sched.dispose();
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it("re-uses a single scheduled frame across a tight burst of requests", () => {
+    const draw = vi.fn();
+    const { raf, cancel, tick } = makeFakeRaf();
+    const sched = new CanvasRedrawScheduler(draw, { raf, cancel });
+
+    for (let i = 0; i < 1000; i++) sched.request();
+    expect(raf).toHaveBeenCalledTimes(1);
+
+    tick();
+    expect(draw).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("hasActivePings", () => {
+  const DURATION = 3000;
+
+  it("returns false for an empty array", () => {
+    expect(hasActivePings([], 1000, DURATION)).toBe(false);
+  });
+
+  it("returns true when at least one ping is within the duration window", () => {
+    const now = 10000;
+    const pings = [
+      { timestamp: 4000 }, // 6000ms old — expired
+      { timestamp: 8000 }, // 2000ms old — still active
+    ];
+    expect(hasActivePings(pings, now, DURATION)).toBe(true);
+  });
+
+  it("returns false when all pings have expired", () => {
+    const now = 10000;
+    const pings = [
+      { timestamp: 4000 },
+      { timestamp: 5000 },
+      { timestamp: 6000 }, // 4000ms old — expired
+    ];
+    expect(hasActivePings(pings, now, DURATION)).toBe(false);
+  });
+
+  it("treats ping exactly at the duration boundary as expired", () => {
+    const now = 10000;
+    const pings = [{ timestamp: now - DURATION }];
+    expect(hasActivePings(pings, now, DURATION)).toBe(false);
+  });
+
+  it("treats ping just inside the duration boundary as active", () => {
+    const now = 10000;
+    const pings = [{ timestamp: now - DURATION + 1 }];
+    expect(hasActivePings(pings, now, DURATION)).toBe(true);
+  });
+
+  it("treats a fresh ping (now == timestamp) as active", () => {
+    const now = 10000;
+    const pings = [{ timestamp: now }];
+    expect(hasActivePings(pings, now, DURATION)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/components/map/map-canvas-scheduler.ts
+++ b/apps/web/src/lib/components/map/map-canvas-scheduler.ts
@@ -1,0 +1,81 @@
+/**
+ * Coalesces multiple redraw requests within the same animation frame into a
+ * single draw call. Used by MapCanvas to switch from a 60 fps continuous
+ * render loop to a redraw-on-dirty pattern.
+ */
+
+export interface RedrawSchedulerDeps {
+  raf: (cb: FrameRequestCallback) => number;
+  cancel: (id: number) => void;
+}
+
+const defaultDeps = (): RedrawSchedulerDeps => ({
+  raf:
+    typeof requestAnimationFrame !== "undefined"
+      ? requestAnimationFrame
+      : (cb) =>
+          setTimeout(() => cb(performance.now()), 16) as unknown as number,
+  cancel:
+    typeof cancelAnimationFrame !== "undefined"
+      ? cancelAnimationFrame
+      : (id) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>),
+});
+
+export class CanvasRedrawScheduler {
+  private animationFrameId: number | null = null;
+  private readonly draw: () => void;
+  private readonly raf: (cb: FrameRequestCallback) => number;
+  private readonly cancel: (id: number) => void;
+
+  constructor(draw: () => void, deps: Partial<RedrawSchedulerDeps> = {}) {
+    this.draw = draw;
+    const defaults = defaultDeps();
+    this.raf = deps.raf ?? defaults.raf;
+    this.cancel = deps.cancel ?? defaults.cancel;
+  }
+
+  /**
+   * Request a redraw on the next animation frame. Multiple calls within the
+   * same frame coalesce into one. No-op if a frame is already scheduled.
+   */
+  request(): void {
+    if (this.animationFrameId !== null) return;
+    this.animationFrameId = this.raf(() => {
+      this.animationFrameId = null;
+      this.draw();
+    });
+  }
+
+  /**
+   * True iff a frame is currently pending.
+   */
+  get pending(): boolean {
+    return this.animationFrameId !== null;
+  }
+
+  /**
+   * Cancel any pending frame.  Call from component teardown.
+   */
+  dispose(): void {
+    if (this.animationFrameId !== null) {
+      this.cancel(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+  }
+}
+
+/**
+ * Returns true if any ping is still within its animation window.  Used to
+ * decide whether the canvas should keep an rAF loop alive between input
+ * changes (pings animate from a timestamp, so they need time-driven redraws).
+ */
+export function hasActivePings(
+  pings: ReadonlyArray<{ timestamp: number }>,
+  now: number,
+  durationMs: number,
+): boolean {
+  for (const p of pings) {
+    if (now - p.timestamp < durationMs) return true;
+  }
+  return false;
+}

--- a/apps/web/src/lib/stores/vtt/vtt-measurement-manager.svelte.ts
+++ b/apps/web/src/lib/stores/vtt/vtt-measurement-manager.svelte.ts
@@ -7,6 +7,13 @@ import type {
 import type { Point } from "schema";
 import { hashToColor, cloneMeasurement } from "$lib/utils/vtt-helpers";
 
+/**
+ * How long a ping stays alive — both for visual animation in MapCanvas and
+ * for the manager's cleanup timeout below.  Centralised so the two can't
+ * drift out of sync.
+ */
+export const PING_DURATION_MS = 3000;
+
 export interface VTTMeasurementManagerDependencies {
   emit: (message: VTTMessage) => void;
   getMyPeerId: () => string | null;
@@ -235,7 +242,7 @@ export class VTTMeasurementManager {
         }
       }
       this.pingTimeouts.delete(ping.peerId);
-    }, 3000);
+    }, PING_DURATION_MS);
     this.pingTimeouts.set(ping.peerId, timeoutId);
   }
 


### PR DESCRIPTION
## Summary

- Replaces the unconditional 60 fps `requestAnimationFrame(draw)` loop in `MapCanvas.svelte` with a redraw-on-dirty pattern (same idea as `Minimap.svelte`).
- Idle map view drops from ~60 draws/s to **0** draws/s. Battery + main-thread CPU win, especially on retina/4K displays.
- Extracts the rAF coalescing into a small `CanvasRedrawScheduler` utility so the logic is unit-testable without mounting the Svelte component.

## What changed

- New `apps/web/src/lib/components/map/map-canvas-scheduler.ts`
  - `CanvasRedrawScheduler` — coalesces multiple redraw requests within one frame into a single rAF callback. Injectable `raf`/`cancel` for tests.
  - `hasActivePings(pings, now, durationMs)` — pure helper used to decide whether the canvas should self-perpetuate its rAF loop while pings are mid-animation.
- New `map-canvas-scheduler.test.ts` — 14 Vitest cases covering coalescing, dispose, burst behaviour, and ping window edges.
- `MapCanvas.svelte`
  - `$effect` tracks every reactive input that affects the canvas and calls `scheduler.request()`.
  - `draw()` self-perpetuates only while a ping is still within its 3 s window.
  - rAF is cancelled in the `onMount` teardown.

## Why this matters

Per `docs/reports/PERFORMANCE_OPTIMIZATION_REPORT.md` §2.1, this was the single biggest preventable CPU cost in the app — every mounted map page rendered the canvas 60 ×/s for the entire session, regardless of whether anything had changed.

## Test plan

- [x] `bunx vitest run src/lib/components/map/map-canvas-scheduler.test.ts` — 14/14 pass.
- [x] `bun run lint` — clean.
- [ ] **Manual verification needed:** open `/map`, confirm:
  - Map renders correctly on initial load.
  - Pan/zoom updates the canvas immediately.
  - Token drag preview, fog brush preview, measurement, remote measurement all render.
  - Player ping animation plays smoothly for the full 3 s and stops after.
  - Performance: with the map idle, no rAF activity in DevTools' Performance panel.

Closes #977. Part of #969.