### PR TITLE
:zap: perf(graph): remove console.log from GraphStore.elements derived

### DIFF
--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -45,21 +45,6 @@ export class GraphStore {
       defaultVisibility: this.vault.defaultVisibility,
     };
 
-    // DEBUG VISIBILITY
-    if (this.vault.isGuest) {
-      console.log("[GraphStore] Visibility Check:", {
-        settings,
-        totalEntities: allEntities.length,
-        sampleEntity: allEntities[0]
-          ? {
-              id: allEntities[0].id,
-              labels: allEntities[0].labels,
-              visible: isEntityVisible(allEntities[0], settings),
-            }
-          : "none",
-      });
-    }
-
     // OPTIMIZATION: Build visible list and valid ID set in a single pass
     // to avoid multiple iterations and array allocations.
     // Also passes validIds to GraphTransformer to skip set reconstruction.


### PR DESCRIPTION
## Summary

Removes a debug `console.log` that was **inside the `elements` `$derived` block** in `GraphStore`. It ran synchronously on every entity write for guest sessions — serialising a payload into the console even with DevTools closed. For large vaults this was pure wasted CPU on every keystroke, drag, or sync event.

## What changed

`apps/web/src/lib/stores/graph.svelte.ts` — deleted the `// DEBUG VISIBILITY` block (lines 48–61 pre-patch):

```ts
// BEFORE
if (this.vault.isGuest) {
  console.log("[GraphStore] Visibility Check:", { settings, totalEntities, sampleEntity });
}

// AFTER
// (removed)
```

## Test plan

- [x] `bun run lint` — clean.
- [ ] Open a guest session (P2P join); confirm the DevTools console no longer floods with `[GraphStore] Visibility Check:` on every entity change.
- [ ] Graph still renders correctly in both host and guest modes.

Closes #981. Part of #969.