### PR TITLE
Serve bundle report via Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,8 +196,6 @@ jobs:
             echo "| Build directory | $(du -sh apps/web/build | cut -f1) |"
             echo "| JavaScript assets | $(find apps/web/build -type f -name '*.js' -print0 | du -ch --files0-from=- | tail -n 1 | cut -f1) |"
             echo "| CSS assets | $(find apps/web/build -type f -name '*.css' -print0 | du -ch --files0-from=- | tail -n 1 | cut -f1) |"
-            echo
-            echo "Bundle treemap is served at \`<deploy-url>/bundle-report.html\` and also in the \`bundle-report\` artifact."
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
@@ -259,6 +257,8 @@ jobs:
             | cut -c1-28 \
             | sed -E 's/-+$//')
           DEPLOYMENT_URL="https://${CF_BRANCH}.codex-cryptica.pages.dev"
+
+          echo "[Bundle report](${DEPLOYMENT_URL}/bundle-report.html)" >> "$GITHUB_STEP_SUMMARY"
 
           COMMENT="🚀 **Preview Deployment Ready!**
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,9 +154,12 @@ jobs:
       - name: Copy bundle report into build output
         run: |
           REPORT=$(find apps/web/.svelte-kit/output -name "bundle-report.html" | head -n 1)
-          if [ -n "$REPORT" ]; then
-            cp "$REPORT" apps/web/build/bundle-report.html
+          if [ -z "$REPORT" ]; then
+            echo "::error::bundle-report.html not found in Vite build output — visualizer may not have run"
+            exit 1
           fi
+          mkdir -p apps/web/build
+          cp "$REPORT" apps/web/build/bundle-report.html
 
       - name: Upload intermediate artifact
         uses: actions/upload-artifact@v7
@@ -260,13 +263,16 @@ jobs:
 
           echo "[Bundle report](${DEPLOYMENT_URL}/bundle-report.html)" >> "$GITHUB_STEP_SUMMARY"
 
-          COMMENT="🚀 **Preview Deployment Ready!**
+          COMMENT=$(cat <<EOF
+🚀 **Preview Deployment Ready!**
 
-          **URL:** ${DEPLOYMENT_URL}
-          **Bundle report:** ${DEPLOYMENT_URL}/bundle-report.html
-          **Branch:** \`${BRANCH}\`
+**URL:** ${DEPLOYMENT_URL}
+**Bundle report:** ${DEPLOYMENT_URL}/bundle-report.html
+**Branch:** \`${BRANCH}\`
 
-          _Changes will be live shortly._"
+_Changes will be live shortly._
+EOF
+)
 
           EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("Preview Deployment Ready!")) | .id' | head -n 1)
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,13 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: bun run build
 
+      - name: Copy bundle report into build output
+        run: |
+          REPORT=$(find apps/web/.svelte-kit/output -name "bundle-report.html" | head -n 1)
+          if [ -n "$REPORT" ]; then
+            cp "$REPORT" apps/web/build/bundle-report.html
+          fi
+
       - name: Upload intermediate artifact
         uses: actions/upload-artifact@v7
         with:
@@ -190,7 +197,7 @@ jobs:
             echo "| JavaScript assets | $(find apps/web/build -type f -name '*.js' -print0 | du -ch --files0-from=- | tail -n 1 | cut -f1) |"
             echo "| CSS assets | $(find apps/web/build -type f -name '*.css' -print0 | du -ch --files0-from=- | tail -n 1 | cut -f1) |"
             echo
-            echo "Bundle treemap and stats are available in the \`bundle-report\` artifact."
+            echo "Bundle treemap is served at \`<deploy-url>/bundle-report.html\` and also in the \`bundle-report\` artifact."
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
@@ -256,6 +263,7 @@ jobs:
           COMMENT="🚀 **Preview Deployment Ready!**
 
           **URL:** ${DEPLOYMENT_URL}
+          **Bundle report:** ${DEPLOYMENT_URL}/bundle-report.html
           **Branch:** \`${BRANCH}\`
 
           _Changes will be live shortly._"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,20 @@ jobs:
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: bun run build
 
+      - name: Download coverage reports
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage
+          path: coverage-download/
+
+      - name: Copy coverage into build output
+        run: |
+          if [ -d "coverage-download/apps/web/coverage" ]; then
+            cp -r coverage-download/apps/web/coverage apps/web/build/coverage
+          else
+            echo "::warning::Web coverage directory not found — skipping"
+          fi
+
       - name: Copy bundle report into build output
         run: |
           REPORT=$(find apps/web/.svelte-kit/output -name "bundle-report.html" | head -n 1)
@@ -260,7 +274,7 @@ jobs:
 
           echo "[Bundle report](${DEPLOYMENT_URL}/bundle-report.html)" >> "$GITHUB_STEP_SUMMARY"
 
-          COMMENT="$(printf '🚀 **Preview Deployment Ready!**\n\n**URL:** %s\n**Bundle report:** %s/bundle-report.html\n**Branch:** `%s`\n\n_Changes will be live shortly._' "$DEPLOYMENT_URL" "$DEPLOYMENT_URL" "$BRANCH")"
+          COMMENT="$(printf '🚀 **Preview Deployment Ready!**\n\n**URL:** %s\n**Bundle report:** %s/bundle-report.html\n**Coverage:** %s/coverage/\n**Branch:** `%s`\n\n_Changes will be live shortly._' "$DEPLOYMENT_URL" "$DEPLOYMENT_URL" "$DEPLOYMENT_URL" "$BRANCH")"
 
           EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("Preview Deployment Ready!")) | .id' | head -n 1)
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -263,16 +263,7 @@ jobs:
 
           echo "[Bundle report](${DEPLOYMENT_URL}/bundle-report.html)" >> "$GITHUB_STEP_SUMMARY"
 
-          COMMENT=$(cat <<EOF
-🚀 **Preview Deployment Ready!**
-
-**URL:** ${DEPLOYMENT_URL}
-**Bundle report:** ${DEPLOYMENT_URL}/bundle-report.html
-**Branch:** \`${BRANCH}\`
-
-_Changes will be live shortly._
-EOF
-)
+          COMMENT="$(printf '🚀 **Preview Deployment Ready!**\n\n**URL:** %s\n**Bundle report:** %s/bundle-report.html\n**Branch:** `%s`\n\n_Changes will be live shortly._' "$DEPLOYMENT_URL" "$DEPLOYMENT_URL" "$BRANCH")"
 
           EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("Preview Deployment Ready!")) | .id' | head -n 1)
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,6 +205,9 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     environment:
       name: ${{ github.ref_name == 'main' && 'production' || (github.ref_name == 'staging' && 'staging' || 'preview') }}
     steps:
@@ -227,9 +230,6 @@ jobs:
       - name: Deploy Staging to Cloudflare Pages
         if: github.ref_name == 'staging' && github.event_name == 'push'
         uses: cloudflare/wrangler-action@v4
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -239,9 +239,6 @@ jobs:
         if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != ''
         id: deploy_preview
         uses: cloudflare/wrangler-action@v4
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Copies `bundle-report.html` from the Vite build output into `apps/web/build/` so it's served by Cloudflare Pages at `<deploy-url>/bundle-report.html`
- Adds a **Bundle report** link to the PR preview comment alongside the app URL

## How to use

On any PR, the preview comment now looks like:

> 🚀 **Preview Deployment Ready!**
> **URL:** https://feature-branch.codex-cryptica.pages.dev
> **Bundle report:** https://feature-branch.codex-cryptica.pages.dev/bundle-report.html

On staging: `https://staging.codexcryptica.com/bundle-report.html`

Part of #946 / #1010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)