### PR TITLE
:zap: perf: share search keyword builders and preserve metadata values in indexing (#992)

### DIFF
--- a/apps/web/src/lib/services/search-entry-fields.test.ts
+++ b/apps/web/src/lib/services/search-entry-fields.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildSearchAliases, buildSearchKeywords } from "./search-entry-fields";
+
+describe("search-entry-fields", () => {
+  it("preserves non-nullish metadata values and stringifies array values", () => {
+    const keywords = buildSearchKeywords({
+      labels: ["tag-a"],
+      lore: "Lore",
+      metadata: {
+        chapter: 0,
+        hidden: false,
+        facets: [1, false, "north", null, undefined],
+      },
+    });
+
+    expect(keywords).toBe("tag-a Lore 0 false 1 false north");
+  });
+
+  it("stringifies non-nullish aliases", () => {
+    const aliases = buildSearchAliases({
+      aliases: ["The Hero", 0, false, null, undefined],
+    });
+
+    expect(aliases).toBe("The Hero 0 false");
+  });
+});

--- a/apps/web/src/lib/services/search-entry-fields.ts
+++ b/apps/web/src/lib/services/search-entry-fields.ts
@@ -1,0 +1,64 @@
+type SearchEntryEntity = {
+  labels?: unknown;
+  tags?: unknown;
+  lore?: unknown;
+  metadata?: unknown;
+  aliases?: unknown;
+};
+
+const isNotNullish = (value: unknown): value is NonNullable<unknown> =>
+  value !== null && value !== undefined;
+
+const asString = (value: unknown): string =>
+  typeof value === "string" ? value : String(value);
+
+export function buildSearchKeywords(entity: SearchEntryEntity): string {
+  const keywordBuffer: string[] = [];
+
+  const labelsOrTags = entity.labels || entity.tags;
+  if (Array.isArray(labelsOrTags)) {
+    for (let i = 0; i < labelsOrTags.length; i++) {
+      const tag = labelsOrTags[i];
+      if (isNotNullish(tag)) {
+        keywordBuffer.push(asString(tag));
+      }
+    }
+  }
+
+  if (isNotNullish(entity.lore)) {
+    keywordBuffer.push(asString(entity.lore));
+  }
+
+  if (entity.metadata && typeof entity.metadata === "object") {
+    const vals = Object.values(entity.metadata);
+    for (let i = 0; i < vals.length; i++) {
+      const val = vals[i];
+      if (Array.isArray(val)) {
+        for (let j = 0; j < val.length; j++) {
+          const innerVal = val[j];
+          if (isNotNullish(innerVal)) {
+            keywordBuffer.push(asString(innerVal));
+          }
+        }
+      } else if (isNotNullish(val)) {
+        keywordBuffer.push(asString(val));
+      }
+    }
+  }
+
+  return keywordBuffer.join(" ");
+}
+
+export function buildSearchAliases(entity: SearchEntryEntity): string {
+  if (!Array.isArray(entity.aliases)) return "";
+
+  const aliasesBuffer: string[] = [];
+  for (let i = 0; i < entity.aliases.length; i++) {
+    const alias = entity.aliases[i];
+    if (isNotNullish(alias)) {
+      aliasesBuffer.push(asString(alias));
+    }
+  }
+
+  return aliasesBuffer.join(" ");
+}

--- a/apps/web/src/lib/services/search-index-pipeline.svelte.ts
+++ b/apps/web/src/lib/services/search-index-pipeline.svelte.ts
@@ -346,16 +346,51 @@ export class SearchIndexPipeline {
 
   private mapToSearchEntry(entity: any): SearchEntry {
     const path = entity._path?.join("/") || `${entity.id}.md`;
-    const keywords = [
-      ...(entity.labels || entity.tags || []),
-      entity.lore || "",
-      ...Object.values(entity.metadata || {}).flat(),
-    ].join(" ");
+
+    // Avoid spreading, flattening, and intermediate arrays for keywords
+    const keywordBuffer: string[] = [];
+
+    const labelsOrTags = entity.labels || entity.tags;
+    if (labelsOrTags && Array.isArray(labelsOrTags)) {
+      for (let i = 0; i < labelsOrTags.length; i++) {
+        const tag = labelsOrTags[i];
+        if (tag) {
+          keywordBuffer.push(tag);
+        }
+      }
+    }
+
+    if (entity.lore) {
+      keywordBuffer.push(entity.lore);
+    }
+
+    if (entity.metadata && typeof entity.metadata === "object") {
+      const vals = Object.values(entity.metadata);
+      for (let i = 0; i < vals.length; i++) {
+        const val = vals[i];
+        if (Array.isArray(val)) {
+          for (let j = 0; j < val.length; j++) {
+            const innerVal = val[j];
+            if (innerVal) {
+              keywordBuffer.push(innerVal);
+            }
+          }
+        } else if (val) {
+          keywordBuffer.push(typeof val === "string" ? val : String(val));
+        }
+      }
+    }
+
+    const keywords = keywordBuffer.join(" ");
+    const aliases =
+      entity.aliases && Array.isArray(entity.aliases)
+        ? entity.aliases.join(" ")
+        : "";
 
     return {
       id: entity.id,
       title: entity.title,
-      aliases: (entity.aliases || []).join(" "),
+      aliases,
       content: entity.content || "",
       type: entity.type,
       path,

--- a/apps/web/src/lib/services/search-index-pipeline.svelte.ts
+++ b/apps/web/src/lib/services/search-index-pipeline.svelte.ts
@@ -10,6 +10,7 @@ import type {
   SearchProgressCoordinator,
   TimerApi,
 } from "./search-progress-coordinator";
+import { buildSearchAliases, buildSearchKeywords } from "./search-entry-fields";
 
 const INDEX_BATCH_SIZE = 100;
 
@@ -346,46 +347,8 @@ export class SearchIndexPipeline {
 
   private mapToSearchEntry(entity: any): SearchEntry {
     const path = entity._path?.join("/") || `${entity.id}.md`;
-
-    // Avoid spreading, flattening, and intermediate arrays for keywords
-    const keywordBuffer: string[] = [];
-
-    const labelsOrTags = entity.labels || entity.tags;
-    if (labelsOrTags && Array.isArray(labelsOrTags)) {
-      for (let i = 0; i < labelsOrTags.length; i++) {
-        const tag = labelsOrTags[i];
-        if (tag) {
-          keywordBuffer.push(tag);
-        }
-      }
-    }
-
-    if (entity.lore) {
-      keywordBuffer.push(entity.lore);
-    }
-
-    if (entity.metadata && typeof entity.metadata === "object") {
-      const vals = Object.values(entity.metadata);
-      for (let i = 0; i < vals.length; i++) {
-        const val = vals[i];
-        if (Array.isArray(val)) {
-          for (let j = 0; j < val.length; j++) {
-            const innerVal = val[j];
-            if (innerVal) {
-              keywordBuffer.push(innerVal);
-            }
-          }
-        } else if (val) {
-          keywordBuffer.push(typeof val === "string" ? val : String(val));
-        }
-      }
-    }
-
-    const keywords = keywordBuffer.join(" ");
-    const aliases =
-      entity.aliases && Array.isArray(entity.aliases)
-        ? entity.aliases.join(" ")
-        : "";
+    const keywords = buildSearchKeywords(entity);
+    const aliases = buildSearchAliases(entity);
 
     return {
       id: entity.id,

--- a/apps/web/src/lib/stores/vault/search-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/search-store.svelte.ts
@@ -10,16 +10,51 @@ export class SearchStore {
 
   private async indexEntity(entity: LocalEntity, services: any) {
     const path = entity._path?.join("/") || `${entity.id}.md`;
-    const keywords = [
-      ...(entity.labels || entity.tags || []),
-      entity.lore || "",
-      ...Object.values(entity.metadata || {}).flat(),
-    ].join(" ");
+
+    // Avoid spreading, flattening, and intermediate arrays for keywords
+    const keywordBuffer: string[] = [];
+
+    const labelsOrTags = entity.labels || entity.tags;
+    if (labelsOrTags && Array.isArray(labelsOrTags)) {
+      for (let i = 0; i < labelsOrTags.length; i++) {
+        const tag = labelsOrTags[i];
+        if (tag) {
+          keywordBuffer.push(tag);
+        }
+      }
+    }
+
+    if (entity.lore) {
+      keywordBuffer.push(entity.lore);
+    }
+
+    if (entity.metadata && typeof entity.metadata === "object") {
+      const vals = Object.values(entity.metadata);
+      for (let i = 0; i < vals.length; i++) {
+        const val = vals[i];
+        if (Array.isArray(val)) {
+          for (let j = 0; j < val.length; j++) {
+            const innerVal = val[j];
+            if (innerVal) {
+              keywordBuffer.push(innerVal);
+            }
+          }
+        } else if (val) {
+          keywordBuffer.push(typeof val === "string" ? val : String(val));
+        }
+      }
+    }
+
+    const keywords = keywordBuffer.join(" ");
+    const aliases =
+      entity.aliases && Array.isArray(entity.aliases)
+        ? entity.aliases.join(" ")
+        : "";
 
     await services.search.index({
       id: entity.id,
       title: entity.title,
-      aliases: (entity.aliases || []).join(" "),
+      aliases,
       content: entity.content,
       lore: entity.lore,
       type: entity.type,

--- a/apps/web/src/lib/stores/vault/search-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/search-store.svelte.ts
@@ -1,5 +1,6 @@
 import { ServiceRegistry } from "./service-registry";
 import type { LocalEntity } from "./types";
+import { buildSearchAliases, buildSearchKeywords } from "../../services/search-entry-fields";
 
 export class SearchStore {
   constructor(private _serviceRegistry: ServiceRegistry) {
@@ -10,46 +11,8 @@ export class SearchStore {
 
   private async indexEntity(entity: LocalEntity, services: any) {
     const path = entity._path?.join("/") || `${entity.id}.md`;
-
-    // Avoid spreading, flattening, and intermediate arrays for keywords
-    const keywordBuffer: string[] = [];
-
-    const labelsOrTags = entity.labels || entity.tags;
-    if (labelsOrTags && Array.isArray(labelsOrTags)) {
-      for (let i = 0; i < labelsOrTags.length; i++) {
-        const tag = labelsOrTags[i];
-        if (tag) {
-          keywordBuffer.push(tag);
-        }
-      }
-    }
-
-    if (entity.lore) {
-      keywordBuffer.push(entity.lore);
-    }
-
-    if (entity.metadata && typeof entity.metadata === "object") {
-      const vals = Object.values(entity.metadata);
-      for (let i = 0; i < vals.length; i++) {
-        const val = vals[i];
-        if (Array.isArray(val)) {
-          for (let j = 0; j < val.length; j++) {
-            const innerVal = val[j];
-            if (innerVal) {
-              keywordBuffer.push(innerVal);
-            }
-          }
-        } else if (val) {
-          keywordBuffer.push(typeof val === "string" ? val : String(val));
-        }
-      }
-    }
-
-    const keywords = keywordBuffer.join(" ");
-    const aliases =
-      entity.aliases && Array.isArray(entity.aliases)
-        ? entity.aliases.join(" ")
-        : "";
+    const keywords = buildSearchKeywords(entity);
+    const aliases = buildSearchAliases(entity);
 
     await services.search.index({
       id: entity.id,


### PR DESCRIPTION
## 🎯 Purpose

Improve search indexing performance while correcting keyword/alias value handling and preventing drift between indexing paths.

## 🛠️ Changes

- Extracted shared search field helpers:
  - `buildSearchKeywords(entity)`
  - `buildSearchAliases(entity)`
- Reused these helpers in both:
  - `mapToSearchEntry()` in `search-index-pipeline.svelte.ts`
  - `indexEntity()` in `search-store.svelte.ts`
- Corrected value handling to preserve valid non-nullish values like `0` and `false` (instead of dropping them via truthy checks).
- Normalized string coercion for metadata/alias array values to keep keyword generation consistent.
- Added focused tests for helper behavior in:
  - `apps/web/src/lib/services/search-entry-fields.test.ts`

## 🚦 Target Branch Reminder

> [!IMPORTANT]
> **This PR must target the `staging` branch.**
> All features and fixes must be verified on staging before being promoted to `main`.

## 🧪 Testing

- `bun run lint`
- `bun run build`
- `bun run test`
- `bun run --filter web lint -- <changed files>`
- `bun run --filter web test -- src/lib/services/search-entry-fields.test.ts src/lib/stores/vault/search-store.test.ts`
- `bun run --filter web test -- src/lib/services/search.svelte.test.ts`
- `bun run --filter web lint:types` (warnings only, no errors)

## 🏷️ Release Labeling

- `minor`: New features / Major enhancements (triggers a formal release)
- `major`: Breaking changes
- (No label): Bug fixes / Chores / Internal updates