### PR TITLE
:zap: perf(graph): clamp cytoscape pixelRatio to 1.5 on HiDPI displays

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -88,6 +88,7 @@
     "@vitest/coverage-v8": "^4.1.7",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
+    "rollup-plugin-visualizer": "^7.0.1",
     "start-server-and-test": "^3.0.5",
     "svelte": "^5.55.9",
     "svelte-check": "^4.4.8",

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
         "@vitest/coverage-v8": "^4.1.7",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
+        "rollup-plugin-visualizer": "^7.0.1",
         "start-server-and-test": "^3.0.5",
         "svelte": "^5.55.9",
         "svelte-check": "^4.4.8",

--- a/packages/graph-engine/src/index.ts
+++ b/packages/graph-engine/src/index.ts
@@ -77,7 +77,13 @@ export const initGraph = async (options: GraphOptions) => {
     // Rendering Optimizations
     hideLabelsOnViewport: true,
     textureOnViewport: true,
-    pixelRatio: "auto",
+    // Cap DPR at 1.5 — on 2× retina "auto" rasterises at 4× pixel area,
+    // which dominates GPU cost for large graphs. 1.5 is imperceptible to
+    // users while halving rasterisation work on HiDPI displays.
+    pixelRatio:
+      typeof window !== "undefined"
+        ? Math.min(window.devicePixelRatio || 1, 1.5)
+        : 1,
     minZoom: Math.max(0.01, 0.3 - nodeCount * 0.0005),
     maxZoom: 9.0,
     wheelSensitivity: 1.0,


### PR DESCRIPTION
## Summary

`pixelRatio: "auto"` tells Cytoscape to rasterise the graph canvas at the native device DPR. On a 2× retina display that's **4× the pixel area** of a standard screen. For large graphs this is the dominant GPU cost.

Caps DPR at **1.5** — halves rasterisation work on 2× screens with no perceptible visual difference (subpixel anti-aliasing on graph edges doesn't benefit from full native resolution the way text does). SSR/headless falls back to `1`.

Also fixes a **pre-existing staging breakage**: `vite.config.ts` imported `rollup-plugin-visualizer` but the package wasn't in `apps/web/package.json`, causing all `bun run test` runs to fail with `ERR_MODULE_NOT_FOUND`. Added it as a `devDependency`.

## Test plan

- [x] `graph-engine` test suite — 102/102 pass.
- [x] All web tests — 1617/1617 pass (213 test files).
- [x] `bun run lint` — clean.
- [ ] Open the graph view on a retina/HiDPI display; confirm nodes and edges look sharp enough.

Closes #979. Part of #969.