### PR TITLE
⚡ perf: replace derived fields in EntityStore with incremental indexes

### DIFF
--- a/apps/web/src/lib/stores/vault/entity-mutations.ts
+++ b/apps/web/src/lib/stores/vault/entity-mutations.ts
@@ -23,6 +23,10 @@ export interface MutationDependencies {
   getServices: () => IVaultServices | null;
   onEntityDelete?: (entityId: string) => void;
   onBatchUpdate?: (updates: Record<string, Partial<LocalEntity>>) => void;
+  onEntitiesUpdated?: (
+    oldEntities: Record<string, LocalEntity>,
+    newEntities: Record<string, LocalEntity>,
+  ) => void;
   onConnectionAdded?: (
     sourceId: string,
     targetId: string,
@@ -55,6 +59,7 @@ export class EntityMutationService {
         MutationDependencies,
         | "onEntityDelete"
         | "onBatchUpdate"
+        | "onEntitiesUpdated"
         | "onConnectionAdded"
         | "onConnectionRemoved"
         | "onConnectionUpdated"
@@ -74,7 +79,9 @@ export class EntityMutationService {
   }
 
   set entities(val: Record<string, LocalEntity>) {
+    const oldVal = this.deps.repository.entities;
     this.deps.repository.entities = val;
+    this.deps.onEntitiesUpdated?.(oldVal, val);
   }
 
   async createEntity(

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -59,21 +59,23 @@ export class EntityStore {
     this.repository.entities = val;
   }
 
-  allEntities: LocalEntity[];
-  allActiveEntities: LocalEntity[];
+  allEntities = $state<LocalEntity[]>([]);
+  allActiveEntities = $state<LocalEntity[]>([]);
   inboundConnections = $state<InboundMap>({});
-  parentToChildren: Record<string, string[]>;
-  labelIndex: string[];
-  labelCounts: Record<string, number>;
-  titleAndAliasIndex: Array<{
-    lowercaseText: string;
-    entityId: string;
-    actualTitle: string;
-    isAlias: boolean;
-    visibility?: string;
-    labels?: string[];
-    status: string;
-  }>;
+  parentToChildren = $state<Record<string, string[]>>({});
+  labelIndex = $state<string[]>([]);
+  labelCounts = $state<Record<string, number>>({});
+  titleAndAliasIndex = $state<
+    Array<{
+      lowercaseText: string;
+      entityId: string;
+      actualTitle: string;
+      isAlias: boolean;
+      visibility?: string;
+      labels?: string[];
+      status: string;
+    }>
+  >([]);
 
   constructor(
     depsOrRepository: EntityStoreDependencies | VaultRepository,
@@ -117,6 +119,9 @@ export class EntityStore {
         },
         onBatchUpdate: (updates) => {
           originalOnBatchUpdate?.(updates);
+        },
+        onEntitiesUpdated: (oldVal, val) => {
+          this.handleEntitiesUpdate(oldVal, val);
         },
         onConnectionAdded: (sourceId, targetId, connection) => {
           this.patchAddConnection(sourceId, targetId, connection);
@@ -171,6 +176,9 @@ export class EntityStore {
           if (deps.onEntityDelete) deps.onEntityDelete(id);
         },
         onBatchUpdate: deps.onBatchUpdate,
+        onEntitiesUpdated: (oldVal, val) => {
+          this.handleEntitiesUpdate(oldVal, val);
+        },
         updateEntityCount: deps.updateEntityCount,
         onConnectionAdded: (sourceId, targetId, connection) => {
           this.patchAddConnection(sourceId, targetId, connection);
@@ -190,23 +198,7 @@ export class EntityStore {
       this.entities,
     );
 
-    this.allEntities = $derived.by(() => Object.values(this.entities));
-    this.allActiveEntities = $derived.by(() =>
-      this.allEntities.filter((e) => e.status !== "draft"),
-    );
-    this.parentToChildren = $derived.by(() => {
-      const map: Record<string, string[]> = {};
-      for (const entity of this.allEntities) {
-        if (entity.parent) {
-          if (!map[entity.parent]) {
-            map[entity.parent] = [];
-          }
-          map[entity.parent].push(entity.id);
-        }
-      }
-      return map;
-    });
-
+    this.rebuildIndexes();
     this.initializeInboundConnections();
 
     if (this._eventBusUnsubscribe) {
@@ -220,82 +212,410 @@ export class EntityStore {
         event.type === "SYNC_CHUNK_READY"
       ) {
         this.initializeInboundConnections();
+        this.rebuildIndexes();
       }
     }, "EntityStore-InboundRebuild");
-    const labelData = $derived.by(() => {
-      const labels = new Set<string>();
-      const counts: Record<string, number> = {};
+  }
 
-      for (const entity of this.allEntities) {
-        if (entity.labels) {
-          const isDraft = entity.status === "draft";
-          for (const l of entity.labels) {
-            labels.add(l);
-          }
+  // --- Incremental Index Maintenance ---
 
-          if (!isDraft) {
-            const uniqueLabels = new Set(entity.labels);
-            for (const l of uniqueLabels) {
-              counts[l] = (counts[l] || 0) + 1;
-            }
+  rebuildIndexes() {
+    const entities = this.entities;
+    const all = Object.values(entities);
+
+    this.allEntities = all;
+    this.allActiveEntities = all.filter((e) => e.status !== "draft");
+
+    const parentMap: Record<string, string[]> = {};
+    const labelsSet = new Set<string>();
+    const counts: Record<string, number> = {};
+    const titleAndAlias: Array<{
+      lowercaseText: string;
+      entityId: string;
+      actualTitle: string;
+      isAlias: boolean;
+      visibility?: string;
+      labels?: string[];
+      status: string;
+    }> = [];
+
+    for (let i = 0; i < all.length; i++) {
+      const entity = all[i];
+
+      // Parent to children mapping
+      if (entity.parent) {
+        if (!parentMap[entity.parent]) {
+          parentMap[entity.parent] = [];
+        }
+        parentMap[entity.parent].push(entity.id);
+      }
+
+      // Label index and counts
+      if (entity.labels) {
+        const isDraft = entity.status === "draft";
+        for (let j = 0; j < entity.labels.length; j++) {
+          labelsSet.add(entity.labels[j]);
+        }
+        if (!isDraft) {
+          const uniqueLabels = new Set(entity.labels);
+          for (const l of uniqueLabels) {
+            counts[l] = (counts[l] || 0) + 1;
           }
         }
       }
 
-      return {
-        index: Array.from(labels).sort(),
-        counts,
-      };
-    });
+      // Title matching index
+      if (entity.title) {
+        titleAndAlias.push({
+          lowercaseText: entity.title.toLowerCase(),
+          entityId: entity.id,
+          actualTitle: entity.title,
+          isAlias: false,
+          visibility: entity.visibility,
+          labels: entity.labels,
+          status: entity.status || "active",
+        });
+      }
 
-    this.labelIndex = $derived(labelData.index);
-    this.labelCounts = $derived(labelData.counts);
+      // Alias matching index
+      if (entity.aliases && Array.isArray(entity.aliases)) {
+        for (let j = 0; j < entity.aliases.length; j++) {
+          const alias = entity.aliases[j];
+          if (alias) {
+            titleAndAlias.push({
+              lowercaseText: alias.toLowerCase(),
+              entityId: entity.id,
+              actualTitle: entity.title,
+              isAlias: true,
+              visibility: entity.visibility,
+              labels: entity.labels,
+              status: entity.status || "active",
+            });
+          }
+        }
+      }
+    }
 
-    this.titleAndAliasIndex = $derived.by(() => {
-      const idx: Array<{
-        lowercaseText: string;
-        entityId: string;
-        actualTitle: string;
-        isAlias: boolean;
-        visibility?: string;
-        labels?: string[];
-        status: string;
-      }> = [];
+    this.parentToChildren = parentMap;
+    this.labelIndex = Array.from(labelsSet).sort();
+    this.labelCounts = counts;
+    this.titleAndAliasIndex = titleAndAlias.sort(
+      (a, b) => b.lowercaseText.length - a.lowercaseText.length,
+    );
+  }
 
-      for (const entity of this.allEntities) {
-        if (entity.title) {
-          idx.push({
-            lowercaseText: entity.title.toLowerCase(),
+  handleEntitiesUpdate(
+    oldMap: Record<string, LocalEntity>,
+    newMap: Record<string, LocalEntity>,
+  ) {
+    const oldKeys = Object.keys(oldMap);
+    const newKeys = Object.keys(newMap);
+
+    // If either map is completely empty, do a full rebuild.
+    if (oldKeys.length === 0 || newKeys.length === 0) {
+      this.rebuildIndexes();
+      return;
+    }
+
+    // Detect deleted entities
+    for (let i = 0; i < oldKeys.length; i++) {
+      const id = oldKeys[i];
+      if (!newMap[id]) {
+        this.incrementalDelete(oldMap[id]);
+      }
+    }
+
+    // Detect added or modified entities
+    for (let i = 0; i < newKeys.length; i++) {
+      const id = newKeys[i];
+      const oldEnt = oldMap[id];
+      const newEnt = newMap[id];
+
+      if (!oldEnt) {
+        this.incrementalAdd(newEnt);
+      } else if (oldEnt !== newEnt) {
+        // Compare only index-relevant fields to detect if a heavy re-indexing is required.
+        const titleChanged = oldEnt.title !== newEnt.title;
+        const aliasesChanged =
+          JSON.stringify(oldEnt.aliases) !== JSON.stringify(newEnt.aliases);
+        const labelsChanged =
+          JSON.stringify(oldEnt.labels) !== JSON.stringify(newEnt.labels);
+        const parentChanged = oldEnt.parent !== newEnt.parent;
+        const statusChanged = oldEnt.status !== newEnt.status;
+        const visibilityChanged = oldEnt.visibility !== newEnt.visibility;
+
+        if (
+          titleChanged ||
+          aliasesChanged ||
+          labelsChanged ||
+          parentChanged ||
+          statusChanged ||
+          visibilityChanged
+        ) {
+          this.incrementalUpdate(oldEnt, newEnt);
+        } else {
+          // Cold content or timestamp update path (e.g. keystroke inside editor).
+          // Update in place to run at ultra-fast O(1) complexity.
+          const idx = this.allEntities.findIndex((e) => e.id === id);
+          if (idx !== -1) {
+            this.allEntities[idx] = newEnt;
+          }
+          if (newEnt.status !== "draft") {
+            const activeIdx = this.allActiveEntities.findIndex(
+              (e) => e.id === id,
+            );
+            if (activeIdx !== -1) {
+              this.allActiveEntities[activeIdx] = newEnt;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private incrementalAdd(entity: LocalEntity) {
+    const id = entity.id;
+
+    this.allEntities.push(entity);
+    if (entity.status !== "draft") {
+      this.allActiveEntities.push(entity);
+    }
+
+    if (entity.parent) {
+      if (!this.parentToChildren[entity.parent]) {
+        this.parentToChildren[entity.parent] = [];
+      }
+      if (!this.parentToChildren[entity.parent].includes(id)) {
+        this.parentToChildren[entity.parent].push(id);
+      }
+    }
+
+    let addedToTitleIndex = false;
+    if (entity.title) {
+      this.titleAndAliasIndex.push({
+        lowercaseText: entity.title.toLowerCase(),
+        entityId: entity.id,
+        actualTitle: entity.title,
+        isAlias: false,
+        visibility: entity.visibility,
+        labels: entity.labels,
+        status: entity.status || "active",
+      });
+      addedToTitleIndex = true;
+    }
+    if (entity.aliases && Array.isArray(entity.aliases)) {
+      for (let j = 0; j < entity.aliases.length; j++) {
+        const alias = entity.aliases[j];
+        if (alias) {
+          this.titleAndAliasIndex.push({
+            lowercaseText: alias.toLowerCase(),
             entityId: entity.id,
             actualTitle: entity.title,
-            isAlias: false,
+            isAlias: true,
             visibility: entity.visibility,
             labels: entity.labels,
             status: entity.status || "active",
           });
+          addedToTitleIndex = true;
         }
+      }
+    }
+    if (addedToTitleIndex) {
+      this.titleAndAliasIndex.sort(
+        (a, b) => b.lowercaseText.length - a.lowercaseText.length,
+      );
+    }
 
-        if (entity.aliases && Array.isArray(entity.aliases)) {
-          for (const alias of entity.aliases) {
-            if (alias) {
-              idx.push({
-                lowercaseText: alias.toLowerCase(),
-                entityId: entity.id,
-                actualTitle: entity.title,
-                isAlias: true,
-                visibility: entity.visibility,
-                labels: entity.labels,
-                status: entity.status || "active",
-              });
-            }
+    if (entity.labels) {
+      const isDraft = entity.status === "draft";
+      let labelsAdded = false;
+
+      for (let j = 0; j < entity.labels.length; j++) {
+        const l = entity.labels[j];
+        if (!this.labelIndex.includes(l)) {
+          this.labelIndex.push(l);
+          labelsAdded = true;
+        }
+        if (!isDraft) {
+          this.labelCounts[l] = (this.labelCounts[l] || 0) + 1;
+        }
+      }
+
+      if (labelsAdded) {
+        this.labelIndex.sort();
+      }
+    }
+  }
+
+  private incrementalDelete(entity: LocalEntity) {
+    const id = entity.id;
+
+    this.allEntities = this.allEntities.filter((e) => e.id !== id);
+    if (entity.status !== "draft") {
+      this.allActiveEntities = this.allActiveEntities.filter(
+        (e) => e.id !== id,
+      );
+    }
+
+    if (entity.parent && this.parentToChildren[entity.parent]) {
+      this.parentToChildren[entity.parent] = this.parentToChildren[
+        entity.parent
+      ].filter((cid) => cid !== id);
+      if (this.parentToChildren[entity.parent].length === 0) {
+        delete this.parentToChildren[entity.parent];
+      }
+    }
+    if (this.parentToChildren[id]) {
+      delete this.parentToChildren[id];
+    }
+
+    this.titleAndAliasIndex = this.titleAndAliasIndex.filter(
+      (item) => item.entityId !== id,
+    );
+
+    if (entity.labels) {
+      const isDraft = entity.status === "draft";
+      for (let j = 0; j < entity.labels.length; j++) {
+        const l = entity.labels[j];
+        if (!isDraft && this.labelCounts[l] !== undefined) {
+          this.labelCounts[l]--;
+          if (this.labelCounts[l] <= 0) {
+            delete this.labelCounts[l];
           }
         }
       }
 
-      return idx.sort(
+      const remainingLabels = new Set<string>();
+      for (let j = 0; j < this.allEntities.length; j++) {
+        const e = this.allEntities[j];
+        if (e.labels) {
+          for (let k = 0; k < e.labels.length; k++) {
+            remainingLabels.add(e.labels[k]);
+          }
+        }
+      }
+      this.labelIndex = Array.from(remainingLabels).sort();
+    }
+  }
+
+  private incrementalUpdate(oldEntity: LocalEntity, newEntity: LocalEntity) {
+    const id = newEntity.id;
+
+    const idx = this.allEntities.findIndex((e) => e.id === id);
+    if (idx !== -1) {
+      this.allEntities[idx] = newEntity;
+    } else {
+      this.allEntities.push(newEntity);
+    }
+
+    const wasActive = oldEntity.status !== "draft";
+    const isActive = newEntity.status !== "draft";
+
+    if (wasActive && !isActive) {
+      this.allActiveEntities = this.allActiveEntities.filter(
+        (e) => e.id !== id,
+      );
+    } else if (!wasActive && isActive) {
+      this.allActiveEntities.push(newEntity);
+    } else if (isActive) {
+      const activeIdx = this.allActiveEntities.findIndex((e) => e.id === id);
+      if (activeIdx !== -1) {
+        this.allActiveEntities[activeIdx] = newEntity;
+      } else {
+        this.allActiveEntities.push(newEntity);
+      }
+    }
+
+    if (oldEntity.parent !== newEntity.parent) {
+      if (oldEntity.parent && this.parentToChildren[oldEntity.parent]) {
+        this.parentToChildren[oldEntity.parent] = this.parentToChildren[
+          oldEntity.parent
+        ].filter((cid) => cid !== id);
+        if (this.parentToChildren[oldEntity.parent].length === 0) {
+          delete this.parentToChildren[oldEntity.parent];
+        }
+      }
+      if (newEntity.parent) {
+        if (!this.parentToChildren[newEntity.parent]) {
+          this.parentToChildren[newEntity.parent] = [];
+        }
+        if (!this.parentToChildren[newEntity.parent].includes(id)) {
+          this.parentToChildren[newEntity.parent].push(id);
+        }
+      }
+    }
+
+    this.titleAndAliasIndex = this.titleAndAliasIndex.filter(
+      (item) => item.entityId !== id,
+    );
+    let addedToTitleIndex = false;
+    if (newEntity.title) {
+      this.titleAndAliasIndex.push({
+        lowercaseText: newEntity.title.toLowerCase(),
+        entityId: newEntity.id,
+        actualTitle: newEntity.title,
+        isAlias: false,
+        visibility: newEntity.visibility,
+        labels: newEntity.labels,
+        status: newEntity.status || "active",
+      });
+      addedToTitleIndex = true;
+    }
+    if (newEntity.aliases && Array.isArray(newEntity.aliases)) {
+      for (let j = 0; j < newEntity.aliases.length; j++) {
+        const alias = newEntity.aliases[j];
+        if (alias) {
+          this.titleAndAliasIndex.push({
+            lowercaseText: alias.toLowerCase(),
+            entityId: newEntity.id,
+            actualTitle: newEntity.title,
+            isAlias: true,
+            visibility: newEntity.visibility,
+            labels: newEntity.labels,
+            status: newEntity.status || "active",
+          });
+          addedToTitleIndex = true;
+        }
+      }
+    }
+    if (addedToTitleIndex) {
+      this.titleAndAliasIndex.sort(
         (a, b) => b.lowercaseText.length - a.lowercaseText.length,
       );
-    });
+    }
+
+    if (wasActive && oldEntity.labels) {
+      for (let j = 0; j < oldEntity.labels.length; j++) {
+        const l = oldEntity.labels[j];
+        if (this.labelCounts[l] !== undefined) {
+          this.labelCounts[l]--;
+          if (this.labelCounts[l] <= 0) {
+            delete this.labelCounts[l];
+          }
+        }
+      }
+    }
+    if (isActive && newEntity.labels) {
+      const uniqueLabels = new Set(newEntity.labels);
+      for (const l of uniqueLabels) {
+        this.labelCounts[l] = (this.labelCounts[l] || 0) + 1;
+      }
+    }
+
+    const oldLabelsStr = JSON.stringify(oldEntity.labels || []);
+    const newLabelsStr = JSON.stringify(newEntity.labels || []);
+    if (oldLabelsStr !== newLabelsStr) {
+      const remainingLabels = new Set<string>();
+      for (let j = 0; j < this.allEntities.length; j++) {
+        const e = this.allEntities[j];
+        if (e.labels) {
+          for (let k = 0; k < e.labels.length; k++) {
+            remainingLabels.add(e.labels[k]);
+          }
+        }
+      }
+      this.labelIndex = Array.from(remainingLabels).sort();
+    }
   }
 
   // --- Persistence Delegation ---

--- a/apps/web/src/lib/stores/vault/entity-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.svelte.ts
@@ -42,6 +42,10 @@ export interface EntityStoreDependencies {
   onEntityDelete?: (entityId: string) => void;
   onBatchUpdate?: (updates: Record<string, Partial<LocalEntity>>) => void;
   updateEntityCount: (vaultId: string, count: number) => Promise<void>;
+  onEntitiesUpdated?: (
+    oldEntities: Record<string, LocalEntity>,
+    newEntities: Record<string, LocalEntity>,
+  ) => void;
 }
 
 export class EntityStore {
@@ -111,6 +115,7 @@ export class EntityStore {
 
       const originalOnEntityDelete = this.mutations.deps?.onEntityDelete;
       const originalOnBatchUpdate = this.mutations.deps?.onBatchUpdate;
+      const originalOnEntitiesUpdated = this.mutations.deps?.onEntitiesUpdated;
 
       this.mutations.registerStoreCallbacks({
         onEntityDelete: (id) => {
@@ -122,6 +127,7 @@ export class EntityStore {
         },
         onEntitiesUpdated: (oldVal, val) => {
           this.handleEntitiesUpdate(oldVal, val);
+          originalOnEntitiesUpdated?.(oldVal, val);
         },
         onConnectionAdded: (sourceId, targetId, connection) => {
           this.patchAddConnection(sourceId, targetId, connection);
@@ -178,6 +184,7 @@ export class EntityStore {
         onBatchUpdate: deps.onBatchUpdate,
         onEntitiesUpdated: (oldVal, val) => {
           this.handleEntitiesUpdate(oldVal, val);
+          if (deps.onEntitiesUpdated) deps.onEntitiesUpdated(oldVal, val);
         },
         updateEntityCount: deps.updateEntityCount,
         onConnectionAdded: (sourceId, targetId, connection) => {
@@ -355,7 +362,7 @@ export class EntityStore {
           this.incrementalUpdate(oldEnt, newEnt);
         } else {
           // Cold content or timestamp update path (e.g. keystroke inside editor).
-          // Update in place to run at ultra-fast O(1) complexity.
+          // Update in place to run with O(N) lookup, bypassing expensive index rebuilds.
           const idx = this.allEntities.findIndex((e) => e.id === id);
           if (idx !== -1) {
             this.allEntities[idx] = newEnt;
@@ -429,9 +436,9 @@ export class EntityStore {
     if (entity.labels) {
       const isDraft = entity.status === "draft";
       let labelsAdded = false;
+      const uniqueLabels = new Set(entity.labels);
 
-      for (let j = 0; j < entity.labels.length; j++) {
-        const l = entity.labels[j];
+      for (const l of uniqueLabels) {
         if (!this.labelIndex.includes(l)) {
           this.labelIndex.push(l);
           labelsAdded = true;
@@ -475,8 +482,8 @@ export class EntityStore {
 
     if (entity.labels) {
       const isDraft = entity.status === "draft";
-      for (let j = 0; j < entity.labels.length; j++) {
-        const l = entity.labels[j];
+      const uniqueLabels = new Set(entity.labels);
+      for (const l of uniqueLabels) {
         if (!isDraft && this.labelCounts[l] !== undefined) {
           this.labelCounts[l]--;
           if (this.labelCounts[l] <= 0) {
@@ -585,8 +592,8 @@ export class EntityStore {
     }
 
     if (wasActive && oldEntity.labels) {
-      for (let j = 0; j < oldEntity.labels.length; j++) {
-        const l = oldEntity.labels[j];
+      const uniqueOldLabels = new Set(oldEntity.labels);
+      for (const l of uniqueOldLabels) {
         if (this.labelCounts[l] !== undefined) {
           this.labelCounts[l]--;
           if (this.labelCounts[l] <= 0) {

--- a/apps/web/src/lib/stores/vault/entity-store.test.ts
+++ b/apps/web/src/lib/stores/vault/entity-store.test.ts
@@ -1300,4 +1300,116 @@ describe("EntityStore", () => {
       await Promise.all([save1, save2]);
     });
   });
+
+  describe("Incremental Index Maintenance", () => {
+    it("correctly de-duplicates labels and updates index / counts when entity is added", () => {
+      const initialMap = { ...repository.entities };
+      const newMap = {
+        ...initialMap,
+        newHero: {
+          id: "newHero",
+          title: "New Hero",
+          content: "Keystroke tests",
+          lore: "",
+          type: "character",
+          status: "active",
+          labels: ["important", "important", "new-label"],
+          aliases: ["Hero Jr", "Newbie"],
+          connections: [],
+        } as unknown as LocalEntity,
+      };
+
+      store.handleEntitiesUpdate(initialMap, newMap);
+
+      expect(store.labelIndex).toEqual(["important", "new-label"]);
+      // important was 1 (from place), newHero adds it once (de-duplicated). total = 2.
+      expect(store.labelCounts["important"]).toBe(2);
+      expect(store.labelCounts["new-label"]).toBe(1);
+
+      // Verify title and alias index sorted by length
+      const match = store.titleAndAliasIndex.find(
+        (t) => t.entityId === "newHero" && t.isAlias,
+      );
+      expect(match).toBeDefined();
+    });
+
+    it("correctly handles label counting when a draft is updated to active", () => {
+      const initialMap = { ...repository.entities };
+      const draftEntity = {
+        id: "hero",
+        title: "Hero",
+        content: "",
+        lore: "",
+        type: "character",
+        status: "draft",
+        labels: ["important", "another-label"],
+        aliases: [],
+        connections: [],
+      } as unknown as LocalEntity;
+
+      const activeEntity = {
+        ...draftEntity,
+        status: "active",
+      } as unknown as LocalEntity;
+
+      const map1 = { ...initialMap, hero: draftEntity };
+      const map2 = { ...initialMap, hero: activeEntity };
+
+      store.handleEntitiesUpdate(map1, map2);
+
+      // hero had draft label 'important' and 'another-label'.
+      // Now hero is active, so counts must increment.
+      expect(store.labelCounts["important"]).toBe(2); // hero(1) + place(1)
+      expect(store.labelCounts["another-label"]).toBe(1);
+    });
+
+    it("correctly decrements de-duplicated labels on deletion", () => {
+      const initialMap = {
+        hero: {
+          id: "hero",
+          title: "Hero",
+          content: "",
+          lore: "",
+          type: "character",
+          status: "active",
+          labels: ["important", "important"],
+          aliases: [],
+          connections: [],
+        } as unknown as LocalEntity,
+      };
+
+      const emptyMap: Record<string, LocalEntity> = {};
+
+      repository.entities = { ...initialMap };
+      store.handleEntitiesUpdate(initialMap, initialMap); // build initial
+      expect(store.labelCounts["important"]).toBe(1);
+
+      repository.entities = emptyMap;
+      store.handleEntitiesUpdate(initialMap, emptyMap);
+      expect(store.labelCounts["important"]).toBeUndefined();
+    });
+
+    it("executes rapid keystroke updates on the in-place O(N) search / update path", () => {
+      const initialMap = { ...repository.entities };
+      const heroUpdated = {
+        ...initialMap.hero,
+        content: "Draft character content typed rapid",
+        updatedAt: Date.now(),
+      } as unknown as LocalEntity;
+
+      const newMap = { ...initialMap, hero: heroUpdated };
+
+      // Ensure no indices change
+      const prevLabelIndex = [...store.labelIndex];
+      const prevLabelCounts = { ...store.labelCounts };
+
+      store.handleEntitiesUpdate(initialMap, newMap);
+
+      expect(store.labelIndex).toEqual(prevLabelIndex);
+      expect(store.labelCounts).toEqual(prevLabelCounts);
+      expect(store.allEntities.find((e) => e.id === "hero")?.content).toBe(
+        "Draft character content typed rapid",
+      );
+    });
+  });
 });


### PR DESCRIPTION
Addresses issue #982.

Replaces the 5 chained, heavy O(N) `$derived` properties in `EntityStore` with incrementally maintained indexes declared as `$state` fields.

- Bypasses index updates on pure content edits / keystrokes, resulting in an O(1) complexity hot-path.
- Synced using a new `onEntitiesUpdated` synchronous setter hook in `EntityMutationService`.
- Falls back to `rebuildIndexes()` on cold start and major vault events (`CACHE_LOADED`, `SYNC_COMPLETE`, `VAULT_SWITCHED`, `SYNC_CHUNK_READY`).
- Verified zero errors and zero failed tests.