### PR TITLE
:zap: perf(cache): drop redundant JSON.parse/stringify around $state.snapshot

### DIFF
--- a/apps/web/src/lib/services/cache.svelte.ts
+++ b/apps/web/src/lib/services/cache.svelte.ts
@@ -162,19 +162,17 @@ export class CacheService {
     entity: LocalEntity,
   ): Promise<void> {
     try {
-      // Svelte 5: Ensure we have a non-reactive, serializable clone.
-      // We use JSON.parse/stringify as the absolute filter to strip any
-      // Proxies, Symbols, or non-serializable garbage that Dexie/IndexedDB might reject.
-      const raw = JSON.parse(JSON.stringify($state.snapshot(entity)));
+      // $state.snapshot() returns a deep non-reactive POJO — Proxies and
+      // Symbols are already stripped, so a second JSON round-trip is redundant.
+      const raw = $state.snapshot(entity) as Record<string, any>;
 
       const { vaultId, filePath } = parseKey(path);
 
       // Separate heavy text from graph metadata
       const { content, lore, ...graphData } = raw;
 
-      // We manually construct the record to be absolutely sure no hidden
-      // non-serializable fields (like Proxies or nested arrays with issues)
-      // are passed to Dexie.
+      // Explicitly shape the Dexie record to match the GraphEntityRecord
+      // schema and coerce values to the expected primitive types.
       const graphRecord = {
         id: String(raw.id),
         type: String(raw.type),
@@ -262,7 +260,7 @@ export class CacheService {
 
       for (const entry of entries) {
         const { path, lastModified, entity } = entry;
-        const raw = JSON.parse(JSON.stringify($state.snapshot(entity)));
+        const raw = $state.snapshot(entity) as Record<string, any>;
         const { vaultId, filePath } = parseKey(path);
         const { content, lore, ...graphData } = raw;
 

--- a/apps/web/tests/cache-persistence.spec.ts
+++ b/apps/web/tests/cache-persistence.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * End-to-end regression for the CacheService write path.
+ *
+ * Guards against regressions in the $state.snapshot() change (perf/983)
+ * that removed the redundant JSON.parse/JSON.stringify wrapper. If
+ * $state.snapshot() produces a non-serializable value that Dexie's
+ * structured clone rejects, these writes would throw and data would not
+ * survive a page reload.
+ *
+ * Approach: directly invoke CacheService.set / bulkSet via the app's
+ * exposed globals, then reload and read back via CacheService.get.
+ * This bypasses OPFS (unavailable in the Playwright sandbox) while still
+ * exercising the real Dexie + $state.snapshot() code path.
+ */
+
+async function waitForVaultIdle(page: any) {
+  await page.waitForFunction(
+    () =>
+      (window as any).vault !== undefined &&
+      (window as any).vault.status === "idle",
+    { timeout: 15000 },
+  );
+}
+
+/** Expose cacheService on window so evaluate() can reach it. */
+async function exposeCacheService(page: any) {
+  await page.evaluate(async () => {
+    if (!(window as any).__cacheService) {
+      const mod = await import("/src/lib/services/cache.svelte.ts");
+      (window as any).__cacheService = mod.cacheService;
+    }
+  });
+}
+
+test.describe("CacheService persistence (set + bulkSet)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      (window as any).DISABLE_ONBOARDING = true;
+      (window as any).__E2E__ = true;
+      try {
+        localStorage.setItem("codex_skip_landing", "true");
+      } catch {
+        /* ignore */
+      }
+    });
+
+    await page.goto("/");
+    await waitForVaultIdle(page);
+  });
+
+  test("CacheService.set() writes survive a page reload", async ({ page }) => {
+    const vaultId = `e2e-vault-${Date.now()}`;
+    const entityId = `e2e-entity-${Date.now()}`;
+    const path = `${vaultId}:${entityId}.md`;
+
+    const entity = {
+      id: entityId,
+      title: "Persist Test Entity",
+      type: "npc",
+      content: "Some content",
+      lore: "",
+      tags: [],
+      labels: ["important"],
+      aliases: [],
+      connections: [],
+      updatedAt: Date.now(),
+      status: "active",
+      _path: [`${entityId}.md`],
+    };
+
+    // Write via CacheService.set()
+    const writeResult = await page.evaluate(
+      async ({ p, e }: { p: string; e: any }) => {
+        try {
+          const { cacheService } = await import(
+            "/src/lib/services/cache.svelte.ts"
+          );
+          await cacheService.set(p, Date.now(), e as any);
+          return { ok: true, error: null };
+        } catch (err: any) {
+          return { ok: false, error: err?.message ?? String(err) };
+        }
+      },
+      { p: path, e: entity },
+    );
+
+    expect(writeResult.error).toBeNull();
+    expect(writeResult.ok).toBe(true);
+
+    // Reload
+    await page.reload();
+    await waitForVaultIdle(page);
+
+    // Read back — must still be there
+    const readResult = await page.evaluate(
+      async (p: string) => {
+        try {
+          const { cacheService } = await import(
+            "/src/lib/services/cache.svelte.ts"
+          );
+          const hit = await cacheService.get(p);
+          return { title: hit?.entity?.title ?? null, labels: hit?.entity?.labels ?? null, error: null };
+        } catch (err: any) {
+          return { title: null, labels: null, error: err?.message ?? String(err) };
+        }
+      },
+      path,
+    );
+
+    expect(readResult.error).toBeNull();
+    expect(readResult.title).toBe("Persist Test Entity");
+    expect(readResult.labels).toContain("important");
+  });
+
+  test("CacheService.bulkSet() writes survive a page reload", async ({
+    page,
+  }) => {
+    const vaultId = `e2e-bulk-vault-${Date.now()}`;
+    const ts = Date.now();
+
+    const entries = [0, 1, 2].map((i) => ({
+      path: `${vaultId}:entity-${ts}-${i}.md`,
+      lastModified: ts,
+      entity: {
+        id: `entity-${ts}-${i}`,
+        title: `Bulk Entity ${i}`,
+        type: "npc",
+        content: `Content ${i}`,
+        lore: "",
+        tags: [],
+        labels: [`label-${i}`],
+        aliases: [],
+        connections: [],
+        updatedAt: ts,
+        status: "active",
+        _path: [`entity-${ts}-${i}.md`],
+      },
+    }));
+
+    // Write via CacheService.bulkSet()
+    const writeResult = await page.evaluate(
+      async (ents: typeof entries) => {
+        try {
+          const { cacheService } = await import(
+            "/src/lib/services/cache.svelte.ts"
+          );
+          await cacheService.bulkSet(ents as any);
+          return { ok: true, error: null };
+        } catch (err: any) {
+          return { ok: false, error: err?.message ?? String(err) };
+        }
+      },
+      entries,
+    );
+
+    expect(writeResult.error).toBeNull();
+    expect(writeResult.ok).toBe(true);
+
+    // Reload
+    await page.reload();
+    await waitForVaultIdle(page);
+
+    // Read all three back
+    const readResult = await page.evaluate(
+      async (paths: string[]) => {
+        try {
+          const { cacheService } = await import(
+            "/src/lib/services/cache.svelte.ts"
+          );
+          const titles: (string | null)[] = [];
+          for (const p of paths) {
+            const hit = await cacheService.get(p);
+            titles.push(hit?.entity?.title ?? null);
+          }
+          return { titles, error: null };
+        } catch (err: any) {
+          return { titles: [], error: err?.message ?? String(err) };
+        }
+      },
+      entries.map((e) => e.path),
+    );
+
+    expect(readResult.error).toBeNull();
+    expect(readResult.titles).toEqual(["Bulk Entity 0", "Bulk Entity 1", "Bulk Entity 2"]);
+  });
+});

--- a/apps/web/tests/cache-persistence.spec.ts
+++ b/apps/web/tests/cache-persistence.spec.ts
@@ -13,7 +13,16 @@ import { test, expect } from "@playwright/test";
  * exposed globals, then reload and read back via CacheService.get.
  * This bypasses OPFS (unavailable in the Playwright sandbox) while still
  * exercising the real Dexie + $state.snapshot() code path.
+ *
+ * The dynamic import path below is a Vite-resolved browser URL, not a
+ * TypeScript module path — tsc never executes page.evaluate() callbacks.
+ * We use a runtime variable to prevent tsc from treating the string as a
+ * module specifier and emitting a "Cannot find module" error.
  */
+
+// Stored in a variable so tsc doesn't try to resolve it as a module path.
+// Vite resolves this correctly at runtime inside page.evaluate().
+const CACHE_SERVICE_PATH = ["/src/lib/services", "cache.svelte.ts"].join("/");
 
 async function waitForVaultIdle(page: any) {
   await page.waitForFunction(
@@ -62,43 +71,40 @@ test.describe("CacheService persistence (set + bulkSet)", () => {
       _path: [`${entityId}.md`],
     };
 
-    // Write via CacheService.set()
     const writeResult = await page.evaluate(
-      async ({ p, e }: { p: string; e: any }) => {
+      async ({ p, e, modulePath }: { p: string; e: any; modulePath: string }) => {
         try {
-          const { cacheService } = await import(
-            "/src/lib/services/cache.svelte.ts"
-          );
-          await cacheService.set(p, Date.now(), e as any);
+          const { cacheService } = await import(modulePath);
+          await cacheService.set(p, Date.now(), e);
           return { ok: true, error: null };
         } catch (err: any) {
           return { ok: false, error: err?.message ?? String(err) };
         }
       },
-      { p: path, e: entity },
+      { p: path, e: entity, modulePath: CACHE_SERVICE_PATH },
     );
 
     expect(writeResult.error).toBeNull();
     expect(writeResult.ok).toBe(true);
 
-    // Reload
     await page.reload();
     await waitForVaultIdle(page);
 
-    // Read back — must still be there
     const readResult = await page.evaluate(
-      async (p: string) => {
+      async ({ p, modulePath }: { p: string; modulePath: string }) => {
         try {
-          const { cacheService } = await import(
-            "/src/lib/services/cache.svelte.ts"
-          );
+          const { cacheService } = await import(modulePath);
           const hit = await cacheService.get(p);
-          return { title: hit?.entity?.title ?? null, labels: hit?.entity?.labels ?? null, error: null };
+          return {
+            title: hit?.entity?.title ?? null,
+            labels: hit?.entity?.labels ?? null,
+            error: null,
+          };
         } catch (err: any) {
           return { title: null, labels: null, error: err?.message ?? String(err) };
         }
       },
-      path,
+      { p: path, modulePath: CACHE_SERVICE_PATH },
     );
 
     expect(readResult.error).toBeNull();
@@ -106,11 +112,9 @@ test.describe("CacheService persistence (set + bulkSet)", () => {
     expect(readResult.labels).toContain("important");
   });
 
-  test("CacheService.bulkSet() writes survive a page reload", async ({
-    page,
-  }) => {
-    const vaultId = `e2e-bulk-vault-${Date.now()}`;
+  test("CacheService.bulkSet() writes survive a page reload", async ({ page }) => {
     const ts = Date.now();
+    const vaultId = `e2e-bulk-vault-${ts}`;
 
     const entries = [0, 1, 2].map((i) => ({
       path: `${vaultId}:entity-${ts}-${i}.md`,
@@ -131,36 +135,29 @@ test.describe("CacheService persistence (set + bulkSet)", () => {
       },
     }));
 
-    // Write via CacheService.bulkSet()
     const writeResult = await page.evaluate(
-      async (ents: typeof entries) => {
+      async ({ ents, modulePath }: { ents: typeof entries; modulePath: string }) => {
         try {
-          const { cacheService } = await import(
-            "/src/lib/services/cache.svelte.ts"
-          );
+          const { cacheService } = await import(modulePath);
           await cacheService.bulkSet(ents as any);
           return { ok: true, error: null };
         } catch (err: any) {
           return { ok: false, error: err?.message ?? String(err) };
         }
       },
-      entries,
+      { ents: entries, modulePath: CACHE_SERVICE_PATH },
     );
 
     expect(writeResult.error).toBeNull();
     expect(writeResult.ok).toBe(true);
 
-    // Reload
     await page.reload();
     await waitForVaultIdle(page);
 
-    // Read all three back
     const readResult = await page.evaluate(
-      async (paths: string[]) => {
+      async ({ paths, modulePath }: { paths: string[]; modulePath: string }) => {
         try {
-          const { cacheService } = await import(
-            "/src/lib/services/cache.svelte.ts"
-          );
+          const { cacheService } = await import(modulePath);
           const titles: (string | null)[] = [];
           for (const p of paths) {
             const hit = await cacheService.get(p);
@@ -171,10 +168,14 @@ test.describe("CacheService persistence (set + bulkSet)", () => {
           return { titles: [], error: err?.message ?? String(err) };
         }
       },
-      entries.map((e) => e.path),
+      { paths: entries.map((e) => e.path), modulePath: CACHE_SERVICE_PATH },
     );
 
     expect(readResult.error).toBeNull();
-    expect(readResult.titles).toEqual(["Bulk Entity 0", "Bulk Entity 1", "Bulk Entity 2"]);
+    expect(readResult.titles).toEqual([
+      "Bulk Entity 0",
+      "Bulk Entity 1",
+      "Bulk Entity 2",
+    ]);
   });
 });

--- a/apps/web/tests/cache-persistence.spec.ts
+++ b/apps/web/tests/cache-persistence.spec.ts
@@ -24,16 +24,6 @@ async function waitForVaultIdle(page: any) {
   );
 }
 
-/** Expose cacheService on window so evaluate() can reach it. */
-async function exposeCacheService(page: any) {
-  await page.evaluate(async () => {
-    if (!(window as any).__cacheService) {
-      const mod = await import("/src/lib/services/cache.svelte.ts");
-      (window as any).__cacheService = mod.cacheService;
-    }
-  });
-}
-
 test.describe("CacheService persistence (set + bulkSet)", () => {
   test.describe.configure({ mode: "serial" });
 


### PR DESCRIPTION
## Summary

`$state.snapshot(entity)` already returns a deep, non-reactive POJO — Proxies and Symbols are stripped by the Svelte 5 runtime. Wrapping it in `JSON.parse(JSON.stringify(...))` was cloning the object a second time for nothing, adding a full serialise+parse pass per entity on every cache write.

**`set()`** — one redundant clone removed.
**`bulkSet()`** — one redundant clone removed per entry, so N clones saved on every vault sync.

Also updates two comments that had become stale/misleading after the JSON guard was the original motivation.

## Test plan

- [x] `vitest run src/lib/services/cache` — 9/9 pass.
- [x] `bun run lint` — clean.

Closes #983. Part of #969.