### PR TITLE
:zap: perf(logging): route bare console.log calls through debugStore

### DIFF
--- a/apps/web/src/lib/app/init/app-init.ts
+++ b/apps/web/src/lib/app/init/app-init.ts
@@ -158,7 +158,7 @@ export function setupWindowGlobals(context: {
 
   if (!isSpecialEnv) return;
 
-  console.log("[WindowGlobals] Attaching:", Object.keys(context));
+  debugStore.log("[WindowGlobals] Attaching:", Object.keys(context));
   Object.assign(window, context);
   (window as any).codexUI = {
     onboarding: context.onboardingStore,

--- a/apps/web/src/lib/cloud-bridge/p2p/client-adapter.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/client-adapter.ts
@@ -1,5 +1,6 @@
 import type { IStorageAdapter, SerializedGraph } from "../types";
 import { createPeer, type PeerFactory } from "./peer-factory";
+import { debugStore } from "../../stores/debug.svelte";
 
 export class P2PClientAdapter implements IStorageAdapter {
   private hostId: string;
@@ -34,7 +35,7 @@ export class P2PClientAdapter implements IStorageAdapter {
       this.peer = this.peerFactory(undefined, { debug: 1 });
 
       this.peer.on("open", () => {
-        console.log("[P2P Client] Connected to signaling server.");
+        debugStore.log("[P2P Client] Connected to signaling server.");
         this.connectToHost(resolve, reject);
       });
 
@@ -46,13 +47,13 @@ export class P2PClientAdapter implements IStorageAdapter {
   }
 
   private connectToHost(resolve: () => void, _reject: (e: any) => void) {
-    console.log("[P2P Client] Connecting to host:", this.hostId);
+    debugStore.log("[P2P Client] Connecting to host:", this.hostId);
     const conn = this.peer.connect(this.hostId, { reliable: true });
     this.conn = conn;
 
     conn.on("open", () => {
       if (this.conn !== conn) return;
-      console.log("[P2P Client] Connection established!");
+      debugStore.log("[P2P Client] Connection established!");
       resolve();
     });
 
@@ -81,10 +82,10 @@ export class P2PClientAdapter implements IStorageAdapter {
 
   private handleMessage(data: any) {
     if (data.type === "GRAPH_SYNC") {
-      console.log("[P2P Client] Received Graph Sync");
+      debugStore.log("[P2P Client] Received Graph Sync");
       this.graphResolver(data.payload);
     } else if (data.type === "ENTITY_UPDATE") {
-      console.log("[P2P Client] Received Realtime Update");
+      debugStore.log("[P2P Client] Received Realtime Update");
       // vault.ingestRemoteUpdate(data.payload);
     } else if (data.type === "FILE_RESPONSE") {
       const requestId = data.requestId;
@@ -136,7 +137,7 @@ export class P2PClientAdapter implements IStorageAdapter {
   }
 
   async loadGraph(): Promise<SerializedGraph | null> {
-    console.log("[P2P Client] Waiting for graph...");
+    debugStore.log("[P2P Client] Waiting for graph...");
     return this.graphPromise;
   }
 
@@ -187,7 +188,7 @@ export class P2PClientAdapter implements IStorageAdapter {
   }
 
   async dispose(): Promise<void> {
-    console.log("[P2P Client] Disposing adapter...");
+    debugStore.log("[P2P Client] Disposing adapter...");
     try {
       if (this.conn) {
         this.conn.close();

--- a/apps/web/src/lib/cloud-bridge/p2p/connection-manager.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/connection-manager.svelte.ts
@@ -1,4 +1,5 @@
 import { createPeer, type PeerFactory } from "./peer-factory";
+import { debugStore } from "../../stores/debug.svelte";
 
 export interface ConnectionState {
   status:
@@ -542,7 +543,7 @@ export class PeerJSConnectionManager {
         this.setStatus("reconnecting");
         const delay = this.reconnectDelays[this._state.retryCount];
         this._state.retryCount++;
-        console.log(
+        debugStore.log(
           `[P2P Connection] Reconnecting in ${delay}ms (Attempt ${this._state.retryCount}/${this.reconnectDelays.length})...`,
         );
 

--- a/apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/handlers/file-handler.ts
@@ -1,6 +1,7 @@
 import { BaseHandler, type P2PHandlerContext } from "./base-handler";
 import type { P2PMessage } from "../p2p-protocol";
 import type { P2PConnection } from "../transport/transport-interface";
+import { debugStore } from "../../../stores/debug.svelte";
 
 export class FileHandler extends BaseHandler {
   canHandle(message: P2PMessage): boolean {
@@ -18,7 +19,7 @@ export class FileHandler extends BaseHandler {
     const { vault } = context;
 
     try {
-      console.log(`[P2P Host] Handling file request for: ${path}`);
+      debugStore.log(`[P2P Host] Handling file request for: ${path}`);
       const vaultHandle = await vault.getActiveVaultHandle();
 
       if (!vaultHandle) {

--- a/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/host-service.svelte.ts
@@ -1,4 +1,5 @@
 import { vault as defaultVault } from "../../stores/vault.svelte";
+import { debugStore } from "../../stores/debug.svelte";
 import { themeStore as defaultThemeStore } from "../../stores/theme.svelte";
 import { guestStore as defaultGuestStore } from "../../stores/guest.svelte";
 import { mapStore as defaultMapStore } from "../../stores/map.svelte";
@@ -85,14 +86,14 @@ export class P2PHostService {
 
   private setupTransportListeners() {
     this.transport.on("connection", (conn: P2PConnection) => {
-      console.log("[P2P Host] New guest connected:", conn.peer);
+      debugStore.log("[P2P Host] New guest connected:", conn.peer);
       this.connections.push(conn);
     });
 
     this.transport.on("data", async ({ conn, data }) => {
       if (data && typeof data === "object") {
         if (data.type === "handshake") {
-          console.log("[P2P Host] Received handshake from:", conn.peer);
+          debugStore.log("[P2P Host] Received handshake from:", conn.peer);
           const ack = {
             type: "handshake_ack",
             senderId: this.transport.id || "",
@@ -177,7 +178,7 @@ export class P2PHostService {
 
     this.state.status = "connecting";
     const id = await this.transport.start(peerId);
-    console.log("[P2P Host] Hosting started. ID:", id);
+    debugStore.log("[P2P Host] Hosting started. ID:", id);
 
     this._isHosting = true;
     this.state.status = "connected";

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p-protocol.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p-protocol.ts
@@ -5,7 +5,7 @@ import type {
   SessionSnapshotPayload,
   VTTMessage,
 } from "../../../types/vtt";
-import { debugStore } from "../../../stores/debug.svelte";
+import { debugStore } from "../../stores/debug.svelte";
 
 const SNAPSHOT_COMPRESS_THRESHOLD = 10_000; // bytes
 

--- a/apps/web/src/lib/cloud-bridge/p2p/p2p-protocol.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/p2p-protocol.ts
@@ -5,6 +5,7 @@ import type {
   SessionSnapshotPayload,
   VTTMessage,
 } from "../../../types/vtt";
+import { debugStore } from "../../../stores/debug.svelte";
 
 const SNAPSHOT_COMPRESS_THRESHOLD = 10_000; // bytes
 
@@ -79,7 +80,7 @@ export async function encodeSessionSnapshot(
     source.pipeThrough(new CompressionStream("gzip")),
   ).arrayBuffer();
   const ratio = ((1 - data.byteLength / json.length) * 100).toFixed(1);
-  console.log(
+  debugStore.log(
     `[P2P] SESSION_SNAPSHOT_GZIP: ${json.length} → ${data.byteLength} bytes (${ratio}% smaller)`,
   );
   return { type: "SESSION_SNAPSHOT_GZIP", data };

--- a/apps/web/src/lib/cloud-bridge/p2p/transport/peerjs-client-transport.ts
+++ b/apps/web/src/lib/cloud-bridge/p2p/transport/peerjs-client-transport.ts
@@ -1,4 +1,5 @@
 import { createPeer, type PeerFactory } from "../peer-factory";
+import { debugStore } from "../../../stores/debug.svelte";
 import { isValidP2PMessage } from "../p2p-protocol";
 import type {
   ClientTransportEventType,
@@ -53,7 +54,7 @@ export class PeerJsClientTransport implements P2PClientTransport {
     const connectionPromise = new Promise<void>((resolve, reject) => {
       const startConnection = () => {
         if (epoch !== this.activeEpoch) return;
-        console.log(
+        debugStore.log(
           `[P2P Guest Transport] Initiating connection to: ${hostId}`,
         );
         const connection = this.peer.connect(hostId);
@@ -63,7 +64,7 @@ export class PeerJsClientTransport implements P2PClientTransport {
           if (epoch !== this.activeEpoch) return;
           this.isConnecting = false;
           if (timeoutHandle) clearTimeout(timeoutHandle);
-          console.log(`[P2P Guest Transport] Connected to host: ${hostId}`);
+          debugStore.log(`[P2P Guest Transport] Connected to host: ${hostId}`);
           this.emit("open");
           resolve();
         });

--- a/apps/web/src/lib/components/oracle/chat-message.actions.ts
+++ b/apps/web/src/lib/components/oracle/chat-message.actions.ts
@@ -1,4 +1,5 @@
 import { graph as defaultGraph } from "$lib/stores/graph.svelte";
+import { debugStore } from "$lib/stores/debug.svelte";
 import {
   oracle as defaultOracle,
   type ChatMessage,
@@ -104,16 +105,16 @@ export class ChatMessageActions {
       params.activeEntityId,
     );
 
-    console.log("[Oracle] Smart Apply triggered for:", finalTargetId);
+    debugStore.log("[Oracle] Smart Apply triggered for:", finalTargetId);
 
     if (!finalTargetId || !params.message.content) {
-      console.warn("[Oracle] Smart Apply aborted: Missing target or content");
+      debugStore.warn("[Oracle] Smart Apply aborted: Missing target or content");
       return;
     }
 
     const entity = this.vault.entities[finalTargetId] as EntityLike | undefined;
     if (!entity) {
-      console.error(
+      debugStore.error(
         "[Oracle] Smart Apply failed: Entity not found in vault",
         finalTargetId,
       );
@@ -125,7 +126,7 @@ export class ChatMessageActions {
     if (params.parsed.lore) incoming.lore = params.parsed.lore;
 
     if (Object.keys(incoming).length === 0) {
-      console.warn("[Oracle] Smart Apply aborted: No updates extracted");
+      debugStore.warn("[Oracle] Smart Apply aborted: No updates extracted");
       return;
     }
 
@@ -134,7 +135,7 @@ export class ChatMessageActions {
       incoming,
     );
 
-    console.log("[Oracle] Smart Apply reconciled updates:", updates);
+    debugStore.log("[Oracle] Smart Apply reconciled updates:", updates);
 
     // Instead of immediate update with undo, use the draft flow for a unified experience
     this.regenerationService.pendingDraft = {

--- a/apps/web/src/lib/components/oracle/chat-message.actions.ts
+++ b/apps/web/src/lib/components/oracle/chat-message.actions.ts
@@ -135,7 +135,17 @@ export class ChatMessageActions {
       incoming,
     );
 
-    debugStore.log("[Oracle] Smart Apply reconciled updates:", updates);
+    debugStore.log(
+      "[Oracle] Smart Apply reconciled updates:",
+      // Log a summary only — `updates` may contain full content/lore strings
+      // which would hold large references in debugStore's ring buffer.
+      Object.fromEntries(
+        Object.entries(updates ?? {}).map(([k, v]) => [
+          k,
+          typeof v === "string" ? `${v.length} chars` : v,
+        ]),
+      ),
+    );
 
     // Instead of immediate update with undo, use the draft flow for a unified experience
     this.regenerationService.pendingDraft = {

--- a/apps/web/src/lib/listeners/oracle-events.ts
+++ b/apps/web/src/lib/listeners/oracle-events.ts
@@ -1,6 +1,7 @@
 import { appEventBus } from "@codex/events";
 import { ORACLE_EVENTS } from "@codex/oracle-engine";
 import { notificationStore } from "$lib/stores/ui/notification.svelte";
+import { debugStore } from "$lib/stores/debug.svelte";
 
 /**
  * Initializes global event listeners for Oracle actions.
@@ -26,7 +27,7 @@ export function initOracleEventListeners(): () => void {
   unsubs.push(
     appEventBus.subscribe(ORACLE_EVENTS.COMMAND_COMPLETED, (event) => {
       const { intent } = event.payload;
-      console.log(`[Oracle] Command completed: ${intent.type}`);
+      debugStore.log(`[Oracle] Command completed: ${intent.type}`);
     }),
   );
 
@@ -42,7 +43,7 @@ export function initOracleEventListeners(): () => void {
   unsubs.push(
     appEventBus.subscribe(ORACLE_EVENTS.ENTITY_DISCOVERED, (event) => {
       const { proposal } = event.payload;
-      console.log(`[Oracle] Entity discovered: ${proposal.title}`);
+      debugStore.log(`[Oracle] Entity discovered: ${proposal.title}`);
     }),
   );
 

--- a/apps/web/src/lib/stores/categories.svelte.ts
+++ b/apps/web/src/lib/stores/categories.svelte.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CATEGORIES, type Category } from "schema";
 import { getDB } from "../utils/idb";
+import { debugStore } from "./debug.svelte";
 
 export interface ICategoryStorage {
   load(): Promise<Category[] | undefined>;
@@ -100,5 +101,5 @@ if (
   (import.meta.env.DEV || (window as any).__E2E__)
 ) {
   (window as any).categories = categories;
-  console.log("[CategoryStore] Module loaded, categories attached to window");
+  debugStore.log("[CategoryStore] Module loaded, categories attached to window");
 }

--- a/apps/web/src/lib/stores/help.svelte.ts
+++ b/apps/web/src/lib/stores/help.svelte.ts
@@ -1,6 +1,7 @@
 import { browser } from "$app/environment";
 import { base } from "$app/paths";
 import { VERSION } from "$lib/config";
+import { debugStore } from "$lib/stores/debug.svelte";
 import {
   type GuideStep,
   ONBOARDING_TOUR,
@@ -103,7 +104,7 @@ export class HelpStore {
 
           // Version Tracking
           if (loaded.lastSeenVersion !== VERSION) {
-            console.log(
+            debugStore.log(
               `[HelpStore] Version updated: ${loaded.lastSeenVersion} -> ${VERSION}`,
             );
             this.state.lastSeenVersion = VERSION;

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -516,5 +516,5 @@ if (
   (import.meta.env.DEV || (window as any).__E2E__)
 ) {
   (window as any).vault = vault;
-  console.log("[VaultStore] Module loaded, vault attached to window");
+  debugStore.log("[VaultStore] Module loaded, vault attached to window");
 }

--- a/apps/web/src/lib/stores/vtt/vtt-media-manager.svelte.ts
+++ b/apps/web/src/lib/stores/vtt/vtt-media-manager.svelte.ts
@@ -4,6 +4,7 @@ import type {
   Token,
 } from "../../../types/vtt";
 import type { VaultStore } from "../vault.svelte";
+import { debugStore } from "../debug.svelte";
 
 export interface VTTMediaDependencies {
   emit: (message: VTTMessage) => void;
@@ -56,7 +57,7 @@ export class VTTMediaManager {
       return false;
     }
 
-    console.log("[MapSession] showTokenImageToPlayers", {
+    debugStore.log("[MapSession] showTokenImageToPlayers", {
       tokenId,
       title: token.name,
       imagePath,
@@ -79,7 +80,7 @@ export class VTTMediaManager {
       return false;
     }
 
-    console.log("[MapSession] showImageToPlayers", {
+    debugStore.log("[MapSession] showImageToPlayers", {
       title,
       imagePath,
     });


### PR DESCRIPTION
## Summary

Replaces bare `console.log`/`warn`/`error` calls in 13 files with `debugStore` equivalents. `debugStore` is silenced in production builds, so these logs no longer serialise objects or hold references in the DevTools memory store during long DM sessions.

## Files changed

| File | Calls | Context |
|------|-------|---------|
| `stores/vault.svelte.ts` | 1 | Module-load log |
| `stores/categories.svelte.ts` | 1 | Module-load log |
| `stores/help.svelte.ts` | 1 | Version-check log |
| `stores/vtt/vtt-media-manager.svelte.ts` | 2 | Fires on every media-share action |
| `app/init/app-init.ts` | 1 | Window globals attachment |
| `cloud-bridge/p2p/host-service.svelte.ts` | 3 | P2P connection events |
| `cloud-bridge/p2p/client-adapter.ts` | 7 | P2P client events |
| `cloud-bridge/p2p/connection-manager.svelte.ts` | 1 | Reconnect |
| `cloud-bridge/p2p/p2p-protocol.ts` | 1 | Snapshot compression |
| `cloud-bridge/p2p/handlers/file-handler.ts` | 1 | File request |
| `cloud-bridge/p2p/transport/peerjs-client-transport.ts` | 2 | Transport connect |
| `listeners/oracle-events.ts` | 2 | Command/discovery events |
| `components/oracle/chat-message.actions.ts` | 4 | Smart-apply trace |

**Excluded:** workers (no debugStore access), `mock-transport.ts` (test helper only), AI service files (deferred, separate concern).

## Test plan

- [x] `bun run lint` — clean.
- [ ] Start app, open DevTools console: no `[P2P]`, `[MapSession]`, or `[Oracle]` noise at idle.
- [ ] Enable debug mode: confirm logs reappear.

Closes #984. Part of #969.