### PR TITLE
:zap: perf(images): add loading="lazy" decoding="async" to all <img> tags

### DIFF
--- a/apps/web/src/lib/components/canvas/EntityNode.svelte
+++ b/apps/web/src/lib/components/canvas/EntityNode.svelte
@@ -145,6 +145,8 @@
           <img
             src={imageUrl}
             alt={entity?.title}
+            loading="lazy"
+            decoding="async"
             class="w-full h-full object-cover object-[center_20%] transition-transform duration-500 group-hover:scale-105"
           />
         </div>

--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -190,6 +190,8 @@
         <img
           src={resolvedImageUrl}
           alt={entity.title}
+          loading="lazy"
+          decoding="async"
           class="w-full h-auto max-h-48 md:max-h-80 object-contain opacity-90 group-hover:opacity-100 transition mx-auto"
         />
         <div

--- a/apps/web/src/lib/components/entity-detail/DetailMapTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailMapTab.svelte
@@ -135,6 +135,8 @@
           <img
             src={url}
             alt={linkedMap.name}
+            loading="lazy"
+            decoding="async"
             class="w-full h-full object-cover opacity-60 group-hover:opacity-100 transition-opacity"
           />
         {/await}

--- a/apps/web/src/lib/components/oracle/ImageMessage.svelte
+++ b/apps/web/src/lib/components/oracle/ImageMessage.svelte
@@ -57,6 +57,8 @@
       <img
         src={message.imageUrl}
         alt={message.content}
+        loading="lazy"
+        decoding="async"
         class="w-full rounded-lg border border-theme-border shadow-lg cursor-zoom-in group-hover:border-theme-primary/50 transition-all"
         draggable="true"
         ondragstart={handleDragStart}

--- a/apps/web/src/lib/components/zen/ZenImageLightbox.svelte
+++ b/apps/web/src/lib/components/zen/ZenImageLightbox.svelte
@@ -221,6 +221,8 @@
       <img
         src={loadedUrl}
         alt={title}
+        loading="lazy"
+        decoding="async"
         class="max-w-full max-h-full object-contain shadow-2xl rounded pointer-events-none"
         transition:zoomFrom
       />

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -297,6 +297,8 @@
         <img
           src={resolvedImageUrl}
           alt={entity.title}
+          loading="lazy"
+          decoding="async"
           class="w-full h-auto max-h-[500px] object-contain opacity-90 group-hover:opacity-100 transition mx-auto"
         />
         <div


### PR DESCRIPTION
## Summary

All 6 `<img>` elements in the app were missing `loading` attributes. Adds `loading="lazy" decoding="async"` to all of them.

None are above-the-fold LCP candidates — they're all in entity detail panels, canvas nodes, Oracle chat, zen mode, or map thumbnails. Browsers defer fetch and decode until each image approaches the viewport.

## Files

| File | Context |
|------|---------|
| `entity-detail/DetailImage.svelte` | Entity image in detail panel |
| `entity-detail/DetailMapTab.svelte` | Map thumbnail in entity tab |
| `oracle/ImageMessage.svelte` | AI-generated image in chat |
| `zen/ZenImageLightbox.svelte` | Full-screen lightbox (user-triggered) |
| `zen/ZenSidebar.svelte` | Entity image in Zen sidebar |
| `canvas/EntityNode.svelte` | Entity card image in canvas view |

## Test plan

- [x] `bun run lint` — clean.
- [ ] Open entity detail → image loads correctly.
- [ ] Open Zen mode → image displays.
- [ ] Canvas view with entities that have images → thumbnails render.
- [ ] Oracle chat with generated image → image renders.

Closes #996. Part of #969.