### PR TITLE
:zap: perf(ui): add content-visibility:auto to entity list and connection rows

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityListItem.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListItem.svelte
@@ -51,7 +51,7 @@
 </script>
 
 <div
-  class="group relative flex items-center rounded-xl border transition-all {!isMatching
+  class="[content-visibility:auto] [contain-intrinsic-size:0_56px] group relative flex items-center rounded-xl border transition-all {!isMatching
     ? 'opacity-50'
     : ''} {entity.id === focusedEntityId
     ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -560,7 +560,7 @@
                 </div>
               {:else}
                 <div
-                  class="w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
+                  class="[content-visibility:auto] [contain-intrinsic-size:0_44px] w-full flex items-center gap-3 p-2 rounded border border-transparent hover:border-theme-border hover:bg-theme-primary/10 transition text-left group"
                 >
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

Adds `content-visibility: auto` + `contain-intrinsic-size` to two high-item-count list rows. The browser skips layout and paint for rows outside the visible scroll area, which materially reduces rendering cost on large vaults.

### `EntityListItem.svelte`
`contain-intrinsic-size: 0 56px` — the explorer sidebar list. Vaults with 500+ entities currently lay out and paint every row on every scroll. With this change the browser only processes visible rows.

### `ZenSidebar.svelte` connection rows
`contain-intrinsic-size: 0 44px` — entities with many connections (quest hubs, major NPCs) rendered all rows regardless of scroll position.

Both sizes were measured from the actual rendered height of the rows.

## Test plan

- [x] `bun run lint` — clean.
- [ ] Open explorer with a large vault (100+ entities): sidebar scrolls smoothly, no visual regressions.
- [ ] Open Zen mode on an entity with many connections: rows render correctly, no layout shifts on scroll.

Closes #998. Part of #969.