### PR TITLE
:zap: perf(map): debounce persistSettings to avoid localStorage writes per pixel

### DIFF
--- a/apps/web/src/lib/stores/map.svelte.ts
+++ b/apps/web/src/lib/stores/map.svelte.ts
@@ -60,6 +60,7 @@ export class MapStore {
   gridColor = $state<string | null>(null); // null means use theme primary
   private isRestoringSettings = false;
   private pendingActiveMapId = $state<string | null>(null);
+  private _persistTimer: ReturnType<typeof setTimeout> | null = null;
 
   activeMap = $derived.by(() => {
     const maps = vault.maps ?? {};
@@ -101,7 +102,7 @@ export class MapStore {
             this.showLabels,
           ];
           void tracked;
-          this.persistSettings();
+          this.schedulePersistSettings();
         });
       });
     }
@@ -190,6 +191,14 @@ export class MapStore {
     } catch {
       return null;
     }
+  }
+
+  private schedulePersistSettings() {
+    if (this._persistTimer !== null) clearTimeout(this._persistTimer);
+    this._persistTimer = setTimeout(() => {
+      this._persistTimer = null;
+      this.persistSettings();
+    }, 250);
   }
 
   private persistSettings() {


### PR DESCRIPTION
## Summary

The `$effect` in `MapStore` that watches grid/fog/brush settings called `persistSettings()` synchronously on every reactive change. Dragging the `brushRadius` or `gridSize` sliders fired `localStorage.setItem()` on every pixel of movement — typically 300–500 writes per drag.

Adds a **250 ms debounce**: `schedulePersistSettings()` coalesces rapid changes into a single write after the user stops interacting.

## Test plan

- [x] Map store tests — 62/62 pass.
- [x] `bun run lint` — clean.
- [ ] Drag brush radius or grid size slider; settings persist correctly after release.

Closes #985. Part of #969.