### PR TITLE
perf: replace offset() pagination with keyset in search-index-pipeline

### DIFF
--- a/apps/web/src/lib/services/search-index-pipeline.svelte.ts
+++ b/apps/web/src/lib/services/search-index-pipeline.svelte.ts
@@ -4,6 +4,7 @@ import type {
   ProgressiveBatchResult,
 } from "@codex/search-engine";
 import type * as Comlink from "comlink";
+import Dexie from "dexie";
 import { entityDb } from "../utils/entity-db";
 import { debugStore } from "../stores/debug.svelte";
 import type {
@@ -254,7 +255,7 @@ export class SearchIndexPipeline {
         .toArray();
 
       const metaMap = new Map(metadatas.map((m: any) => [m.id, m]));
-      let offset = 0;
+      let lastSeenId = "";
 
       while (true) {
         if (this.coordinator.activeVaultId !== vaultId) {
@@ -265,9 +266,8 @@ export class SearchIndexPipeline {
         }
 
         const records = await this.db.entityContent
-          .where("vaultId")
-          .equals(vaultId)
-          .offset(offset)
+          .where("[vaultId+entityId]")
+          .between([vaultId, lastSeenId], [vaultId, Dexie.maxKey], false, true)
           .limit(INDEX_BATCH_SIZE)
           .toArray();
 
@@ -291,7 +291,7 @@ export class SearchIndexPipeline {
         }
 
         if (records.length < INDEX_BATCH_SIZE) break;
-        offset += records.length;
+        lastSeenId = records[records.length - 1].entityId;
 
         // Stagger batches to let the main thread and IndexedDB breathe.
         await this.delay(500);

--- a/apps/web/src/lib/services/search.test.ts
+++ b/apps/web/src/lib/services/search.test.ts
@@ -234,23 +234,27 @@ describe("SearchService progressive indexing", () => {
     let failContentRead = true;
     let contentReads = 0;
     const db = createDb({ graphEntities: metadata });
-    db.entityContent.where = vi.fn(() => {
+    db.entityContent.where = vi.fn((field) => {
       if (failContentRead) {
         throw new Error("content read failed");
       }
+      if (field === "vaultId") {
+        return {
+          equals: vi.fn(() => ({
+            count: vi.fn().mockResolvedValue(contentRecords.length),
+          })),
+        } as any;
+      }
       return {
-        equals: vi.fn(() => ({
-          count: vi.fn().mockResolvedValue(contentRecords.length),
-          offset: vi.fn(() => ({
-            limit: vi.fn(() => ({
-              toArray: vi.fn().mockImplementation(async () => {
-                contentReads += 1;
-                return contentReads === 1 ? contentRecords : [];
-              }),
-            })),
+        between: vi.fn(() => ({
+          limit: vi.fn(() => ({
+            toArray: vi.fn().mockImplementation(async () => {
+              contentReads += 1;
+              return contentReads === 1 ? contentRecords : [];
+            }),
           })),
         })),
-      };
+      } as any;
     });
     const { service, handler } = createHarness({ api, db });
 

--- a/apps/web/src/tests/search.test.ts
+++ b/apps/web/src/tests/search.test.ts
@@ -416,9 +416,16 @@ describe("SearchService", () => {
       }));
 
       let contentCallCount = 0;
-      vi.spyOn(entityDb.entityContent, "where").mockReturnValue({
-        equals: vi.fn().mockReturnValue({
-          offset: vi.fn().mockReturnThis(),
+      vi.spyOn(entityDb.entityContent, "where").mockImplementation((indexName?: any) => {
+        if (indexName === "vaultId") {
+          return {
+            equals: vi.fn().mockReturnValue({
+              count: vi.fn().mockResolvedValue(120),
+            }),
+          } as any;
+        }
+        return {
+          between: vi.fn().mockReturnThis(),
           limit: vi.fn().mockReturnThis(),
           toArray: vi.fn().mockImplementation(() => {
             if (contentCallCount === 0) {
@@ -430,8 +437,8 @@ describe("SearchService", () => {
             }
             return Promise.resolve([]);
           }),
-        }),
-      } as any);
+        } as any;
+      });
 
       vi.spyOn(entityDb.graphEntities, "where").mockReturnValue({
         equals: vi.fn().mockReturnValue({


### PR DESCRIPTION
Closes #986

Optimizes search indexing by switching `search-index-pipeline` from offset-based pagination to keyset pagination via compound primary key index lookups `[vaultId+entityId]` and `Dexie.maxKey`. This drops full-sweep boot index scanning complexity from O(N²/batch) to O(N). All unit tests have been updated and are passing successfully.