### PR TITLE
perf: disable usePolling for vite dev watch by default

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -20,6 +20,16 @@ try {
   console.warn("Could not get git hash for versioning", e);
 }
 
+let usePolling = false;
+try {
+  usePolling = readFileSync("/proc/version", "utf8").toLowerCase().includes("microsoft");
+} catch {
+  // Ignore
+}
+if (process.env.VITE_USE_POLLING === "true") {
+  usePolling = true;
+}
+
 export default defineConfig({
   plugins: [
     tailwindcss(),
@@ -172,7 +182,7 @@ export default defineConfig({
       host: "localhost",
     },
     watch: {
-      usePolling: true,
+      usePolling,
     },
     fs: {
       // Allow serving files from the workspace root and all packages


### PR DESCRIPTION
Closes #1002

Disables Vite dev server file watch polling by default on Linux/macOS to reduce battery and CPU usage from constant `stat` syscalls.
- Checks `/proc/version` to conditionally keep polling enabled if running on WSL2.
- Supports explicit override via `VITE_USE_POLLING=true` env variable.