### PR TITLE
perf: eliminate image CLS using stable aspect-ratio bounding boxes

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -193,7 +193,8 @@
             entity.image,
           );
         }}
-        class="mb-4 w-full aspect-[16/10] max-h-48 md:max-h-80 rounded border border-theme-border overflow-hidden relative group cursor-pointer hover:border-theme-primary transition block shadow-inner bg-theme-bg/30"
+        disabled={!resolvedImageUrl}
+        class="mb-4 w-full aspect-[16/10] max-h-48 md:max-h-80 rounded border border-theme-border overflow-hidden relative group cursor-pointer hover:border-theme-primary transition block shadow-inner bg-theme-bg/30 disabled:cursor-wait"
       >
         {#if !isImageLoaded}
           <div class="absolute inset-0 flex flex-col items-center justify-center bg-theme-bg/40 animate-pulse text-theme-muted gap-2">
@@ -207,6 +208,7 @@
           loading="lazy"
           decoding="async"
           onload={() => { isImageLoaded = true; }}
+          onerror={() => { isImageLoaded = true; }}
           class="w-full h-full object-contain transition-all duration-300 mx-auto {isImageLoaded ? 'opacity-90 group-hover:opacity-100 scale-100' : 'opacity-0 scale-95'}"
         />
         <div

--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -23,6 +23,14 @@
 
   let resolvedImageUrl = $state("");
   let isDraggingOver = $state(false);
+  let isImageLoaded = $state(false);
+
+  $effect(() => {
+    // Reset loaded state when image URL changes
+    if (resolvedImageUrl) {
+      isImageLoaded = false;
+    }
+  });
   const isVisualizing = $derived(oracle.isVisualizingEntity(entity?.id));
 
   // Check if this entity is visible in guest/shared mode
@@ -185,14 +193,21 @@
             entity.image,
           );
         }}
-        class="mb-4 w-full rounded border border-theme-border overflow-hidden relative group cursor-pointer hover:border-theme-primary transition block shadow-inner bg-theme-bg/30"
+        class="mb-4 w-full aspect-[16/10] max-h-48 md:max-h-80 rounded border border-theme-border overflow-hidden relative group cursor-pointer hover:border-theme-primary transition block shadow-inner bg-theme-bg/30"
       >
+        {#if !isImageLoaded}
+          <div class="absolute inset-0 flex flex-col items-center justify-center bg-theme-bg/40 animate-pulse text-theme-muted gap-2">
+            <span class="icon-[lucide--image] w-8 h-8 opacity-30"></span>
+            <span class="text-[9px] font-mono uppercase tracking-wider opacity-40">Resolving Neural Visual...</span>
+          </div>
+        {/if}
         <img
           src={resolvedImageUrl}
           alt={entity.title}
           loading="lazy"
           decoding="async"
-          class="w-full h-auto max-h-48 md:max-h-80 object-contain opacity-90 group-hover:opacity-100 transition mx-auto"
+          onload={() => { isImageLoaded = true; }}
+          class="w-full h-full object-contain transition-all duration-300 mx-auto {isImageLoaded ? 'opacity-90 group-hover:opacity-100 scale-100' : 'opacity-0 scale-95'}"
         />
         <div
           class="absolute bottom-2 right-2 bg-theme-surface text-theme-primary text-[9px] px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 transition"

--- a/apps/web/src/lib/components/oracle/ImageMessage.svelte
+++ b/apps/web/src/lib/components/oracle/ImageMessage.svelte
@@ -75,6 +75,7 @@
         loading="lazy"
         decoding="async"
         onload={() => { isImageLoaded = true; }}
+        onerror={() => { isImageLoaded = true; }}
         class="w-full h-full object-contain cursor-zoom-in group-hover:scale-105 transition-all duration-300 mx-auto {isImageLoaded ? 'opacity-90' : 'opacity-0'}"
         draggable="true"
         ondragstart={handleDragStart}

--- a/apps/web/src/lib/components/oracle/ImageMessage.svelte
+++ b/apps/web/src/lib/components/oracle/ImageMessage.svelte
@@ -13,6 +13,15 @@
     vault.selectedEntityId ? vault.entities[vault.selectedEntityId] : null,
   );
 
+  let isImageLoaded = $state(false);
+
+  $effect(() => {
+    // Reset loaded state when image URL changes
+    if (message.imageUrl) {
+      isImageLoaded = false;
+    }
+  });
+
   const handleSave = async () => {
     if (!message.imageBlob || !activeEntity || vault.isGuest) return;
 
@@ -50,7 +59,13 @@
 
 <div class="flex flex-col gap-3 w-full max-w-sm">
   {#if message.imageUrl}
-    <div class="relative group">
+    <div class="aspect-square w-full rounded-lg border border-theme-border shadow-lg overflow-hidden relative group bg-theme-bg/30">
+      {#if !isImageLoaded}
+        <div class="absolute inset-0 flex flex-col items-center justify-center bg-theme-bg/40 animate-pulse text-theme-muted gap-2">
+          <span class="icon-[lucide--image] w-8 h-8 opacity-30"></span>
+          <span class="text-[10px] font-mono uppercase tracking-wider opacity-40">Resolving Neural Visual...</span>
+        </div>
+      {/if}
       <!-- Image Preview -->
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -59,7 +74,8 @@
         alt={message.content}
         loading="lazy"
         decoding="async"
-        class="w-full rounded-lg border border-theme-border shadow-lg cursor-zoom-in group-hover:border-theme-primary/50 transition-all"
+        onload={() => { isImageLoaded = true; }}
+        class="w-full h-full object-contain cursor-zoom-in group-hover:scale-105 transition-all duration-300 mx-auto {isImageLoaded ? 'opacity-90' : 'opacity-0'}"
         draggable="true"
         ondragstart={handleDragStart}
         onclick={(e) => {

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -75,6 +75,15 @@
     isPopout?: boolean;
   }>();
 
+  let isImageLoaded = $state(false);
+
+  $effect(() => {
+    // Reset loaded state when image URL changes
+    if (resolvedImageUrl) {
+      isImageLoaded = false;
+    }
+  });
+
   interface ConnectionListItem {
     id: string;
     key: string;
@@ -291,15 +300,22 @@
           });
         }}
         disabled={!resolvedImageUrl}
-        class="w-full rounded-lg border border-theme-border overflow-hidden relative group cursor-pointer hover:border-theme-primary transition block shadow-lg bg-theme-bg/50 focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none disabled:cursor-wait"
+        class="w-full aspect-square rounded-lg border border-theme-border overflow-hidden relative group cursor-pointer hover:border-theme-primary transition block shadow-lg bg-theme-bg/50 focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none disabled:cursor-wait"
         aria-label="View full size image"
       >
+        {#if !isImageLoaded}
+          <div class="absolute inset-0 flex flex-col items-center justify-center bg-theme-bg/40 animate-pulse text-theme-muted gap-2">
+            <span class="icon-[lucide--image] w-8 h-8 opacity-30"></span>
+            <span class="text-[10px] font-mono uppercase tracking-wider opacity-40">Resolving Neural Visual...</span>
+          </div>
+        {/if}
         <img
           src={resolvedImageUrl}
           alt={entity.title}
           loading="lazy"
           decoding="async"
-          class="w-full h-auto max-h-[500px] object-contain opacity-90 group-hover:opacity-100 transition mx-auto"
+          onload={() => { isImageLoaded = true; }}
+          class="w-full h-full object-contain transition-all duration-300 mx-auto {isImageLoaded ? 'opacity-90 group-hover:opacity-100 scale-100' : 'opacity-0 scale-95'}"
         />
         <div
           class="absolute bottom-2 right-2 bg-theme-bg/70 text-theme-primary text-xs font-header tracking-widest uppercase px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition"

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -315,6 +315,7 @@
           loading="lazy"
           decoding="async"
           onload={() => { isImageLoaded = true; }}
+          onerror={() => { isImageLoaded = true; }}
           class="w-full h-full object-contain transition-all duration-300 mx-auto {isImageLoaded ? 'opacity-90 group-hover:opacity-100 scale-100' : 'opacity-0 scale-95'}"
         />
         <div


### PR DESCRIPTION
💡 **What**: Optimized image-heavy layouts to completely eliminate Layout Shift (CLS) when loading AI-generated dynamic-aspect-ratio images.
🎯 **Why**: AI-generated images have varying aspect ratios. Previously, setting h-auto with no container constraints meant the image starting height was 0, causing the UI to expand and jump suddenly when loaded.
♿ **How (Strategy 1)**:
- Kept the image sizing dynamic (object-contain) within fixed premium aspect-ratio containers (aspect-square or aspect-[16/10]).
- Added Svelte 5 reactive isImageLoaded state tracking via onload.
- Introduced elegant loading skeletons featuring a pulse animation and generic asset placeholder that smoothly fades and scales out once the image resolves.

**Components Optimized**:
1. DetailImage.svelte (Primary entity illustration - aspect-[16/10])
2. ZenSidebar.svelte (Zen view card illustration - aspect-square)
3. ImageMessage.svelte (Oracle AI chat illustration - aspect-square)

*Note: EntityNode.svelte (spatial canvas) and DetailMapTab.svelte are already perfectly stable due to static box heights/aspects.*