### PR TITLE
perf/997 image aspect ratio cls

### DIFF
--- a/apps/web/src/lib/components/map/map-canvas-scheduler.ts
+++ b/apps/web/src/lib/components/map/map-canvas-scheduler.ts
@@ -12,12 +12,12 @@ export interface RedrawSchedulerDeps {
 const defaultDeps = (): RedrawSchedulerDeps => ({
   raf:
     typeof requestAnimationFrame !== "undefined"
-      ? requestAnimationFrame
+      ? (cb) => requestAnimationFrame(cb)
       : (cb) =>
           setTimeout(() => cb(performance.now()), 16) as unknown as number,
   cancel:
     typeof cancelAnimationFrame !== "undefined"
-      ? cancelAnimationFrame
+      ? (id) => cancelAnimationFrame(id)
       : (id) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>),
 });
 

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -205,7 +205,8 @@
 
     if (headerEl) {
       const updateHeight = () => {
-        const height = headerEl!.getBoundingClientRect().height;
+        if (!headerEl) return;
+        const height = headerEl.getBoundingClientRect().height;
         document.documentElement.style.setProperty(
           "--header-height",
           `${height}px`,

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@emnapi/core": "^1.10.0",
         "@emnapi/runtime": "^1.10.0",
         "@eslint/js": "^10.0.1",
+        "@types/js-yaml": "^4.0.9",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
         "@typescript-eslint/parser": "^8.59.4",
         "commitlint-config-gitmoji": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",
     "@eslint/js": "^10.0.1",
+    "@types/js-yaml": "^4.0.9",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",
     "commitlint-config-gitmoji": "^2.3.1",


### PR DESCRIPTION
- **perf(image): prevent CLS using stable aspect-ratio bounding boxes with shimmering state transitions**
- **fix: address PR comments on image skeleton and lightbox loading errors**
- **fix: prevent Illegal invocation in MapCanvas requestAnimationFrame and guard unmounted layout ResizeObserver**
- **Merge branch 'perf/986-keyset-pagination' into staging**
