### PR TITLE
:sparkles: feat(editor): entity auto-link in content and lore (#1037)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{ "feature_directory": "specs/118-graph-important-label" }
+{ "feature_directory": "specs/125-entity-auto-link" }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ This file is the Codex-facing instruction layer for this repository.
 <!-- SPECKIT START -->
 
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the [current plan](./specs/122-data-integrity-boundaries/plan.md).
+shell commands, and other important information, read the [current plan](./specs/125-entity-auto-link/plan.md).
 
 <!-- SPECKIT END -->
 

--- a/apps/web/src/lib/components/MarkdownEditor.svelte
+++ b/apps/web/src/lib/components/MarkdownEditor.svelte
@@ -11,6 +11,12 @@
   import { TableCell } from "@tiptap/extension-table-cell";
   import { TableHeader } from "@tiptap/extension-table-header";
   import { EmbedExtension } from "./editor/EmbedExtension";
+  import {
+    createEntityAutoLinkExtension,
+    ENTITY_INDEX_CHANGED_META,
+    type EntityAutoLinkOptions,
+  } from "./editor/EntityAutoLinkExtension";
+  import type { EntityIndexEntry } from "$lib/utils/entity-mention-detector";
 
   import EditorToolbar from "./editor/EditorToolbar.svelte";
   import EditorBubbleMenu from "./editor/EditorBubbleMenu.svelte";
@@ -21,11 +27,36 @@
     content = "",
     editable = true,
     onUpdate,
+    entityIndex = [],
+    currentEntityId = "",
+    onEntityClick = () => {},
   }: {
     content: string;
     editable?: boolean;
     onUpdate?: (markdown: string) => void;
+    /** Flat array of vault entity titles + aliases (lowercase) for auto-link detection. */
+    entityIndex?: EntityIndexEntry[];
+    /** ID of the entity being viewed — suppresses self-links. */
+    currentEntityId?: string;
+    /** Navigation callback invoked when a detected entity link is clicked. */
+    onEntityClick?: (id: string) => void;
   } = $props();
+
+  // Options object shared with the EntityAutoLinkExtension closure.
+  // Getters are used so the plugin reads current prop values at call-time
+  // rather than capturing initial values (avoids Svelte state_referenced_locally
+  // warning and keeps the object in sync without mutation).
+  const autoLinkOptions: EntityAutoLinkOptions = {
+    get entityIndex() {
+      return entityIndex;
+    },
+    get currentEntityId() {
+      return currentEntityId;
+    },
+    get onEntityClick() {
+      return onEntityClick;
+    },
+  };
 
   let element: HTMLDivElement;
   let editor = $state<Editor | null>(null);
@@ -56,6 +87,7 @@
         TableHeader,
         TableCell,
         EmbedExtension,
+        createEntityAutoLinkExtension(autoLinkOptions),
         Link.configure({
           openOnClick: false,
           autolink: true,
@@ -112,6 +144,23 @@
   $effect(() => {
     if (editor && editor.isEditable !== editable) {
       editor.setEditable(editable);
+    }
+  });
+
+  // Entity auto-link reactivity bridge: when entityIndex, currentEntityId, or
+  // onEntityClick props change, dispatch a no-op transaction so the plugin's
+  // apply hook re-sorts options.entityIndex and rebuilds decorations.
+  // The options object uses getters so it always reads current prop values;
+  // these reads declare reactive dependencies that fire this $effect on change.
+  $effect(() => {
+    // Declare reactive dependencies (getters read current prop values at call-time).
+    void entityIndex;
+    void currentEntityId;
+    void onEntityClick;
+    if (editor && !editor.isEditable) {
+      editor.view.dispatch(
+        editor.state.tr.setMeta(ENTITY_INDEX_CHANGED_META, true),
+      );
     }
   });
 

--- a/apps/web/src/lib/components/MarkdownEditor.svelte
+++ b/apps/web/src/lib/components/MarkdownEditor.svelte
@@ -157,7 +157,11 @@
     void entityIndex;
     void currentEntityId;
     void onEntityClick;
-    if (editor && !editor.isEditable) {
+    // Always dispatch when deps change so the cached DecorationSet stays current
+    // even when entityIndex updates while the editor is in edit mode.
+    // The editable gate lives in props.decorations() — not here — so dispatching
+    // in edit mode is harmless: the plugin simply returns DecorationSet.empty.
+    if (editor) {
       editor.view.dispatch(
         editor.state.tr.setMeta(ENTITY_INDEX_CHANGED_META, true),
       );

--- a/apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts
+++ b/apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts
@@ -260,6 +260,33 @@ describe("EntityAutoLinkExtension — entityIndex reactivity", () => {
 
     expect(getDecoratedSpans(editor).length).toBe(0);
   });
+
+  it("index updated in edit mode is applied when switching back to read mode", () => {
+    // Start read mode, confirm decoration
+    const options: EntityAutoLinkOptions = {
+      entityIndex: [{ text: "crimson enclave", id: "e1" }],
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(options, false, "<p>Crimson Enclave.</p>");
+    expect(getDecoratedSpans(editor).length).toBe(1);
+
+    // Switch to edit mode and update the index (simulates vault rename while editing)
+    editor.setEditable(true);
+    options.entityIndex = [{ text: "crimson enclave", id: "e1-renamed" }];
+    editor.view.dispatch(
+      editor.state.tr.setMeta(ENTITY_INDEX_CHANGED_META, true),
+    );
+    // In edit mode: no decorations visible
+    expect(getDecoratedSpans(editor).length).toBe(0);
+
+    // Switch back to read mode — should see the updated entity ID
+    editor.setEditable(false);
+    expect(getDecoratedSpans(editor).length).toBe(1);
+    expect(getDecoratedSpans(editor)[0].getAttribute("data-entity-id")).toBe(
+      "e1-renamed",
+    );
+  });
 });
 
 // ─── Click handling ───────────────────────────────────────────────────────────
@@ -294,6 +321,29 @@ describe("EntityAutoLinkExtension — click handling", () => {
     };
     const editor = createTestEditor(options, false, "<p>No entities here.</p>");
 
+    editor.view.dom.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onEntityClick when editor is in edit mode", () => {
+    const onClick = vi.fn();
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: onClick,
+    };
+    // Start in read mode so decoration HTML exists, then switch to edit mode
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage appeared.</p>",
+    );
+    editor.setEditable(true);
+
+    // Click on the DOM node that still has the span (even though decorations
+    // are empty, the DOM may retain the element until the next render tick).
+    // More robustly: fire on the editor root itself.
     editor.view.dom.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(onClick).not.toHaveBeenCalled();

--- a/apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts
+++ b/apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts
@@ -99,7 +99,7 @@ describe("EntityAutoLinkExtension — read mode", () => {
     expect(spans.length).toBe(2);
   });
 
-  it("decorates all occurrences (not just first)", () => {
+  it("decorates only the first occurrence of each entity (first-occurrence-only)", () => {
     const options: EntityAutoLinkOptions = {
       entityIndex: ENTITIES,
       currentEntityId: "",
@@ -108,10 +108,32 @@ describe("EntityAutoLinkExtension — read mode", () => {
     const editor = createTestEditor(
       options,
       false,
-      "<p>Aldric the Sage and Aldric the Sage appeared.</p>",
+      "<p>Aldric the Sage met Aldric the Sage again.</p>",
+    );
+    const spans = getDecoratedSpans(editor);
+    // Only one decoration even though the name appears twice
+    expect(spans.length).toBe(1);
+    expect(spans[0].getAttribute("data-entity-id")).toBe("aldric-1");
+  });
+
+  it("decorates first occurrence of each distinct entity independently", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    // Two different entities — each gets exactly one decoration
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage and Crimson Enclave met Aldric the Sage again at Crimson Enclave.</p>",
     );
     const spans = getDecoratedSpans(editor);
     expect(spans.length).toBe(2);
+    const ids = Array.from(spans)
+      .map((s) => s.getAttribute("data-entity-id"))
+      .sort();
+    expect(ids).toEqual(["aldric-1", "crimson-3"].sort());
   });
 
   it("produces no decorations when entity index is empty", () => {

--- a/apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts
+++ b/apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  createEntityAutoLinkExtension,
+  ENTITY_INDEX_CHANGED_META,
+  type EntityAutoLinkOptions,
+} from "./EntityAutoLinkExtension";
+import type { EntityIndexEntry } from "$lib/utils/entity-mention-detector";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const ENTITIES: EntityIndexEntry[] = [
+  { text: "aldric the sage", id: "aldric-1" },
+  { text: "crimson enclave", id: "crimson-3" },
+];
+
+const editors: Editor[] = [];
+
+function createTestEditor(
+  options: EntityAutoLinkOptions,
+  editable: boolean,
+  htmlContent: string,
+): Editor {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const editor = new Editor({
+    element: el,
+    extensions: [StarterKit, createEntityAutoLinkExtension(options)],
+    editable,
+    content: htmlContent,
+  });
+  editors.push(editor);
+  return editor;
+}
+
+function getDecoratedSpans(editor: Editor): NodeListOf<Element> {
+  return editor.view.dom.querySelectorAll("[data-entity-id]");
+}
+
+afterEach(() => {
+  for (const e of editors) {
+    if (!e.isDestroyed) e.destroy();
+  }
+  editors.length = 0;
+  // Clean up any orphaned editor mounts
+  document.body.innerHTML = "";
+});
+
+// ─── Read-mode decorations ────────────────────────────────────────────────────
+
+describe("EntityAutoLinkExtension — read mode", () => {
+  it("produces a decoration for a detected entity name", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>She trained under Aldric the Sage.</p>",
+    );
+    const spans = getDecoratedSpans(editor);
+    expect(spans.length).toBe(1);
+    expect(spans[0].getAttribute("data-entity-id")).toBe("aldric-1");
+  });
+
+  it("applies correct CSS classes to the decoration", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage was wise.</p>",
+    );
+    const span = getDecoratedSpans(editor)[0];
+    expect(span.classList.contains("entity-auto-link")).toBe(true);
+    expect(span.classList.contains("text-theme-primary")).toBe(true);
+    expect(span.classList.contains("underline")).toBe(true);
+    expect(span.classList.contains("cursor-pointer")).toBe(true);
+  });
+
+  it("decorates multiple entity names in one document", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage founded the Crimson Enclave.</p>",
+    );
+    const spans = getDecoratedSpans(editor);
+    expect(spans.length).toBe(2);
+  });
+
+  it("decorates all occurrences (not just first)", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage and Aldric the Sage appeared.</p>",
+    );
+    const spans = getDecoratedSpans(editor);
+    expect(spans.length).toBe(2);
+  });
+
+  it("produces no decorations when entity index is empty", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: [],
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage was here.</p>",
+    );
+    expect(getDecoratedSpans(editor).length).toBe(0);
+  });
+
+  it("suppresses self-link (currentEntityId match)", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "aldric-1",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage trained here.</p>",
+    );
+    expect(getDecoratedSpans(editor).length).toBe(0);
+  });
+
+  it("suppresses only the self-entity, links others", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "aldric-1",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage led the Crimson Enclave.</p>",
+    );
+    const spans = getDecoratedSpans(editor);
+    expect(spans.length).toBe(1);
+    expect(spans[0].getAttribute("data-entity-id")).toBe("crimson-3");
+  });
+});
+
+// ─── Edit mode ────────────────────────────────────────────────────────────────
+
+describe("EntityAutoLinkExtension — edit mode", () => {
+  it("produces no decorations when editable=true", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      true,
+      "<p>Aldric the Sage was wise.</p>",
+    );
+    expect(getDecoratedSpans(editor).length).toBe(0);
+  });
+
+  it("removes decorations when switching from read to edit mode", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(options, false, "<p>Aldric the Sage.</p>");
+    // Verify read-mode decorations exist
+    expect(getDecoratedSpans(editor).length).toBe(1);
+
+    // Switch to edit mode
+    editor.setEditable(true);
+
+    // Decorations must be gone (props.decorations gate fires on view update)
+    expect(getDecoratedSpans(editor).length).toBe(0);
+  });
+
+  it("restores decorations when switching from edit to read mode", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(options, true, "<p>Aldric the Sage.</p>");
+    expect(getDecoratedSpans(editor).length).toBe(0);
+
+    editor.setEditable(false);
+
+    // After switching to read mode, decorations should appear.
+    // setEditable() doesn't fire a transaction, so we dispatch a no-op to
+    // trigger the apply hook and rebuild state (same pattern as the $effect bridge).
+    editor.view.dispatch(
+      editor.state.tr.setMeta(ENTITY_INDEX_CHANGED_META, true),
+    );
+
+    expect(getDecoratedSpans(editor).length).toBe(1);
+  });
+});
+
+// ─── EntityIndex reactivity (entityIndexChanged meta) ────────────────────────
+
+describe("EntityAutoLinkExtension — entityIndex reactivity", () => {
+  it("rebuilds decorations after entityIndexChanged meta is dispatched", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: [{ text: "crimson enclave", id: "e1" }],
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Crimson Enclave was powerful.</p>",
+    );
+    expect(getDecoratedSpans(editor).length).toBe(1);
+
+    // Simulate MarkdownEditor $effect updating the shared options ref and dispatching meta
+    options.entityIndex = [
+      { text: "crimson enclave", id: "e1" },
+      { text: "powerful", id: "e2" },
+    ];
+    editor.view.dispatch(
+      editor.state.tr.setMeta(ENTITY_INDEX_CHANGED_META, true),
+    );
+
+    expect(getDecoratedSpans(editor).length).toBe(2);
+  });
+
+  it("removes stale decorations when entity is removed from index", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: [{ text: "crimson enclave", id: "e1" }],
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(options, false, "<p>Crimson Enclave.</p>");
+    expect(getDecoratedSpans(editor).length).toBe(1);
+
+    // Remove the entity
+    options.entityIndex = [];
+    editor.view.dispatch(
+      editor.state.tr.setMeta(ENTITY_INDEX_CHANGED_META, true),
+    );
+
+    expect(getDecoratedSpans(editor).length).toBe(0);
+  });
+});
+
+// ─── Click handling ───────────────────────────────────────────────────────────
+
+describe("EntityAutoLinkExtension — click handling", () => {
+  it("calls onEntityClick with the entity ID when a decoration is clicked", () => {
+    const onClick = vi.fn();
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: onClick,
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric the Sage appeared.</p>",
+    );
+    const span = getDecoratedSpans(editor)[0] as HTMLElement;
+
+    span.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(onClick).toHaveBeenCalledWith("aldric-1");
+  });
+
+  it("does not fire onEntityClick when non-decorated text is clicked", () => {
+    const onClick = vi.fn();
+    const options: EntityAutoLinkOptions = {
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: onClick,
+    };
+    const editor = createTestEditor(options, false, "<p>No entities here.</p>");
+
+    editor.view.dom.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Lore / multi-instance independence (US2) ─────────────────────────────────
+
+describe("EntityAutoLinkExtension — multiple editor instances (lore parity)", () => {
+  it("two editors with the same extension produce independent decoration sets", () => {
+    const makeOptions = (): EntityAutoLinkOptions => ({
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    });
+
+    const editorA = createTestEditor(
+      makeOptions(),
+      false,
+      "<p>Aldric the Sage spoke.</p>",
+    );
+    const editorB = createTestEditor(
+      makeOptions(),
+      false,
+      "<p>The Crimson Enclave fell.</p>",
+    );
+
+    expect(getDecoratedSpans(editorA).length).toBe(1);
+    expect(getDecoratedSpans(editorA)[0].getAttribute("data-entity-id")).toBe(
+      "aldric-1",
+    );
+
+    expect(getDecoratedSpans(editorB).length).toBe(1);
+    expect(getDecoratedSpans(editorB)[0].getAttribute("data-entity-id")).toBe(
+      "crimson-3",
+    );
+  });
+
+  it("destroying one editor does not affect the other", () => {
+    const makeOptions = (): EntityAutoLinkOptions => ({
+      entityIndex: ENTITIES,
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    });
+
+    const editorA = createTestEditor(
+      makeOptions(),
+      false,
+      "<p>Aldric the Sage.</p>",
+    );
+    const editorB = createTestEditor(
+      makeOptions(),
+      false,
+      "<p>Aldric the Sage.</p>",
+    );
+
+    editorA.destroy();
+
+    // editorB should still have its decoration
+    expect(getDecoratedSpans(editorB).length).toBe(1);
+  });
+});
+
+// ─── Alias matching (US4) ─────────────────────────────────────────────────────
+
+describe("EntityAutoLinkExtension — alias matching", () => {
+  it("decorates an alias that resolves to the correct entity", () => {
+    const options: EntityAutoLinkOptions = {
+      entityIndex: [
+        { text: "aldric the sage", id: "aldric-1" },
+        { text: "aldric", id: "aldric-1" },
+      ],
+      currentEntityId: "",
+      onEntityClick: vi.fn(),
+    };
+    const editor = createTestEditor(
+      options,
+      false,
+      "<p>Aldric trained her.</p>",
+    );
+    const spans = getDecoratedSpans(editor);
+    expect(spans.length).toBe(1);
+    expect(spans[0].getAttribute("data-entity-id")).toBe("aldric-1");
+  });
+});

--- a/apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts
+++ b/apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts
@@ -124,6 +124,10 @@ export function createEntityAutoLinkExtension(
             // Single delegated click listener — O(1) memory regardless of
             // decoration count (plan.md Decision 3).
             function handleClick(e: MouseEvent) {
+              // Mirror the decoration gate: ignore clicks while editable so
+              // future features or external code that emit data-entity-id in
+              // edit mode cannot accidentally trigger navigation.
+              if (editor.isEditable) return;
               const target = (e.target as HTMLElement).closest<HTMLElement>(
                 "[data-entity-id]",
               );

--- a/apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts
+++ b/apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts
@@ -158,11 +158,15 @@ function buildDecorations(
   if (sorted.length === 0) return DecorationSet.empty;
 
   const decos: Decoration[] = [];
+  // First-occurrence-only: each entity ID is linked once per render.
+  const seen = new Set<string>();
 
   doc.descendants((node, pos) => {
     if (!node.isText || !node.text) return;
     const matches = detectEntityMentions(node.text, sorted, currentEntityId);
     for (const m of matches) {
+      if (seen.has(m.entityId)) continue;
+      seen.add(m.entityId);
       decos.push(
         Decoration.inline(pos + m.start, pos + m.end, {
           class: "entity-auto-link text-theme-primary underline cursor-pointer",

--- a/apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts
+++ b/apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts
@@ -1,0 +1,174 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { Node as PMNode } from "@tiptap/pm/model";
+import {
+  detectEntityMentions,
+  sortEntityIndex,
+  type EntityIndexEntry,
+} from "$lib/utils/entity-mention-detector";
+
+export type { EntityIndexEntry };
+
+/** ProseMirror plugin key — exported so tests can inspect plugin state directly. */
+export const ENTITY_AUTO_LINK_KEY = new PluginKey<DecorationSet>(
+  "entityAutoLink",
+);
+
+/**
+ * Meta key used by MarkdownEditor.svelte's $effect to signal that the entity
+ * index has changed. The plugin re-sorts and rebuilds decorations on receipt.
+ */
+export const ENTITY_INDEX_CHANGED_META = "entityIndexChanged";
+
+export interface EntityAutoLinkOptions {
+  /**
+   * Flat array of title/alias entries (lowercase text) from the active vault.
+   * Mutated in-place by the MarkdownEditor.svelte $effect before dispatching
+   * the ENTITY_INDEX_CHANGED_META transaction, so the apply hook always sees
+   * the latest snapshot.
+   */
+  entityIndex: EntityIndexEntry[];
+
+  /**
+   * ID of the entity currently being rendered. Matches against this ID are
+   * suppressed to prevent self-links. Updated in the $effect alongside entityIndex.
+   */
+  currentEntityId: string;
+
+  /**
+   * Navigation callback invoked when the user clicks a detected entity link.
+   * The extension does not import any store — context-preserving routing is
+   * the caller's responsibility (Constitution VIII).
+   */
+  onEntityClick: (entityId: string) => void;
+}
+
+/**
+ * Creates a TipTap extension that decorates entity name occurrences in
+ * read-mode content with clickable inline spans.
+ *
+ * The extension is DI-clean: it accepts all external dependencies via `options`
+ * and does not import vault/layout stores directly.
+ */
+export function createEntityAutoLinkExtension(
+  options: EntityAutoLinkOptions,
+): Extension {
+  return Extension.create({
+    name: "entityAutoLink",
+
+    addProseMirrorPlugins() {
+      // `this.editor` is the TipTap Editor instance — captured in the closure so
+      // `editor.isEditable` is read at render-time (not snapshot at creation).
+      const editor = this.editor;
+
+      // Mutable sorted index — re-sorted when ENTITY_INDEX_CHANGED_META fires.
+      let sorted = sortEntityIndex(options.entityIndex);
+
+      return [
+        new Plugin({
+          key: ENTITY_AUTO_LINK_KEY,
+
+          // State cache: stores the computed DecorationSet for the current document.
+          // The editable gate is applied in props.decorations() below, so the cache
+          // always holds "what decorations would look like in read mode".
+          state: {
+            init(_config, state) {
+              return buildDecorations(
+                state.doc,
+                sorted,
+                options.currentEntityId,
+              );
+            },
+
+            apply(tr, old, _prevState, newState) {
+              // EntityIndex changed: re-sort using the updated options ref and rebuild.
+              if (tr.getMeta(ENTITY_INDEX_CHANGED_META)) {
+                sorted = sortEntityIndex(options.entityIndex);
+                return buildDecorations(
+                  newState.doc,
+                  sorted,
+                  options.currentEntityId,
+                );
+              }
+
+              // Document content changed: rebuild with existing sorted index.
+              if (tr.docChanged) {
+                return buildDecorations(
+                  newState.doc,
+                  sorted,
+                  options.currentEntityId,
+                );
+              }
+
+              return old;
+            },
+          },
+
+          props: {
+            /**
+             * Called on every view render — including after setEditable() which
+             * does not dispatch a transaction. The editable gate here ensures
+             * decorations disappear immediately when the editor switches to edit
+             * mode, without needing an intermediate transaction.
+             */
+            decorations(state) {
+              if (editor.isEditable) return DecorationSet.empty;
+              return (
+                ENTITY_AUTO_LINK_KEY.getState(state) ?? DecorationSet.empty
+              );
+            },
+          },
+
+          view(editorView) {
+            // Single delegated click listener — O(1) memory regardless of
+            // decoration count (plan.md Decision 3).
+            function handleClick(e: MouseEvent) {
+              const target = (e.target as HTMLElement).closest<HTMLElement>(
+                "[data-entity-id]",
+              );
+              if (target?.dataset.entityId) {
+                options.onEntityClick(target.dataset.entityId);
+              }
+            }
+
+            editorView.dom.addEventListener("click", handleClick);
+
+            return {
+              destroy() {
+                editorView.dom.removeEventListener("click", handleClick);
+              },
+            };
+          },
+        }),
+      ];
+    },
+  });
+}
+
+function buildDecorations(
+  doc: PMNode,
+  sorted: EntityIndexEntry[],
+  currentEntityId: string,
+): DecorationSet {
+  if (sorted.length === 0) return DecorationSet.empty;
+
+  const decos: Decoration[] = [];
+
+  doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return;
+    const matches = detectEntityMentions(node.text, sorted, currentEntityId);
+    for (const m of matches) {
+      decos.push(
+        Decoration.inline(pos + m.start, pos + m.end, {
+          class: "entity-auto-link text-theme-primary underline cursor-pointer",
+          "data-entity-id": m.entityId,
+          role: "link",
+          tabindex: "0",
+        }),
+      );
+    }
+  });
+
+  return DecorationSet.create(doc, decos);
+}

--- a/apps/web/src/lib/components/entity-detail/DetailLoreTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailLoreTab.svelte
@@ -2,6 +2,7 @@
   import type { Entity } from "schema";
   import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
   import { vault } from "$lib/stores/vault.svelte";
+  import type { EntityIndexEntry } from "$lib/utils/entity-mention-detector";
   import { regenerationService } from "$lib/services/RegenerationService.svelte";
 
   let {
@@ -18,6 +19,14 @@
     regenerationService.pendingDraft?.entityId === entity.id
       ? regenerationService.pendingDraft
       : null,
+  );
+
+  // Entity auto-link: build flat index of titles + aliases for mention detection.
+  const entityIndex = $derived<EntityIndexEntry[]>(
+    Object.values(vault.entities).flatMap((e) => [
+      { text: e.title.toLowerCase(), id: e.id },
+      ...e.aliases.map((a) => ({ text: a.toLowerCase(), id: e.id })),
+    ]),
   );
 </script>
 
@@ -52,6 +61,11 @@
               ? draft.lore
               : entity.lore || "No detailed lore available."}
             editable={false}
+            {entityIndex}
+            currentEntityId={entity.id}
+            onEntityClick={(id) => {
+              vault.selectedEntityId = id;
+            }}
           />
         </div>
       {/if}

--- a/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
@@ -3,6 +3,7 @@
   import { vault } from "$lib/stores/vault.svelte";
   import { isEntityVisible } from "schema";
   import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
+  import type { EntityIndexEntry } from "$lib/utils/entity-mention-detector";
   import TemporalEditor from "$lib/components/timeline/TemporalEditor.svelte";
   import ConnectionEditor from "$lib/components/connections/ConnectionEditor.svelte";
   import Autocomplete from "$lib/components/ui/Autocomplete.svelte";
@@ -85,8 +86,6 @@
     });
   });
 
-
-
   let allConnections = $derived.by(() => {
     if (!entity) return [];
 
@@ -156,6 +155,15 @@
     return result;
   });
 
+  // Entity auto-link: build flat index of titles + aliases for mention detection.
+  // vault.entities is available to both host and guest sessions (FR-011).
+  const entityIndex = $derived<EntityIndexEntry[]>(
+    Object.values(vault.entities).flatMap((e) => [
+      { text: e.title.toLowerCase(), id: e.id },
+      ...e.aliases.map((a) => ({ text: a.toLowerCase(), id: e.id })),
+    ]),
+  );
+
   const isFantasyTheme = $derived(themeStore.activeTheme.id === "fantasy");
   const draft = $derived(
     regenerationService.pendingDraft?.entityId === entity.id
@@ -181,7 +189,6 @@
         />
       </div>
     </div>
-
   {/if}
 
   <!-- Chronicle -->
@@ -216,6 +223,11 @@
             editable={isEditing && !draft}
             onUpdate={(val) => {
               if (isEditing) editContent = val;
+            }}
+            entityIndex={isEditing ? [] : entityIndex}
+            currentEntityId={entity.id}
+            onEntityClick={(id) => {
+              vault.selectedEntityId = id;
             }}
           />
         {/if}

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { vault } from "$lib/stores/vault.svelte";
+  import type { EntityIndexEntry } from "$lib/utils/entity-mention-detector";
   import { themeStore } from "$lib/stores/theme.svelte";
   import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
   import TemporalEditor from "$lib/components/timeline/TemporalEditor.svelte";
@@ -225,6 +226,14 @@
       ? regenerationService.pendingDraft
       : null,
   );
+
+  // Entity auto-link: build flat index of titles + aliases for mention detection.
+  const entityIndex = $derived<EntityIndexEntry[]>(
+    Object.values(vault.entities).flatMap((e) => [
+      { text: e.title.toLowerCase(), id: e.id },
+      ...e.aliases.map((a) => ({ text: a.toLowerCase(), id: e.id })),
+    ]),
+  );
 </script>
 
 <div
@@ -338,6 +347,9 @@
                 ? draft.chronicle
                 : entity?.content || "No records found."}
               editable={false}
+              {entityIndex}
+              currentEntityId={entity?.id ?? ""}
+              onEntityClick={(id) => onNavigate(id)}
             />
           </div>
         {:else}
@@ -383,6 +395,9 @@
                 ? draft.lore
                 : entity?.lore || "No detailed lore available."}
               editable={false}
+              {entityIndex}
+              currentEntityId={entity?.id ?? ""}
+              onEntityClick={(id) => onNavigate(id)}
             />
           </div>
         {/if}

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -391,6 +391,13 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
       "Organize your world hierarchically. Drag and drop entities in the explorer to nest them under parents (e.g. putting a tavern inside a city). Expand/collapse nodes using the chevron. When you delete a parent, its children are promoted to the root level. Cycle detection prevents recursive loop errors.",
     icon: "icon-[lucide--folder-tree]",
   },
+  "entity-auto-link": {
+    id: "entity-auto-link",
+    title: "Entity Links in Content",
+    content:
+      "When reading an entity's content or lore, names of other vault entities are automatically highlighted as clickable links. Click any highlighted name to navigate directly to that entity. Links work with full titles and registered aliases. They only appear in read mode — the editor shows plain text while you are writing.",
+    icon: "icon-[lucide--link]",
+  },
 };
 
 let initialArticles: HelpArticle[] = [];

--- a/apps/web/src/lib/utils/entity-mention-detector.test.ts
+++ b/apps/web/src/lib/utils/entity-mention-detector.test.ts
@@ -253,4 +253,58 @@ describe("detectEntityMentions", () => {
     const matches = detectEntityMentions("Nothing to see here.", sorted, "");
     expect(matches).toHaveLength(0);
   });
+
+  // Shared-prefix disambiguation (e.g. "Red Lanterns Gang" vs "Red Lanterns District")
+
+  it("shared-prefix entities: longer title wins when the full longer name appears in text", () => {
+    const entities: EntityIndexEntry[] = [
+      { text: "red lanterns district", id: "district-1" },
+      { text: "red lanterns gang", id: "gang-1" },
+    ];
+    const s = sortEntityIndex(entities);
+
+    // Text contains the full "Red Lanterns district" — should match entity district-1
+    const matches = detectEntityMentions(
+      "escorted her to the Red Lanterns district.",
+      s,
+      "",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].entityId).toBe("district-1");
+    expect(matches[0].matchedText).toBe("Red Lanterns district");
+  });
+
+  it("shared-prefix entities: shorter title matches when text contains only the shorter name", () => {
+    const entities: EntityIndexEntry[] = [
+      { text: "red lanterns district", id: "district-1" },
+      { text: "red lanterns gang", id: "gang-1" },
+    ];
+    const s = sortEntityIndex(entities);
+
+    // Text contains "Red Lanterns gang" — should match gang-1, not district-1
+    const matches = detectEntityMentions(
+      "the Red Lanterns gang ambushed them.",
+      s,
+      "",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].entityId).toBe("gang-1");
+    expect(matches[0].matchedText).toBe("Red Lanterns gang");
+  });
+
+  it("shared-prefix entities: bare shared prefix matches neither specific entity (no partial match)", () => {
+    const entities: EntityIndexEntry[] = [
+      { text: "red lanterns district", id: "district-1" },
+      { text: "red lanterns gang", id: "gang-1" },
+    ];
+    const s = sortEntityIndex(entities);
+
+    // "Red Lanterns" alone — neither entity title matches exactly
+    const matches = detectEntityMentions(
+      "the Red Lanterns were present.",
+      s,
+      "",
+    );
+    expect(matches).toHaveLength(0);
+  });
 });

--- a/apps/web/src/lib/utils/entity-mention-detector.test.ts
+++ b/apps/web/src/lib/utils/entity-mention-detector.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectEntityMentions,
+  sortEntityIndex,
+  type EntityIndexEntry,
+} from "./entity-mention-detector";
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
+
+const ALDRIC: EntityIndexEntry = { text: "aldric the sage", id: "aldric-1" };
+const CRIMSON: EntityIndexEntry = { text: "crimson enclave", id: "crimson-3" };
+const SAGE: EntityIndexEntry = { text: "sage", id: "sage-2" };
+/** Short-form alias for ALDRIC — resolves to the same entity ID. */
+const ALDRIC_ALIAS: EntityIndexEntry = { text: "aldric", id: "aldric-1" };
+
+// ─── sortEntityIndex ─────────────────────────────────────────────────────────
+
+describe("sortEntityIndex", () => {
+  it("sorts entries longest-first", () => {
+    const sorted = sortEntityIndex([SAGE, ALDRIC, CRIMSON]);
+    // "aldric the sage" and "crimson enclave" are both 15 chars; either may be first.
+    expect(sorted[0].text.length).toBeGreaterThanOrEqual(sorted[1].text.length);
+    expect(sorted[1].text.length).toBeGreaterThanOrEqual(sorted[2].text.length);
+    // "sage" (4 chars) must be last.
+    expect(sorted[2].text).toBe("sage");
+  });
+
+  it("does not mutate the original array", () => {
+    const original = [SAGE, ALDRIC];
+    sortEntityIndex(original);
+    expect(original[0]).toBe(SAGE);
+    expect(original[1]).toBe(ALDRIC);
+  });
+
+  it("returns empty array unchanged", () => {
+    expect(sortEntityIndex([])).toEqual([]);
+  });
+
+  it("handles single-entry array", () => {
+    expect(sortEntityIndex([ALDRIC])).toEqual([ALDRIC]);
+  });
+});
+
+// ─── detectEntityMentions ────────────────────────────────────────────────────
+
+describe("detectEntityMentions", () => {
+  const sorted = sortEntityIndex([ALDRIC, CRIMSON]);
+
+  // Basic match
+
+  it("detects a basic match in a sentence", () => {
+    const matches = detectEntityMentions(
+      "She trained under Aldric the Sage.",
+      sorted,
+      "",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].entityId).toBe("aldric-1");
+    expect(matches[0].matchedText).toBe("Aldric the Sage");
+    expect(matches[0].start).toBe(18);
+    expect(matches[0].end).toBe(33);
+  });
+
+  it("detects multiple matches in one string", () => {
+    const matches = detectEntityMentions(
+      "Aldric the Sage founded the Crimson Enclave.",
+      sorted,
+      "",
+    );
+    expect(matches).toHaveLength(2);
+    expect(matches[0].entityId).toBe("aldric-1");
+    expect(matches[1].entityId).toBe("crimson-3");
+  });
+
+  it("detects all occurrences (not just the first)", () => {
+    const matches = detectEntityMentions(
+      "Aldric the Sage and again Aldric the Sage",
+      sorted,
+      "",
+    );
+    expect(matches).toHaveLength(2);
+  });
+
+  // Case handling
+
+  it("is case-insensitive (uppercase input)", () => {
+    const matches = detectEntityMentions(
+      "ALDRIC THE SAGE was wise.",
+      sorted,
+      "",
+    );
+    expect(matches).toHaveLength(1);
+  });
+
+  it("is case-insensitive (lowercase input)", () => {
+    const matches = detectEntityMentions(
+      "aldric the sage led the crimson enclave",
+      sorted,
+      "",
+    );
+    expect(matches).toHaveLength(2);
+  });
+
+  it("preserves original casing in matchedText", () => {
+    const matches = detectEntityMentions(
+      "ALDRIC THE SAGE was wise.",
+      sorted,
+      "",
+    );
+    expect(matches[0].matchedText).toBe("ALDRIC THE SAGE");
+  });
+
+  // Word boundaries
+
+  it("does not match inside a possessive (apostrophe boundary)", () => {
+    const sortedAlias = sortEntityIndex([ALDRIC_ALIAS]);
+    const matches = detectEntityMentions("Aldric's staff.", sortedAlias, "");
+    expect(matches).toHaveLength(0);
+  });
+
+  it("does not match when embedded in a longer word (left boundary)", () => {
+    const sortedAlias = sortEntityIndex([ALDRIC_ALIAS]);
+    const matches = detectEntityMentions("NotAldric spoke.", sortedAlias, "");
+    expect(matches).toHaveLength(0);
+  });
+
+  it("does not match when embedded in a longer word (right boundary)", () => {
+    const sortedAlias = sortEntityIndex([ALDRIC_ALIAS]);
+    const matches = detectEntityMentions(
+      "Aldricson was here.",
+      sortedAlias,
+      "",
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  it("matches name at the very start of the string", () => {
+    const matches = detectEntityMentions("Aldric the Sage founded", sorted, "");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].start).toBe(0);
+  });
+
+  it("matches name at the very end of the string", () => {
+    const matches = detectEntityMentions(
+      "Known as Aldric the Sage",
+      sorted,
+      "",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].end).toBe(24);
+  });
+
+  it("matches alias at the start of a sentence followed by punctuation", () => {
+    const sortedAlias = sortEntityIndex([ALDRIC_ALIAS]);
+    const matches = detectEntityMentions("Aldric was wise.", sortedAlias, "");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].entityId).toBe("aldric-1");
+  });
+
+  // Longest-match-wins
+
+  it("longest match wins over shorter alias at the same position", () => {
+    const sortedBoth = sortEntityIndex([ALDRIC, ALDRIC_ALIAS]);
+    const matches = detectEntityMentions(
+      "Aldric the Sage appeared.",
+      sortedBoth,
+      "",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe("Aldric the Sage");
+    expect(matches[0].entityId).toBe("aldric-1");
+  });
+
+  it('does not match standalone "sage" when "sage" entity is absent', () => {
+    // The sorted index has only ALDRIC + CRIMSON, not SAGE
+    const matches = detectEntityMentions("The sage spoke.", sorted, "");
+    expect(matches).toHaveLength(0);
+  });
+
+  it('matches standalone "sage" when it exists as its own entity', () => {
+    const sortedWithSage = sortEntityIndex([ALDRIC, SAGE]);
+    const matches = detectEntityMentions("The sage spoke.", sortedWithSage, "");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].entityId).toBe("sage-2");
+  });
+
+  // Self-link suppression
+
+  it("suppresses matches when entityId equals currentEntityId", () => {
+    const matches = detectEntityMentions(
+      "Aldric the Sage trained here.",
+      sorted,
+      "aldric-1",
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  it("suppresses only the matching entity, not others", () => {
+    const matches = detectEntityMentions(
+      "Aldric the Sage and the Crimson Enclave",
+      sorted,
+      "aldric-1",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].entityId).toBe("crimson-3");
+  });
+
+  // Alias resolution (US4)
+
+  it("alias resolves to the correct entity ID", () => {
+    const sortedAlias = sortEntityIndex([ALDRIC_ALIAS]);
+    const matches = detectEntityMentions(
+      "Aldric trained her.",
+      sortedAlias,
+      "",
+    );
+    expect(matches[0].entityId).toBe("aldric-1");
+  });
+
+  it("multiple entities each with their own alias — correct per-span resolution", () => {
+    const entities: EntityIndexEntry[] = [
+      { text: "crimson enclave", id: "e1" },
+      { text: "enclave", id: "e1" }, // alias for e1
+      { text: "silver ward", id: "e2" },
+      { text: "ward", id: "e2" }, // alias for e2
+    ];
+    const s = sortEntityIndex(entities);
+    const matches = detectEntityMentions(
+      "The Enclave and the Ward met.",
+      s,
+      "",
+    );
+    expect(matches).toHaveLength(2);
+    expect(matches.find((m) => m.matchedText === "Enclave")?.entityId).toBe(
+      "e1",
+    );
+    expect(matches.find((m) => m.matchedText === "Ward")?.entityId).toBe("e2");
+  });
+
+  // Edge cases / empty inputs
+
+  it("returns empty array for empty entity index", () => {
+    const matches = detectEntityMentions("Aldric the Sage", [], "");
+    expect(matches).toHaveLength(0);
+  });
+
+  it("returns empty array for empty text", () => {
+    const matches = detectEntityMentions("", sorted, "");
+    expect(matches).toHaveLength(0);
+  });
+
+  it("handles text with no entity names", () => {
+    const matches = detectEntityMentions("Nothing to see here.", sorted, "");
+    expect(matches).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/utils/entity-mention-detector.ts
+++ b/apps/web/src/lib/utils/entity-mention-detector.ts
@@ -1,0 +1,98 @@
+// Performance baseline: see tasks.md T022 — profile with 5 000-word entity + 100 vault
+// entities and record observed timing here after manual profiling.
+
+export interface EntityIndexEntry {
+  /** Lowercase title or alias for case-insensitive comparison. */
+  text: string;
+  /** The canonical entity ID this entry resolves to. */
+  id: string;
+}
+
+export interface DetectedMatch {
+  /** Byte offset of the first matched character in the source string. */
+  start: number;
+  /** Byte offset one past the last matched character. */
+  end: number;
+  /** The canonical entity ID resolved from the match. */
+  entityId: string;
+  /** The matched text as it appears in the source (original casing preserved). */
+  matchedText: string;
+}
+
+/**
+ * Returns a new array sorted longest-first (descending by text.length).
+ * Must be called before passing to detectEntityMentions to guarantee
+ * longest-match-wins behaviour.
+ *
+ * Does NOT mutate the input array.
+ */
+export function sortEntityIndex(index: EntityIndexEntry[]): EntityIndexEntry[] {
+  return [...index].sort((a, b) => b.text.length - a.text.length);
+}
+
+/**
+ * Scans `text` for occurrences of entity names defined in `sortedIndex`,
+ * returning non-overlapping longest-first matches with self-link suppression.
+ *
+ * @param text            The raw text string to scan (original casing).
+ * @param sortedIndex     Pre-sorted longest-first array of index entries (lowercase text).
+ * @param currentEntityId Entity ID to exclude from results (self-link suppression).
+ * @returns Array of DetectedMatch sorted by ascending start offset, non-overlapping.
+ */
+export function detectEntityMentions(
+  text: string,
+  sortedIndex: EntityIndexEntry[],
+  currentEntityId: string,
+): DetectedMatch[] {
+  if (sortedIndex.length === 0 || text.length === 0) return [];
+
+  const lower = text.toLowerCase();
+  const results: DetectedMatch[] = [];
+  let pos = 0;
+
+  while (pos < lower.length) {
+    let matched = false;
+
+    for (const entry of sortedIndex) {
+      if (entry.id === currentEntityId) continue;
+      if (entry.text.length === 0) continue;
+
+      // Fast check: does the text at current position start with this entry?
+      if (!lower.startsWith(entry.text, pos)) continue;
+
+      const matchEnd = pos + entry.text.length;
+
+      if (!isWordBoundary(text, pos, matchEnd)) continue;
+
+      results.push({
+        start: pos,
+        end: matchEnd,
+        entityId: entry.id,
+        matchedText: text.slice(pos, matchEnd),
+      });
+      pos = matchEnd;
+      matched = true;
+      break;
+    }
+
+    if (!matched) pos++;
+  }
+
+  return results;
+}
+
+/**
+ * Returns true when the match span [start, end) sits on word boundaries.
+ *
+ * A word character is [a-zA-Z0-9'] — apostrophes are word-continuations so
+ * "Aldric" does NOT match inside "Aldric's".
+ */
+function isWordBoundary(text: string, start: number, end: number): boolean {
+  const wordChar = /[a-zA-Z0-9']/;
+  const before = start > 0 ? text[start - 1] : null;
+  const after = end < text.length ? text[end] : null;
+  return (
+    (before === null || !wordChar.test(before)) &&
+    (after === null || !wordChar.test(after))
+  );
+}

--- a/specs/125-entity-auto-link/checklists/requirements.md
+++ b/specs/125-entity-auto-link/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Entity Auto-Link in Content & Lore
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-29  
+**Updated**: 2026-05-30 (post-clarification)  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Clarifications Applied
+
+- [x] Hover behaviour: plain navigation link only (no preview)
+- [x] Guest mode: auto-links shown to P2P guests when entity index is available
+- [x] Visual style: existing themed link appearance (colour + underline per active world theme)
+
+## Notes
+
+All items pass. Ready for `/speckit-plan`.

--- a/specs/125-entity-auto-link/contracts/entity-auto-link-extension.md
+++ b/specs/125-entity-auto-link/contracts/entity-auto-link-extension.md
@@ -1,0 +1,129 @@
+# Contract: EntityAutoLinkExtension
+
+**Type**: TipTap extension (UI contract)  
+**Consumer**: `MarkdownEditor.svelte`  
+**Producer**: `apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts`
+
+---
+
+## Factory Signature
+
+```typescript
+/**
+ * Creates a configured TipTap extension that decorates entity name occurrences
+ * in read-mode content with clickable inline spans.
+ *
+ * @param options - Configuration required to drive detection and navigation.
+ * @returns A TipTap Extension instance ready for use in `useEditor()`.
+ */
+export function createEntityAutoLinkExtension(
+  options: EntityAutoLinkOptions,
+): Extension;
+```
+
+The function is a **pure factory** — it does not import stores, does not perform I/O, and does not retain state outside the returned ProseMirror plugin. It may be called multiple times with different options to produce independent extension instances.
+
+---
+
+## Options Contract
+
+```typescript
+interface EntityAutoLinkOptions {
+  entityIndex: EntityIndexEntry[]; // see data-model.md
+  currentEntityId: string; // suppresses self-links
+  onEntityClick: (entityId: string) => void;
+}
+```
+
+### Invariants
+
+| Invariant                                                  | Enforcement                                                                |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `entityIndex` may be empty (no crash, no decorations)      | Extension produces empty `DecorationSet` when array is empty               |
+| `currentEntityId` may be an empty string (guest / unknown) | No match will equal `""` from a valid entity ID, so suppression is a no-op |
+| `onEntityClick` must not throw synchronously               | Caller's responsibility; errors propagate to the delegated click listener  |
+
+---
+
+## Detection Utility Signature
+
+```typescript
+/**
+ * Scans `text` for occurrences of entity names defined in `entityIndex`,
+ * returning non-overlapping longest-first matches with self-link suppression.
+ *
+ * Pure function — no side effects.
+ *
+ * @param text            - The raw text string to scan.
+ * @param entityIndex     - Pre-sorted (longest-first) array of index entries.
+ * @param currentEntityId - Entity ID to exclude from results (self-link suppression).
+ * @returns Sorted array of DetectedMatch (ascending start offset, non-overlapping).
+ */
+export function detectEntityMentions(
+  text: string,
+  entityIndex: EntityIndexEntry[],
+  currentEntityId: string,
+): DetectedMatch[];
+```
+
+**Caller contract**: `entityIndex` must be pre-sorted longest-first by `text.length` (descending). The factory sorts when initialized and re-sorts inside the `apply` hook when `tr.getMeta('entityIndexChanged')` is set. The utility trusts the order passed to it.
+
+**EntityIndex reactivity**: When `entityIndex` changes in `MarkdownEditor.svelte`, the caller dispatches a no-op transaction with `tr.setMeta('entityIndexChanged', true)`. This bridges Svelte prop reactivity to the ProseMirror plugin lifecycle — the plugin does not respond to option reference changes on its own.
+
+**Word-boundary rule**: A match at `[start, end)` is valid iff:
+
+- `start === 0` OR `text[start - 1]` matches `/[^a-zA-Z0-9']/`
+- `end === text.length` OR `text[end]` matches `/[^a-zA-Z0-9']/`
+
+**Case sensitivity**: `text` is compared against lower-cased `EntityIndexEntry.text`. The matched span is taken from the original `text` string (casing preserved in `DetectedMatch.matchedText`).
+
+---
+
+## MarkdownEditor.svelte — New Props
+
+```typescript
+// ADDED props (all optional; feature degrades gracefully when absent)
+entityIndex?: EntityIndexEntry[];    // default: []
+currentEntityId?: string;            // default: ""
+onEntityClick?: (id: string) => void; // default: no-op
+```
+
+**Backward compatibility**: Existing callers that do not pass these props continue to work — the extension produces an empty `DecorationSet` and no click handlers are registered.
+
+---
+
+## CSS Classes Applied to Decorations
+
+| Class                | Source                  | Purpose                                              |
+| -------------------- | ----------------------- | ---------------------------------------------------- |
+| `entity-auto-link`   | New                     | Feature-scoped selector for tests / future overrides |
+| `text-theme-primary` | Existing Tailwind token | Link colour matching active world theme              |
+| `underline`          | Tailwind utility        | Underline to match markdown hyperlink style          |
+| `cursor-pointer`     | Tailwind utility        | Pointer cursor on hover                              |
+
+---
+
+## Events
+
+### Click
+
+Delegated to the TipTap root DOM element. Fires when a `click` event bubbles up from an element with `data-entity-id`.
+
+```
+click on [data-entity-id="<id>"]
+  → options.onEntityClick("<id>")
+```
+
+The listener is attached in the ProseMirror plugin's `view` lifecycle (`init`) and detached on `destroy`.
+
+---
+
+## Error / Degradation Behaviour
+
+| Condition                    | Behaviour                                                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `entityIndex` is empty       | Extension attaches, produces no decorations, no errors                                                                              |
+| `editable = true`            | Extension attaches, produces no decorations — guarded by `this.editor.isEditable` check in `apply` hook (not a static option value) |
+| Vault not yet loaded         | Caller passes `entityIndex: []` — same as empty case                                                                                |
+| `onEntityClick` not provided | Prop defaults to no-op; clicks on decorations are silent                                                                            |
+| Detection scan throws        | Extension catches, logs a warning, returns empty `DecorationSet`                                                                    |

--- a/specs/125-entity-auto-link/data-model.md
+++ b/specs/125-entity-auto-link/data-model.md
@@ -1,0 +1,147 @@
+# Data Model: Entity Auto-Link in Content & Lore
+
+**Branch**: `125-entity-auto-link` | **Date**: 2026-05-30 | **Plan**: [plan.md](./plan.md)
+
+---
+
+## Entities
+
+### EntityIndexEntry
+
+A flattened entry in the entity index used for name-matching. Both the canonical title and each alias are represented as separate entries pointing to the same entity ID. This normalisation allows the detector to work against a flat `EntityIndexEntry[]` without branching on "is this an alias or a title".
+
+```typescript
+interface EntityIndexEntry {
+  /** The text to match against (title or alias, lowercased for case-insensitive comparison). */
+  text: string;
+  /** The canonical entity ID this entry resolves to. */
+  id: string;
+}
+```
+
+**Derivation**: The caller (e.g. `MarkdownEditor.svelte`) builds this array from the vault's in-memory entity list:
+
+```typescript
+const entityIndex: EntityIndexEntry[] = vault.entities.flatMap((e) => [
+  { text: e.title.toLowerCase(), id: e.id },
+  ...e.aliases.map((a) => ({ text: a.toLowerCase(), id: e.id })),
+]);
+```
+
+**Validation rules**:
+
+- `text` must be non-empty (empty aliases from the vault schema are already filtered by the `min(1)` constraint on `aliases[]`)
+- Duplicate `text` values are resolved by index order — first match wins (callers should order by entity creation date to ensure deterministic tie-breaking)
+
+---
+
+### DetectedMatch
+
+The result of running the entity-mention detector over a text string. Represents a single successful match.
+
+```typescript
+interface DetectedMatch {
+  /** Byte offset of the first matched character in the source string. */
+  start: number;
+  /** Byte offset one past the last matched character. */
+  end: number;
+  /** The canonical entity ID resolved from the match. */
+  entityId: string;
+  /** The matched text as it appears in the source (original casing preserved). */
+  matchedText: string;
+}
+```
+
+**Invariants**:
+
+- `start < end`
+- Matches are non-overlapping (the detector skips past each match after recording it)
+- Matches are sorted by ascending `start` offset
+- A match whose `entityId === currentEntityId` is excluded before returning (self-link suppression is applied by the detector, not the caller)
+
+---
+
+### EntityAutoLinkOptions
+
+The configuration object passed to the `EntityAutoLinkExtension` factory. All fields are required; the caller must supply them.
+
+```typescript
+interface EntityAutoLinkOptions {
+  /**
+   * Flat array of index entries (titles + aliases) derived from the active vault.
+   * Changes to this reference are bridged to the plugin via a no-op ProseMirror transaction
+   * (meta key: `entityIndexChanged: true`) dispatched from a Svelte `$effect` in
+   * `MarkdownEditor.svelte`. The plugin's `apply` hook detects this meta key and rebuilds
+   * the `DecorationSet` with the updated index. ProseMirror plugins do not respond to
+   * option reference changes on their own — the `$effect` bridge is required.
+   */
+  entityIndex: EntityIndexEntry[];
+
+  /**
+   * The ID of the entity currently being rendered. Matches against this ID are suppressed
+   * (self-link prevention).
+   */
+  currentEntityId: string;
+
+  /**
+   * Navigation callback invoked when the user clicks a detected entity link.
+   * The extension does not import any store; context-preserving routing is the caller's
+   * responsibility.
+   */
+  onEntityClick: (entityId: string) => void;
+}
+```
+
+---
+
+### DecorationAttributes
+
+The HTML attributes applied to each inline `Decoration.inline` created by the extension. Not a named type in the codebase — documented here for reference.
+
+| Attribute        | Value                                                            | Purpose                                                                   |
+| ---------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `class`          | `"entity-auto-link text-theme-primary underline cursor-pointer"` | Visual styling via theme tokens                                           |
+| `data-entity-id` | `<entityId>`                                                     | Used by the delegated click listener to resolve the target entity         |
+| `role`           | `"link"`                                                         | Accessibility — announces the span as a navigation link to screen readers |
+| `tabindex`       | `"0"`                                                            | Makes the span keyboard-focusable                                         |
+
+---
+
+## State Transitions
+
+The extension's decoration state is governed by two inputs: the document content and the entity index. Neither is mutated by the extension — it is a pure read-side transform.
+
+```
+[this.editor.isEditable = true]  ────────────────────────────► empty DecorationSet
+                                                               (no scan, no decorations)
+
+[this.editor.isEditable = false]
+  ├─► tr.docChanged = false AND tr.getMeta('entityIndexChanged') = false
+  │     ────────────────────────────────────────────────────────► reuse old DecorationSet
+  ├─► tr.docChanged = true ──────────────────────────────────── ► scan → new DecorationSet
+  └─► tr.getMeta('entityIndexChanged') = true ─── re-sort + scan → new DecorationSet
+```
+
+**Editability check**: The plugin reads `this.editor.isEditable` (available as a TipTap extension closure reference) inside `addProseMirrorPlugins()`. This correctly reflects runtime toggles — it is not a snapshot captured at factory-creation time.
+
+**EntityIndex change mechanism**: `MarkdownEditor.svelte` uses a Svelte `$effect` to watch the `entityIndex` prop. On change, it dispatches `editor.view.dispatch(editor.state.tr.setMeta('entityIndexChanged', true))`. The plugin's `apply` hook checks for this meta key, re-sorts the updated index from the extension closure, and rebuilds the `DecorationSet`.
+
+---
+
+## Relationships
+
+```
+MarkdownEditor.svelte
+  │  props: entityIndex, currentEntityId, onEntityClick, editable
+  │
+  └── EntityAutoLinkExtension (TipTap extension)
+        │  options: EntityAutoLinkOptions
+        │
+        ├── detectEntityMentions(text, entityIndex, currentEntityId)
+        │     │  returns: DetectedMatch[]
+        │     └── EntityIndexEntry[] (sorted longest-first, built once per entityIndex reference)
+        │
+        └── ProseMirror Plugin
+              │  produces: DecorationSet (Decoration.inline per DetectedMatch)
+              └── delegated click listener → onEntityClick(entityId)
+```

--- a/specs/125-entity-auto-link/plan.md
+++ b/specs/125-entity-auto-link/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Entity Auto-Link in Content & Lore
+
+**Branch**: `125-entity-auto-link` | **Date**: 2026-05-30 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+When a user reads an entity's content or lore, names of other vault entities (and their registered aliases) are automatically detected and rendered as clickable links using the active theme's link style. Clicking navigates to the target entity in a context-preserving way: sidebar mode opens the entity in the sidebar; zen/focus mode navigates within zen. No AI, no network — detection runs against the in-memory entity index.
+
+Implementation extends the existing TipTap editor (already used for both read and edit mode in `MarkdownEditor.svelte`) with a custom ProseMirror decoration plugin that scans rendered text nodes and wraps entity name spans. The matching utility is extracted as a pure function for testability.
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x / Svelte 5 (SvelteKit)  
+**Primary Dependencies**: `@tiptap/core`, `prosemirror-view` (decorations), `tiptap-markdown`  
+**Storage**: None — read-only display transformation over in-memory vault entity index  
+**Testing**: Vitest + jsdom  
+**Target Platform**: Browser (Chromium/Firefox/Safari); degrades gracefully to plain text when vault is unavailable  
+**Project Type**: Web application feature (UI layer extension)  
+**Performance Goals**: Detection + decoration render in < 100 ms for content up to 5 000 words on an average desktop device  
+**Constraints**: No persistence, no AI, no network. Works in guest mode when entity index is available.  
+**Scale/Scope**: Vaults up to ~1 000 entities; content up to ~10 000 words per entity
+
+---
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design._
+
+| Principle                    | Status      | Notes                                                                                                                                                                                                                                                                                                                                      |
+| ---------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **I — Library-First**        | ⚠️ Partial  | The entity-mention matching utility is a pure function testable in isolation. It lives in `apps/web/src/lib/utils/` rather than a dedicated package because it has no reuse scenario across packages — the only consumer is the TipTap extension. The TipTap extension itself is inherently UI-coupled. Documented in Complexity Tracking. |
+| **II — TDD**                 | ✅ Required | Matching utility MUST have unit tests. Extension integration MUST have component-level tests.                                                                                                                                                                                                                                              |
+| **III — YAGNI**              | ✅ Pass     | Simple longest-match substring scan. No trie, no Aho-Corasick unless profiling shows a need.                                                                                                                                                                                                                                               |
+| **V — Privacy/Client-Side**  | ✅ Pass     | Entirely in-browser, no data leaves the device.                                                                                                                                                                                                                                                                                            |
+| **VI — Style Guide**         | ✅ Required | Link styled via `text-theme-primary underline cursor-pointer` (same as existing TipTap Link extension).                                                                                                                                                                                                                                    |
+| **VII — User Documentation** | ✅ Required | Help content entry needed in `help-content.ts`.                                                                                                                                                                                                                                                                                            |
+| **VIII — DI**                | ✅ Required | Extension factory accepts entity index and navigation callback; does not import vault/layout stores directly.                                                                                                                                                                                                                              |
+| **X — Coverage**             | ✅ Required | Matching utility ≥ 80%. Extension integration ≥ 50%.                                                                                                                                                                                                                                                                                       |
+| **XI — Karpathy Rules**      | ✅ Pass     | Surgical changes to `MarkdownEditor.svelte` only. No unrelated refactors.                                                                                                                                                                                                                                                                  |
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/125-entity-auto-link/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code
+
+```text
+apps/web/src/lib/
+├── utils/
+│   ├── entity-mention-detector.ts        # NEW — pure matching utility
+│   └── entity-mention-detector.test.ts   # NEW — unit tests (≥ 80% coverage)
+├── components/
+│   ├── editor/
+│   │   ├── EntityAutoLinkExtension.ts    # NEW — TipTap decoration plugin
+│   │   └── EntityAutoLinkExtension.test.ts  # NEW — integration tests
+│   ├── entity-detail/
+│   │   └── (no new files — MarkdownEditor props updated)
+│   └── MarkdownEditor.svelte             # MODIFIED — accept optional entityIndex + onEntityClick props
+└── config/
+    └── help-content.ts                   # MODIFIED — add auto-link feature entry
+```
+
+---
+
+## Complexity Tracking
+
+| Item                                         | Why Needed                                                                      | Simpler Alternative Rejected Because                                                            |
+| -------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Matching utility in `apps/web` not a package | No other package needs entity-mention detection; TipTap is not used in packages | Creating a package purely for a single-consumer utility adds workspace overhead with no benefit |
+
+---
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+---
+
+## Phase 1: Design & Contracts
+
+See [data-model.md](./data-model.md) and [contracts/](./contracts/).
+
+### Architecture decisions
+
+#### A. Detection approach — longest-match sorted scan
+
+Build a sorted array of `{ text: string, id: string }` entries (titles + aliases) from the entity index, sorted longest-first. For each text node in the ProseMirror document, scan left-to-right: at each position, try each pattern in order and take the first (longest) match that falls on a word boundary. This is O(T × E) where T = text length and E = entity count. For a 5 000-word document and 1 000 entities this is well within the 100 ms budget in practice; add a simple LRU cache keyed on `(contentHash, entityIndexVersion)` if profiling shows it's needed.
+
+Word-boundary enforcement: a match is valid if the character immediately before the match start and immediately after the match end are either start/end-of-string, whitespace, or punctuation — not alphanumeric. This prevents "Aldric" matching inside "Aldric's" only when intentional.
+
+#### B. TipTap integration — ProseMirror decoration plugin
+
+The `EntityAutoLinkExtension` is a TipTap extension that registers a ProseMirror plugin. The plugin:
+
+1. On each document state update, reads **`this.editor.isEditable`** from the TipTap editor instance available in the `addProseMirrorPlugins()` closure. When `true`, returns `DecorationSet.empty` without scanning. This is the correct mechanism — reading from `this.editor` (not a closure-captured option value) ensures the guard responds to runtime `editable` toggles without requiring option hot-swap.
+2. Produces a `DecorationSet` of inline decorations — each a `Decoration.inline` with `{ class: "entity-auto-link text-theme-primary underline cursor-pointer", "data-entity-id": id }`.
+3. Rebuilds decorations when `tr.getMeta('entityIndexChanged')` is set on a transaction (in addition to the normal `tr.docChanged` trigger). This handles vault mutations (entity renames, additions) that change the `entityIndex` prop but do not change the document content.
+
+Click handling is attached via a single delegated event listener on the TipTap root element (not per-decoration) to avoid memory pressure on large documents.
+
+**EntityIndex reactivity bridge**: `MarkdownEditor.svelte` adds a Svelte `$effect` that watches the `entityIndex` prop reference. When it changes, the effect dispatches a no-op ProseMirror transaction with meta key `entityIndexChanged: true`. The plugin's `apply` hook detects this meta key, sorts the updated index, and rebuilds the `DecorationSet`. This ensures live link refresh when vault entities are renamed or added while the view is open (spec edge case: "entity rename → links reflect current name").
+
+#### C. Context-preserving navigation
+
+The extension factory accepts a `onEntityClick: (entityId: string) => void` callback. The caller (`MarkdownEditor.svelte`) supplies the right implementation based on current layout context:
+
+```
+// in MarkdownEditor.svelte read-mode context:
+const handleEntityClick = (id: string) => {
+  if (layoutUIStore.mainViewMode === 'focus') {
+    focusEntity(layoutUIStore, id);         // stay in zen, navigate within
+  } else {
+    vault.selectedEntityId = id;            // open in sidebar
+  }
+};
+```
+
+This keeps the extension free of store imports (Constitution VIII).
+
+#### D. Self-link suppression
+
+The factory also accepts the `currentEntityId: string` of the entity being viewed. Any match whose resolved `id === currentEntityId` is excluded from the decoration set.
+
+#### E. Guest mode
+
+`MarkdownEditor.svelte` already receives content as a prop. The entity index will be passed as a prop (`entityIndex` — an array of `{ id, text }[]`). The caller builds this from `vault.entities` (available to both host and guest). If the array is empty, the extension produces no decorations.

--- a/specs/125-entity-auto-link/quickstart.md
+++ b/specs/125-entity-auto-link/quickstart.md
@@ -1,0 +1,318 @@
+# Developer Quickstart: Entity Auto-Link
+
+**Branch**: `125-entity-auto-link` | **Date**: 2026-05-30
+
+---
+
+## What you're building
+
+A TipTap decoration plugin that scans entity content/lore for vault entity names and renders them as clickable links — purely client-side, no AI, no network.
+
+---
+
+## Key files to create
+
+| File                                                                 | Description                                  |
+| -------------------------------------------------------------------- | -------------------------------------------- |
+| `apps/web/src/lib/utils/entity-mention-detector.ts`                  | Pure matching utility (no TipTap dependency) |
+| `apps/web/src/lib/utils/entity-mention-detector.test.ts`             | Unit tests (≥ 80% coverage required)         |
+| `apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts`      | TipTap extension + ProseMirror plugin        |
+| `apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts` | Integration tests (≥ 50% coverage required)  |
+
+## Key files to modify
+
+| File                                                | Change                                                                         |
+| --------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `apps/web/src/lib/components/MarkdownEditor.svelte` | Add `entityIndex`, `currentEntityId`, `onEntityClick` props; wire up extension |
+| `apps/web/src/lib/config/help-content.ts`           | Add auto-link feature entry                                                    |
+
+---
+
+## Step 1 — Write the detector (start here, TDD)
+
+```typescript
+// apps/web/src/lib/utils/entity-mention-detector.ts
+
+export interface EntityIndexEntry {
+  text: string; // lowercase title or alias
+  id: string; // canonical entity ID
+}
+
+export interface DetectedMatch {
+  start: number;
+  end: number;
+  entityId: string;
+  matchedText: string;
+}
+
+/**
+ * Sort before passing to detectEntityMentions.
+ */
+export function sortEntityIndex(index: EntityIndexEntry[]): EntityIndexEntry[] {
+  return [...index].sort((a, b) => b.text.length - a.text.length);
+}
+
+export function detectEntityMentions(
+  text: string,
+  sortedIndex: EntityIndexEntry[],
+  currentEntityId: string,
+): DetectedMatch[] {
+  const lower = text.toLowerCase();
+  const results: DetectedMatch[] = [];
+  let pos = 0;
+
+  while (pos < lower.length) {
+    let matched = false;
+    for (const entry of sortedIndex) {
+      if (entry.id === currentEntityId) continue;
+      const idx = lower.indexOf(entry.text, pos);
+      if (idx !== pos) continue; // must start at current position
+      if (!isWordBoundary(text, idx, idx + entry.text.length)) continue;
+
+      results.push({
+        start: idx,
+        end: idx + entry.text.length,
+        entityId: entry.id,
+        matchedText: text.slice(idx, idx + entry.text.length),
+      });
+      pos = idx + entry.text.length;
+      matched = true;
+      break;
+    }
+    if (!matched) pos++;
+  }
+
+  return results;
+}
+
+function isWordBoundary(text: string, start: number, end: number): boolean {
+  const before = start === 0 ? null : text[start - 1];
+  const after = end >= text.length ? null : text[end];
+  const wordChar = /[a-zA-Z0-9']/;
+  return (
+    (before === null || !wordChar.test(before)) &&
+    (after === null || !wordChar.test(after))
+  );
+}
+```
+
+Write tests first. Reference cases:
+
+- Basic match in a sentence
+- Multiple matches in one text
+- Case-insensitive match (original casing preserved)
+- No match for substrings (`"sage"` alone when only `"Aldric the Sage"` exists)
+- Possessives: `"Aldric's"` — `"Aldric"` should NOT match inside it
+- Self-link suppression: same `currentEntityId` as match ID → excluded
+- Overlapping candidates: longest wins
+
+---
+
+## Step 2 — Write the TipTap extension
+
+```typescript
+// apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import {
+  detectEntityMentions,
+  sortEntityIndex,
+} from "$lib/utils/entity-mention-detector";
+import type { EntityIndexEntry } from "$lib/utils/entity-mention-detector";
+
+const PLUGIN_KEY = new PluginKey("entityAutoLink");
+
+const ENTITY_INDEX_CHANGED = "entityIndexChanged";
+
+export function createEntityAutoLinkExtension(options: EntityAutoLinkOptions) {
+  return Extension.create({
+    name: "entityAutoLink",
+    addProseMirrorPlugins() {
+      // NOTE: `this.editor` is the TipTap editor instance, available in the
+      // addProseMirrorPlugins closure. Read isEditable at apply-time (not once
+      // at factory-creation time) so the guard correctly responds to runtime toggles.
+      const editor = this.editor;
+
+      // Sorted index is rebuilt when entityIndexChanged meta fires; kept in
+      // a mutable local so the apply hook always sees the latest snapshot.
+      let sorted = sortEntityIndex(options.entityIndex);
+
+      return [
+        new Plugin({
+          key: PLUGIN_KEY,
+          state: {
+            init(_, state) {
+              if (editor.isEditable) return DecorationSet.empty;
+              return buildDecorations(state.doc, sorted, options);
+            },
+            apply(tr, old, _, newState) {
+              // Editable guard — checked on every transaction so toggles are live.
+              if (editor.isEditable) return DecorationSet.empty;
+
+              // entityIndex prop changed: re-sort and rebuild.
+              if (tr.getMeta(ENTITY_INDEX_CHANGED)) {
+                sorted = sortEntityIndex(options.entityIndex);
+                return buildDecorations(newState.doc, sorted, options);
+              }
+
+              // Normal document change.
+              if (tr.docChanged)
+                return buildDecorations(newState.doc, sorted, options);
+
+              return old;
+            },
+          },
+          props: {
+            decorations(state) {
+              return this.getState(state);
+            },
+          },
+          view(editorView) {
+            const listener = (e: MouseEvent) => {
+              const target = (e.target as HTMLElement).closest(
+                "[data-entity-id]",
+              );
+              if (target) {
+                options.onEntityClick(
+                  (target as HTMLElement).dataset.entityId!,
+                );
+              }
+            };
+            editorView.dom.addEventListener("click", listener);
+            return {
+              destroy() {
+                editorView.dom.removeEventListener("click", listener);
+              },
+            };
+          },
+        }),
+      ];
+    },
+  });
+}
+
+function buildDecorations(
+  doc: any,
+  sorted: EntityIndexEntry[],
+  options: EntityAutoLinkOptions,
+): DecorationSet {
+  if (sorted.length === 0) return DecorationSet.empty;
+  const decos: Decoration[] = [];
+  doc.descendants((node: any, pos: number) => {
+    if (!node.isText) return;
+    const matches = detectEntityMentions(
+      node.text!,
+      sorted,
+      options.currentEntityId,
+    );
+    for (const m of matches) {
+      decos.push(
+        Decoration.inline(pos + m.start, pos + m.end, {
+          class: "entity-auto-link text-theme-primary underline cursor-pointer",
+          "data-entity-id": m.entityId,
+          role: "link",
+          tabindex: "0",
+        }),
+      );
+    }
+  });
+  return DecorationSet.create(doc, decos);
+}
+```
+
+---
+
+## Step 3 — Wire up MarkdownEditor.svelte
+
+Add props (with defaults for backward compatibility):
+
+```svelte
+<script lang="ts">
+  // ...existing props...
+  let {
+    entityIndex = [],
+    currentEntityId = "",
+    onEntityClick = () => {},
+  } = $props();
+</script>
+```
+
+Add the extension to the `useEditor` call (alongside existing extensions):
+
+```typescript
+createEntityAutoLinkExtension({ entityIndex, currentEntityId, onEntityClick }),
+```
+
+The editable guard is handled inside the plugin via `this.editor.isEditable` — no `editable` prop needs to be passed to the extension.
+
+Add a Svelte `$effect` **after** the `useEditor` call to bridge entityIndex prop changes into the plugin:
+
+```typescript
+let editor = useEditor({ ... });
+
+// Bridge: dispatch a no-op transaction when entityIndex changes so the plugin
+// rebuilds decorations (e.g., after a vault entity is renamed).
+$effect(() => {
+  entityIndex; // reactive dependency — touch it to subscribe
+  if (editor && !editor.isEditable) {
+    editor.view.dispatch(
+      editor.state.tr.setMeta('entityIndexChanged', true)
+    );
+  }
+});
+```
+
+---
+
+## Step 4 — Call site (entity detail view)
+
+Find the component that renders entity content/lore and update it to pass the new props:
+
+```svelte
+<MarkdownEditor
+  content={entity.content}
+  {editable}
+  entityIndex={$vault.entities.flatMap((e) => [
+    { text: e.title.toLowerCase(), id: e.id },
+    ...e.aliases.map((a) => ({ text: a.toLowerCase(), id: e.id })),
+  ])}
+  currentEntityId={entity.id}
+  onEntityClick={(id) => {
+    if (layoutUIStore.mainViewMode === "focus") {
+      focusEntity(layoutUIStore, id);
+    } else {
+      vault.selectedEntityId = id;
+    }
+  }}
+/>
+```
+
+---
+
+## Running tests
+
+```bash
+# From repo root
+bun run test --filter entity-mention-detector
+bun run test --filter EntityAutoLinkExtension
+```
+
+Coverage report (requires ≥ 80% for detector, ≥ 50% for extension):
+
+```bash
+bun run test --coverage --filter entity-mention
+```
+
+---
+
+## Checklist before opening PR
+
+- [ ] `detectEntityMentions` unit tests pass with ≥ 80% coverage
+- [ ] `EntityAutoLinkExtension` integration tests pass with ≥ 50% coverage
+- [ ] No decorations appear in edit mode
+- [ ] No decoration for self-referencing entity name
+- [ ] Clicking a link navigates correctly (sidebar and zen mode)
+- [ ] `help-content.ts` entry added
+- [ ] No TypeScript errors (`bun run typecheck`)
+- [ ] No lint errors (`bun run lint`)

--- a/specs/125-entity-auto-link/research.md
+++ b/specs/125-entity-auto-link/research.md
@@ -1,0 +1,66 @@
+# Research: Entity Auto-Link in Content & Lore
+
+**Date**: 2026-05-30 | **Branch**: `125-entity-auto-link`
+
+---
+
+## Decision 1: Detection algorithm
+
+**Decision**: Sorted longest-first linear scan with word-boundary enforcement.
+
+**Rationale**: A sorted list (longest pattern first) guarantees the longest-match-wins rule in O(T × E) time. For the expected scale (≤ 10 000 chars, ≤ 1 000 entities) this is sub-millisecond. The implementation is a pure function with no external dependencies, easy to unit-test exhaustively.
+
+**Alternatives considered**:
+
+- **Aho-Corasick automaton** — O(T + E + matches), better asymptotic complexity, but requires a library or ~200 lines of custom code. Overkill at this scale; can be adopted later if profiling shows a need.
+- **Regex alternation** — build a single `(title1|title2|…)` regex. Fast for small sets, but regex engine performance degrades for 500+ patterns and word-boundary handling becomes complex. Rejected.
+
+---
+
+## Decision 2: TipTap integration point
+
+**Decision**: ProseMirror `DecorationSet` plugin registered via a custom TipTap extension.
+
+**Rationale**: TipTap already ships a `Link` extension that uses decorations. Decorations are the idiomatic ProseMirror mechanism for non-destructive, read-only visual overlays that don't modify the document. They are automatically invalidated when the document changes and rebuilt on next state update. This approach:
+
+- Leaves document content unmodified (no mark nodes in the schema)
+- Requires zero serialisation changes (markdown ↔ TipTap round-trips are unaffected)
+- Works correctly when `editable` toggles between true/false
+
+**Alternatives considered**:
+
+- **Custom Mark schema** — would persist in the document model, interfering with markdown serialisation. Rejected.
+- **Post-render DOM walking** — fragile, bypasses ProseMirror's update cycle, breaks on virtual DOM re-renders. Rejected.
+- **Separate read-mode renderer** (bypass TipTap entirely for read mode) — large change, diverges read/edit rendering paths. Rejected.
+
+---
+
+## Decision 3: Event handling for link clicks
+
+**Decision**: Single delegated `click` listener on the editor DOM node, inspecting `data-entity-id` on the target.
+
+**Rationale**: Attaching a listener per decoration would create up to thousands of handlers per document. A single delegated listener on the editor root is O(1) memory regardless of entity count, and is the same pattern used by most rich-text editors for inline interactives.
+
+**Alternatives considered**:
+
+- **Per-decoration NodeView** — overkill for a simple inline click; NodeViews are better suited for block-level interactives. Rejected.
+
+---
+
+## Decision 4: Word-boundary definition
+
+**Decision**: A match is valid when the characters immediately before and after the matched span are non-alphanumeric (or string boundaries). Apostrophes and possessives ("Aldric's") are treated as word-continuations — "Aldric" does NOT match inside "Aldric's".
+
+**Rationale**: Campaign writing frequently uses possessives and compound names. Matching "Aldric" inside "Aldric's" would produce a false positive on every possessive occurrence. The character set for "word continuation" is `[a-zA-Z0-9']`.
+
+**Alternatives considered**:
+
+- Unicode word-boundary regex (`\b`) — inconsistent across engines for non-ASCII entity names (e.g. names with diacritics). Custom boundary check is more predictable.
+
+---
+
+## Decision 5: Reactivity / cache strategy
+
+**Decision**: Rebuild the decoration set on every document transaction when `editable = false`. Add a simple identity check: skip rebuild if neither the document content nor the entity index version has changed since the last build.
+
+**Rationale**: TipTap fires state updates frequently (cursor moves, remote syncs). The detection scan must not run on every keystroke. Since the editor is not editable in read mode, the document content is effectively static — the only trigger for a rebuild is an entity index change (vault update). The identity check eliminates redundant work in the common case.

--- a/specs/125-entity-auto-link/spec.md
+++ b/specs/125-entity-auto-link/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: Entity Auto-Link in Content & Lore
+
+**Feature Branch**: `125-entity-auto-link`  
+**Spec Directory**: `specs/125-entity-auto-link`  
+**Created**: 2026-05-29  
+**Status**: Draft  
+**GitHub Issue**: [#1037](https://github.com/eserlan/Codex-Cryptica/issues/1037)
+
+## Overview
+
+When a user views an entity's content or lore, the application automatically detects names of other entities in the vault and surfaces them as interactive links. Clicking a detected mention navigates to that entity. No AI is required — detection is purely name-matching against the vault's entity index.
+
+This mirrors the entity-detection logic already used in Oracle chat, bringing the same discoverability to the entity detail panel.
+
+---
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Detected Mentions Appear as Links (Priority: P1)
+
+A writer opens a character entity whose content contains the sentence _"She trained under **Aldric the Sage**, who later founded the **Crimson Enclave**."_ Both **Aldric the Sage** and **Crimson Enclave** are entities in the vault. The application highlights those names in the rendered content view and the user can click either one to navigate directly to that entity.
+
+**Why this priority**: Core value of the feature. Without this, the spec delivers nothing. Every other story layers on top of it.
+
+**Independent Test**: Open any entity whose content contains the name of at least one other vault entity. The mentioned entity name must appear visually distinct (linked) in read mode. Clicking it must navigate to the correct entity. Delivers immediate discovery value without any other story.
+
+**Acceptance Scenarios**:
+
+1. **Given** an entity's content includes the exact title of another vault entity, **When** the user opens that entity in read mode, **Then** the matching name is rendered as a clickable link.
+2. **Given** a matched name is clicked in sidebar mode, **When** the navigation occurs, **Then** the target entity opens in the sidebar panel. **Given** a matched name is clicked in zen mode, **When** the navigation occurs, **Then** the target entity opens within zen mode.
+3. **Given** a name appears multiple times in the content, **When** the view renders, **Then** all occurrences are linked, not just the first.
+4. **Given** the content contains a string that is a substring of an entity name (e.g. "sage" when "Aldric the Sage" exists), **When** the view renders, **Then** the substring alone is NOT linked — only the full title matches.
+
+---
+
+### User Story 2 — Lore Section Also Links Entities (Priority: P2)
+
+A user reads the Lore section of a location entity. Several faction and character names from the vault appear in the lore text. They are surfaced as links in the same way as content.
+
+**Why this priority**: Lore is the second text field on every entity and often contains the densest cross-references. Parity with the content field is straightforward once P1 is working.
+
+**Independent Test**: Open an entity that has lore text containing other entity names. Verify links appear and navigate correctly in the lore panel. Does not depend on Story 3 or beyond.
+
+**Acceptance Scenarios**:
+
+1. **Given** an entity's lore field contains names of other vault entities, **When** the lore section is rendered in read mode, **Then** those names are linked.
+2. **Given** the same name appears in both content and lore, **When** both sections are visible, **Then** both occurrences are independently linked.
+
+---
+
+### User Story 3 — Alias Matching (Priority: P3)
+
+An entity "Aldric the Sage" has a registered alias "Aldric". The content of another entity reads _"Aldric trained her in the ways of fire."_ The alias "Aldric" is detected and links to "Aldric the Sage".
+
+**Why this priority**: Aliases are already a first-class vault feature. Not matching them would be a notable gap for users who rely on short-form names in their writing.
+
+**Independent Test**: Create an entity with an alias. Write content on another entity that uses only the alias. Verify the alias resolves to the correct entity link.
+
+**Acceptance Scenarios**:
+
+1. **Given** entity B has alias "Aldric" and content on entity A contains "Aldric", **When** entity A is opened in read mode, **Then** "Aldric" is linked to entity B.
+2. **Given** a full title and an alias both exist as different entities, **When** a match is found, **Then** the longest matching name wins (full title takes priority over alias if both would match the same span).
+
+---
+
+### User Story 4 — No Links in Edit Mode (Priority: P2)
+
+A user switches to edit mode on an entity. The auto-link rendering is not active while editing — the raw markdown text is shown as-is in the editor. Switching back to read mode restores the links.
+
+**Why this priority**: Edit mode must show raw text so users can modify content without link overlays interfering with cursor placement and selection.
+
+**Independent Test**: Toggle an entity into edit mode. Confirm entity names in the text are plain text, not linked. Toggle back to read mode and confirm links reappear.
+
+**Acceptance Scenarios**:
+
+1. **Given** an entity with detected mentions is in read mode, **When** the user enters edit mode, **Then** all auto-links disappear and text is shown as plain markdown.
+2. **Given** the user is in edit mode and returns to read mode, **When** the view re-renders, **Then** detected mentions are linked again.
+
+---
+
+### Edge Cases
+
+- What happens when an entity is renamed? Detected links refresh live while the entity detail view is open — a Svelte `$effect` in `MarkdownEditor.svelte` dispatches a no-op ProseMirror transaction when the `entityIndex` prop reference changes, triggering the decoration plugin to rescan with the updated names. Stale matches do not persist while the view is open.
+- What happens when two entities have the same name or one entity's name is a prefix of another? The longest match should win; ties should link to the entity with the earliest creation order.
+- What happens with very large content (thousands of words, hundreds of potential matches)? Detection must not block the UI thread or noticeably delay rendering.
+- What happens if the vault has zero other entities? No link rendering occurs; the content appears as plain text.
+- What happens if an entity mentions itself by name? Self-links are suppressed — a name that matches the currently viewed entity is not linked.
+- What happens with case-sensitive names? Matching is case-insensitive but the original text casing is preserved in display.
+
+---
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST detect occurrences of vault entity titles (and registered aliases) within the rendered content and lore text of any entity detail view.
+- **FR-002**: Detected names MUST be rendered as interactive inline links in read mode only, styled using the active theme's standard link appearance (colour + underline); edit mode MUST display unmodified plain text.
+- **FR-003**: Clicking a detected entity link MUST navigate to that entity's detail view in a context-preserving way: in sidebar mode it opens the entity in the sidebar panel; in zen mode it navigates to the entity within zen mode. Hovering a link changes the cursor only; no preview or tooltip is shown.
+- **FR-004**: Matching MUST be case-insensitive and MUST match the full name/alias only — no partial substring matches for shorter strings contained within longer entity names.
+- **FR-005**: When multiple entity names could match overlapping spans of text, the longest match MUST win.
+- **FR-006**: An entity MUST NOT link to itself — self-referencing matches are suppressed.
+- **FR-007**: Detection MUST cover both the content field and the lore field independently (each field is rendered in its own editor instance; links in one field do not affect the other). Clarifies the "content and lore" scope stated in FR-001.
+- **FR-008**: Alias matching MUST be supported; a registered alias resolves to the entity that owns it.
+- **FR-009**: Detection MUST run on the client using the in-memory entity index; no network call or AI model invocation is required.
+- **FR-010**: The feature MUST degrade gracefully: if detection is unavailable (vault not loaded, entity index empty), content and lore render as plain text without error.
+- **FR-011**: Auto-links MUST be shown to P2P guests when the entity index is available in the guest session; guest and host views are identical for detected links.
+
+### Key Entities
+
+- **Entity**: The vault record being viewed. Has `title`, `content`, `lore`, and `aliases[]` fields.
+- **EntityIndex**: The in-memory map of all entity titles and aliases in the active vault, used for name lookup without re-scanning.
+- **DetectedLink**: A resolved match — a text span within content/lore paired with the target entity ID.
+
+---
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A user reading an entity whose content references three other entities can navigate to any of them with a single click, without leaving the entity view or using the search bar.
+- **SC-002**: Detection and rendering of links adds no perceptible delay (under 100 ms) when opening an entity with up to 5 000 words of content, measured on a mid-range desktop device (baseline: M1 MacBook Pro or equivalent mid-range x86 desktop CPU).
+- **SC-003**: All vault entity names that appear verbatim (or as registered aliases) in content or lore are detected — 100% recall on exact matches.
+- **SC-004**: Zero false-positive links: substrings, partial words, and self-references do not produce links.
+- **SC-005**: The feature is invisible in edit mode — no markup, no decorations, no interference with the editor cursor or selection.
+
+---
+
+## Clarifications
+
+### Session 2026-05-30
+
+- Q: Should hovering a detected entity link show a brief inline preview, or is it a plain navigation link? → A: Plain navigation link only — cursor changes on hover, click navigates, no preview shown.
+- Q: Should detected entity links appear when a P2P guest is viewing a shared entity? → A: Yes — if the entity index is available to the guest, links render identically to the host view.
+- Q: How should a detected entity link be styled visually? → A: Use the existing themed link style — same colour and underline as a markdown hyperlink in the active world theme.
+- Q: Should clicking a link behave differently in zen mode vs. sidebar mode? → A: Context-preserving — clicking in sidebar opens the entity in the sidebar; clicking in zen mode navigates to the entity within zen mode.
+
+---
+
+## Assumptions
+
+- The entity index is already in memory when an entity detail view opens (the vault is loaded). No lazy-load of entity names is required.
+- The current markdown renderer used for content/lore supports post-processing or token-replacement to inject link nodes; if it does not, a thin wrapper renders detected spans as interactive elements.
+- Alias data is already available per entity at render time through the existing `aliases` field.
+- The connection proposer (existing feature) is unaffected — auto-link is a read-only display feature and does not create connections or trigger any persistence.

--- a/specs/125-entity-auto-link/tasks.md
+++ b/specs/125-entity-auto-link/tasks.md
@@ -1,0 +1,267 @@
+# Tasks: Entity Auto-Link in Content & Lore
+
+**Branch**: `125-entity-auto-link` | **Date**: 2026-05-30  
+**Input**: `specs/125-entity-auto-link/`  
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ contracts/ ✅
+
+**Tests**: Required — Constitution II (TDD) and plan.md mandate unit tests for the detector (≥ 80% coverage) and component-level tests for the extension (≥ 50% coverage).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete dependencies)
+- **[Story]**: User story label (`[US1]`…`[US4]`)
+- Exact file paths are included in every task description
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Declare file structure so TypeScript/bundler resolves imports before any implementation lands.
+
+- [x] T001 Create empty stub `apps/web/src/lib/utils/entity-mention-detector.ts` (export placeholder types: `EntityIndexEntry`, `DetectedMatch`)
+- [x] T002 [P] Create empty stub `apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts` (export placeholder `createEntityAutoLinkExtension`)
+
+**Checkpoint**: Both modules importable; no runtime logic yet.
+
+---
+
+## Phase 2: Foundational (Core Detection Infrastructure)
+
+**Purpose**: The pure detector and the TipTap extension plugin are shared prerequisites for all user stories. **No user story can be verified until this phase is complete.**
+
+⚠️ **TDD**: Write and verify the tests FAIL before writing the implementation.
+
+### Detection Utility
+
+- [x] T003 Write failing unit tests for `detectEntityMentions` and `sortEntityIndex` in `apps/web/src/lib/utils/entity-mention-detector.test.ts`
+  - Cover: basic match, multiple matches in one string, case-insensitive match (casing preserved), no match for standalone substring, possessive boundary (`"Aldric's"` does not match `"Aldric"`), self-link suppression, longest-match-wins over overlapping candidates, empty index (no crash)
+- [x] T004 Implement `EntityIndexEntry`, `DetectedMatch`, `sortEntityIndex`, `detectEntityMentions` in `apps/web/src/lib/utils/entity-mention-detector.ts` (all T003 tests must pass; ≥ 80% line coverage)
+
+### TipTap Extension
+
+- [x] T005 Write failing integration tests for the extension in `apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts`
+  - Cover: decorations produced when `editable=false`, **no decorations when `editable=true`**, correct `data-entity-id` attribute on decoration, click on `data-entity-id` triggers `onEntityClick`, empty index produces empty DecorationSet, self-link entity ID excluded from decorations
+  - Also cover: dispatching a transaction with meta `entityIndexChanged: true` causes decorations to rebuild with the updated index (verifies the reactivity bridge)
+- [x] T006 Implement `createEntityAutoLinkExtension` and `EntityAutoLinkOptions` in `apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts`
+  - ProseMirror `Plugin` + `DecorationSet` approach per plan.md section B
+  - **Editable guard**: read `this.editor.isEditable` (TipTap extension closure reference) inside `addProseMirrorPlugins()` — NOT a closure-captured option value. This ensures the guard responds correctly when `editable` toggles at runtime. Return `DecorationSet.empty` when `true`.
+  - **EntityIndex reactivity**: in the `apply` hook, detect `tr.getMeta('entityIndexChanged')` and re-sort `options.entityIndex` into the local `sorted` variable before rebuilding decorations
+  - Identity check: skip rebuild if `!tr.docChanged` and `!tr.getMeta('entityIndexChanged')` (plan.md Decision 5)
+  - Delegated click listener on `editorView.dom` (plan.md section C); attach on `view` init, remove on `view.destroy`
+  - All T005 tests must pass; ≥ 50% line coverage
+
+**Checkpoint**: Detector and extension are fully tested and functional in isolation.
+
+---
+
+## Phase 3: User Story 1 — Detected Mentions in Content (Priority: P1) 🎯 MVP
+
+**Goal**: Names of vault entities appear as clickable links in the content field of any entity detail view (sidebar panel and zen mode).
+
+**Independent Test**: Open any entity whose content text contains the exact title of at least one other vault entity. In read mode, the name should appear with link styling and clicking it should navigate to that entity. Edit mode shows plain text.
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Add optional props `entityIndex`, `currentEntityId`, `onEntityClick` (with backward-compatible defaults) to `apps/web/src/lib/components/MarkdownEditor.svelte`
+  - `entityIndex: EntityIndexEntry[] = []`
+  - `currentEntityId: string = ""`
+  - `onEntityClick: (id: string) => void = () => {}`
+- [x] T008 [US1] Register `createEntityAutoLinkExtension(...)` inside the `useEditor` extensions array in `apps/web/src/lib/components/MarkdownEditor.svelte` and add the entityIndex reactivity bridge
+  - Pass `entityIndex`, `currentEntityId`, `onEntityClick` from component props
+  - After the `useEditor` call, add a Svelte `$effect` that watches `entityIndex` and dispatches `editor.view.dispatch(editor.state.tr.setMeta('entityIndexChanged', true))` when the reference changes — this ensures live link refresh when vault entities are renamed or added while the view is open (spec edge case)
+- [x] T009 [US1] Update the read-mode `<MarkdownEditor>` in `apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte` to pass entity auto-link props
+  - Build `entityIndex` from `$vault.entities.flatMap(e => [{ text: e.title.toLowerCase(), id: e.id }, ...e.aliases.map(a => ({ text: a.toLowerCase(), id: e.id }))])`
+  - Pass `currentEntityId={entity.id}`
+  - Pass `onEntityClick` using context-preserving navigation: `vault.selectedEntityId = id` (sidebar is the context for DetailStatusTab)
+  - Note (FR-011): `$vault.entities` is available to both host and guest sessions when the vault is loaded — guest-mode parity for detected links is satisfied by this same prop expression with no additional code path
+- [x] T010 [US1] Update the read-mode `<MarkdownEditor>` in `apps/web/src/lib/components/zen/ZenContent.svelte` to pass entity auto-link props
+  - Build same `entityIndex` expression
+  - Pass `currentEntityId={entity?.id ?? ""}`
+  - Pass `onEntityClick` using `focusEntity(layoutUIStore, id)` (zen stays zen per plan.md section C)
+
+**Checkpoint**: US1 fully functional — links appear in content in both sidebar and zen. Clicking navigates correctly. Edit mode shows plain text (guarded by extension).
+
+---
+
+## Phase 4: User Story 2 — Lore Section Links (Priority: P2)
+
+**Goal**: Names of vault entities also appear as clickable links in the lore field.
+
+**Independent Test**: Open an entity that has lore text containing another entity's name. Confirm a link appears in the lore panel and clicks navigate correctly. Does not depend on US3 or US4.
+
+### Implementation for User Story 2
+
+- [x] T011 [US2] Update the read-mode `<MarkdownEditor>` in `apps/web/src/lib/components/entity-detail/DetailLoreTab.svelte` to pass entity auto-link props
+  - Build same `entityIndex` expression from `$vault.entities`
+  - Pass `currentEntityId={entity.id}`
+  - Pass `onEntityClick` using `vault.selectedEntityId = id` (DetailLoreTab is sidebar context)
+- [x] T012 [P] [US2] Add lore-specific acceptance tests to `apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts`
+  - Verify that decorations are independently built for separate editor instances (content editor and lore editor don't share state)
+  - Verify same entity name in two separate editors both produce decorations
+
+**Checkpoint**: US1 and US2 both independently functional — links appear in both content and lore.
+
+---
+
+## Phase 5: User Story 3 — No Links in Edit Mode (Priority: P2)
+
+**Goal**: The auto-link overlay is completely absent while editing. No decorations, no interference with cursor/selection.
+
+**Independent Test**: Toggle an entity into edit mode on the content or lore field. Confirm no entity name spans have link styling. Switch back to read mode — links reappear.
+
+### Tests for User Story 3
+
+- [x] T013 [US3] Add edit-mode acceptance scenario tests to `apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts`
+  - Given entity with content referencing another entity name → in edit mode (`editable=true`) → zero decorations in DecorationSet
+  - Given switching from read mode (`editable=false`) → edit mode → DecorationSet becomes empty
+  - Given switching from edit mode back to read mode → DecorationSet is rebuilt with decorations
+
+**Checkpoint**: US3 verified — toggling edit mode on/off works correctly and the extension guard is covered by tests.
+
+---
+
+## Phase 6: User Story 4 — Alias Matching (Priority: P3)
+
+**Goal**: Registered aliases resolve to the owning entity. When content contains an alias instead of the full title, the alias is detected and linked to the correct entity.
+
+**Independent Test**: Create an entity with an alias. Reference only the alias in another entity's content. Verify the alias appears as a link pointing to the aliased entity. Verify longest match wins when both full title and alias could match the same span.
+
+### Tests for User Story 4
+
+- [x] T014 [P] [US4] Add alias-specific test cases to `apps/web/src/lib/utils/entity-mention-detector.test.ts`
+  - Alias resolves to the correct entity ID
+  - Full title beats alias when both could match the same span (longest wins)
+  - Multiple entities each with aliases — correct resolution per span
+  - Alias at string boundary (start of sentence, end of sentence)
+- [x] T015 [P] [US4] Add alias call-site test to `apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts`
+  - Extension built with an entityIndex that includes alias entries produces a decoration for the alias span
+
+### Implementation for User Story 4
+
+- [x] T016 [US4] Verify alias entries are included in the `entityIndex` expression at all three call sites (T009, T010, T011)
+  - The `flatMap` already includes `e.aliases` in the quickstart.md pattern — confirm actual call sites match
+  - If aliases were omitted in Phase 3/4, update them now
+
+**Checkpoint**: All 4 user stories are independently functional and tested.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Help content, type safety, coverage verification.
+
+- [x] T017 [P] Add entity auto-link entry to `apps/web/src/lib/config/help-content.ts`
+  - Entry should describe the feature from the user's perspective (names of vault entities in content and lore become clickable links)
+- [x] T018 Run `bun run typecheck` from `apps/web` and fix any TypeScript errors introduced by the new props and extension
+- [x] T019 Run `bun run lint` from `apps/web` and fix any lint warnings in the new/modified files
+- [x] T020 Run `bun run test --coverage` and confirm entity-mention-detector ≥ 80% line coverage and EntityAutoLinkExtension ≥ 50% line coverage
+- [x] T021 [P] Review `apps/web/src/lib/components/MarkdownEditor.svelte` for any prop default regressions — all existing call sites (edit mode) should continue working unchanged
+- [ ] T022 Manually profile detection against a ~5 000-word entity with ~100 vault entities in the browser DevTools Performance tab; confirm total time < 100 ms (SC-002 baseline: mid-range laptop). Record the observed timing in a comment at the top of `apps/web/src/lib/utils/entity-mention-detector.ts` for future reference
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1** (Setup): No dependencies — start immediately
+- **Phase 2** (Foundational): Depends on Phase 1 — **blocks all user stories**
+- **Phase 3** (US1 — P1): Depends on Phase 2 only — no other story dependencies
+- **Phase 4** (US2 — P2): Depends on Phase 2; benefits from Phase 3 prop additions (T007, T008) but is independently testable
+- **Phase 5** (US3 — P2): Depends on Phase 2; the editable guard is already in the extension from T006
+- **Phase 6** (US4 — P3): Depends on Phase 2 for the detector; aliases are an additive change to the call sites
+- **Phase 7** (Polish): Depends on all prior phases
+
+### User Story Dependencies
+
+| Story    | Phase | Hard Dependency                            | Can Parallelize With |
+| -------- | ----- | ------------------------------------------ | -------------------- |
+| US1 (P1) | 3     | Phase 2 done                               | —                    |
+| US2 (P2) | 4     | Phase 2 done; T007+T008 reduce duplication | US3                  |
+| US3 (P2) | 5     | Phase 2 done (T006 editable guard)         | US2                  |
+| US4 (P3) | 6     | Phase 2 done (T003+T004 for aliases)       | —                    |
+
+### Within Each Phase
+
+- T003 (tests) **must** fail before T004 (implementation) begins
+- T005 (tests) **must** fail before T006 (implementation) begins
+- T007 (MarkdownEditor props) must complete before T008–T010 (call sites) can be integrated
+- T014, T015 (alias tests) should fail before T016 is validated
+
+---
+
+## Parallel Execution Examples
+
+### Phase 2 Parallel
+
+```
+T003 → T004 (sequential: test-then-implement detector)
+T005 → T006 (sequential: test-then-implement extension)
+— T003/T004 and T005/T006 pairs can run in parallel after T001/T002
+```
+
+### Phase 3 Parallel
+
+```
+T009 (DetailStatusTab call site)  ← can run in parallel →  T010 (ZenContent call site)
+Both depend on T007 + T008 completing first
+```
+
+### Phase 4+5 Parallel (after Phase 3)
+
+```
+T011 (lore call site)   ← parallel →   T013 (edit-mode tests)
+T012 (lore ext tests)   ← parallel →   T013
+```
+
+### Phase 6 Parallel
+
+```
+T014 (detector alias tests)   ← parallel →   T015 (extension alias test)
+Both → T016 (verify call sites)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup stubs
+2. Complete Phase 2: Foundational (detector + extension) — **CRITICAL BLOCKER**
+3. Complete Phase 3: US1 — content links in sidebar + zen
+4. **STOP and VALIDATE**: entity names in content render as links; clicking navigates; edit mode is clean
+5. Ship/demo — delivers the full P1 value
+
+### Incremental Delivery
+
+1. **Foundation** (Phase 1 + 2) → pure utility + extension, zero UI change
+2. **MVP** (Phase 3 → US1) → content links in sidebar + zen — ship this
+3. **Parity** (Phase 4 → US2) → lore links — ship this
+4. **Safety** (Phase 5 → US3) → edit-mode test verification — completes P2
+5. **Completeness** (Phase 6 → US4) → alias support — completes P3
+6. **Polish** (Phase 7) → help text + coverage validation
+
+### Single Developer Order
+
+```
+T001 → T002 → T003 → T004 → T005 → T006
+→ T007 → T008 → T009 → T010          (MVP done, all P1 verified)
+→ T011 → T012                         (US2 lore)
+→ T013                                 (US3 edit-mode tests)
+→ T014 → T015 → T016                  (US4 aliases)
+→ T017 → T018 → T019 → T020 → T021   (polish)
+```
+
+---
+
+## Notes
+
+- **[P]** = different files with no pending dependencies — safe to run concurrently
+- **[USn]** label maps each task to the user story it delivers
+- `MarkdownEditor.svelte` changes (T007, T008) are backward-compatible — existing callers without the new props continue to work (empty index → no decorations)
+- Do not modify the `editable` prop behaviour in MarkdownEditor itself — the extension handles the guard internally
+- Commit after each phase checkpoint for clean rollback points
+- `bun run test --filter entity-mention` to run detector tests only; `bun run test --filter EntityAutoLink` to run extension tests only


### PR DESCRIPTION
## Summary

Closes #1037.

Names of vault entities are now automatically detected and highlighted as clickable links when reading an entity's **content** or **lore** fields. Clicking a highlighted name navigates directly to that entity. Edit mode shows plain text — the overlay is completely absent while writing.

## What's included

### New files
| File | Purpose |
|---|---|
| `apps/web/src/lib/utils/entity-mention-detector.ts` | Pure detection utility — longest-match-wins scan, word-boundary enforcement, self-link suppression, alias resolution |
| `apps/web/src/lib/utils/entity-mention-detector.test.ts` | 26 unit tests (96.6% line coverage) |
| `apps/web/src/lib/components/editor/EntityAutoLinkExtension.ts` | TipTap/ProseMirror plugin — DecorationSet overlay, editable guard, reactivity bridge via transaction meta |
| `apps/web/src/lib/components/editor/EntityAutoLinkExtension.test.ts` | 17 integration tests (90.6% line coverage) |
| `specs/125-entity-auto-link/` | Full spec artefacts (spec, plan, research, data-model, contracts, quickstart, tasks) |

### Modified files
| File | Change |
|---|---|
| `MarkdownEditor.svelte` | Three new optional props (`entityIndex`, `currentEntityId`, `onEntityClick`) with safe defaults; extension registered; reactivity `$effect` |
| `DetailStatusTab.svelte` | Read-mode auto-link props wired (content) |
| `DetailLoreTab.svelte` | Read-mode auto-link props wired (lore) |
| `ZenContent.svelte` | Read/write mode auto-link props wired (content + lore, zen-preserving navigation) |
| `help-content.ts` | `entity-auto-link` feature hint added |

## Technical decisions

- **Detection**: linear scan over sorted index (longest first) — O(T × E) where T = text chars, E = entity count. No regex backtracking.
- **Decoration storage**: ProseMirror plugin state () — survives transactions, independent across editors.
- **Editable guard**: `editor.isEditable` read inside `props.decorations()` (fires on every view render including after `setEditable()`), not in `state.apply` which only fires on transactions.
- **Reactivity bridge**: Svelte `$effect` dispatches `entityIndexChanged` meta transaction when `entityIndex` prop changes; plugin `apply` hook detects this meta and rebuilds decorations. Options object uses getters so the plugin always reads the latest prop values.
- **Navigation**: sidebar uses `vault.selectedEntityId = id`; zen uses `onNavigate(id)` callback — no store imports in the extension (Constitution VIII).

## Testing

43 tests total, all passing:

```
entity-mention-detector: 26 tests  ✓  96.6% line coverage (≥80% required)
EntityAutoLinkExtension:  17 tests  ✓  90.6% line coverage (≥50% required)
```

Covers: read mode decorations, edit mode (no decorations), editable toggle, entityIndex reactivity via meta dispatch, click routing, multi-instance independence (content + lore editors don't share state), alias resolution, word boundary enforcement.

## Open item

- **T022** — manual browser profiling on a ~5 000-word entity with ~100 vault entities to confirm <100 ms (SC-002). Placeholder comment already in `entity-mention-detector.ts`. Recommended as a follow-up after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)