### PR TITLE
:sparkles: feat: auto add superscripted * to names of past/expired entities

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -195,7 +195,9 @@
               : 'text-xl md:text-3xl font-body tracking-wide'} font-bold whitespace-normal break-words overflow-visible w-full md:truncate"
             style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
           >
-            {entity.title}
+            {entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                >*</sup
+              >{/if}
           </h2>
           {#if entity.aliases && entity.aliases.length > 0}
             <div class="flex flex-wrap gap-1 md:gap-1.5 mt-0.5">
@@ -226,7 +228,9 @@
                 onclick={handleOpenParent}
                 class="text-theme-primary hover:text-theme-primary/80 hover:underline font-semibold focus:outline-none transition-all"
               >
-                {parentEntity.title}
+                {parentEntity.title}{#if parentEntity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                    >*</sup
+                  >{/if}
               </button>
             </div>
           {/if}

--- a/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
@@ -112,6 +112,10 @@
           isOutbound: true,
           displayTitle: vault.entities[c.target]?.title || c.target,
           targetId: c.target,
+          hasPastLabel:
+            vault.entities[c.target]?.labels?.some(
+              (l) => l.toLowerCase() === "past",
+            ) ?? false,
         });
       }
     }
@@ -125,6 +129,10 @@
             isOutbound: false,
             displayTitle: vault.entities[item.sourceId]?.title || item.sourceId,
             targetId: item.sourceId,
+            hasPastLabel:
+              vault.entities[item.sourceId]?.labels?.some(
+                (l) => l.toLowerCase() === "past",
+              ) ?? false,
           });
         }
       }
@@ -148,6 +156,8 @@
             isOutbound: false,
             isChild: true,
             displayTitle: child.title,
+            hasPastLabel:
+              child.labels?.some((l) => l.toLowerCase() === "past") ?? false,
           });
         }
       }
@@ -409,32 +419,53 @@
                 class="text-left hover:text-theme-primary transition flex items-center flex-wrap gap-y-1"
               >
                 {#if conn.isChild}
-                  <span class="text-theme-text">{conn.displayTitle}</span>
+                  <span class="text-theme-text"
+                    >{conn.displayTitle}{#if conn.hasPastLabel}<sup>*</sup
+                      >{/if}</span
+                  >
                   <span class="relation-arrow icon-[lucide--move-right]"></span>
                   <strong
                     class="text-theme-text group-hover:text-theme-primary transition"
                     >Child</strong
                   >
                   <span class="relation-arrow icon-[lucide--move-right]"></span>
-                  <span class="text-theme-secondary">{entity.title}</span>
+                  <span class="text-theme-secondary"
+                    >{entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                        >*</sup
+                      >{/if}</span
+                  >
                 {:else if conn.isOutbound}
-                  <span class="text-theme-secondary">{entity.title}</span>
+                  <span class="text-theme-secondary"
+                    >{entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                        >*</sup
+                      >{/if}</span
+                  >
                   <span class="relation-arrow icon-[lucide--move-right]"></span>
                   <strong
                     class="text-theme-text group-hover:text-theme-primary transition"
                     >{conn.label || conn.type}</strong
                   >
                   <span class="relation-arrow icon-[lucide--move-right]"></span>
-                  <span class="text-theme-text">{conn.displayTitle}</span>
+                  <span class="text-theme-text"
+                    >{conn.displayTitle}{#if conn.hasPastLabel}<sup>*</sup
+                      >{/if}</span
+                  >
                 {:else}
-                  <span class="text-theme-text">{conn.displayTitle}</span>
+                  <span class="text-theme-text"
+                    >{conn.displayTitle}{#if conn.hasPastLabel}<sup>*</sup
+                      >{/if}</span
+                  >
                   <span class="relation-arrow icon-[lucide--move-right]"></span>
                   <strong
                     class="text-theme-text group-hover:text-theme-primary transition"
                     >{conn.label || conn.type}</strong
                   >
                   <span class="relation-arrow icon-[lucide--move-right]"></span>
-                  <span class="text-theme-secondary">{entity.title}</span>
+                  <span class="text-theme-secondary"
+                    >{entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                        >*</sup
+                      >{/if}</span
+                  >
                 {/if}
               </button>
 

--- a/apps/web/src/lib/components/explorer/EntityListItem.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListItem.svelte
@@ -164,7 +164,9 @@
       <div
         class="truncate font-header text-xs font-bold uppercase tracking-widest text-theme-text transition-colors group-hover:text-theme-primary"
       >
-        {entity.title}
+        {entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+            >*</sup
+          >{/if}
       </div>
       {#if entity.aliases && entity.aliases.length > 0}
         <div class="truncate text-[9px] text-theme-muted/70 font-mono italic">

--- a/apps/web/src/lib/components/map/MapPinPopover.svelte
+++ b/apps/web/src/lib/components/map/MapPinPopover.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Map } from "schema";
+  import type { Map, Entity } from "schema";
 
   let {
     x,
@@ -13,7 +13,7 @@
   }: {
     x: number;
     y: number;
-    entity?: { id: string; title: string } | null;
+    entity?: Entity | null;
     subMap?: Map | null;
     onOpenEntity: (entityId: string) => void;
     onEnterSubmap: (mapId: string) => void;
@@ -39,7 +39,9 @@
         class="px-2.5 py-1.5 text-[10px] font-bold text-theme-text hover:text-theme-primary transition-all uppercase tracking-wider whitespace-nowrap border-r border-theme-border mr-1 hover:bg-theme-primary/10 rounded-md"
         onclick={() => onOpenEntity(entity.id)}
       >
-        {entity.title}
+        {entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+            >*</sup
+          >{/if}
       </button>
     {/if}
 

--- a/apps/web/src/lib/components/map/PinLinker.svelte
+++ b/apps/web/src/lib/components/map/PinLinker.svelte
@@ -93,7 +93,9 @@
               <div
                 class="text-xs font-bold text-theme-text group-hover:text-theme-primary"
               >
-                {entity.title}
+                {entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                    >*</sup
+                  >{/if}
               </div>
               <div
                 class="text-[10px] text-theme-muted uppercase tracking-tighter"

--- a/apps/web/src/lib/components/modals/NodeReadModal.svelte
+++ b/apps/web/src/lib/components/modals/NodeReadModal.svelte
@@ -88,6 +88,10 @@
       isOutbound: true,
       displayTitle: vault.entities[c.target]?.title || c.target,
       targetId: c.target,
+      hasPastLabel:
+        vault.entities[c.target]?.labels?.some(
+          (l: string) => l.toLowerCase() === "past",
+        ) ?? false,
     }));
 
     const inbound = (vault.inboundConnections[entity.id] || []).map((item) => ({
@@ -95,6 +99,10 @@
       isOutbound: false,
       displayTitle: vault.entities[item.sourceId]?.title || item.sourceId,
       targetId: item.sourceId,
+      hasPastLabel:
+        vault.entities[item.sourceId]?.labels?.some(
+          (l: string) => l.toLowerCase() === "past",
+        ) ?? false,
     }));
 
     return [...outbound, ...inbound];
@@ -278,7 +286,8 @@
                       <div
                         class="text-sm font-bold text-gray-200 group-hover:text-green-400 transition truncate"
                       >
-                        {conn.displayTitle}
+                        {conn.displayTitle}{#if conn.hasPastLabel}<sup>*</sup
+                          >{/if}
                       </div>
                       <div class="text-xs text-gray-500 truncate">
                         {conn.label || conn.type}

--- a/apps/web/src/lib/components/modals/NodeReadModal.svelte
+++ b/apps/web/src/lib/components/modals/NodeReadModal.svelte
@@ -170,7 +170,9 @@
             <h2
               class="text-2xl md:text-3xl font-bold text-gray-100 font-body tracking-wide"
             >
-              {entity.title}
+              {entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                  >*</sup
+                >{/if}
             </h2>
           {:else}
             <h2 class="text-2xl text-red-500 font-mono">Entity Not Found</h2>

--- a/apps/web/src/lib/components/vtt/TokenAddDialog.svelte
+++ b/apps/web/src/lib/components/vtt/TokenAddDialog.svelte
@@ -158,7 +158,9 @@
               }}
             >
               <div class="text-sm font-bold text-theme-text">
-                {entity.title}
+                {entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
+                    >*</sup
+                  >{/if}
               </div>
               <div
                 class="text-[10px] uppercase tracking-widest text-theme-muted"

--- a/packages/graph-engine/src/index.ts
+++ b/packages/graph-engine/src/index.ts
@@ -57,7 +57,8 @@ export const initGraph = async (options: GraphOptions) => {
         selector: "node",
         style: {
           "background-color": "#666",
-          label: "data(label)", // Updated to use label
+          label: (node: any) =>
+            node.data("isPast") ? `${node.data("label")}*` : node.data("label"),
         },
       },
       {

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -229,6 +229,38 @@ describe("GraphTransformer", () => {
     expect(ordinaryNode?.data.isImportant).toBeUndefined();
   });
 
+  it("should append asterisk to the node label if entity has past label case-insensitively", () => {
+    const entities: Entity[] = [
+      {
+        id: "n1",
+        type: "npc",
+        title: "Dead Hero",
+        labels: ["PAST"],
+        connections: [],
+        content: "",
+      },
+      {
+        id: "n2",
+        type: "npc",
+        title: "Living Legend",
+        labels: ["active"],
+        connections: [],
+        content: "",
+      },
+    ];
+
+    const elements = GraphTransformer.entitiesToElements(entities);
+    const deadNode = elements.find(
+      (e): e is GraphNode => e.group === "nodes" && e.data.id === "n1",
+    );
+    const livingNode = elements.find(
+      (e): e is GraphNode => e.group === "nodes" && e.data.id === "n2",
+    );
+
+    expect(deadNode?.data.label).toBe("Dead Hero*");
+    expect(livingNode?.data.label).toBe("Living Legend");
+  });
+
   it("should mark nodes as revealed if tags or labels contain 'revealed' or 'visible'", () => {
     const entities: any[] = [
       {

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -257,8 +257,10 @@ describe("GraphTransformer", () => {
       (e): e is GraphNode => e.group === "nodes" && e.data.id === "n2",
     );
 
-    expect(deadNode?.data.label).toBe("Dead Hero*");
+    expect(deadNode?.data.label).toBe("Dead Hero");
+    expect(deadNode?.data.isPast).toBe(true);
     expect(livingNode?.data.label).toBe("Living Legend");
+    expect(livingNode?.data.isPast).toBeUndefined();
   });
 
   it("should mark nodes as revealed if tags or labels contain 'revealed' or 'visible'", () => {

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -18,6 +18,7 @@ export interface GraphNode {
     thumbnail?: string;
     labels?: string[];
     isImportant?: boolean;
+    isPast?: boolean;
     date?: TemporalMetadata;
     start_date?: TemporalMetadata;
     end_date?: TemporalMetadata;
@@ -160,7 +161,7 @@ export class GraphTransformer {
       );
       const nodeData: GraphNode["data"] = {
         id: entity.id,
-        label: hasPast ? `${entity.title}*` : entity.title,
+        label: entity.title,
         type: entity.type,
         status: entity.status,
         weight: weights.get(entity.id) ?? 0,
@@ -171,6 +172,7 @@ export class GraphTransformer {
         labels: entity.labels ?? EMPTY_LABELS,
         textureVariant: getTextureVariant(),
       };
+      if (hasPast) nodeData.isPast = true;
       if (hasImportantLabel(entity.labels)) nodeData.isImportant = true;
       if (entity.image) nodeData.image = entity.image;
       if (entity.thumbnail) nodeData.thumbnail = entity.thumbnail;
@@ -403,7 +405,8 @@ export const getGraphStyle = (
         width: 32,
         height: 32,
         shape: graph.nodeShape,
-        label: "data(label)",
+        label: (node: any) =>
+          node.data("isPast") ? `${node.data("label")}*` : node.data("label"),
         color: tokens.text,
         "font-family": sanitizeFontForCytoscape(tokens.fontHeader),
         "font-size": 10,

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -155,9 +155,12 @@ export class GraphTransformer {
       }
 
       // Create Node
+      const hasPast = entity.labels?.some(
+        (l: string) => l.toLowerCase() === "past",
+      );
       const nodeData: GraphNode["data"] = {
         id: entity.id,
-        label: entity.title,
+        label: hasPast ? `${entity.title}*` : entity.title,
         type: entity.type,
         status: entity.status,
         weight: weights.get(entity.id) ?? 0,


### PR DESCRIPTION
This PR automatically appends a superscripted * after the name of all entities carrying the 'past' label to indicate expiration/not-with-us status, applying across Svelte component views and plain text graph node labels.