### PR TITLE
:wrench: chore: update default AI model to gemini-3.1-flash-lite

### DIFF
--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -111,7 +111,7 @@ vi.mock("../services/ai", () => ({
     distillVisualPrompt: vi.fn().mockResolvedValue("visual prompt"),
   },
   TIER_MODES: {
-    lite: "gemini-flash-lite-latest",
+    lite: "gemini-3.1-flash-lite",
     advanced: "gemini-3-flash-preview",
   },
 }));

--- a/apps/web/src/lib/stores/quicknote.svelte.test.ts
+++ b/apps/web/src/lib/stores/quicknote.svelte.test.ts
@@ -24,7 +24,7 @@ vi.mock("../services/ai/context-retrieval.service", () => ({
 vi.mock("./oracle.svelte", () => ({
   oracle: {
     effectiveApiKey: "mocked-api-key",
-    modelName: "gemini-3-flash-preview",
+    modelName: "gemini-3.1-flash-lite",
   },
 }));
 

--- a/apps/web/src/lib/stores/quicknote.svelte.ts
+++ b/apps/web/src/lib/stores/quicknote.svelte.ts
@@ -271,7 +271,7 @@ export class QuickNoteStore {
 
     try {
       const apiKey = oracle.effectiveApiKey || "";
-      const modelName = oracle.modelName || "gemini-3-flash-preview";
+      const modelName = oracle.modelName || "gemini-3.1-flash-lite";
 
       // 1. Retrieve semantic context based on note content to feed into LLM
       let context = "";

--- a/apps/workers/oracle-proxy/src/index.ts
+++ b/apps/workers/oracle-proxy/src/index.ts
@@ -230,7 +230,7 @@ export default {
       }
 
       // 1. Determine Model
-      const targetModel = body.model || "gemini-3-flash-preview";
+      const targetModel = body.model || "gemini-3.1-flash-lite";
 
       // 2. Map and clean up configuration for Google REST API (which expects snake_case)
       const rawConfig = {

--- a/packages/importer/src/oracle/analyzer.ts
+++ b/packages/importer/src/oracle/analyzer.ts
@@ -102,10 +102,10 @@ export class OracleAnalyzer implements OracleAnalyzerEngine {
 
     const prompt = `${EXTRACTION_PROMPT}${contextStr}\n\nInput Text:\n${text}`;
 
-    // Attempt models in order of strength/preference, aligned with app configuration
+    // Attempt models in order of preference/strength, aligned with app default
     const models = [
+      "gemini-3.1-flash-lite", // Lite Tier (Free & Default)
       "gemini-3-flash-preview", // Advanced Tier
-      "gemini-flash-lite-latest", // Lite Tier
     ];
 
     for (const modelName of models) {

--- a/packages/oracle-engine/src/oracle-settings.svelte.ts
+++ b/packages/oracle-engine/src/oracle-settings.svelte.ts
@@ -40,7 +40,7 @@ export class OracleSettingsService {
   apiKey = $state<string | null>(null);
 
   /** Model tier: "lite" or "advanced" */
-  tier = $state<"lite" | "advanced">("advanced");
+  tier = $state<"lite" | "advanced">("lite");
 
   /** Loading state for async operations */
   isLoading = $state(false);
@@ -107,7 +107,7 @@ export class OracleSettingsService {
     this.apiKey = setting?.value ?? null;
 
     const tierSetting = await db.appSettings.get("ai_tier");
-    this.tier = tierSetting?.value ?? "advanced";
+    this.tier = tierSetting?.value ?? "lite";
 
     const providerSetting = await db.appSettings.get("image_provider");
     this.imageProvider = providerSetting?.value ?? "cloudflare";
@@ -309,7 +309,7 @@ export class OracleSettingsService {
   get modelName() {
     return this.tier === "advanced"
       ? "gemini-3-flash-preview"
-      : "gemini-2.0-flash-lite";
+      : "gemini-3.1-flash-lite";
   }
 
   /**

--- a/packages/oracle-engine/src/oracle-settings.test.ts
+++ b/packages/oracle-engine/src/oracle-settings.test.ts
@@ -23,7 +23,7 @@ describe("OracleSettingsService", () => {
       const service = new OracleSettingsService();
 
       expect(service.apiKey).toBe(null);
-      expect(service.tier).toBe("advanced");
+      expect(service.tier).toBe("lite");
       expect(service.isLoading).toBe(false);
       expect(service.activeStyleTitle).toBe(null);
       expect(service.imageProvider).toBe("cloudflare");
@@ -57,7 +57,7 @@ describe("OracleSettingsService", () => {
       await service.init(mockDb as any);
 
       expect(service.apiKey).toBe(null);
-      expect(service.tier).toBe("advanced");
+      expect(service.tier).toBe("lite");
       expect(service.imageProvider).toBe("cloudflare");
     });
 
@@ -174,11 +174,11 @@ describe("OracleSettingsService", () => {
       expect(service.modelName).toBe("gemini-3-flash-preview");
     });
 
-    it("should return gemini-2.0-flash-lite for lite tier", () => {
+    it("should return gemini-3.1-flash-lite for lite tier", () => {
       const service = new OracleSettingsService();
       service.tier = "lite";
 
-      expect(service.modelName).toBe("gemini-2.0-flash-lite");
+      expect(service.modelName).toBe("gemini-3.1-flash-lite");
     });
   });
 });

--- a/packages/schema/src/ai.ts
+++ b/packages/schema/src/ai.ts
@@ -1,7 +1,7 @@
 import type { Entity } from "./entity";
 
 export const TIER_MODES = {
-  lite: "gemini-flash-lite-latest",
+  lite: "gemini-3.1-flash-lite",
   advanced: "gemini-3-flash-preview",
 };
 


### PR DESCRIPTION
Updates the default model everywhere to `gemini-3.1-flash-lite` (except image generation) as it is now free and does not count against quota. Also changes default settings tier to lite.