### PR TITLE
[codex] Defer feature store initialization

### DIFF
--- a/apps/web/src/lib/app/init/app-init.test.ts
+++ b/apps/web/src/lib/app/init/app-init.test.ts
@@ -33,6 +33,12 @@ vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
   },
 }));
 
+vi.mock("$lib/stores/calendar.svelte", () => ({
+  calendarStore: {
+    init: vi.fn(),
+  },
+}));
+
 import {
   bootSystem,
   initializeGlobalListeners,
@@ -40,6 +46,7 @@ import {
   registerServiceWorker,
 } from "./app-init";
 import { notificationStore } from "$lib/stores/ui/notification.svelte";
+import { calendarStore } from "$lib/stores/calendar.svelte";
 
 describe("app-init", () => {
   let listenersCleanup: (() => void)[] = [];
@@ -55,7 +62,7 @@ describe("app-init", () => {
   });
 
   describe("bootSystem", () => {
-    it("should initialize all passed stores and set isStaging", () => {
+    it("should initialize core stores and set isStaging", () => {
       const mockStores = {
         categories: { init: vi.fn() },
         timeline: { init: vi.fn() },
@@ -69,9 +76,9 @@ describe("app-init", () => {
 
       expect(result).toBe(true);
       expect(mockStores.categories.init).toHaveBeenCalled();
-      expect(mockStores.timeline.init).toHaveBeenCalled();
-      expect(mockStores.graph.init).toHaveBeenCalled();
-      expect(mockStores.calendar.init).toHaveBeenCalled();
+      expect(mockStores.timeline.init).not.toHaveBeenCalled();
+      expect(mockStores.graph.init).not.toHaveBeenCalled();
+      expect(mockStores.calendar.init).not.toHaveBeenCalled();
       expect(mockStores.vault.init).toHaveBeenCalled();
       expect(mockStores.sessionModeStore.isStaging).toBe(true);
     });
@@ -194,14 +201,17 @@ describe("app-init", () => {
       );
     });
 
-    it("should handle vault-switched event", () => {
+    it("should lazy-load calendar handling for vault-switched event", async () => {
       const mockCalendarStore = { init: vi.fn() };
       const cleanup = initializeGlobalListeners(mockCalendarStore);
       listenersCleanup.push(cleanup);
 
       window.dispatchEvent(new CustomEvent("vault-switched"));
+      await vi.waitFor(() => {
+        expect(calendarStore.init).toHaveBeenCalled();
+      });
 
-      expect(mockCalendarStore.init).toHaveBeenCalled();
+      expect(mockCalendarStore.init).not.toHaveBeenCalled();
     });
 
     it("should remove event listeners on cleanup", () => {

--- a/apps/web/src/lib/app/init/app-init.ts
+++ b/apps/web/src/lib/app/init/app-init.ts
@@ -12,18 +12,11 @@ import { notificationStore } from "$lib/stores/ui/notification.svelte";
  */
 export function bootSystem(stores: {
   categories: any;
-  timeline: any;
-  graph: any;
-  calendar: any;
   vault: any;
   sessionModeStore: any;
-  oracle?: any;
 }): boolean {
-  debugStore.log("System booting: Initializing heavy stores...");
+  debugStore.log("System booting: Initializing core stores...");
   stores.categories.init();
-  stores.timeline.init();
-  stores.graph.init();
-  stores.calendar.init();
 
   // Initialize staging state
   stores.sessionModeStore.isStaging = IS_STAGING;
@@ -32,12 +25,6 @@ export function bootSystem(stores: {
     console.error("Vault initialization failed", error);
   });
 
-  // Initialize Oracle Settings Service with Dexie (if oracle store provided)
-  if (stores.oracle) {
-    // Oracle initialization is handled by OracleStore.init()
-    // This is just a placeholder for future oracle initialization needs
-  }
-
   return true;
 }
 
@@ -45,7 +32,7 @@ export function bootSystem(stores: {
  * Sets up global error and rejection handlers.
  * Returns a cleanup function.
  */
-export function initializeGlobalListeners(calendarStore: any) {
+export function initializeGlobalListeners(_calendarStore?: any) {
   if (!browser) return () => {};
 
   // Initialize Oracle action listeners
@@ -109,7 +96,8 @@ export function initializeGlobalListeners(calendarStore: any) {
     );
   };
 
-  const handleVaultSwitched = () => {
+  const handleVaultSwitched = async () => {
+    const { calendarStore } = await import("$lib/stores/calendar.svelte");
     calendarStore.init();
   };
 
@@ -132,10 +120,10 @@ export function setupWindowGlobals(context: {
   searchStore: any;
   vault: any;
   vaultRegistry: any;
-  canvasRegistry: any;
-  graph: any;
-  oracle: any;
-  calendarStore: any;
+  canvasRegistry?: any;
+  graph?: any;
+  oracle?: any;
+  calendarStore?: any;
   helpStore: any;
   categories: any;
   onboardingStore?: any;

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -126,6 +126,7 @@
   };
 
   onMount(() => {
+    void graph.init();
     controller.init(container, graphStyle);
     if (typeof ResizeObserver !== "undefined") {
       resizeObserver = new ResizeObserver(() => {

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -12,6 +12,7 @@ export class GraphStore {
   private explorerUIStore: typeof explorerUIStore;
   private sessionModeStore: typeof sessionModeStore;
   private connectionModeStore: typeof connectionModeStore;
+  private _initPromise: Promise<void> | null = null;
 
   private get vault() {
     return this._vault ?? defaultVault;
@@ -114,6 +115,15 @@ export class GraphStore {
   }
 
   async init() {
+    if (this._initPromise) {
+      return this._initPromise;
+    }
+
+    this._initPromise = this.loadPersistedState();
+    return this._initPromise;
+  }
+
+  private async loadPersistedState() {
     const db = await getDB();
     const savedEras = await db.getAll("world_eras");
     if (savedEras) {

--- a/apps/web/src/lib/stores/graph.test.ts
+++ b/apps/web/src/lib/stores/graph.test.ts
@@ -74,6 +74,7 @@ describe("GraphStore", () => {
     graph.eras = [];
     graph.centralNodeId = null;
     graph.labelFilterMode = "OR"; // Reset this explicitly
+    (graph as any)._initPromise = null;
 
     // Reset mocks
     (vault as any).allEntities = [];
@@ -163,6 +164,22 @@ describe("GraphStore", () => {
     expect(graph.recentLabels).toEqual(["old"]);
     expect(graph.labelFilterMode).toBe("AND");
     expect(graph.eras).toEqual([{ id: "era1", name: "Era 1" }]);
+  });
+
+  it("should only initialize persisted graph state once", async () => {
+    const db = await getDB();
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const getSpy = vi.spyOn(db, "get").mockResolvedValue(undefined);
+    const getAllSpy = vi.spyOn(db, "getAll").mockResolvedValue([]);
+
+    await graph.init();
+    await graph.init();
+
+    expect(getAllSpy).toHaveBeenCalledTimes(1);
+    expect(getSpy).toHaveBeenCalledTimes(5);
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    addEventListenerSpy.mockRestore();
   });
 
   it("should add recent labels and persist them", async () => {

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -11,13 +11,7 @@
   import { searchStore } from "$lib/stores/search.svelte";
   import { vault } from "$lib/stores/vault.svelte";
   import { vaultRegistry } from "$lib/stores/vault-registry.svelte";
-  import { canvasRegistry } from "$lib/stores/canvas-registry.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
-  import { timelineStore } from "$lib/stores/timeline.svelte";
-  import { calendarStore } from "$lib/stores/calendar.svelte";
-  import { graph } from "$lib/stores/graph.svelte";
-  import { mapSession } from "$lib/stores/map-session.svelte";
-  import { oracle } from "$lib/stores/oracle.svelte";
   import { categories } from "$lib/stores/categories.svelte";
   import { quickNoteStore } from "$lib/stores/quicknote.svelte";
   import { appEventBus, CrossTabBroadcaster } from "@codex/events";
@@ -37,7 +31,6 @@
   import SidebarPanelHost from "$lib/components/layout/SidebarPanelHost.svelte";
   import GlobalModalProvider from "$lib/components/modals/GlobalModalProvider.svelte";
   import GuestSessionBootstrap from "$lib/components/vtt/GuestSessionBootstrap.svelte";
-  import VTTSharedImageLightbox from "$lib/components/vtt/VTTSharedImageLightbox.svelte";
   import QuickNoteScratchpad from "$lib/components/quicknote/QuickNoteScratchpad.svelte";
 
   // Logic & Hooks
@@ -67,6 +60,8 @@
   let globalListenersCleanup: (() => void) | null = null;
   let crossTabBroadcaster: InstanceType<typeof CrossTabBroadcaster> | null =
     null;
+  let mapSession = $state<any>(null);
+  let VTTSharedImageLightbox = $state<any>(null);
 
   // Derived
   const isPopup = $derived(
@@ -78,7 +73,7 @@
     /\/vault\/[^/]+\/entity\/[^/]+$/.test(page.url.pathname),
   );
   const isVttFullscreen = $derived(
-    page.url.pathname.startsWith(`${base}/map`) && mapSession.vttEnabled,
+    page.url.pathname.startsWith(`${base}/map`) && !!mapSession?.vttEnabled,
   );
 
   if (browser) {
@@ -96,7 +91,23 @@
   // Set up global listeners BEFORE bootSystem to avoid missing vault-switched events
   $effect(() => {
     if (browser && !globalListenersCleanup) {
-      globalListenersCleanup = initializeGlobalListeners(calendarStore);
+      globalListenersCleanup = initializeGlobalListeners();
+    }
+  });
+
+  $effect(() => {
+    if (!browser) return;
+
+    if (
+      page.url.pathname.startsWith(`${base}/map`) ||
+      sessionModeStore.isGuestMode
+    ) {
+      import("$lib/stores/map-session.svelte").then((m) => {
+        mapSession = m.mapSession;
+      });
+      import("$lib/components/vtt/VTTSharedImageLightbox.svelte").then((m) => {
+        VTTSharedImageLightbox = m.default;
+      });
     }
   });
 
@@ -112,12 +123,8 @@
       if (!isLandingPage || !shouldShowLanding || isTesting || isPopup) {
         hasBooted = bootSystem({
           categories,
-          timeline: timelineStore,
-          graph,
-          calendar: calendarStore,
           vault,
           sessionModeStore,
-          oracle,
         });
       }
     }
@@ -127,7 +134,6 @@
     (async () => {
       helpStore.init();
       await themeStore.init();
-      oracle.init();
       void initGDriveSync();
 
       // Preload heavy route chunks so first navigation is instant
@@ -141,14 +147,12 @@
       }
 
       console.log("[Layout] Calling setupWindowGlobals");
+      const featureGlobals = await loadFeatureWindowGlobals();
+
       setupWindowGlobals({
         searchStore,
         vault,
         vaultRegistry,
-        canvasRegistry,
-        graph,
-        oracle,
-        calendarStore,
         helpStore,
         categories,
         onboardingStore,
@@ -161,9 +165,29 @@
         explorerUIStore,
         isEntityVisible,
         eventBus: appEventBus,
+        ...featureGlobals,
       });
     })();
   });
+
+  async function loadFeatureWindowGlobals() {
+    const isSpecialEnv =
+      import.meta.env.DEV ||
+      (typeof window !== "undefined" && (window as any).__E2E__) ||
+      import.meta.env.VITE_STAGING === "true";
+
+    if (!isSpecialEnv) return {};
+
+    const [{ canvasRegistry }, { graph }, { oracle }, { calendarStore }] =
+      await Promise.all([
+        import("$lib/stores/canvas-registry.svelte"),
+        import("$lib/stores/graph.svelte"),
+        import("$lib/stores/oracle.svelte"),
+        import("$lib/stores/calendar.svelte"),
+      ]);
+
+    return { canvasRegistry, graph, oracle, calendarStore };
+  }
 
   // Help Hash Navigation
   $effect(() => {
@@ -409,7 +433,7 @@
   {/if}
 
   <GuestSessionBootstrap />
-  {#if sessionModeStore.isGuestMode}
+  {#if sessionModeStore.isGuestMode && mapSession && VTTSharedImageLightbox}
     <VTTSharedImageLightbox
       imageState={mapSession.sharedTokenImage}
       onClose={() => mapSession.clearSharedTokenImage()}

--- a/apps/web/src/routes/(app)/timeline/+page.svelte
+++ b/apps/web/src/routes/(app)/timeline/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
   import { timelineStore } from "$lib/stores/timeline.svelte";
+  import { graph } from "$lib/stores/graph.svelte";
   import VerticalTimeline from "$lib/components/timeline/VerticalTimeline.svelte";
   import HorizontalTimeline from "$lib/components/timeline/HorizontalTimeline.svelte";
   import TimelineLayoutToggle from "$lib/components/timeline/TimelineLayoutToggle.svelte";
   import TimelineFilterBar from "$lib/components/timeline/TimelineFilterBar.svelte";
+  import { onMount } from "svelte";
+
+  onMount(() => {
+    void graph.init();
+    void timelineStore.init();
+  });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- Move feature-specific store initialization out of the app layout boot path
- Lazy-load map session, VTT lightbox, calendar handling, and debug-only feature globals where needed
- Initialize graph/timeline stores from their feature surfaces and make graph init idempotent

## Why
Issue #993 identified heavy per-feature stores being statically imported and initialized from `(app)/+layout.svelte`, increasing route chunk weight for views that do not need Oracle, map, timeline, graph, canvas, or calendar behavior.

## Validation
- bun run --filter web test -- src/lib/stores/graph.test.ts src/lib/app/init/app-init.test.ts
- bun run --filter web check
- bun run lint
- bun run test
- Commit/push hooks: lint:types, lint --cache, test --changed

Closes #993