### PR TITLE
perf: use requestIdleCallback instead of fixed 500ms delay

### DIFF
--- a/apps/web/src/lib/services/search-index-pipeline.svelte.ts
+++ b/apps/web/src/lib/services/search-index-pipeline.svelte.ts
@@ -294,7 +294,7 @@ export class SearchIndexPipeline {
         lastSeenId = records[records.length - 1].entityId;
 
         // Stagger batches to let the main thread and IndexedDB breathe.
-        await this.delay(500);
+        await this.yieldToIdle();
       }
 
       this.debug.log(
@@ -364,5 +364,18 @@ export class SearchIndexPipeline {
 
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => this.timers.setTimeout(resolve, ms));
+  }
+
+  private yieldToIdle(): Promise<void> {
+    if (typeof globalThis.requestIdleCallback === "function") {
+      return new Promise((resolve) => {
+        globalThis.requestIdleCallback(() => resolve());
+      });
+    }
+    const scheduler = (globalThis as any).scheduler;
+    if (scheduler && typeof scheduler.postTask === "function") {
+      return scheduler.postTask(() => {}, { priority: "background" });
+    }
+    return new Promise((resolve) => this.timers.setTimeout(resolve, 0));
   }
 }

--- a/apps/web/src/lib/services/search.test.ts
+++ b/apps/web/src/lib/services/search.test.ts
@@ -310,4 +310,60 @@ describe("SearchService progressive indexing", () => {
       }),
     );
   });
+
+  it("uses requestIdleCallback to schedule yielding during background indexing", async () => {
+    const originalRequestIdleCallback = globalThis.requestIdleCallback;
+    const idleSpy = vi.fn((cb: any) => cb());
+    globalThis.requestIdleCallback = idleSpy as any;
+
+    try {
+      const api = createApi();
+      const metadata = [{ id: "one", title: "One" }];
+
+      const db = createDb({ graphEntities: metadata });
+      let callCount = 0;
+      db.entityContent.where = vi.fn((field) => {
+        if (field === "vaultId") {
+          return {
+            equals: vi.fn(() => ({
+              count: vi.fn().mockResolvedValue(100),
+            })),
+          } as any;
+        }
+        return {
+          between: vi.fn(() => ({
+            limit: vi.fn(() => ({
+              toArray: vi.fn().mockImplementation(async () => {
+                callCount++;
+                if (callCount === 1) {
+                  return Array.from({ length: 100 }, (_, i) => ({
+                    entityId: `entity-${i}`,
+                    vaultId: "vault-1",
+                    content: "dummy",
+                    lore: "dummy",
+                  }));
+                }
+                return [];
+              }),
+            })),
+          })),
+        } as any;
+      });
+
+      const { service, handler } = createHarness({ api, db });
+
+      await handler()(vaultEvent(VAULT_EVENTS.VAULT_OPENING, "vault-1"));
+      await handler()(
+        vaultEvent(VAULT_EVENTS.CACHE_LOADED, "vault-1", {
+          entities: metadata,
+        }),
+      );
+
+      await (service as any).indexContentInBackground("vault-1");
+
+      expect(idleSpy).toHaveBeenCalled();
+    } finally {
+      globalThis.requestIdleCallback = originalRequestIdleCallback;
+    }
+  });
 });


### PR DESCRIPTION
Closes #990. Replaced fixed 500ms timeout delay with requestIdleCallback (with postTask/setTimeout fallbacks) to yield the main thread during background indexing batches.