### PR TITLE
perf: debounce graph hover content loads

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -22,6 +22,7 @@
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { debugStore } from "$lib/stores/debug.svelte";
   import { GraphViewController } from "./graph/graph-view-controller.svelte";
+  import { createHoverContentLoader } from "./graph/hover-content-loader";
 
   let { selectedId = $bindable(null) } = $props<{
     selectedId: string | null;
@@ -40,6 +41,9 @@
   );
 
   let resizeObserver: ResizeObserver | undefined;
+  const hoverContentLoader = createHoverContentLoader((entityId) =>
+    vault.loadEntityContent(entityId),
+  );
 
   // Sync prop -> controller
   $effect(() => {
@@ -74,8 +78,7 @@
   );
 
   $effect(() => {
-    if (controller.hoveredEntityId)
-      vault.loadEntityContent(controller.hoveredEntityId);
+    hoverContentLoader.schedule(controller.hoveredEntityId);
   });
 
   const handleKeyDown = async (e: KeyboardEvent) => {
@@ -139,6 +142,7 @@
   });
 
   onDestroy(() => {
+    hoverContentLoader.cancel();
     if (resizeObserver) {
       resizeObserver.disconnect();
     }

--- a/apps/web/src/lib/components/graph/hover-content-loader.test.ts
+++ b/apps/web/src/lib/components/graph/hover-content-loader.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
+import {
+  createHoverContentLoader,
+  HOVER_CONTENT_LOAD_DELAY_MS,
+} from "./hover-content-loader";
+
+describe("createHoverContentLoader", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("debounces hover content loading", () => {
+    const loadEntityContent = vi.fn();
+    const loader = createHoverContentLoader(loadEntityContent);
+
+    loader.schedule("entity-1");
+    vi.advanceTimersByTime(HOVER_CONTENT_LOAD_DELAY_MS - 1);
+
+    expect(loadEntityContent).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(loadEntityContent).toHaveBeenCalledOnce();
+    expect(loadEntityContent).toHaveBeenCalledWith("entity-1");
+  });
+
+  it("loads only the latest hovered entity when hover changes quickly", () => {
+    const loadEntityContent = vi.fn();
+    const loader = createHoverContentLoader(loadEntityContent);
+
+    loader.schedule("entity-1");
+    vi.advanceTimersByTime(75);
+    loader.schedule("entity-2");
+    vi.advanceTimersByTime(HOVER_CONTENT_LOAD_DELAY_MS - 1);
+
+    expect(loadEntityContent).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(loadEntityContent).toHaveBeenCalledOnce();
+    expect(loadEntityContent).toHaveBeenCalledWith("entity-2");
+  });
+
+  it("cancels pending loads when hover clears", () => {
+    const loadEntityContent = vi.fn();
+    const loader = createHoverContentLoader(loadEntityContent);
+
+    loader.schedule("entity-1");
+    loader.schedule(null);
+    vi.advanceTimersByTime(HOVER_CONTENT_LOAD_DELAY_MS);
+
+    expect(loadEntityContent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/graph/hover-content-loader.ts
+++ b/apps/web/src/lib/components/graph/hover-content-loader.ts
@@ -1,0 +1,33 @@
+export const HOVER_CONTENT_LOAD_DELAY_MS = 150;
+
+export interface HoverContentLoader {
+  schedule(entityId: string | null | undefined): void;
+  cancel(): void;
+}
+
+export function createHoverContentLoader(
+  loadEntityContent: (entityId: string) => void | Promise<void>,
+  delayMs = HOVER_CONTENT_LOAD_DELAY_MS,
+): HoverContentLoader {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  function cancel() {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+  }
+
+  return {
+    schedule(entityId) {
+      cancel();
+      if (!entityId) return;
+
+      timeout = setTimeout(() => {
+        timeout = undefined;
+        void loadEntityContent(entityId);
+      }, delayMs);
+    },
+    cancel,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #980.

- Debounces `GraphView` hover-driven `vault.loadEntityContent` calls by 150 ms.
- Cancels pending hover content loads when hover clears or the component is destroyed.
- Adds focused fake-timer coverage for debounce delay, rapid hover replacement, and cancellation.

## Validation

- `npx -y modern-web-guidance@latest search "debounce hover loading to avoid expensive IndexedDB requests in Svelte component" --skill-version 2026_05_16-c5e7870`
- `npx -y modern-web-guidance@latest retrieve "performance"`
- `npx @sveltejs/mcp svelte-autofixer apps/web/src/lib/components/GraphView.svelte --svelte-version 5`
- `bun run --filter web test -- src/lib/components/graph/hover-content-loader.test.ts`
- `bun run --filter web lint`
- `bun run --filter web test`
- commit hook: `bun run --filter '*' lint:types`
- pre-push hook: cached lint and changed-file tests