### PR TITLE
:zap: perf(web): eliminate lucide-svelte components in favor of Iconify utility classes

### DIFF
--- a/apps/web/src/lib/components/canvas/CanvasContextMenu.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasContextMenu.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Trash2, Type } from "lucide-svelte";
   import { regenerationService } from "$lib/services/RegenerationService.svelte";
   import { vault } from "$lib/stores/vault.svelte";
 
@@ -78,7 +77,7 @@
           onClose();
         }}
       >
-        <Type class="w-3.5 h-3.5" />
+        <span class="icon-[lucide--type] w-3.5 h-3.5"></span>
         Edit Label
       </button>
       <div class="border-t border-theme-border/30 my-1"></div>
@@ -158,7 +157,7 @@
           onClose();
         }}
       >
-        <Trash2 class="w-3.5 h-3.5" />
+        <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
         Delete
       </button>
     {/if}

--- a/apps/web/src/lib/components/canvas/CanvasSelectionModal.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasSelectionModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { canvasRegistry } from "$lib/stores/canvas-registry.svelte";
-  import { Search, Plus, Trash2, Edit2, Layout, X, Check } from "lucide-svelte";
+
   import { page } from "$app/state";
   import { goto } from "$app/navigation";
   import { fade, scale, slide } from "svelte/transition";
@@ -137,7 +137,8 @@
           <h2
             class="text-lg font-bold text-theme-text font-header uppercase tracking-widest flex items-center gap-2"
           >
-            <Layout class="w-5 h-5 text-theme-primary" />
+            <span class="icon-[lucide--layout] w-5 h-5 text-theme-primary"
+            ></span>
             Canvas Registry
           </h2>
           <p
@@ -151,7 +152,7 @@
           class="p-2 rounded-lg hover:bg-theme-bg text-theme-muted hover:text-theme-text transition-colors"
           aria-label="Close modal"
         >
-          <X class="w-5 h-5" />
+          <span class="icon-[lucide--x] w-5 h-5"></span>
         </button>
       </div>
 
@@ -161,9 +162,9 @@
       >
         <div class="flex gap-2">
           <div class="relative flex-1">
-            <Search
-              class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-theme-muted"
-            />
+            <span
+              class="icon-[lucide--search] absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-theme-muted"
+            ></span>
             <input
               type="text"
               bind:value={searchQuery}
@@ -177,7 +178,7 @@
             disabled={isCreating}
             class="px-4 py-2 rounded-lg bg-theme-primary text-theme-bg font-bold text-xs uppercase font-header tracking-widest hover:brightness-110 disabled:opacity-50 transition-all flex items-center gap-2"
           >
-            <Plus class="w-4 h-4" />
+            <span class="icon-[lucide--plus] w-4 h-4"></span>
             Create New
           </button>
         </div>
@@ -190,7 +191,8 @@
             <div
               class="w-8 h-8 rounded-lg bg-theme-primary/20 flex items-center justify-center shrink-0"
             >
-              <Plus class="w-4 h-4 text-theme-primary" />
+              <span class="icon-[lucide--plus] w-4 h-4 text-theme-primary"
+              ></span>
             </div>
             <input
               id="new-canvas-input"
@@ -205,14 +207,14 @@
               class="p-2 bg-theme-primary text-theme-bg rounded-lg hover:brightness-110"
               title="Confirm Creation"
             >
-              <Check class="w-4 h-4" />
+              <span class="icon-[lucide--check] w-4 h-4"></span>
             </button>
             <button
               onclick={() => (isCreating = false)}
               class="p-2 text-theme-muted hover:text-theme-text"
               title="Cancel"
             >
-              <X class="w-4 h-4" />
+              <span class="icon-[lucide--x] w-4 h-4"></span>
             </button>
           </div>
         {/if}
@@ -265,11 +267,12 @@
             <div
               class="w-10 h-10 rounded-lg bg-theme-bg flex items-center justify-center shrink-0 border border-theme-border group-hover:border-theme-primary/30 transition-colors"
             >
-              <Layout
-                class="w-5 h-5 {activeCanvasId === canvas.slug
+              <span
+                class="icon-[lucide--layout] w-5 h-5 {activeCanvasId ===
+                canvas.slug
                   ? 'text-theme-primary'
                   : 'text-theme-muted'}"
-              />
+              ></span>
             </div>
 
             <div class="flex-1 min-w-0">
@@ -295,7 +298,7 @@
                     onclick={() => canvas.id && confirmRename(canvas.id)}
                     class="p-1.5 bg-theme-primary text-theme-bg rounded-lg hover:brightness-110"
                   >
-                    <Check class="w-3 h-3" />
+                    <span class="icon-[lucide--check] w-3 h-3"></span>
                   </button>
                 </div>
               {:else}
@@ -331,7 +334,7 @@
                   title="Rename Workspace"
                   aria-label={`Rename ${canvas.name || "Canvas"}`}
                 >
-                  <Edit2 class="w-4 h-4" />
+                  <span class="icon-[lucide--edit-2] w-4 h-4"></span>
                 </button>
                 <button
                   onclick={(e) => canvas.id && deleteCanvas(canvas.id, e)}
@@ -339,7 +342,7 @@
                   title="Delete Workspace"
                   aria-label={`Delete ${canvas.name || "Canvas"}`}
                 >
-                  <Trash2 class="w-4 h-4" />
+                  <span class="icon-[lucide--trash-2] w-4 h-4"></span>
                 </button>
               {/if}
             </div>
@@ -349,7 +352,7 @@
             <div
               class="w-16 h-16 rounded-full bg-theme-surface border border-theme-border flex items-center justify-center mx-auto mb-4 text-theme-muted opacity-20"
             >
-              <Layout class="w-8 h-8" />
+              <span class="icon-[lucide--layout] w-8 h-8"></span>
             </div>
             <p
               class="text-sm text-theme-muted font-mono uppercase tracking-widest"

--- a/apps/web/src/lib/components/canvas/EdgeLabelModal.svelte
+++ b/apps/web/src/lib/components/canvas/EdgeLabelModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { fade, scale } from "svelte/transition";
-  import { X, Check, Type } from "lucide-svelte";
 
   let {
     isOpen = $bindable(false),
@@ -69,7 +68,7 @@
         class="p-4 border-b border-theme-border flex items-center justify-between bg-theme-bg/30"
       >
         <div class="flex items-center gap-2">
-          <Type class="w-4 h-4 text-theme-primary" />
+          <span class="icon-[lucide--type] w-4 h-4 text-theme-primary"></span>
           <h3
             class="text-xs font-bold text-theme-text font-header uppercase tracking-widest"
           >
@@ -81,7 +80,7 @@
           class="p-1 rounded hover:bg-theme-bg text-theme-muted hover:text-theme-text transition-colors"
           aria-label="Close"
         >
-          <X class="w-4 h-4" />
+          <span class="icon-[lucide--x] w-4 h-4"></span>
         </button>
       </div>
 
@@ -120,7 +119,7 @@
           onclick={handleSave}
           class="px-6 py-2 bg-theme-primary text-theme-bg rounded-lg font-bold text-[10px] uppercase font-header tracking-widest hover:brightness-110 transition-all flex items-center gap-2 shadow-lg shadow-theme-primary/10"
         >
-          <Check class="w-3 h-3" />
+          <span class="icon-[lucide--check] w-3 h-3"></span>
           Save Label
         </button>
       </div>

--- a/apps/web/src/lib/components/canvas/EntityNode.svelte
+++ b/apps/web/src/lib/components/canvas/EntityNode.svelte
@@ -4,7 +4,7 @@
   import { categories } from "$lib/stores/categories.svelte";
   import { getIconClass } from "$lib/utils/icon";
   import { renderMarkdown } from "$lib/utils/markdown";
-  import { Edit2, Check, X } from "lucide-svelte";
+
   import { connectionModeStore } from "$lib/stores/ui/connection-mode.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 
@@ -171,7 +171,7 @@
               aria-label="Quick edit chronicle"
               type="button"
             >
-              <Edit2 class="w-3 h-3" />
+              <span class="icon-[lucide--edit-2] w-3 h-3"></span>
             </button>
           {/if}
         </div>
@@ -219,7 +219,7 @@
                   aria-label="Cancel"
                   type="button"
                 >
-                  <X class="w-3 h-3" />
+                  <span class="icon-[lucide--x] w-3 h-3"></span>
                 </button>
                 <button
                   class="p-1.5 rounded-full bg-theme-primary border border-theme-primary text-theme-surface hover:brightness-110 hover:scale-105 backdrop-blur-sm shadow-sm transition-all"
@@ -229,7 +229,7 @@
                   aria-label="Save"
                   type="button"
                 >
-                  <Check class="w-3 h-3" />
+                  <span class="icon-[lucide--check] w-3 h-3"></span>
                 </button>
               </div>
             </div>

--- a/apps/web/src/lib/components/explorer/EntityExplorer.svelte
+++ b/apps/web/src/lib/components/explorer/EntityExplorer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { vault } from "$lib/stores/vault.svelte";
   import EntityList from "./EntityList.svelte";
-  import { Database, X } from "lucide-svelte";
+
   import {
     dispatchSearchEntityFocus,
     DEFAULT_SEARCH_ENTITY_ZOOM,
@@ -93,7 +93,7 @@
         style:border-color="var(--theme-selected-border)"
         style:color="var(--theme-icon-active)"
       >
-        <Database class="w-4 h-4" />
+        <span class="icon-[lucide--database] w-4 h-4"></span>
       </div>
       <div>
         <div
@@ -114,7 +114,7 @@
       style:color="var(--theme-icon-default)"
       aria-label="Close Explorer"
     >
-      <X class="w-4 h-4" />
+      <span class="icon-[lucide--x] w-4 h-4"></span>
     </button>
   </div>
 

--- a/apps/web/src/lib/components/labels/CategoryFilter.svelte
+++ b/apps/web/src/lib/components/labels/CategoryFilter.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { categories } from "$lib/stores/categories.svelte";
   import { getIconClass } from "$lib/utils/icon";
-  import { LayoutGrid, Filter } from "lucide-svelte";
 
   let {
     activeCategories,
@@ -32,7 +31,7 @@
       : 'text-theme-muted hover:text-theme-text'}"
     data-testid="category-filter-toggle"
   >
-    <Filter class="w-3.5 h-3.5" />
+    <span class="icon-[lucide--filter] w-3.5 h-3.5"></span>
     <span
       class="absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full bg-theme-primary text-theme-bg text-[8px] font-bold flex items-center justify-center leading-none transition-all {expanded ||
       activeCategories.size === 0
@@ -57,7 +56,7 @@
         : 'text-theme-muted hover:text-theme-text hover:bg-theme-primary/10'}"
       data-testid="category-filter-all"
     >
-      <LayoutGrid class="w-3.5 h-3.5" />
+      <span class="icon-[lucide--layout-grid] w-3.5 h-3.5"></span>
     </button>
 
     <!-- Per-category icon buttons -->

--- a/apps/web/src/lib/components/oracle/InlineKeySetup.svelte
+++ b/apps/web/src/lib/components/oracle/InlineKeySetup.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { oracle } from "$lib/stores/oracle.svelte";
-  import { Eye, EyeOff, Sparkles, ExternalLink } from "lucide-svelte";
+
   import { fade } from "svelte/transition";
 
   let inputKey = $state("");
@@ -29,7 +29,7 @@
     <div
       class="w-12 h-12 rounded-xl bg-theme-primary/10 flex items-center justify-center text-theme-primary shrink-0"
     >
-      <Sparkles class="w-6 h-6 animate-pulse" />
+      <span class="icon-[lucide--sparkles] w-6 h-6 animate-pulse"></span>
     </div>
     <div class="space-y-1">
       <h3
@@ -61,9 +61,9 @@
           aria-label="{showKey ? 'Hide' : 'Show'} API Key"
         >
           {#if showKey}
-            <EyeOff class="w-4 h-4" />
+            <span class="icon-[lucide--eye-off] w-4 h-4"></span>
           {:else}
-            <Eye class="w-4 h-4" />
+            <span class="icon-[lucide--eye] w-4 h-4"></span>
           {/if}
         </button>
       </div>
@@ -77,9 +77,9 @@
         class="text-xs text-theme-secondary hover:text-theme-primary flex items-center gap-1.5 transition-colors group font-header tracking-wide uppercase"
       >
         <span>Get free key from Google AI Studio</span>
-        <ExternalLink
-          class="w-3 h-3 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
-        />
+        <span
+          class="icon-[lucide--external-link] w-3 h-3 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+        ></span>
       </a>
 
       <button

--- a/docs/adr/017-eliminate-lucide-svelte-components.md
+++ b/docs/adr/017-eliminate-lucide-svelte-components.md
@@ -1,0 +1,50 @@
+# ADR 017: Eliminate lucide-svelte Components in Favor of Iconify Utility Class Pattern
+
+## Context and Problem Statement
+
+To optimize production bundle sizes and loading performance, we audited the icon imports within Codex Cryptica. Although modern bundlers (Vite/Rollup) support tree-shaking for `lucide-svelte`, we identified the following issues:
+
+1. **Compilation and Runtime Overhead**: Compiling and instantiating Svelte component wrappers for every icon adds rendering cycles and bundle overhead compared to pure CSS class icons.
+2. **Style Guide Non-Compliance**: The repository styling guide explicitly mandates using the Tailwind 4 Iconify utility pattern (`class="icon-[lucide--name]"`) to keep icon rendering lightweight and consistent.
+3. **Lingering Component Imports**: We audited the codebase and located 7 component files that still directly imported and rendered Svelte components from the `lucide-svelte` library.
+
+We needed to systematically eliminate the remaining `lucide-svelte` imports to ensure full compliance with the style guide and optimize production asset size.
+
+## Decision Drivers
+
+- **Performance**: Minimize JavaScript parsing and execution times for UI icons.
+- **Consistency**: Enforce a single, unified styling pattern for icons across all UI modules.
+- **Bundle Optimization**: Ensure that unused icons are never bundled, with zero reliance on complex JS tree-shaking configurations.
+
+## Considered Options
+
+- **Option 1: Audit and Tune lucide-svelte Tree-Shaking (Status Quo)** - Keep using Svelte components but verify bundler output. This leaves runtime JS instantiation overhead and violates style guide rules.
+- **Option 2: Replace with Iconify CSS Utility Classes** - Convert all lingering components to the `<span class="icon-[lucide--icon-name]"></span>` pattern, eliminating JS imports entirely.
+
+## Decision Outcome
+
+Chosen option: **Option 2: Replace with Iconify CSS Utility Classes**.
+
+We converted all 7 identified Svelte components under `apps/web/src/lib/components/` to use the Tailwind 4 Iconify utility class pattern, removing the `lucide-svelte` JS imports completely from these sites.
+
+### Affected Files:
+
+1. `apps/web/src/lib/components/canvas/CanvasContextMenu.svelte`
+2. `apps/web/src/lib/components/canvas/CanvasSelectionModal.svelte`
+3. `apps/web/src/lib/components/canvas/EdgeLabelModal.svelte`
+4. `apps/web/src/lib/components/canvas/EntityNode.svelte`
+5. `apps/web/src/lib/components/explorer/EntityExplorer.svelte`
+6. `apps/web/src/lib/components/labels/CategoryFilter.svelte`
+7. `apps/web/src/lib/components/oracle/InlineKeySetup.svelte`
+
+## Consequences
+
+### Positive
+
+- **Bundle Size Reduction**: Removing `lucide-svelte` from the main component chunks guarantees that icons are resolved purely via CSS, completely bypassing JS tree-shaking risks.
+- **Rendering Performance**: Reusing static CSS-driven icons eliminates Svelte component mounting overhead for icons, reducing CPU time during hot path renders (e.g. node dragging, list filtering).
+- **Style Guide Alignment**: Achieved 100% compliance with repository icon requirements.
+
+### Negative
+
+- **No Significant Negatives**: The CSS utility classes map directly to the same SVG shapes under the hood, preserving visual appearance and accessibility.


### PR DESCRIPTION
## Summary

Closes #976.

* Audited `lucide-svelte` usage and identified 7 lingering components still importing and instantiating icon components.
* Converted all 7 files to use the Tailwind 4 Iconify CSS utility pattern (`class="icon-[lucide--icon-name]"`), eliminating direct JS imports from `lucide-svelte` and ensuring full alignment with the repository style guide.
* Removed the unused `lucide-svelte` imports from those component files.
* Created ADR [017-eliminate-lucide-svelte-components.md](file:///home/espen/proj/remotecodexarcana/docs/adr/017-eliminate-lucide-svelte-components.md) documenting the performance, bundle size, and style benefits of CSS-driven icon class selections.

## Validation
* `bun run test` (All tests passed)
* `bun run lint` (Linter passed cleanly)
* `bun run --filter web lint:types` (All TS type checks in the web app passed)