### PR TITLE
:zap: perf(help): lazy-load FlexSearch to defer ~30 KB gz off main chunk

### DIFF
--- a/apps/web/src/lib/stores/help.svelte.ts
+++ b/apps/web/src/lib/stores/help.svelte.ts
@@ -7,7 +7,6 @@ import {
   ONBOARDING_TOUR,
   HELP_ARTICLES,
 } from "$lib/config/help-content";
-import FlexSearch from "flexsearch";
 import { searchStore as defaultSearchStore } from "./search.svelte";
 import { onboardingStore } from "$lib/stores/ui/onboarding.svelte";
 import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
@@ -92,7 +91,7 @@ export class HelpStore {
     // Init handled explicitly in layout
   }
 
-  init() {
+  async init() {
     if (!browser) return;
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
@@ -117,7 +116,7 @@ export class HelpStore {
       }
     }
 
-    this.buildIndex();
+    await this.buildIndex();
     this.isInitialized = true;
   }
 
@@ -136,11 +135,11 @@ export class HelpStore {
    * Rebuilds the search index.
    * Useful during development if articles change without a full reload.
    */
-  buildIndex(force = false) {
+  async buildIndex(force = false) {
     if (this.index && !force && this.indexedCount === HELP_ARTICLES.length)
       return;
 
-    // Initialize FlexSearch
+    const FlexSearch = (await import("flexsearch")).default;
     this.index = new FlexSearch.Document({
       document: {
         id: "id",

--- a/apps/web/src/lib/stores/help.test.ts
+++ b/apps/web/src/lib/stores/help.test.ts
@@ -18,9 +18,9 @@ import { HELP_ARTICLES } from "$lib/config/help-content";
 import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 
 describe("HelpStore", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.mocked(localStorage.getItem).mockReturnValue(null);
-    helpStore.init();
+    await helpStore.init();
     helpStore.reset();
   });
 
@@ -82,7 +82,7 @@ describe("HelpStore", () => {
     expect(helpStore.hasSeen("initial-onboarding")).toBe(true);
   });
 
-  it("should handle persistence and initialization from localStorage", () => {
+  it("should handle persistence and initialization from localStorage", async () => {
     const savedState = JSON.stringify({
       completedTours: ["test-tour"],
       dismissedHints: ["test-hint"],
@@ -90,7 +90,7 @@ describe("HelpStore", () => {
     });
     vi.mocked(localStorage.getItem).mockReturnValue(savedState);
 
-    helpStore.init();
+    await helpStore.init();
     expect(helpStore.hasSeen("test-tour")).toBe(true);
     expect(helpStore.isHintDismissed("test-hint")).toBe(true);
   });
@@ -133,8 +133,8 @@ describe("HelpStore", () => {
     expect(localStorage.setItem).toHaveBeenCalled();
   });
 
-  it("should force rebuild index", () => {
-    helpStore.buildIndex(true);
+  it("should force rebuild index", async () => {
+    await helpStore.buildIndex(true);
     // Verify no crash, internal count updated
     expect((helpStore as any).indexedCount).toBe(HELP_ARTICLES.length);
   });


### PR DESCRIPTION
## Summary

- Removes static `import FlexSearch from "flexsearch"` from `help.svelte.ts` (line 9)
- Replaces with `await import('flexsearch')` inside `buildIndex()`, so FlexSearch is only fetched when the help store initialises in the browser
- `buildIndex()` and `init()` are now `async`; tests updated to `await` them

## Test plan

- [x] All 12 `help.test.ts` unit tests pass
- [x] `svelte-check` — 0 errors

Closes #973
Parent: #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)