### PR TITLE
:zap: perf(web): add manualChunks for editor, graph, p2p, and pdf deps

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -22,7 +22,9 @@ try {
 
 let usePolling = false;
 try {
-  usePolling = readFileSync("/proc/version", "utf8").toLowerCase().includes("microsoft");
+  usePolling = readFileSync("/proc/version", "utf8")
+    .toLowerCase()
+    .includes("microsoft");
 } catch {
   // Ignore
 }
@@ -79,6 +81,22 @@ export default defineConfig({
     chunkSizeWarningLimit: 900,
     minify: "esbuild",
     target: "es2020",
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (
+            id.includes("@tiptap/") ||
+            id.includes("svelte-tiptap") ||
+            id.includes("tiptap-markdown")
+          )
+            return "chunk-editor";
+          if (id.includes("cytoscape")) return "chunk-graph";
+          if (id.includes("peerjs") || id.includes("peerjs/"))
+            return "chunk-p2p";
+          if (id.includes("pdfjs-dist")) return "chunk-pdf";
+        },
+      },
+    },
   },
   test: {
     include: ["src/**/*.{test,spec}.{js,ts}"],


### PR DESCRIPTION
## Summary

- Adds `build.rollupOptions.output.manualChunks` to `vite.config.ts`
- Groups heavy deps into four stable named chunks:
  - `chunk-editor` — `@tiptap/*`, `svelte-tiptap`, `tiptap-markdown`
  - `chunk-graph` — `cytoscape`, `cytoscape-fcose`
  - `chunk-p2p` — `peerjs`
  - `chunk-pdf` — `pdfjs-dist`
- Isolates these chunks from app code changes so their hashes stay stable across deploys, improving CDN long-term cache reuse

## Test plan

- [x] All 1721 unit tests pass
- [x] `svelte-check` — 0 errors

Closes #975
Parent: #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)