### PR TITLE
:zap: perf(web): subset Google Font preload to workspace defaults only

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -11,12 +11,30 @@
 	<link rel="dns-prefetch" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-			<link rel="preload" as="style"
-			href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Inter:wght@300;400;700&family=Orbitron:wght@400;700&family=Spectral:ital,wght@0,400;0,700;1,400&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Cormorant+Garamond:ital,wght@0,300..700;1,300..700&display=swap"
-			onload="this.onload=null;this.rel='stylesheet'" />
-		<noscript>
-			<link rel="stylesheet"
-				href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Inter:wght@300;400;700&family=Orbitron:wght@400;700&family=Spectral:ital,wght@0,400;0,700;1,400&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Cormorant+Garamond:ital,wght@0,300..700;1,300..700&display=swap" />	</noscript>
+	<!-- First-paint fonts: workspace default theme only (Inter + Fraunces) -->
+	<link rel="preload" as="style"
+		href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap"
+		onload="this.onload=null;this.rel='stylesheet'" />
+	<!-- Theme fonts: deferred until idle so they never block FCP/LCP -->
+	<script>
+		(function () {
+			function loadThemeFonts() {
+				var l = document.createElement('link');
+				l.rel = 'stylesheet';
+				l.href = 'https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Orbitron:wght@400;700&family=Share+Tech+Mono&family=Spectral:ital,wght@0,400;0,700;1,400&display=swap';
+				document.head.appendChild(l);
+			}
+			if ('requestIdleCallback' in window) {
+				requestIdleCallback(loadThemeFonts);
+			} else {
+				window.addEventListener('load', loadThemeFonts);
+			}
+		})();
+	</script>
+	<noscript>
+		<link rel="stylesheet"
+			href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Orbitron:wght@400;700&family=Share+Tech+Mono&family=Spectral:ital,wght@0,400;0,700;1,400&display=swap" />
+	</noscript>
 	<script src="https://accounts.google.com/gsi/client" async defer></script>
 	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 	<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />


### PR DESCRIPTION
## Summary

- **First-paint preload**: only `Inter` + `Fraunces` (the workspace default theme fonts) — down from 9 families
- **Deferred via `requestIdleCallback`**: `Alegreya`, `Courier Prime`, `Fira Code`, `Orbitron`, `Share Tech Mono`, `Spectral` — injected after idle so they never block FCP/LCP
- **Dropped**: `IM Fell English` and `Cormorant Garamond` — not referenced by any theme
- **Added**: `Share Tech Mono` — was missing but is used by the starwars/startrek themes
- `noscript` fallback retains all active fonts

## Test plan

- [x] `svelte-check` — 0 errors

Closes #974
Parent: #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)