### PR TITLE
:sparkles: feat(ui): add shared EmptyState component and apply across views

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -23,6 +23,7 @@
   import { debugStore } from "$lib/stores/debug.svelte";
   import { GraphViewController } from "./graph/graph-view-controller.svelte";
   import { createHoverContentLoader } from "./graph/hover-content-loader";
+  import EmptyState from "$lib/components/ui/EmptyState.svelte";
 
   let { selectedId = $bindable(null) } = $props<{
     selectedId: string | null;
@@ -386,6 +387,9 @@
       ? vault.entities[controller.hoveredEntityId]
       : null,
   );
+  let hasNoEntities = $derived(
+    vault.isInitialized && vault.allEntities.length === 0,
+  );
 </script>
 
 <div
@@ -429,6 +433,19 @@
     <ContextMenu cy={controller.cy} />
     <SelectionConnector cy={controller.cy} />
   {/if}
+  {#if hasNoEntities}
+    <div
+      class="absolute inset-0 flex items-center justify-center pointer-events-none"
+      data-testid="graph-empty-state"
+    >
+      <EmptyState
+        icon="icon-[lucide--network]"
+        headline="Your graph is empty"
+        body="Add entities in the explorer to see them appear here."
+      />
+    </div>
+  {/if}
+
   <FeatureHint hintId="graph-controls" />
   {#if controller.selectedCount === 2}
     <div class="fixed top-20 right-4 z-[60]" data-testid="node-merging-hint">

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -388,7 +388,9 @@
       : null,
   );
   let hasNoEntities = $derived(
-    vault.isInitialized && vault.allEntities.length === 0,
+    vault.isInitialized &&
+      vault.status !== "loading" &&
+      vault.allEntities.length === 0,
   );
 </script>
 

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -295,11 +295,19 @@
         {@render treeNode(node, 0)}
       {:else}
         <div data-testid="no-entities-found">
-          <EmptyState
-            icon="icon-[lucide--ghost]"
-            headline="No entities yet"
-            body="Create your first entity to start building your vault."
-          />
+          {#if vault.allEntities.length === 0}
+            <EmptyState
+              icon="icon-[lucide--ghost]"
+              headline="No entities yet"
+              body="Create your first entity to start building your vault."
+            />
+          {:else}
+            <EmptyState
+              icon="icon-[lucide--search-x]"
+              headline="No entities found"
+              body="Try adjusting your search or filters."
+            />
+          {/if}
         </div>
       {/each}
     {:else if viewMode === "label" && groupedEntities?.type === "label"}

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -10,6 +10,7 @@
   import EntityListItem from "./EntityListItem.svelte";
   import EntityListSearch from "./EntityListSearch.svelte";
   import EntityListFilterBar from "./EntityListFilterBar.svelte";
+  import EmptyState from "$lib/components/ui/EmptyState.svelte";
 
   let {
     onSelect,
@@ -293,8 +294,12 @@
       {#each entityTree as node (node.entity.id)}
         {@render treeNode(node, 0)}
       {:else}
-        <div class="text-center py-10 px-4" data-testid="no-entities-found">
-          <p class="text-xs text-theme-muted">No entities found</p>
+        <div data-testid="no-entities-found">
+          <EmptyState
+            icon="icon-[lucide--ghost]"
+            headline="No entities yet"
+            body="Create your first entity to start building your vault."
+          />
         </div>
       {/each}
     {:else if viewMode === "label" && groupedEntities?.type === "label"}
@@ -389,8 +394,12 @@
         {/each}
       {/if}
       {#if filteredEntities.length === 0}
-        <div class="text-center py-10 px-4" data-testid="no-entities-found">
-          <p class="text-xs text-theme-muted">No entities found</p>
+        <div data-testid="no-entities-found">
+          <EmptyState
+            icon="icon-[lucide--search-x]"
+            headline="No entities found"
+            body="Try adjusting your search or filters."
+          />
         </div>
       {/if}
     {/if}

--- a/apps/web/src/lib/components/oracle/OracleChat.svelte
+++ b/apps/web/src/lib/components/oracle/OracleChat.svelte
@@ -7,6 +7,7 @@
   import { tick } from "svelte";
   import { isChatNearBottom, scrollChatToBottom } from "./oracle-chat-scroll";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+  import EmptyState from "$lib/components/ui/EmptyState.svelte";
 
   let { onOpenSettings } = $props<{ onOpenSettings?: () => void }>();
 
@@ -251,76 +252,14 @@
   >
     {#if oracle.messages.length === 0}
       <div
-        class="h-full flex flex-col items-center justify-center text-center p-8 space-y-6"
+        class="h-full flex items-center justify-center"
+        data-testid="oracle-empty-state"
       >
-        <div class="relative">
-          <div
-            class="absolute inset-0 bg-theme-primary/10 blur-xl rounded-full animate-pulse"
-          ></div>
-          <span
-            class="icon-[heroicons--sparkles] w-12 h-12 text-theme-primary relative z-10 opacity-50"
-          ></span>
-        </div>
-
-        <div class="space-y-2">
-          <h4
-            class="text-theme-text font-bold uppercase font-header tracking-[0.2em] text-[10px]"
-          >
-            The Archives are Open
-          </h4>
-          <p
-            class="text-xs text-theme-muted leading-relaxed font-body hidden sm:block"
-          >
-            Greetings, Seeker. I am the Oracle, the keeper of your recorded
-            lore. Ask of the robber, the mayor, or the shadows beyond the
-            village... I shall consult the echoes of your vault.
-          </p>
-          <p
-            class="text-[10px] text-theme-muted leading-relaxed font-body sm:hidden"
-          >
-            Consult the echoes of your vault.
-          </p>
-        </div>
-
-        <div class="pt-4 space-y-2">
-          <p
-            class="text-[9px] text-theme-muted uppercase tracking-widest animate-bounce"
-          >
-            Awaiting your query...
-          </p>
-          <div class="flex items-center justify-center gap-3 pt-3">
-            <!-- Tier Badge -->
-            <div class="flex flex-col items-center gap-1">
-              <span
-                class="text-[9px] text-theme-muted uppercase tracking-widest font-bold font-header"
-                >Model Tier</span
-              >
-              <span
-                class="text-xs px-2 py-0.5 rounded border font-bold uppercase font-header tracking-wider shadow-sm
-                                {oracle.tier === 'lite'
-                  ? 'border-theme-primary/30 bg-theme-primary/10 text-theme-primary'
-                  : 'border-theme-accent/50 bg-theme-accent/10 text-theme-accent shadow-theme-accent/20'}"
-              >
-                {oracle.tier}
-              </span>
-            </div>
-
-            {#if !oracle.apiKey}
-              <div class="w-px h-6 bg-theme-border mx-1"></div>
-              <div class="flex flex-col items-center gap-1">
-                <span
-                  class="text-[9px] text-theme-muted uppercase tracking-widest font-bold font-header"
-                  >Access</span
-                >
-                <span
-                  class="text-xs px-2 py-0.5 rounded border border-theme-primary/30 bg-theme-primary/10 text-theme-primary uppercase tracking-wider font-bold font-header"
-                >
-                  SHARED
-                </span>
-              </div>
-            {/if}
-          </div>
-        </div>
+        <EmptyState
+          icon="icon-[heroicons--sparkles]"
+          headline="The Archives are Open"
+          body="Greetings, Seeker. Ask of any entity in your vault and I shall consult the echoes of your lore."
+        />
       </div>
     {/if}
 

--- a/apps/web/src/lib/components/ui/EmptyState.svelte
+++ b/apps/web/src/lib/components/ui/EmptyState.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  let {
+    icon = "icon-[lucide--inbox]",
+    headline,
+    body,
+    cta,
+    onCta,
+  }: {
+    icon?: string;
+    headline: string;
+    body?: string;
+    cta?: string;
+    onCta?: () => void;
+  } = $props();
+</script>
+
+<div
+  class="flex flex-col items-center justify-center gap-3 py-10 px-4 text-center"
+>
+  <span class="{icon} h-8 w-8 text-theme-muted/40"></span>
+  <p
+    class="text-[10px] font-bold font-header uppercase tracking-[0.2em] text-theme-muted"
+  >
+    {headline}
+  </p>
+  {#if body}
+    <p
+      class="text-xs text-theme-muted/70 font-body leading-relaxed max-w-[22ch]"
+    >
+      {body}
+    </p>
+  {/if}
+  {#if cta && onCta}
+    <button
+      type="button"
+      onclick={onCta}
+      class="mt-1 px-3 py-1 text-[10px] font-bold font-header uppercase tracking-wider rounded border border-theme-primary/40 text-theme-primary hover:bg-theme-primary/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-accent/40"
+    >
+      {cta}
+    </button>
+  {/if}
+</div>

--- a/apps/web/src/lib/components/ui/EmptyState.svelte
+++ b/apps/web/src/lib/components/ui/EmptyState.svelte
@@ -17,7 +17,7 @@
 <div
   class="flex flex-col items-center justify-center gap-3 py-10 px-4 text-center"
 >
-  <span class="{icon} h-8 w-8 text-theme-muted/40"></span>
+  <span class="{icon} h-8 w-8 text-theme-muted/40" aria-hidden="true"></span>
   <p
     class="text-[10px] font-bold font-header uppercase tracking-[0.2em] text-theme-muted"
   >


### PR DESCRIPTION
Closes #1061. Part of #947.

## Summary
- Adds `EmptyState.svelte` — a shared component with `icon`, `headline`, `body`, and optional `cta`/`onCta` props, styled to match the app's design language
- Replaces inline "No entities found" text in `EntityList` (two call sites) with distinct empty states for empty vault vs. no search results
- Adds an empty-state overlay to `GraphView` when the vault has no entities
- Replaces the elaborate inline welcome block in `OracleChat` with the shared component using thematic copy

## Test plan
- [ ] Open explorer with empty vault → see ghost icon + "No entities yet"
- [ ] Search with no matches → see search-x icon + "No entities found"
- [ ] Open graph view with empty vault → see network icon overlay
- [ ] Open Oracle with no messages → see sparkles icon + "The Archives are Open"
- [ ] Verify no TypeScript errors (`bun run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)