### PR TITLE
:bug: fix(ux): replace all alert() calls with notificationStore.notify()

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -145,7 +145,7 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[DetailImage] Failed to save external file:", err);
-        notificationStore.notify("Failed to save image. Please try a JPEG, PNG, or WebP file.", "error");
+        notificationStore.notify("Failed to save image. Check the console for details.", "error");
       }
     }
   }

--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -123,7 +123,7 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[DetailImage] Failed to save Oracle image:", err);
-        alert("Failed to archive image from Oracle.");
+        notificationStore.notify("Failed to archive image from Oracle. Check the console for details.", "error");
       }
       return;
     }
@@ -145,7 +145,7 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[DetailImage] Failed to save external file:", err);
-        alert("Failed to save external image.");
+        notificationStore.notify("Failed to save image. Please try a JPEG, PNG, or WebP file.", "error");
       }
     }
   }

--- a/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
+++ b/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
@@ -16,6 +16,7 @@
   import { discoveryPolicyStore } from "$lib/stores/ui/discovery-policy.svelte";
   import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+  import { notificationStore } from "$lib/stores/ui/notification.svelte";
   import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
 
   let showHint = $state(false);
@@ -248,9 +249,7 @@
               `Failed to convert demo to ${themeStore.jargon.vault}`,
               error,
             );
-            window.alert(
-              `Failed to save ${themeStore.jargon.vault}. Please try again.`,
-            );
+            notificationStore.notify(`Failed to save ${themeStore.jargon.vault}. Please try again.`, "error");
           }
         }}
         class="w-full py-2 bg-theme-primary text-theme-bg text-[10px] font-bold uppercase font-header tracking-widest rounded hover:bg-theme-secondary transition-colors"

--- a/apps/web/src/lib/components/oracle/OracleWindow.svelte
+++ b/apps/web/src/lib/components/oracle/OracleWindow.svelte
@@ -10,6 +10,7 @@
   import { discoveryPolicyStore } from "$lib/stores/ui/discovery-policy.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
+  import { notificationStore } from "$lib/stores/ui/notification.svelte";
 
   const _isPopup = $derived(page.url.pathname === `${base}/oracle`);
 
@@ -166,9 +167,7 @@
                 `Failed to convert demo to ${themeStore.jargon.vault}`,
                 error,
               );
-              window.alert(
-                `Failed to save ${themeStore.jargon.vault}. Please try again.`,
-              );
+              notificationStore.notify(`Failed to save ${themeStore.jargon.vault}. Please try again.`, "error");
             }
           }}
           class="w-full py-2 bg-theme-primary text-theme-bg text-[10px] font-bold uppercase font-header tracking-widest rounded hover:bg-theme-secondary transition-colors"

--- a/apps/web/src/lib/components/settings/ImportSettings.svelte
+++ b/apps/web/src/lib/components/settings/ImportSettings.svelte
@@ -28,6 +28,7 @@
   import { aiClientManager } from "$lib/services/ai/client-manager";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { connectionModeStore } from "$lib/stores/ui/connection-mode.svelte";
+  import { notificationStore } from "$lib/stores/ui/notification.svelte";
 
   type MarkdownFrontmatterValidator =
     typeof import("@codex/vault-engine").validateMarkdownFrontmatter;
@@ -410,7 +411,7 @@
     } catch (err) {
       console.error("Batch import failed:", err);
 
-      alert("Failed to save imported entities. Check console for details.");
+      notificationStore.notify("Import failed — entities could not be saved. Check the console for details.", "error");
 
       step = "review";
 

--- a/apps/web/src/lib/components/settings/VaultSettings.svelte
+++ b/apps/web/src/lib/components/settings/VaultSettings.svelte
@@ -94,9 +94,7 @@
               `Failed to convert demo to ${themeStore.jargon.vault}:`,
               error,
             );
-            window.alert(
-              `Failed to save ${themeStore.jargon.vault}. Please try again.`,
-            );
+            notificationStore.notify(`Failed to save ${themeStore.jargon.vault}. Please try again.`, "error");
           }
         }}
         class="px-8 py-3 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-xs rounded hover:bg-theme-secondary transition-all active:scale-95 shadow-[0_0_20px_rgba(var(--color-accent-primary-rgb),0.2)]"

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -121,7 +121,7 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[ZenSidebar] Failed to save Oracle image:", err);
-        alert("Failed to archive image from Oracle.");
+        notificationStore.notify("Failed to archive image from Oracle. Check the console for details.", "error");
       }
       return;
     }
@@ -143,7 +143,7 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[ZenSidebar] Failed to save external file:", err);
-        alert("Failed to save external image.");
+        notificationStore.notify("Failed to save image. Please try a JPEG, PNG, or WebP file.", "error");
       }
     }
   }

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -143,7 +143,7 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[ZenSidebar] Failed to save external file:", err);
-        notificationStore.notify("Failed to save image. Please try a JPEG, PNG, or WebP file.", "error");
+        notificationStore.notify("Failed to save image. Check the console for details.", "error");
       }
     }
   }

--- a/apps/web/src/routes/(app)/oracle/+page.svelte
+++ b/apps/web/src/routes/(app)/oracle/+page.svelte
@@ -2,6 +2,7 @@
   import OracleChat from "$lib/components/oracle/OracleChat.svelte";
   import { oracle } from "$lib/stores/oracle.svelte";
   import { onMount } from "svelte";
+  import { notificationStore } from "$lib/stores/ui/notification.svelte";
 
   onMount(() => {
     oracle.init();
@@ -55,7 +56,7 @@
 
   <OracleChat
     onOpenSettings={() => {
-      alert("Please update settings in the main Codex Cryptica window.");
+      notificationStore.notify("To update Oracle settings, open the Settings panel in the main Codex Cryptica window.", "error");
     }}
   />
 </div>


### PR DESCRIPTION
Closes #1058. Part of #947.

## Summary
- Replaces every remaining `alert()` / `window.alert()` call with `notificationStore.notify(message, "error")` so errors surface as non-blocking toasts with actionable copy
- Files changed: `DetailImage`, `ZenSidebar`, `ImportSettings`, `VaultSettings`, `OracleWindow`, `OracleSidebarPanel`, `oracle/+page.svelte`
- Adds `notificationStore` import where it was missing

## Test plan
- [ ] Drop an unsupported file onto an entity image → toast instead of browser alert
- [ ] Fail an import batch → toast with actionable copy
- [ ] Trigger vault-save error in demo mode → toast
- [ ] Open Oracle pop-out and click settings → toast directing user to main window
- [ ] `bun run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)