### PR TITLE
:safety_vest: feat(ux): guard unsaved entity-detail edits with confirmation

### DIFF
--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -77,7 +77,10 @@
         editLore !== (entity.lore ?? "") ||
         editType !== entity.type ||
         editImage !== (entity.image ?? "") ||
-        JSON.stringify(editAliases) !== JSON.stringify(entity.aliases ?? [])),
+        JSON.stringify(editAliases) !== JSON.stringify(entity.aliases ?? []) ||
+        JSON.stringify(editDate) !== JSON.stringify(entity.date ?? null) ||
+        JSON.stringify(editStartDate) !== JSON.stringify(entity.start_date ?? null) ||
+        JSON.stringify(editEndDate) !== JSON.stringify(entity.end_date ?? null)),
   );
 
   $effect(() => {
@@ -148,7 +151,7 @@
   };
 
   const guardedClose = async () => {
-    if (isEditing && isDirty) {
+    if (isDirty) {
       const confirmed = await notificationStore.confirm({
         title: "Discard changes?",
         message: "You have unsaved edits. Close the panel and discard them?",

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -58,13 +58,6 @@
   let isEditing = $state(false);
   let previousEntityId = $state<string | undefined>(undefined);
 
-  $effect(() => {
-    if (entity?.id !== previousEntityId) {
-      isEditing = false;
-      previousEntityId = entity?.id;
-    }
-  });
-
   // Edit State
   let editTitle = $state("");
   let editAliases = $state<string[]>([]);
@@ -75,6 +68,27 @@
   let editDate = $state<Entity["date"]>();
   let editStartDate = $state<Entity["start_date"]>();
   let editEndDate = $state<Entity["end_date"]>();
+
+  let isDirty = $derived(
+    isEditing &&
+      entity != null &&
+      (editTitle !== entity.title ||
+        editContent !== (entity.content ?? "") ||
+        editLore !== (entity.lore ?? "") ||
+        editType !== entity.type ||
+        editImage !== (entity.image ?? "") ||
+        JSON.stringify(editAliases) !== JSON.stringify(entity.aliases ?? [])),
+  );
+
+  $effect(() => {
+    if (entity?.id !== previousEntityId) {
+      if (isEditing && isDirty) {
+        notificationStore.notify("Unsaved changes were discarded.", "info");
+      }
+      isEditing = false;
+      previousEntityId = entity?.id;
+    }
+  });
 
   let activeTab = $state<EntityDetailTab>("status");
   let isSaving = $state(false);
@@ -119,8 +133,32 @@
     isEditing = true;
   };
 
-  const cancelEditing = () => {
+  const cancelEditing = async () => {
+    if (isDirty) {
+      const confirmed = await notificationStore.confirm({
+        title: "Discard changes?",
+        message: "You have unsaved edits. Discard them and revert to the saved version?",
+        confirmLabel: "Discard changes",
+        cancelLabel: "Keep editing",
+        isDangerous: false,
+      });
+      if (!confirmed) return;
+    }
     isEditing = false;
+  };
+
+  const guardedClose = async () => {
+    if (isEditing && isDirty) {
+      const confirmed = await notificationStore.confirm({
+        title: "Discard changes?",
+        message: "You have unsaved edits. Close the panel and discard them?",
+        confirmLabel: "Discard and close",
+        cancelLabel: "Keep editing",
+        isDangerous: false,
+      });
+      if (!confirmed) return;
+    }
+    onClose();
   };
 
   const saveChanges = async () => {
@@ -271,7 +309,7 @@
         {isEditing}
         bind:editTitle
         bind:editAliases
-        {onClose}
+        onClose={guardedClose}
       />
 
       <div
@@ -392,6 +430,7 @@
       <DetailFooter
         {isEditing}
         {isSaving}
+        {isDirty}
         onCancel={cancelEditing}
         onSave={saveChanges}
         onDelete={handleDelete}

--- a/apps/web/src/lib/components/entity-detail/DetailFooter.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailFooter.svelte
@@ -5,6 +5,7 @@
   let {
     isEditing,
     isSaving = false,
+    isDirty = false,
     onCancel,
     onSave,
     onDelete,
@@ -12,6 +13,7 @@
   } = $props<{
     isEditing: boolean;
     isSaving?: boolean;
+    isDirty?: boolean;
     onCancel: () => void;
     onSave: () => void;
     onDelete: () => void;
@@ -24,7 +26,12 @@
   style:background-image="var(--bg-texture-overlay)"
 >
   {#if isEditing}
-    <div class="flex gap-2 w-full justify-end">
+    <div class="flex gap-2 w-full justify-end items-center">
+      {#if isDirty}
+        <span class="text-[9px] text-theme-accent font-bold font-header uppercase tracking-widest animate-pulse mr-auto">
+          • Unsaved changes
+        </span>
+      {/if}
       <button
         onclick={onCancel}
         class="text-theme-muted hover:text-theme-text text-xs font-bold px-4 py-2 rounded tracking-widest transition disabled:opacity-50"


### PR DESCRIPTION
Closes #1060. Part of #947.

## Summary
- Adds `isDirty` derived state in `EntityDetailPanel` — true when any edit field differs from the saved entity
- Wraps `cancelEditing` with an async confirm dialog ("Discard changes?") when dirty
- Adds `guardedClose` wrapper that confirms before closing the panel when dirty
- Shows a pulsing **"• Unsaved changes"** indicator in the footer toolbar while editing with unsaved edits
- On entity navigation while editing+dirty, emits an "Unsaved changes were discarded" info toast (reverting the selection would require parent coordination)

## Test plan
- [ ] Edit an entity field → "• Unsaved changes" appears in footer
- [ ] Click CANCEL with unsaved changes → confirm dialog appears; choosing "Keep editing" stays in edit mode
- [ ] Click × to close panel with unsaved changes → confirm dialog appears
- [ ] Click a different entity while editing with unsaved changes → info toast shown
- [ ] Save changes normally → dirty indicator disappears
- [ ] `bun run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)