### PR TITLE
:wheelchair: feat(a11y): add modal focus trap and inert background

### DIFF
--- a/apps/web/src/lib/actions/focusTrap.ts
+++ b/apps/web/src/lib/actions/focusTrap.ts
@@ -10,9 +10,17 @@ export function focusTrap(node: HTMLElement) {
   const triggerEl = document.activeElement as HTMLElement | null;
 
   const focusable = () =>
-    [...node.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
-      (el) => !el.closest("[inert]") && el.offsetParent !== null,
-    );
+    [...node.querySelectorAll<HTMLElement>(FOCUSABLE)].filter((el) => {
+      if (el.closest("[inert]")) return false;
+      // offsetParent is null for display:none but also for position:fixed — use
+      // getComputedStyle for the latter so fixed-position children aren't skipped.
+      if (el.offsetParent === null) {
+        const style = window.getComputedStyle(el);
+        if (style.position !== "fixed" && style.position !== "sticky")
+          return false;
+      }
+      return true;
+    });
 
   // Auto-focus first focusable element
   const first = focusable()[0];

--- a/apps/web/src/lib/actions/focusTrap.ts
+++ b/apps/web/src/lib/actions/focusTrap.ts
@@ -1,0 +1,55 @@
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Svelte action: traps Tab/Shift-Tab focus within `node`, auto-focuses the
+ * first focusable child on mount, and restores focus to the triggering element
+ * on destroy. Apply to the dialog/modal root element.
+ */
+export function focusTrap(node: HTMLElement) {
+  const triggerEl = document.activeElement as HTMLElement | null;
+
+  const focusable = () =>
+    [...node.querySelectorAll<HTMLElement>(FOCUSABLE)].filter(
+      (el) => !el.closest("[inert]") && el.offsetParent !== null,
+    );
+
+  // Auto-focus first focusable element
+  const first = focusable()[0];
+  if (first) {
+    // Defer one tick so transitions don't fight focus
+    requestAnimationFrame(() => first.focus());
+  } else {
+    node.tabIndex = -1;
+    requestAnimationFrame(() => node.focus());
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key !== "Tab") return;
+    const items = focusable();
+    if (!items.length) return;
+    const firstEl = items[0];
+    const lastEl = items[items.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === firstEl || document.activeElement === node) {
+        e.preventDefault();
+        lastEl.focus();
+      }
+    } else {
+      if (document.activeElement === lastEl || document.activeElement === node) {
+        e.preventDefault();
+        firstEl.focus();
+      }
+    }
+  }
+
+  node.addEventListener("keydown", handleKeydown);
+
+  return {
+    destroy() {
+      node.removeEventListener("keydown", handleKeydown);
+      triggerEl?.focus();
+    },
+  };
+}

--- a/apps/web/src/lib/components/modals/ConfirmationModal.svelte
+++ b/apps/web/src/lib/components/modals/ConfirmationModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { fade, scale } from "svelte/transition";
   import { notificationStore } from "$lib/stores/ui/notification.svelte";
+  import { focusTrap } from "$lib/actions/focusTrap";
 
   const dialog = $derived(notificationStore.confirmationDialog);
 
@@ -39,6 +40,7 @@
       aria-modal="true"
       aria-labelledby="confirmation-modal-title"
       tabindex="-1"
+      use:focusTrap
       class="relative w-full max-w-md overflow-hidden rounded-[2rem] border border-theme-border bg-theme-surface shadow-2xl"
       transition:scale={{ duration: 250, start: 0.95 }}
       onclick={(e) => e.stopPropagation()}

--- a/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
@@ -207,6 +207,8 @@ export class ModalUIStore {
     return (
       this.showSettings ||
       this.showZenMode ||
+      this.showDiceModal ||
+      this.showCanvasSelector ||
       this.mergeDialog.open ||
       this.bulkLabelDialog.open ||
       this.relatedEntityDialog.open ||

--- a/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
@@ -202,6 +202,20 @@ export class ModalUIStore {
   closeReadMode() {
     this.closeZenMode();
   }
+
+  get isAnyModalOpen() {
+    return (
+      this.showSettings ||
+      this.showZenMode ||
+      this.mergeDialog.open ||
+      this.bulkLabelDialog.open ||
+      this.relatedEntityDialog.open ||
+      this.showVaultSwitcher ||
+      this.showShare ||
+      this.lightbox.show ||
+      this.soundBite.show
+    );
+  }
 }
 
 // The version suffix must be bumped whenever the shape of ModalUIStore changes

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -69,6 +69,13 @@
       page.url.pathname === `${base}/help` ||
       page.url.pathname === `${base}/import`,
   );
+  const anyModalOpen = $derived(
+    modalUIStore.isAnyModalOpen ||
+      searchStore.isOpen ||
+      notificationStore.confirmationDialog.open ||
+      onboardingStore.showChangelog ||
+      isMobileMenuOpen,
+  );
   const isZenPopout = $derived(
     /\/vault\/[^/]+\/entity\/[^/]+$/.test(page.url.pathname),
   );
@@ -401,29 +408,33 @@
 <div
   class="h-[var(--app-viewport-height)] bg-chrome-bg text-chrome-text flex flex-col font-body app-layout"
 >
-  <NotificationToast />
+  <!-- Background content — inert when any modal is open so keyboard/AT cannot reach it -->
+  <div class="contents" inert={anyModalOpen || undefined} aria-hidden={anyModalOpen || undefined}>
+    <NotificationToast />
 
-  {#if !isPopup && !isVttFullscreen && !isZenPopout}
-    <AppHeader bind:isMobileMenuOpen bind:headerEl />
-  {/if}
-
-  <div
-    class="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative overflow-hidden"
-  >
     {#if !isPopup && !isVttFullscreen && !isZenPopout}
-      <ActivityBar />
-      <SidebarPanelHost />
+      <AppHeader bind:isMobileMenuOpen bind:headerEl />
     {/if}
 
-    <main class="flex-1 relative flex flex-col min-h-0 overflow-y-auto">
-      {@render children()}
-    </main>
+    <div
+      class="flex-1 flex flex-col-reverse md:flex-row min-h-0 relative overflow-hidden"
+    >
+      {#if !isPopup && !isVttFullscreen && !isZenPopout}
+        <ActivityBar />
+        <SidebarPanelHost />
+      {/if}
+
+      <main class="flex-1 relative flex flex-col min-h-0 overflow-y-auto">
+        {@render children()}
+      </main>
+    </div>
+
+    {#if !isPopup && !isVttFullscreen && !isZenPopout}
+      <AppFooter />
+    {/if}
   </div>
 
-  {#if !isPopup && !isVttFullscreen && !isZenPopout}
-    <AppFooter />
-  {/if}
-
+  <!-- Modals rendered outside the inert wrapper -->
   {#if !isPopup}
     <GlobalModalProvider bind:isMobileMenuOpen />
   {/if}


### PR DESCRIPTION
Closes #1059. Part of #947.

## Summary
- Adds `src/lib/actions/focusTrap.ts` — a Svelte action that auto-focuses the first focusable element inside a dialog on mount, traps Tab/Shift-Tab cycling within it, and restores focus to the triggering element on destroy
- Applies `use:focusTrap` to `ConfirmationModal` (the most frequently used programmatic dialog)
- Adds `isAnyModalOpen` getter to `ModalUIStore` aggregating all tracked modal flags
- Wraps the background app content in a `display: contents` div that receives `inert` + `aria-hidden` when any modal is open — keyboard and screen-reader users cannot reach background content while a dialog is active

## How to apply `focusTrap` to other modals
Import and add `use:focusTrap` to the root `role="dialog"` element in any modal component.

## Test plan
- [ ] Open confirmation dialog (e.g. delete entity) → focus jumps to first button
- [ ] Tab through confirmation modal → cycles only between Cancel/Confirm buttons
- [ ] Shift-Tab wraps correctly from first to last button
- [ ] Close modal → focus returns to element that opened it
- [ ] With modal open, Tab from outside (browser address bar) → cannot reach background app content
- [ ] `bun run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)