### PR TITLE
:sparkles: feat(images): enable default CF image generation

### DIFF
--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -123,7 +123,10 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[DetailImage] Failed to save Oracle image:", err);
-        notificationStore.notify("Failed to archive image from Oracle. Check the console for details.", "error");
+        notificationStore.notify(
+          "Failed to archive image from Oracle. Check the console for details.",
+          "error",
+        );
       }
       return;
     }
@@ -145,7 +148,10 @@
         await vault.updateEntity(entity.id, { image, thumbnail });
       } catch (err) {
         debugStore.error("[DetailImage] Failed to save external file:", err);
-        notificationStore.notify("Failed to save image. Check the console for details.", "error");
+        notificationStore.notify(
+          "Failed to save image. Check the console for details.",
+          "error",
+        );
       }
     }
   }
@@ -274,7 +280,7 @@
     </div>
   {:else}
     <div class="px-4 md:px-6">
-      {#if !discoveryPolicyStore.aiDisabled && !vault.isGuest && canGenerateImage}
+      {#if !discoveryPolicyStore.aiDisabled && !vault.isGuest}
         <div
           class="mb-4 w-full py-2 md:py-4 md:h-40 rounded border border-dashed border-theme-border flex flex-col items-center justify-center gap-2 md:gap-4 text-theme-muted hover:border-theme-primary/50 transition relative overflow-hidden bg-theme-bg/30"
         >

--- a/apps/web/src/lib/components/entity-detail/DetailImage.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailImage.svelte
@@ -274,7 +274,7 @@
     </div>
   {:else}
     <div class="px-4 md:px-6">
-      {#if oracle.tier === "advanced" && !discoveryPolicyStore.aiDisabled && !vault.isGuest && (canGenerateImage || !entity.artDirection)}
+      {#if !discoveryPolicyStore.aiDisabled && !vault.isGuest && canGenerateImage}
         <div
           class="mb-4 w-full py-2 md:py-4 md:h-40 rounded border border-dashed border-theme-border flex flex-col items-center justify-center gap-2 md:gap-4 text-theme-muted hover:border-theme-primary/50 transition relative overflow-hidden bg-theme-bg/30"
         >

--- a/apps/web/src/lib/components/settings/AISettings.svelte
+++ b/apps/web/src/lib/components/settings/AISettings.svelte
@@ -327,7 +327,7 @@
               id="cfModelName"
               type="text"
               class="w-full bg-theme-bg border border-theme-border rounded px-3 py-2 text-sm"
-              placeholder="@cf/black-forest-labs/flux-1-schnell"
+              placeholder="@cf/stabilityai/stable-diffusion-xl-base-1.0"
               value={oracle.settings.cloudflareModel}
               onchange={(e) =>
                 oracle.updateSettings({

--- a/apps/web/src/lib/components/settings/AISettings.svelte
+++ b/apps/web/src/lib/components/settings/AISettings.svelte
@@ -4,6 +4,7 @@
   import InlineKeySetup from "../oracle/InlineKeySetup.svelte";
   import { notificationStore } from "$lib/stores/ui/notification.svelte";
   import { discoveryPolicyStore } from "$lib/stores/ui/discovery-policy.svelte";
+  import { DEFAULT_CF_IMAGE_MODEL } from "@codex/oracle-engine";
 
   onMount(() => {
     oracle.init();
@@ -327,7 +328,7 @@
               id="cfModelName"
               type="text"
               class="w-full bg-theme-bg border border-theme-border rounded px-3 py-2 text-sm"
-              placeholder="@cf/stabilityai/stable-diffusion-xl-base-1.0"
+              placeholder={DEFAULT_CF_IMAGE_MODEL}
               value={oracle.settings.cloudflareModel}
               onchange={(e) =>
                 oracle.updateSettings({

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -428,7 +428,7 @@
         </div>
       </button>
     {:else}
-      {#if oracle.tier === "advanced" && !discoveryPolicyStore.aiDisabled && !vault.isGuest && (oracle.apiKey || !entity?.artDirection)}
+      {#if !discoveryPolicyStore.aiDisabled && !vault.isGuest}
         <div
           class="w-full py-2 md:py-4 md:aspect-square rounded-lg border border-dashed border-theme-border flex flex-col items-center justify-center gap-2 md:gap-4 text-theme-muted bg-theme-primary/5 relative overflow-hidden"
         >
@@ -510,7 +510,7 @@
       {/if}
     {/if}
 
-    {#if oracle.tier === "advanced" && !discoveryPolicyStore.aiDisabled && entity && !editState.isEditing && !vault.isGuest}
+    {#if !discoveryPolicyStore.aiDisabled && entity && !editState.isEditing && !vault.isGuest}
       <div class="flex flex-row md:flex-col gap-2 mt-2 md:mt-4 w-full px-0">
         <button
           onclick={() => oracle.drawEntity(entity.id)}

--- a/apps/web/src/lib/stores/world.svelte.ts
+++ b/apps/web/src/lib/stores/world.svelte.ts
@@ -35,7 +35,7 @@ const worldService = new WorldServiceImplementation({
       } else if (isCloudflare) {
         targetModel =
           oracle.settings.cloudflareModel ||
-          "@cf/black-forest-labs/flux-1-schnell";
+          "@cf/stabilityai/stable-diffusion-xl-base-1.0";
       }
 
       return imageGenerationService.generateImage(

--- a/apps/web/src/lib/stores/world.svelte.ts
+++ b/apps/web/src/lib/stores/world.svelte.ts
@@ -10,6 +10,7 @@ import { vault } from "$lib/stores/vault.svelte";
 import { oracle } from "$lib/stores/oracle.svelte";
 import { imageGenerationService } from "$lib/services/ai/image-generation.service";
 import { textGenerationService } from "$lib/services/ai/text-generation.service.svelte";
+import { DEFAULT_CF_IMAGE_MODEL } from "@codex/oracle-engine";
 
 const WORLD_IMAGE_MODEL = "gemini-2.5-flash-image";
 
@@ -33,9 +34,7 @@ const worldService = new WorldServiceImplementation({
           oracle.settings.customImageModel ||
           "black-forest-labs/FLUX.1-schnell";
       } else if (isCloudflare) {
-        targetModel =
-          oracle.settings.cloudflareModel ||
-          "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+        targetModel = oracle.settings.cloudflareModel || DEFAULT_CF_IMAGE_MODEL;
       }
 
       return imageGenerationService.generateImage(

--- a/apps/workers/oracle-proxy/src/index.test.ts
+++ b/apps/workers/oracle-proxy/src/index.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { isOriginAllowed } from "./index";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { DEFAULT_CF_IMAGE_MODEL } from "../../../../packages/oracle-engine/src/image-defaults";
+import worker, { isOriginAllowed } from "./index";
 
 describe("Oracle Proxy Worker CORS", () => {
   const emptyEnv = { GEMINI_API_KEY: "test-key" };
@@ -90,5 +91,68 @@ describe("Oracle Proxy Worker CORS", () => {
     ).toBeFalsy();
     expect(isOriginAllowed("http://192.168.0.15:4173", emptyEnv)).toBeFalsy();
     expect(isOriginAllowed("file://localhost", emptyEnv)).toBeFalsy();
+  });
+});
+
+describe("Oracle Proxy Worker image generation", () => {
+  beforeEach(() => {
+    (globalThis as any).caches = {
+      default: {
+        match: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      },
+    };
+  });
+
+  const request = (body: Record<string, unknown>) =>
+    new Request(
+      "https://oracle-proxy.espen-erlandsen.workers.dev/v1/images/generations",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://codex-cryptica.com",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+  it("uses the shared Cloudflare image model when no model is provided", async () => {
+    const ai = {
+      run: vi.fn(async () => ({ image: "base64-image" })),
+    };
+
+    const response = await worker.fetch(
+      request({ prompt: "castle at sunset" }),
+      { GEMINI_API_KEY: "test-key", AI: ai },
+      {} as ExecutionContext,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      result: { image: "base64-image" },
+    });
+    expect(ai.run).toHaveBeenCalledWith(DEFAULT_CF_IMAGE_MODEL, {
+      prompt: "castle at sunset",
+    });
+  });
+
+  it("uses the requested Cloudflare image model when one is provided", async () => {
+    const ai = {
+      run: vi.fn(async () => ({ image: "base64-image" })),
+    };
+    const model = "@cf/example/custom-image-model";
+
+    const response = await worker.fetch(
+      request({ prompt: "castle at sunset", model }),
+      { GEMINI_API_KEY: "test-key", AI: ai },
+      {} as ExecutionContext,
+    );
+
+    expect(response.status).toBe(200);
+    expect(ai.run).toHaveBeenCalledWith(model, {
+      prompt: "castle at sunset",
+    });
   });
 });

--- a/apps/workers/oracle-proxy/src/index.ts
+++ b/apps/workers/oracle-proxy/src/index.ts
@@ -83,7 +83,7 @@ export default {
         const body = (await request.json()) as any;
         const prompt = body.prompt;
         const targetModel =
-          body.model || "@cf/black-forest-labs/flux-1-schnell";
+          body.model || "@cf/stabilityai/stable-diffusion-xl-base-1.0";
 
         if (!prompt) {
           return new Response(

--- a/apps/workers/oracle-proxy/src/index.ts
+++ b/apps/workers/oracle-proxy/src/index.ts
@@ -10,6 +10,8 @@
  * - ALLOW_CLOUDFLARE_PAGES_PREVIEW_ORIGINS: Optional opt-in for Pages previews
  */
 
+import { DEFAULT_CF_IMAGE_MODEL } from "../../../../packages/oracle-engine/src/image-defaults";
+
 interface Env {
   GEMINI_API_KEY: string;
   ALLOWED_ORIGINS?: string;
@@ -82,8 +84,7 @@ export default {
       try {
         const body = (await request.json()) as any;
         const prompt = body.prompt;
-        const targetModel =
-          body.model || "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+        const targetModel = body.model || DEFAULT_CF_IMAGE_MODEL;
 
         if (!prompt) {
           return new Response(

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "typescript-eslint": "^8.59.4",
         "vite": "^8.0.14",
         "vitefu": "^1.1.3",
-        "wrangler": "^4.93.1",
+        "wrangler": "^4.95.0",
       },
     },
     "apps/web": {
@@ -371,15 +371,15 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "optionalDependencies": { "workerd": "1.20260508.1" }, "peerDependencies": { "unenv": "2.0.0-rc.24" } }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260520.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7ilR8QUWpFO2RdulPuYkrwRYZxi7iuX8+11G9z97bdS7wCSFuetBsgsr2ISK7l/qzCiG5zshnfIwcdlYWD01Ag=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260526.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260520.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6LVIEI0Tx3hfcXiEM+eHsIQVsOz1IAAoAMMsRlrx+7YaNiuHMib7yWfyzAlZPhiAg1BgiS5oB8iDn7Ws1amG+Q=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260526.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260520.1", "", { "os": "linux", "cpu": "x64" }, "sha512-7oV9YK7o63aiHnpBeKlxOIA3nK4sKxuwhnklCwJFb0LirkSemSG1LQlVvtVInoWSYDCTCoUeGkiPsS8WsZqcEw=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260526.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260520.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-hzc/UKzw1/z+iTptBZVX7XYZTmJXsgn6RC9uKtQGUQxENxkoO1teba8qxVlKZT0AbPCQs5rg63Lsk0/eQhteqQ=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260526.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260520.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BjMBhXqlEPaVc68tXihFI+YcU/5T4Jmj4ELDJaEa6NuCcbUMORESgO4OJZIDS4+rC2Lkv37telOktQxEOkqY3g=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260526.1", "", { "os": "win32", "cpu": "x64" }, "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q=="],
 
     "@codex/canvas-engine": ["@codex/canvas-engine@workspace:packages/canvas-engine"],
 
@@ -1555,7 +1555,7 @@
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
-    "miniflare": ["miniflare@4.20260520.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260520.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-krgebvYME9k7CjxiveTzx89kAMeIstfK3KfTqtzLb/4mtLMD74KHtU009h/I0CTDSVIYtXm0JzJ40OtiVRGmOA=="],
+    "miniflare": ["miniflare@4.20260526.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260526.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -1732,6 +1732,14 @@
     "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.0.1", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^18.0.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg=="],
 
     "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
+
+    "rosie-skills": ["rosie-skills@0.6.4", "", { "optionalDependencies": { "rosie-skills-darwin-arm64": "0.6.4", "rosie-skills-freebsd-x64": "0.6.4", "rosie-skills-linux-x64": "0.6.4" }, "bin": { "rosie-skills": "dist/bin.js" } }, "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA=="],
+
+    "rosie-skills-darwin-arm64": ["rosie-skills-darwin-arm64@0.6.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg=="],
+
+    "rosie-skills-freebsd-x64": ["rosie-skills-freebsd-x64@0.6.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng=="],
+
+    "rosie-skills-linux-x64": ["rosie-skills-linux-x64@0.6.4", "", { "os": "linux", "cpu": "x64" }, "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
@@ -1925,9 +1933,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20260520.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260520.1", "@cloudflare/workerd-darwin-arm64": "1.20260520.1", "@cloudflare/workerd-linux-64": "1.20260520.1", "@cloudflare/workerd-linux-arm64": "1.20260520.1", "@cloudflare/workerd-windows-64": "1.20260520.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-mwW6H/NEKObeBVd0qkq91EGyOIC3TaNJBxp7kj5uChif/+qYD7nM5HE8ZYruwvEd15pRwUet+V8r21DCXCGDQQ=="],
+    "workerd": ["workerd@1.20260526.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260526.1", "@cloudflare/workerd-darwin-arm64": "1.20260526.1", "@cloudflare/workerd-linux-64": "1.20260526.1", "@cloudflare/workerd-linux-arm64": "1.20260526.1", "@cloudflare/workerd-windows-64": "1.20260526.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ=="],
 
-    "wrangler": ["wrangler@4.93.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260520.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260520.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260520.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-vV2GyKNWORysoJtryo45N2Tkk8wCnt/MTyW7wsevAAY+MiUArfJGvMiCb6SRB7pV5uWvEyIly1/rslehEjV32g=="],
+    "wrangler": ["wrangler@4.95.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260526.0", "path-to-regexp": "6.3.0", "rosie-skills": "^0.6.3", "unenv": "2.0.0-rc.24", "workerd": "1.20260526.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260526.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "4.3.0", "string-width": "4.2.3", "strip-ansi": "6.0.1" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint": "^8.59.4",
     "vite": "^8.0.14",
     "vitefu": "^1.1.3",
-    "wrangler": "^4.93.1"
+    "wrangler": "^4.95.0"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/packages/oracle-engine/src/image-defaults.ts
+++ b/packages/oracle-engine/src/image-defaults.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_CF_IMAGE_MODEL =
+  "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+
+export const DEFAULT_CUSTOM_IMAGE_MODEL = "black-forest-labs/FLUX.1-schnell";
+export const DEFAULT_CUSTOM_IMAGE_BASE_URL =
+  "https://api.together.xyz/v1/images/generations";

--- a/packages/oracle-engine/src/index.ts
+++ b/packages/oracle-engine/src/index.ts
@@ -9,3 +9,4 @@ export * from "./undo-redo.svelte";
 export * from "./drafting-engine";
 export * from "./reconciliation-context";
 export * from "./sound-bite-generator";
+export * from "./image-defaults";

--- a/packages/oracle-engine/src/oracle-settings.svelte.ts
+++ b/packages/oracle-engine/src/oracle-settings.svelte.ts
@@ -58,7 +58,7 @@ export class OracleSettingsService {
 
   cloudflareAccountId = $state<string>("");
   cloudflareApiToken = $state<string>("");
-  cloudflareModel = $state<string>("@cf/black-forest-labs/flux-1-schnell");
+  cloudflareModel = $state<string>("@cf/stabilityai/stable-diffusion-xl-base-1.0");
 
   private channel: BroadcastChannel | null = null;
   private db: AppSettingsStore | null = null;
@@ -128,7 +128,7 @@ export class OracleSettingsService {
     this.cloudflareApiToken = cfApiTokenSetting?.value ?? "";
     const cfModelSetting = await db.appSettings.get("cloudflare_model");
     this.cloudflareModel =
-      cfModelSetting?.value ?? "@cf/black-forest-labs/flux-1-schnell";
+      cfModelSetting?.value ?? "@cf/stabilityai/stable-diffusion-xl-base-1.0";
 
     this.broadcast();
   }

--- a/packages/oracle-engine/src/oracle-settings.svelte.ts
+++ b/packages/oracle-engine/src/oracle-settings.svelte.ts
@@ -1,4 +1,9 @@
 import type { ConnectionMode } from "./types";
+import {
+  DEFAULT_CF_IMAGE_MODEL,
+  DEFAULT_CUSTOM_IMAGE_MODEL,
+  DEFAULT_CUSTOM_IMAGE_BASE_URL,
+} from "./image-defaults";
 
 /**
  * Minimal interface for app settings persistence.
@@ -50,15 +55,13 @@ export class OracleSettingsService {
 
   /** Image Provider Setting */
   imageProvider = $state<"gemini" | "cloudflare" | "custom">("cloudflare");
-  customImageBaseUrl = $state<string>(
-    "https://api.together.xyz/v1/images/generations",
-  );
+  customImageBaseUrl = $state<string>(DEFAULT_CUSTOM_IMAGE_BASE_URL);
   customImageApiKey = $state<string>("");
-  customImageModel = $state<string>("black-forest-labs/FLUX.1-schnell");
+  customImageModel = $state<string>(DEFAULT_CUSTOM_IMAGE_MODEL);
 
   cloudflareAccountId = $state<string>("");
   cloudflareApiToken = $state<string>("");
-  cloudflareModel = $state<string>("@cf/stabilityai/stable-diffusion-xl-base-1.0");
+  cloudflareModel = $state<string>(DEFAULT_CF_IMAGE_MODEL);
 
   private channel: BroadcastChannel | null = null;
   private db: AppSettingsStore | null = null;
@@ -113,12 +116,11 @@ export class OracleSettingsService {
     this.imageProvider = providerSetting?.value ?? "cloudflare";
     const baseUrlSetting = await db.appSettings.get("custom_image_base_url");
     this.customImageBaseUrl =
-      baseUrlSetting?.value ?? "https://api.together.xyz/v1/images/generations";
+      baseUrlSetting?.value ?? DEFAULT_CUSTOM_IMAGE_BASE_URL;
     const apiKeySetting = await db.appSettings.get("custom_image_api_key");
     this.customImageApiKey = apiKeySetting?.value ?? "";
     const modelSetting = await db.appSettings.get("custom_image_model");
-    this.customImageModel =
-      modelSetting?.value ?? "black-forest-labs/FLUX.1-schnell";
+    this.customImageModel = modelSetting?.value ?? DEFAULT_CUSTOM_IMAGE_MODEL;
 
     const cfAccountIdSetting = await db.appSettings.get(
       "cloudflare_account_id",
@@ -127,8 +129,7 @@ export class OracleSettingsService {
     const cfApiTokenSetting = await db.appSettings.get("cloudflare_api_token");
     this.cloudflareApiToken = cfApiTokenSetting?.value ?? "";
     const cfModelSetting = await db.appSettings.get("cloudflare_model");
-    this.cloudflareModel =
-      cfModelSetting?.value ?? "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+    this.cloudflareModel = cfModelSetting?.value ?? DEFAULT_CF_IMAGE_MODEL;
 
     this.broadcast();
   }

--- a/packages/oracle-engine/src/oracle-settings.test.ts
+++ b/packages/oracle-engine/src/oracle-settings.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { OracleSettingsService } from "./oracle-settings.svelte";
+import {
+  DEFAULT_CF_IMAGE_MODEL,
+  DEFAULT_CUSTOM_IMAGE_BASE_URL,
+  DEFAULT_CUSTOM_IMAGE_MODEL,
+  OracleSettingsService,
+} from "./index";
 
 // Mock EntityDb
 class MockEntityDb {
@@ -27,6 +32,9 @@ describe("OracleSettingsService", () => {
       expect(service.isLoading).toBe(false);
       expect(service.activeStyleTitle).toBe(null);
       expect(service.imageProvider).toBe("cloudflare");
+      expect(service.customImageBaseUrl).toBe(DEFAULT_CUSTOM_IMAGE_BASE_URL);
+      expect(service.customImageModel).toBe(DEFAULT_CUSTOM_IMAGE_MODEL);
+      expect(service.cloudflareModel).toBe(DEFAULT_CF_IMAGE_MODEL);
     });
 
     it("should accept optional db in constructor", () => {
@@ -59,6 +67,9 @@ describe("OracleSettingsService", () => {
       expect(service.apiKey).toBe(null);
       expect(service.tier).toBe("lite");
       expect(service.imageProvider).toBe("cloudflare");
+      expect(service.customImageBaseUrl).toBe(DEFAULT_CUSTOM_IMAGE_BASE_URL);
+      expect(service.customImageModel).toBe(DEFAULT_CUSTOM_IMAGE_MODEL);
+      expect(service.cloudflareModel).toBe(DEFAULT_CF_IMAGE_MODEL);
     });
 
     it("should preserve gemini as image provider when no API key is set", async () => {


### PR DESCRIPTION
## Summary
- Enables Cloudflare proxy image generation as the default path for users without their own image provider credentials.
- Centralizes image generation defaults in `@codex/oracle-engine` so settings, world image generation, and the worker fallback all use the same model constants.
- Keeps saved user model settings intact while giving clean installs and unset Cloudflare model values the shared SDXL default.
- Updates Wrangler from `^4.93.1` to `^4.95.0` and refreshes `bun.lock`.

## Validation
- `bun test apps/workers/oracle-proxy/src/index.test.ts`
- `bun test packages/oracle-engine/src/oracle-settings.test.ts`
- `bun run --filter @codex/oracle-engine lint`
- Commit hook: `bun run --filter '*' lint:types`
- Pre-push hook: `bun run --filter '*' lint -- --cache --cache-strategy content`
- Pre-push hook: `BUN_NUM_THREADS=2 bun run --filter '*' test -- --changed`
- `bun x wrangler --version` -> `4.95.0`
