### PR TITLE
Fix CLS from font FOUT and SSR hydration flash

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -217,7 +217,8 @@
     min-height: var(--app-viewport-height);
   }
 
-  html.skip-landing .marketing-layer {
+  html.skip-landing .marketing-layer,
+  html.dismissed-landing .marketing-layer {
     display: none !important;
   }
 

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -12,8 +12,9 @@
 	<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<!-- First-paint fonts: workspace default theme only (Inter + Fraunces) -->
+	<!-- display=optional: skip the font swap if not in cache, eliminating FOUT-driven CLS on the landing heading -->
 	<link rel="preload" as="style"
-		href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap"
+		href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=optional"
 		onload="this.onload=null;this.rel='stylesheet'" />
 	<!-- Theme fonts: deferred until idle so they never block FCP/LCP -->
 	<script>
@@ -33,7 +34,7 @@
 	</script>
 	<noscript>
 		<link rel="stylesheet"
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Orbitron:wght@400;700&family=Share+Tech+Mono&family=Spectral:ital,wght@0,400;0,700;1,400&display=swap" />
+			href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Alegreya:ital,wght@0,400;0,700;1,400;1,700&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=Fira+Code:wght@300;500;700&family=Orbitron:wght@400;700&family=Share+Tech+Mono&family=Spectral:ital,wght@0,400;0,700;1,400&display=optional" />
 	</noscript>
 	<script src="https://accounts.google.com/gsi/client" async defer></script>
 	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
@@ -42,8 +43,14 @@
 	<script>
 		// Prevent FOUC for Skip Welcome and Theme
 		try {
-			if (localStorage.getItem("codex_skip_landing") === "true" || new URLSearchParams(window.location.search).has("demo")) {
+			var params = new URLSearchParams(window.location.search);
+			if (localStorage.getItem("codex_skip_landing") === "true" || params.has("demo")) {
 				document.documentElement.classList.add("skip-landing");
+			}
+			// Returning users who dismissed the landing: hide it before first paint
+			// to prevent the SSR-rendered marketing layer from flashing on hydration.
+			if (localStorage.getItem("codex_dismissed_landing") === "true") {
+				document.documentElement.classList.add("dismissed-landing");
 			}
 			let appearance = localStorage.getItem("codex-cryptica-app-appearance") || "system";
 			if (appearance !== "neutral-light" && appearance !== "neutral-dark" && appearance !== "system") {


### PR DESCRIPTION
## Problem

Cloudflare RUM reports CLS 0.316 (poor) at all percentiles on `codexcryptica.com/`. Investigation in #1067 found two root causes — not the SoundBiteModal that Cloudflare attributed it to.

## Root causes

**1. Font FOUT on the landing heading (primary)**

The first-paint fonts (Inter + Fraunces) use `display=swap`. The marketing layer has a `text-5xl md:text-8xl` heading in Fraunces. On a cold visit, the browser paints with the system fallback first, then swaps to Fraunces when it arrives — triggering a heading reflow that shifts everything below it.

`display=optional` eliminates this: the browser only uses the font if it's already cached (e.g. second visit, or if it loads within ~100ms). If not, the fallback sticks for that page load — no swap, no CLS. The tradeoff is the font may not show on cold visits, but a sane system-font fallback is used instead.

**2. Hydration flash for returning users (secondary)**

`onboardingStore` reads `localStorage` client-side but SSR defaults `dismissedLandingPage = false`. A returning user who dismissed the landing gets the marketing layer rendered by SSR, then Svelte removes it on hydration — a layout flash.

The existing `html.skip-landing` trick (inline script in `app.html` → CSS `display:none`) covered `codex_skip_landing` but not `codex_dismissed_landing`.

## Changes

- `app.html`: `display=swap` → `display=optional` on first-paint font URL (+ noscript fallback)
- `app.html`: extend inline pre-hydration script to check `codex_dismissed_landing` and add `dismissed-landing` class to `<html>` before first paint
- `app.css`: extend existing `.skip-landing` rule to also match `.dismissed-landing`

## Test plan

- [ ] Cold visit (cleared cache): landing page shows with system-font fallback; no heading reflow visible
- [ ] Warm visit (fonts cached): Fraunces renders immediately, no swap
- [ ] Returning user (dismissed landing): marketing layer never flashes — inspect DevTools Elements to confirm `.dismissed-landing` is on `<html>` before Svelte hydrates
- [ ] New user (no localStorage): landing shows normally, no regression

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)