### PR TITLE
feat(art-direction): theme-aware faction image prompts

### DIFF
--- a/packages/schema/src/art-direction.test.ts
+++ b/packages/schema/src/art-direction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CATEGORY_ART_DIRECTION_DEFAULTS,
+  FACTION_THEME_TEMPLATES,
   GLOBAL_ART_DIRECTION_DEFAULT,
   THEME_ART_DIRECTION_DEFAULTS,
   resolveArtDirection,
@@ -204,11 +205,39 @@ describe("art direction resolver", () => {
       GLOBAL_ART_DIRECTION_DEFAULT.template,
       ...Object.values(CATEGORY_ART_DIRECTION_DEFAULTS).map((t) => t.template),
       ...Object.values(THEME_ART_DIRECTION_DEFAULTS).map((t) => t.template),
+      ...Object.values(FACTION_THEME_TEMPLATES),
     ].join("\n");
 
     expect(shippedText).not.toMatch(
       /\b(in the style of|by artgerm|by greg rutkowski|by loish|by sakimichan|by beeple)\b/i,
     );
+  });
+
+  it("uses a theme-specific faction template when category is faction and theme has an entry", () => {
+    const result = resolveArtDirection({
+      subject: "The Iron Covenant",
+      surface: "entity",
+      categoryId: "faction",
+      themeId: "fantasy",
+    });
+
+    expect(result.source).toBe("category-default");
+    expect(result.templateId).toBe("category.faction.fantasy");
+    expect(result.prompt).toContain("heraldic banners");
+    expect(result.prompt).toContain("Oil painting style");
+  });
+
+  it("falls back to generic faction template when theme has no faction entry", () => {
+    const result = resolveArtDirection({
+      subject: "The Iron Covenant",
+      surface: "entity",
+      categoryId: "faction",
+      themeId: "workspace",
+    });
+
+    expect(result.source).toBe("category-default");
+    expect(result.templateId).toBe("category.faction");
+    expect(result.prompt).toContain("defining moment");
   });
 
   it("resolves each canonical theme id and alias correctly and includes expected text", () => {

--- a/packages/schema/src/art-direction.ts
+++ b/packages/schema/src/art-direction.ts
@@ -95,7 +95,7 @@ export const CATEGORY_ART_DIRECTION_DEFAULTS: Record<
     label: "Faction Default",
     source: "category-default",
     template:
-      "{subject}, faction visual identity with banners, colors, uniforms or regalia, symbolic motifs, and an organized group composition.",
+      "{subject}, illustration of the faction caught in a defining moment — taking tribute, guarding a stronghold, performing a ritual, raiding a convoy, or preaching to a crowd — members shown in their distinctive colours, armour, regalia, or uniforms, faction symbols and banners visible, setting and activity that reveals their social role and emotional character, cinematic composition, dramatic lighting, richly detailed costumes and environmental storytelling.",
   },
   event: {
     id: "category.event",
@@ -338,6 +338,29 @@ export const THEME_ART_DIRECTION_DEFAULTS: Record<
   },
 };
 
+const FACTION_THEME_TEMPLATES: Record<string, string> = {
+  fantasy:
+    "{subject}, a faction shown in a defining moment — taking tribute, blessing soldiers before battle, marching under heraldic banners, or guarding a sacred site — members in distinctive armour, livery, tabards, or vestments, heraldic symbols and battle standards prominent, composition that reveals their power, ideology, and social role",
+  scifi:
+    "{subject}, a faction shown in a defining moment — inspecting contested cargo, patrolling a station perimeter, broadcasting a manifesto, or claiming a new installation — members in uniform with faction insignia and ship markings, environment communicating their territory and ideology, composition that reveals their reach and methods",
+  cyberpunk:
+    "{subject}, a faction shown in a defining moment — controlling a block, shaking down rivals, broadcasting propaganda, or jacking into secured systems — members with faction implants, gang tags, and neon colours, urban environment showing their grip on the city, composition that reveals their ruthlessness and style",
+  apocalyptic:
+    "{subject}, a faction shown in a defining moment — guarding a water source, raiding a supply convoy, distributing salvage to followers, or holding a fortified ruin — members in scavenged armour painted with faction markings, wasteland environment, composition that reveals their survival strategy and authority",
+  horror:
+    "{subject}, a faction shown in a defining moment — conducting a ritual, hunting prey in shadow, inducting a new member, or convening in secret — members in cult regalia, ceremonial dress, or aristocratic decay, faction symbols and sacred objects prominent, composition that reveals their agenda and what they are willing to do",
+  fallout:
+    "{subject}, a faction shown in a defining moment — issuing rations, enforcing doctrine in a settlement, scavenging pre-war technology, or holding a vault checkpoint — members in faction jumpsuits, power armour, or scavenged gear with painted insignia, retro-futurist wasteland environment, composition that reveals their ideology and claim to order",
+  starwars:
+    "{subject}, a faction shown in a defining moment — assembling forces, accepting a surrender, guarding a sacred site, or conducting a diplomatic exchange — members in faction uniforms, armour, or robes with clear allegiance markings, capital ships or iconic architecture establishing scale, composition that conveys their place in the galactic order",
+  startrek:
+    "{subject}, a faction shown in a defining moment — negotiating a treaty, conducting a joint survey, commanding a vessel during crisis, or establishing first contact — members with clear rank and division markings, starship or station environment, composition that reveals their values, methods, and place in the interstellar community",
+  lancer:
+    "{subject}, a faction shown in a defining moment — deploying mechs for a theatre operation, issuing mission orders, holding contested ground, or processing field intelligence — members in tactical uniform or mech pilot suits with faction insignia, military hardware and operational banners visible, composition that reveals their command structure and combat doctrine",
+  modern:
+    "{subject}, a faction shown in a defining moment — holding a press conference, coordinating a field operation, making an arrest, or rallying supporters — members in contemporary uniform, suit, or civilian dress with faction identifiers, real-world institutional setting, composition that reveals their social function and source of power",
+};
+
 const CATEGORY_ALIASES: Record<string, string> = {
   npc: "character",
   person: "character",
@@ -409,9 +432,20 @@ export function resolveArtDirection(
   let source: ArtDirectionSource = "global-default";
   let templateId: string | undefined = GLOBAL_ART_DIRECTION_DEFAULT.id;
 
-  const categoryTemplate = categoryId
-    ? CATEGORY_ART_DIRECTION_DEFAULTS[categoryId]
-    : undefined;
+  const factionThemeTemplate =
+    categoryId === "faction" && themeId && FACTION_THEME_TEMPLATES[themeId]
+      ? {
+          id: `category.faction.${themeId}`,
+          label: `Faction ${themeId} Default`,
+          source: "category-default" as ArtDirectionSource,
+          template: FACTION_THEME_TEMPLATES[themeId],
+        }
+      : undefined;
+  const categoryTemplate = factionThemeTemplate
+    ? factionThemeTemplate
+    : categoryId
+      ? CATEGORY_ART_DIRECTION_DEFAULTS[categoryId]
+      : undefined;
   const themeTemplate = themeId
     ? THEME_ART_DIRECTION_DEFAULTS[themeId]
     : undefined;

--- a/packages/schema/src/art-direction.ts
+++ b/packages/schema/src/art-direction.ts
@@ -338,7 +338,7 @@ export const THEME_ART_DIRECTION_DEFAULTS: Record<
   },
 };
 
-const FACTION_THEME_TEMPLATES: Record<string, string> = {
+export const FACTION_THEME_TEMPLATES: Record<string, string> = {
   fantasy:
     "{subject}, a faction shown in a defining moment — taking tribute, blessing soldiers before battle, marching under heraldic banners, or guarding a sacred site — members in distinctive armour, livery, tabards, or vestments, heraldic symbols and battle standards prominent, composition that reveals their power, ideology, and social role",
   scifi:


### PR DESCRIPTION
## Summary

- Rewrites the generic faction category template with a **defining-moment scene framing** — activity + visual identifiers + composition intent — replacing the old static group-portrait prompt
- Adds `FACTION_THEME_TEMPLATES`: per-theme faction scene descriptions for all 10 world themes, giving the AI genre-appropriate activities and iconography:
  - **Fantasy** → tribute, heraldic banners, sacred site guard
  - **Sci-Fi** → cargo inspection, station patrol, manifesto broadcast
  - **Cyberpunk** → block control, rival shakedown, propaganda hack
  - **Apocalyptic** → water source guard, convoy raid, salvage distribution
  - **Horror** → ritual, induction, secret convening
  - **Fallout** → ration issue, doctrine enforcement, vault checkpoint
  - **Star Wars** → force assembly, surrender, diplomatic exchange
  - **Star Trek** → treaty negotiation, joint survey, first contact
  - **Lancer** → mech deployment, mission orders, contested theatre
  - **Modern** → press conference, field operation, rally
- Theme art-direction templates still handle medium/palette — faction templates only define scene content
- Falls back to the generic faction template for any theme without a specific entry

## Test plan

- [ ] Schema tests pass: `cd packages/schema && bun run test`
- [ ] Generate a faction image under fantasy — scene should reference banners/battle/tribute, rendered in oil painting style
- [ ] Generate a faction image under lancer — scene should reference mechs/mission orders, rendered in tactical style
- [ ] Generate a faction image under a theme with no entry (e.g. workspace) — should fall back gracefully to generic template

🤖 Generated with [Claude Code](https://claude.com/claude-code)