### PR TITLE
:sparkles: Add prompt review and reusable art prompts

### DIFF
--- a/apps/web/src/lib/components/layout/NotificationToast.svelte
+++ b/apps/web/src/lib/components/layout/NotificationToast.svelte
@@ -8,7 +8,7 @@
 {#if notification}
   <div
     data-testid="toast-{notification.type}"
-    class="fixed top-20 left-1/2 -translate-x-1/2 z-[1001] px-6 py-3 rounded-lg shadow-2xl border flex items-center gap-3 animate-in slide-in-from-top-4 fade-in"
+    class="fixed top-20 left-1/2 z-[1001] flex max-w-[min(92vw,44rem)] -translate-x-1/2 items-center gap-3 rounded-lg border px-4 py-3 pr-3 shadow-2xl animate-in slide-in-from-top-4 fade-in"
     class:bg-theme-surface={true}
     class:border-theme-primary={notification.type === "success"}
     class:text-theme-primary={notification.type === "success"}
@@ -31,7 +31,7 @@
       class="icon-[lucide--alert-circle] w-5 h-5"
       class:hidden={notification.type !== "error"}
     ></span>
-    <span class="font-header text-xs font-bold tracking-widest uppercase"
+    <span class="font-header text-xs font-bold uppercase tracking-widest"
       >{notification.message}</span
     >
     {#if notification.persistent}
@@ -50,5 +50,14 @@
         ></span>
       </span>
     {/if}
+    <button
+      type="button"
+      class="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-current/20 opacity-70 transition hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-current/40"
+      aria-label="Dismiss notification"
+      title="Dismiss"
+      onclick={() => notificationStore.clearNotification()}
+    >
+      <span class="icon-[lucide--x] h-4 w-4"></span>
+    </button>
   </div>
 {/if}

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -186,6 +186,14 @@
       {/await}
     {/if}
 
+    {#if modalUIStore.imagePromptReview.open}
+      {#await loadModal(() => import("./ImagePromptReviewModal.svelte"), "ImagePromptReviewModal") then ImagePromptReviewModal}
+        {#if ImagePromptReviewModal}
+          <ImagePromptReviewModal />
+        {/if}
+      {/await}
+    {/if}
+
     <!-- Global Image Lightbox -->
     {#if hasOpenedLightbox}
       {#await loadModal(() => import("$lib/components/zen/ZenImageLightbox.svelte"), "ZenImageLightbox") then ZenImageLightbox}

--- a/apps/web/src/lib/components/modals/ImagePromptReviewModal.svelte
+++ b/apps/web/src/lib/components/modals/ImagePromptReviewModal.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { fade, scale } from "svelte/transition";
+  import { focusTrap } from "$lib/actions/focusTrap";
+  import { oracle } from "$lib/stores/oracle.svelte";
+  import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+  import { notificationStore } from "$lib/stores/ui/notification.svelte";
+
+  const dialog = $derived(modalUIStore.imagePromptReview);
+  const target = $derived(dialog.target);
+  let editedPrompt = $state("");
+  let error = $state("");
+  let isRegeneratingPrompt = $state(false);
+
+  $effect(() => {
+    if (dialog.open) {
+      editedPrompt = dialog.prompt;
+      error = "";
+      isRegeneratingPrompt = false;
+    }
+  });
+
+  const isGenerating = $derived.by(() => {
+    if (!target) return false;
+    return target.kind === "entity"
+      ? oracle.isVisualizingEntity(target.id)
+      : oracle.isVisualizingMessage(target.id);
+  });
+  const isBusy = $derived(isGenerating || isRegeneratingPrompt);
+
+  const handleCancel = () => {
+    if (isBusy) return;
+    modalUIStore.closeImagePromptReview();
+  };
+
+  const handleSubmit = async (event: SubmitEvent) => {
+    event.preventDefault();
+    if (!target || isBusy) return;
+
+    const prompt = editedPrompt.trim();
+    if (!prompt) {
+      error = "Prompt is required.";
+      return;
+    }
+
+    error = "";
+    if (target.kind === "entity") {
+      await oracle.generateEntityFromPrompt(target.id, prompt);
+    } else {
+      await oracle.generateMessageFromPrompt(target.id, prompt);
+    }
+    modalUIStore.closeImagePromptReview();
+  };
+
+  const copyPrompt = async () => {
+    await navigator.clipboard.writeText(editedPrompt);
+    notificationStore.notify("Copied image prompt", "success");
+  };
+
+  const regeneratePrompt = async () => {
+    if (!target || isBusy) return;
+
+    isRegeneratingPrompt = true;
+    error = "";
+    try {
+      const prompt =
+        target.kind === "entity"
+          ? await oracle.regenerateEntityPrompt(target.id)
+          : await oracle.regenerateMessagePrompt(target.id);
+      if (prompt?.trim()) {
+        editedPrompt = prompt.trim();
+      } else {
+        error = "Could not regenerate a prompt.";
+      }
+    } catch (err) {
+      error =
+        err instanceof Error ? err.message : "Could not regenerate a prompt.";
+    } finally {
+      isRegeneratingPrompt = false;
+    }
+  };
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (!dialog.open) return;
+    if (event.key === "Escape") {
+      handleCancel();
+    }
+  };
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if dialog.open && target}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-[210] flex items-center justify-center bg-black/85 p-3 backdrop-blur-md md:p-6"
+    transition:fade={{ duration: 160 }}
+    onclick={handleCancel}
+  >
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="image-prompt-title"
+      aria-describedby="image-prompt-help"
+      tabindex="-1"
+      use:focusTrap
+      class="relative flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-theme-border bg-theme-surface shadow-2xl"
+      transition:scale={{ duration: 180, start: 0.97 }}
+      onclick={(event) => event.stopPropagation()}
+    >
+      <form class="flex min-h-0 flex-1 flex-col" onsubmit={handleSubmit}>
+        <div
+          class="flex items-start justify-between gap-4 border-b border-theme-border px-4 py-4 md:px-6"
+        >
+          <div class="min-w-0">
+            <h2
+              id="image-prompt-title"
+              class="font-header text-sm font-bold uppercase tracking-widest text-theme-primary"
+            >
+              Review Image Prompt
+            </h2>
+            <p
+              id="image-prompt-help"
+              class="mt-1 truncate text-xs text-theme-muted"
+            >
+              {target.title}
+            </p>
+          </div>
+          <button
+            type="button"
+            onclick={handleCancel}
+            disabled={isBusy}
+            class="flex h-9 w-9 shrink-0 items-center justify-center rounded border border-theme-border text-theme-muted transition hover:border-theme-primary hover:text-theme-primary disabled:cursor-wait disabled:opacity-50"
+            aria-label="Close prompt review"
+            title="Close"
+          >
+            <span class="icon-[lucide--x] h-4 w-4"></span>
+          </button>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-4 py-4 md:px-6">
+          <label
+            for="image-prompt-review-text"
+            class="mb-2 block text-[10px] font-bold uppercase tracking-widest text-theme-secondary"
+          >
+            Prompt
+          </label>
+          <textarea
+            id="image-prompt-review-text"
+            name="prompt"
+            bind:value={editedPrompt}
+            required
+            rows="14"
+            aria-describedby={error
+              ? "image-prompt-error"
+              : "image-prompt-help"}
+            class="min-h-72 w-full resize-y rounded border border-theme-border bg-theme-bg/60 p-3 font-body text-sm leading-relaxed text-theme-text outline-none transition focus:border-theme-primary focus:ring-1 focus:ring-theme-primary"
+          ></textarea>
+          {#if error}
+            <p
+              id="image-prompt-error"
+              class="mt-2 text-xs font-bold text-red-400"
+              aria-live="polite"
+            >
+              {error}
+            </p>
+          {/if}
+        </div>
+
+        <div
+          class="flex flex-col-reverse gap-2 border-t border-theme-border bg-theme-bg/30 px-4 py-4 md:flex-row md:justify-end md:px-6"
+        >
+          <button
+            type="button"
+            onclick={copyPrompt}
+            disabled={isBusy}
+            class="inline-flex min-h-11 items-center justify-center gap-2 rounded border border-theme-border bg-theme-surface px-4 py-2 text-xs font-bold uppercase tracking-widest text-theme-muted transition hover:border-theme-primary hover:text-theme-primary disabled:cursor-wait disabled:opacity-50"
+          >
+            <span class="icon-[lucide--copy] h-4 w-4"></span>
+            Copy
+          </button>
+          <button
+            type="button"
+            onclick={regeneratePrompt}
+            disabled={isBusy}
+            aria-busy={isRegeneratingPrompt}
+            class="inline-flex min-h-11 items-center justify-center gap-2 rounded border border-theme-border bg-theme-surface px-4 py-2 text-xs font-bold uppercase tracking-widest text-theme-muted transition hover:border-theme-primary hover:text-theme-primary disabled:cursor-wait disabled:opacity-50"
+          >
+            {#if isRegeneratingPrompt}
+              <span class="icon-[lucide--loader-2] h-4 w-4 animate-spin"></span>
+              Regenerating
+            {:else}
+              <span class="icon-[lucide--refresh-cw] h-4 w-4"></span>
+              Regenerate Prompt
+            {/if}
+          </button>
+          <button
+            type="button"
+            onclick={handleCancel}
+            disabled={isBusy}
+            class="inline-flex min-h-11 items-center justify-center rounded border border-theme-border bg-theme-surface px-4 py-2 text-xs font-bold uppercase tracking-widest text-theme-muted transition hover:text-theme-text disabled:cursor-wait disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isBusy}
+            aria-busy={isGenerating}
+            class="inline-flex min-h-11 items-center justify-center gap-2 rounded border border-theme-primary bg-theme-primary px-4 py-2 text-xs font-bold uppercase tracking-widest text-theme-bg transition hover:bg-theme-secondary disabled:cursor-wait disabled:opacity-60"
+          >
+            {#if isGenerating}
+              <span class="icon-[lucide--loader-2] h-4 w-4 animate-spin"></span>
+              Generating
+            {:else}
+              <span class="icon-[lucide--image-plus] h-4 w-4"></span>
+              Generate
+            {/if}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}

--- a/apps/web/src/lib/components/world/FrontPage.test.ts
+++ b/apps/web/src/lib/components/world/FrontPage.test.ts
@@ -343,7 +343,7 @@ describe("FrontPage", () => {
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Theme Style: Moonfall. Digital concept art style",
+        "Theme Style: Moonfall. Cyberpunk digital concept art style",
       ),
     );
     expect(mocks.generateCoverImage).toHaveBeenCalledWith(

--- a/apps/web/src/lib/services/ai/api-error-classifier.test.ts
+++ b/apps/web/src/lib/services/ai/api-error-classifier.test.ts
@@ -26,6 +26,20 @@ describe("classifyApiError", () => {
     expect(result.type).toBe("rate-limit");
   });
 
+  it("preserves explicit proxy daily image limit guidance", () => {
+    vi.stubGlobal("navigator", { onLine: true });
+    const result = classifyApiError(
+      new Error(
+        "Proxy Cloudflare Image Generation Error (@cf/model): Daily image generation limit exceeded. Please try again tomorrow, or configure your own Cloudflare Account ID and API Token in settings.",
+      ),
+    );
+
+    expect(result.type).toBe("rate-limit");
+    expect(result.message).toBe(
+      "Daily image generation limit exceeded. Please try again tomorrow, or configure your own Cloudflare Account ID and API Token in settings.",
+    );
+  });
+
   it("returns quota for RESOURCE_EXHAUSTED errors", () => {
     vi.stubGlobal("navigator", { onLine: true });
     const result = classifyApiError(

--- a/apps/web/src/lib/services/ai/api-error-classifier.ts
+++ b/apps/web/src/lib/services/ai/api-error-classifier.ts
@@ -18,6 +18,13 @@ export function classifyApiError(err: unknown): ClassifiedError {
     };
   }
   const msg = err instanceof Error ? err.message : String(err);
+  const explicitRateLimitMessage = extractExplicitRateLimitMessage(msg);
+  if (explicitRateLimitMessage) {
+    return {
+      type: "rate-limit",
+      message: explicitRateLimitMessage,
+    };
+  }
   if (/429|rate.?limit/i.test(msg)) {
     return {
       type: "rate-limit",
@@ -37,4 +44,11 @@ export function classifyApiError(err: unknown): ClassifiedError {
     };
   }
   return { type: "unknown", message: "Generation failed. Please try again." };
+}
+
+function extractExplicitRateLimitMessage(message: string): string | null {
+  const dailyLimitMatch = message.match(
+    /(Daily image generation limit exceeded\.[\s\S]*)$/i,
+  );
+  return dailyLimitMatch?.[1]?.trim() || null;
 }

--- a/apps/web/src/lib/services/ai/image-generation.service.test.ts
+++ b/apps/web/src/lib/services/ai/image-generation.service.test.ts
@@ -65,7 +65,7 @@ describe("DefaultImageGenerationService", () => {
 
     it("should preserve a resolved art direction query when context is missing", async () => {
       const resolvedPrompt =
-        "Almos, full character concept art with readable silhouette";
+        "Almos, full-body character concept art with readable silhouette";
 
       const result = await service.distillVisualPrompt(
         "key",
@@ -304,8 +304,13 @@ describe("DefaultImageGenerationService", () => {
           headers: expect.objectContaining({
             Authorization: "Bearer cf-token",
           }),
+          body: expect.any(FormData),
         }),
       );
+      const body = (global.fetch as any).mock.calls[0][1].body as FormData;
+      expect(body.get("prompt")).toBe("prompt");
+      expect(body.get("width")).toBe("1024");
+      expect(body.get("height")).toBe("1024");
       expect(blob).toBeInstanceOf(Blob);
       expect(await blob.text()).toBe("cloudflare-image");
     });
@@ -342,6 +347,60 @@ describe("DefaultImageGenerationService", () => {
       );
       expect(blob).toBeInstanceOf(Blob);
       expect(await blob.text()).toBe("proxy-cloudflare-image");
+    });
+
+    it("should preserve proxy Cloudflare daily image limit guidance", async () => {
+      (global.fetch as any).mockResolvedValue({
+        ok: false,
+        statusText: "Too Many Requests",
+        json: () =>
+          Promise.resolve({
+            error: {
+              message:
+                "Daily image generation limit exceeded. Please try again tomorrow, or configure your own Cloudflare Account ID and API Token in settings.",
+              code: "RATE_LIMIT_EXCEEDED",
+            },
+          }),
+      });
+
+      await expect(
+        service.generateImage(
+          "",
+          "prompt",
+          "@cf/black-forest-labs/flux-2-klein-4b",
+          {
+            provider: "cloudflare",
+          },
+        ),
+      ).rejects.toThrow(
+        "Daily image generation limit exceeded. Please try again tomorrow, or configure your own Cloudflare Account ID and API Token in settings.",
+      );
+    });
+
+    it("should process a raw Cloudflare Workers AI image payload", async () => {
+      const mockImageData = "ZGVidWctaW1hZ2U="; // "debug-image" in base64
+      (global.fetch as any).mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            result: {
+              image: `data:image/png;base64,\n${mockImageData}\n`,
+            },
+          }),
+      });
+
+      const blob = await service.generateImage(
+        "",
+        "prompt",
+        "@cf/black-forest-labs/flux-2-klein-4b",
+        {
+          provider: "cloudflare",
+        },
+      );
+
+      expect(blob.type).toBe("image/png");
+      expect(await blob.text()).toBe("debug-image");
     });
 
     it("should fail fast when Cloudflare account ID is provided but API token is missing", async () => {

--- a/apps/web/src/lib/services/ai/image-generation.service.ts
+++ b/apps/web/src/lib/services/ai/image-generation.service.ts
@@ -93,15 +93,16 @@ export class DefaultImageGenerationService implements ImageGenerationService {
             `[ImageGenerationService] Generating image via direct Cloudflare Workers AI: ${modelName}`,
           );
           const url = `https://api.cloudflare.com/client/v4/accounts/${cfAccountId}/ai/run/${modelName}`;
+          const form = new FormData();
+          form.append("prompt", prompt);
+          form.append("width", "1024");
+          form.append("height", "1024");
           const response = await fetch(url, {
             method: "POST",
             headers: {
-              "Content-Type": "application/json",
               Authorization: `Bearer ${cfApiToken}`,
             },
-            body: JSON.stringify({
-              prompt: prompt,
-            }),
+            body: form,
           });
 
           if (!response.ok) {
@@ -272,7 +273,11 @@ export class DefaultImageGenerationService implements ImageGenerationService {
 
     // Find the part containing image data
     const imagePart = parts.find((p: any) => p.inlineData);
-    const base64Data = imagePart?.inlineData?.data;
+    const directImageData =
+      typeof data?.result?.image === "string" ? data.result.image : undefined;
+    const base64Data = this.cleanBase64ImageData(
+      imagePart?.inlineData?.data || directImageData,
+    );
 
     if (!base64Data) {
       // Fallback for text-only responses or errors
@@ -296,12 +301,29 @@ export class DefaultImageGenerationService implements ImageGenerationService {
         bytes[i] = binaryString.charCodeAt(i);
       }
 
-      const mimeType = imagePart.inlineData.mimeType || "image/png";
+      const mimeType =
+        imagePart?.inlineData?.mimeType ||
+        this.inferMimeTypeFromBase64(base64Data) ||
+        "image/png";
       return new Blob([bytes], { type: mimeType });
     } catch (e) {
       console.error("[ImageGenerationService] Failed to decode base64:", e);
       throw new Error("Failed to process image data from AI", { cause: e });
     }
+  }
+
+  private cleanBase64ImageData(value?: string): string | undefined {
+    if (!value) return undefined;
+    const trimmed = value.trim();
+    const dataUrlMatch = trimmed.match(/^data:([^;]+);base64,([\s\S]+)$/i);
+    return (dataUrlMatch?.[2] || trimmed).replace(/\s+/g, "");
+  }
+
+  private inferMimeTypeFromBase64(value: string): string | undefined {
+    if (value.startsWith("iVBORw0KGgo")) return "image/png";
+    if (value.startsWith("/9j/")) return "image/jpeg";
+    if (value.startsWith("UklGR")) return "image/webp";
+    return undefined;
   }
 }
 

--- a/apps/web/src/lib/services/ai/prompts/visual-distillation.test.ts
+++ b/apps/web/src/lib/services/ai/prompts/visual-distillation.test.ts
@@ -24,6 +24,13 @@ describe("visual-distillation prompts", () => {
       expect(result).toContain("cat");
       expect(result).toContain("CanonSummary");
       expect(result).toContain("Visual Prompt Architect");
+      expect(result).toContain(
+        "Preserve all explicit theme, genre, medium, palette, lighting, and material directives",
+      );
+      expect(result).toContain("Keep named genre/style anchors verbatim");
+      expect(result).toContain(
+        "carry the theme information into the final prompt",
+      );
     });
   });
 

--- a/apps/web/src/lib/services/ai/prompts/visual-distillation.ts
+++ b/apps/web/src/lib/services/ai/prompts/visual-distillation.ts
@@ -52,6 +52,9 @@ ORIGINAL REQUEST:
 ${u(userQuery)}
 
 GUIDELINES:
+- Preserve all explicit theme, genre, medium, palette, lighting, and material directives from the original request in the final prompt. Treat theme/default-art-style language as required art direction, not optional flavor.
+- Keep named genre/style anchors verbatim when present, such as "Cyberpunk", "gothic horror", "oil painting", "photographic", "noir", or "pulp adventure", unless they directly conflict with stronger vault canon.
+- If the original request includes a composed category + theme + global art direction, carry the theme information into the final prompt even while reducing repetition.
 - Prioritize concrete, visual details (e.g., specific clothing materials, physical features, worn gear, posture, and facial expressions) over abstract character names or name repetition.
 - Emphasize distinctive setting identity and preserve cultural specificity.
 - Ground the mood in environmental storytelling, lighting, and architecture.

--- a/apps/web/src/lib/stores/oracle.svelte.test.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.test.ts
@@ -234,6 +234,10 @@ describe("OracleStore", () => {
       }),
       drawEntity: vi.fn(),
       drawMessage: vi.fn(),
+      prepareEntityPrompt: vi.fn().mockResolvedValue({ prompt: "prompt" }),
+      prepareMessagePrompt: vi.fn().mockResolvedValue({ prompt: "prompt" }),
+      generateEntityFromPrompt: vi.fn(),
+      generateMessageFromPrompt: vi.fn(),
     };
 
     const mockDiceHistory = {
@@ -322,9 +326,15 @@ describe("OracleStore", () => {
 
   describe("Domain Operations", () => {
     it("should handle drawEntity", async () => {
-      mockExecutor.drawEntity = vi.fn().mockResolvedValue(undefined);
+      mockVault.entities["entity-1"] = {
+        id: "entity-1",
+        title: "Entity One",
+      } as any;
+      mockExecutor.prepareEntityPrompt = vi
+        .fn()
+        .mockResolvedValue({ prompt: "prompt" });
       await oracle.drawEntity("entity-1");
-      expect(mockExecutor.drawEntity).toHaveBeenCalledWith(
+      expect(mockExecutor.prepareEntityPrompt).toHaveBeenCalledWith(
         "entity-1",
         expect.any(Object),
       );
@@ -332,10 +342,14 @@ describe("OracleStore", () => {
 
     it("should track visualizing state for an entity draw", async () => {
       let resolveDraw!: () => void;
-      mockExecutor.drawEntity = vi.fn(
+      mockVault.entities["entity-1"] = {
+        id: "entity-1",
+        title: "Entity One",
+      } as any;
+      mockExecutor.prepareEntityPrompt = vi.fn(
         () =>
-          new Promise<void>((resolve) => {
-            resolveDraw = resolve;
+          new Promise<{ prompt: string }>((resolve) => {
+            resolveDraw = () => resolve({ prompt: "prompt" });
           }),
       );
 
@@ -352,9 +366,11 @@ describe("OracleStore", () => {
     });
 
     it("should handle drawMessage", async () => {
-      mockExecutor.drawMessage = vi.fn().mockResolvedValue(undefined);
+      mockExecutor.prepareMessagePrompt = vi
+        .fn()
+        .mockResolvedValue({ prompt: "prompt" });
       await oracle.drawMessage("msg-1");
-      expect(mockExecutor.drawMessage).toHaveBeenCalledWith(
+      expect(mockExecutor.prepareMessagePrompt).toHaveBeenCalledWith(
         "msg-1",
         expect.any(Object),
       );

--- a/apps/web/src/lib/stores/oracle.svelte.ts
+++ b/apps/web/src/lib/stores/oracle.svelte.ts
@@ -387,6 +387,22 @@ export class OracleStore implements IOracleStore {
     await this.actions.drawMessage(messageId);
   }
 
+  async generateEntityFromPrompt(entityId: string, prompt: string) {
+    await this.actions.generateEntityFromPrompt(entityId, prompt);
+  }
+
+  async generateMessageFromPrompt(messageId: string, prompt: string) {
+    await this.actions.generateMessageFromPrompt(messageId, prompt);
+  }
+
+  async regenerateEntityPrompt(entityId: string): Promise<string | null> {
+    return this.actions.regenerateEntityPrompt(entityId);
+  }
+
+  async regenerateMessagePrompt(messageId: string): Promise<string | null> {
+    return this.actions.regenerateMessagePrompt(messageId);
+  }
+
   isVisualizingEntity(entityId: string | null | undefined) {
     return this.ui.isVisualizingEntity(entityId);
   }

--- a/apps/web/src/lib/stores/oracle/action-manager.svelte.ts
+++ b/apps/web/src/lib/stores/oracle/action-manager.svelte.ts
@@ -1,6 +1,7 @@
 import { appEventBus } from "@codex/events";
 import { ORACLE_EVENTS } from "@codex/oracle-engine";
 import type { IOracleStore } from "./types";
+import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 
 export class OracleActionManager {
   constructor(private store: IOracleStore) {}
@@ -43,10 +44,29 @@ export class OracleActionManager {
 
     this.store.ui.visualizingEntityId = entityId;
     try {
-      await this.store.executor.drawEntity(
+      const entity = this.store.vault.entities[entityId];
+      if (!entity) return;
+
+      if (entity.artDirection?.trim()) {
+        modalUIStore.openImagePromptReview(
+          { kind: "entity", id: entityId, title: entity.title },
+          entity.artDirection.trim(),
+        );
+        return;
+      }
+
+      const result = await this.store.executor.prepareEntityPrompt(
         entityId,
         this.store.getExecutionContext(),
       );
+      if (result) {
+        modalUIStore.openImagePromptReview(
+          { kind: "entity", id: entityId, title: entity.title },
+          result.prompt,
+        );
+      }
+    } catch (err) {
+      this.notifyImageGenerationFailure(err);
     } finally {
       if (this.store.ui.visualizingEntityId === entityId) {
         this.store.ui.visualizingEntityId = null;
@@ -59,15 +79,111 @@ export class OracleActionManager {
 
     this.store.ui.visualizingMessageId = messageId;
     try {
-      await this.store.executor.drawMessage(
+      const message = this.store.chatHistoryService.messages.find(
+        (m: any) => m.id === messageId,
+      );
+      const linkedEntity = message?.entityId
+        ? this.store.vault.entities[message.entityId]
+        : null;
+      if (message && linkedEntity?.artDirection?.trim()) {
+        modalUIStore.openImagePromptReview(
+          {
+            kind: "message",
+            id: messageId,
+            title: linkedEntity.title,
+            entityId: message.entityId,
+          },
+          linkedEntity.artDirection.trim(),
+        );
+        return;
+      }
+
+      const result = await this.store.executor.prepareMessagePrompt(
         messageId,
         this.store.getExecutionContext(),
       );
+      if (result && message) {
+        modalUIStore.openImagePromptReview(
+          {
+            kind: "message",
+            id: messageId,
+            title: linkedEntity?.title || "Oracle image",
+            entityId: message.entityId,
+          },
+          result.prompt,
+        );
+      }
+    } catch (err) {
+      this.notifyImageGenerationFailure(err);
     } finally {
       if (this.store.ui.visualizingMessageId === messageId) {
         this.store.ui.visualizingMessageId = null;
       }
     }
+  }
+
+  async generateEntityFromPrompt(entityId: string, prompt: string) {
+    if (this.store.ui.visualizingEntityId === entityId) return;
+
+    this.store.ui.visualizingEntityId = entityId;
+    try {
+      await this.store.vault.updateEntity(entityId, { artDirection: prompt });
+      await this.store.executor.generateEntityFromPrompt(
+        entityId,
+        prompt,
+        this.store.getExecutionContext(),
+      );
+    } catch (err) {
+      this.notifyImageGenerationFailure(err);
+    } finally {
+      if (this.store.ui.visualizingEntityId === entityId) {
+        this.store.ui.visualizingEntityId = null;
+      }
+    }
+  }
+
+  async generateMessageFromPrompt(messageId: string, prompt: string) {
+    if (this.store.ui.visualizingMessageId === messageId) return;
+
+    this.store.ui.visualizingMessageId = messageId;
+    try {
+      const message = this.store.chatHistoryService.messages.find(
+        (m: any) => m.id === messageId,
+      );
+      if (message?.entityId) {
+        await this.store.vault.updateEntity(message.entityId, {
+          artDirection: prompt,
+        });
+      }
+      await this.store.executor.generateMessageFromPrompt(
+        messageId,
+        prompt,
+        this.store.getExecutionContext(),
+      );
+    } catch (err) {
+      this.notifyImageGenerationFailure(err);
+    } finally {
+      if (this.store.ui.visualizingMessageId === messageId) {
+        this.store.ui.visualizingMessageId = null;
+      }
+    }
+  }
+
+  async regenerateEntityPrompt(entityId: string): Promise<string | null> {
+    const result = await this.store.executor.prepareEntityPrompt(
+      entityId,
+      this.store.getExecutionContext(),
+      { ignoreSavedArtDirection: true },
+    );
+    return result?.prompt ?? null;
+  }
+
+  async regenerateMessagePrompt(messageId: string): Promise<string | null> {
+    const result = await this.store.executor.prepareMessagePrompt(
+      messageId,
+      this.store.getExecutionContext(),
+    );
+    return result?.prompt ?? null;
   }
 
   pushUndoAction(
@@ -77,5 +193,16 @@ export class OracleActionManager {
     redo?: () => Promise<void>,
   ) {
     this.store.undoRedo.pushUndoAction(description, undo, messageId, redo);
+  }
+
+  private notifyImageGenerationFailure(err: unknown) {
+    const message =
+      err instanceof Error && err.message
+        ? err.message
+        : "Image generation failed. Please try again.";
+    this.store.notificationStore.notify(
+      message.startsWith("❌") ? message : `❌ ${message}`,
+      "error",
+    );
   }
 }

--- a/apps/web/src/lib/stores/oracle/tests/action-manager.test.ts
+++ b/apps/web/src/lib/stores/oracle/tests/action-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { OracleActionManager } from "../action-manager.svelte";
+import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 import type { IOracleStore } from "../types";
 
 describe("OracleActionManager", () => {
@@ -13,6 +14,10 @@ describe("OracleActionManager", () => {
       execute: vi.fn(),
       drawEntity: vi.fn(),
       drawMessage: vi.fn(),
+      prepareEntityPrompt: vi.fn().mockResolvedValue({ prompt: "prompt" }),
+      prepareMessagePrompt: vi.fn().mockResolvedValue({ prompt: "prompt" }),
+      generateEntityFromPrompt: vi.fn(),
+      generateMessageFromPrompt: vi.fn(),
     };
     mockUndoRedo = {
       undo: vi.fn(),
@@ -24,8 +29,30 @@ describe("OracleActionManager", () => {
       undoRedo: mockUndoRedo,
       getExecutionContext: vi.fn(),
       ui: { visualizingEntityId: null, visualizingMessageId: null },
+      vault: {
+        entities: { "entity-1": { title: "Entity One" } },
+        updateEntity: vi.fn().mockResolvedValue(true),
+      },
+      notificationStore: {
+        notify: vi.fn(),
+      },
+      chatHistoryService: { messages: [{ id: "message-1", content: "Draw" }] },
     };
+    modalUIStore.closeImagePromptReview();
     manager = new OracleActionManager(mockStore as IOracleStore);
+  });
+
+  it("should reuse an existing saved entity image prompt", async () => {
+    mockStore.vault.entities["entity-1"].artDirection = "saved prompt";
+
+    await manager.drawEntity("entity-1");
+
+    expect(mockExecutor.prepareEntityPrompt).not.toHaveBeenCalled();
+    expect(modalUIStore.imagePromptReview).toMatchObject({
+      open: true,
+      prompt: "saved prompt",
+      target: { kind: "entity", id: "entity-1", title: "Entity One" },
+    });
   });
 
   it("should execute undo", async () => {
@@ -49,14 +76,22 @@ describe("OracleActionManager", () => {
     );
   });
 
-  it("should draw an entity through the shared execution context", async () => {
+  it("should prepare an entity image prompt through the shared execution context", async () => {
     const context = { uiStore: { activeThemeId: "fantasy" } };
     mockStore.getExecutionContext.mockReturnValue(context);
 
     await manager.drawEntity("entity-1");
 
     expect(mockStore.ui.visualizingEntityId).toBeNull();
-    expect(mockExecutor.drawEntity).toHaveBeenCalledWith("entity-1", context);
+    expect(mockExecutor.prepareEntityPrompt).toHaveBeenCalledWith(
+      "entity-1",
+      context,
+    );
+    expect(modalUIStore.imagePromptReview).toMatchObject({
+      open: true,
+      prompt: "prompt",
+      target: { kind: "entity", id: "entity-1", title: "Entity One" },
+    });
   });
 
   it("should not start a duplicate entity draw while one is active", async () => {
@@ -64,19 +99,161 @@ describe("OracleActionManager", () => {
 
     await manager.drawEntity("entity-1");
 
-    expect(mockExecutor.drawEntity).not.toHaveBeenCalled();
+    expect(mockExecutor.prepareEntityPrompt).not.toHaveBeenCalled();
   });
 
-  it("should draw a message through the shared execution context", async () => {
+  it("should toast entity prompt preparation failures instead of throwing", async () => {
+    mockExecutor.prepareEntityPrompt.mockRejectedValue(
+      new Error("Generation quota reached."),
+    );
+
+    await expect(manager.drawEntity("entity-1")).resolves.toBeUndefined();
+
+    expect(mockStore.notificationStore.notify).toHaveBeenCalledWith(
+      "❌ Generation quota reached.",
+      "error",
+    );
+    expect(mockStore.ui.visualizingEntityId).toBeNull();
+    expect(modalUIStore.imagePromptReview.open).toBe(false);
+  });
+
+  it("should prepare a message image prompt through the shared execution context", async () => {
     const context = { uiStore: { activeThemeId: "cyberpunk" } };
     mockStore.getExecutionContext.mockReturnValue(context);
 
     await manager.drawMessage("message-1");
 
     expect(mockStore.ui.visualizingMessageId).toBeNull();
-    expect(mockExecutor.drawMessage).toHaveBeenCalledWith(
+    expect(mockExecutor.prepareMessagePrompt).toHaveBeenCalledWith(
       "message-1",
       context,
     );
+    expect(modalUIStore.imagePromptReview).toMatchObject({
+      open: true,
+      prompt: "prompt",
+      target: { kind: "message", id: "message-1" },
+    });
+  });
+
+  it("should reuse a linked entity image prompt for message draws", async () => {
+    mockStore.vault.entities["entity-1"].artDirection = "linked saved prompt";
+    mockStore.chatHistoryService.messages = [
+      { id: "message-1", content: "Draw", entityId: "entity-1" },
+    ];
+
+    await manager.drawMessage("message-1");
+
+    expect(mockExecutor.prepareMessagePrompt).not.toHaveBeenCalled();
+    expect(modalUIStore.imagePromptReview).toMatchObject({
+      open: true,
+      prompt: "linked saved prompt",
+      target: {
+        kind: "message",
+        id: "message-1",
+        title: "Entity One",
+        entityId: "entity-1",
+      },
+    });
+  });
+
+  it("should toast message prompt preparation failures instead of throwing", async () => {
+    mockExecutor.prepareMessagePrompt.mockRejectedValue(
+      new Error("Generation limit reached."),
+    );
+
+    await expect(manager.drawMessage("message-1")).resolves.toBeUndefined();
+
+    expect(mockStore.notificationStore.notify).toHaveBeenCalledWith(
+      "❌ Generation limit reached.",
+      "error",
+    );
+    expect(mockStore.ui.visualizingMessageId).toBeNull();
+    expect(modalUIStore.imagePromptReview.open).toBe(false);
+  });
+
+  it("should generate an entity image from an approved prompt", async () => {
+    const context = { uiStore: { activeThemeId: "fantasy" } };
+    mockStore.getExecutionContext.mockReturnValue(context);
+
+    await manager.generateEntityFromPrompt("entity-1", "edited prompt");
+
+    expect(mockStore.ui.visualizingEntityId).toBeNull();
+    expect(mockStore.vault.updateEntity).toHaveBeenCalledWith("entity-1", {
+      artDirection: "edited prompt",
+    });
+    expect(mockExecutor.generateEntityFromPrompt).toHaveBeenCalledWith(
+      "entity-1",
+      "edited prompt",
+      context,
+    );
+  });
+
+  it("should save an approved linked message prompt to its entity", async () => {
+    const context = { uiStore: { activeThemeId: "fantasy" } };
+    mockStore.getExecutionContext.mockReturnValue(context);
+    mockStore.chatHistoryService.messages = [
+      { id: "message-1", content: "Draw", entityId: "entity-1" },
+    ];
+
+    await manager.generateMessageFromPrompt("message-1", "message prompt");
+
+    expect(mockStore.vault.updateEntity).toHaveBeenCalledWith("entity-1", {
+      artDirection: "message prompt",
+    });
+    expect(mockExecutor.generateMessageFromPrompt).toHaveBeenCalledWith(
+      "message-1",
+      "message prompt",
+      context,
+    );
+  });
+
+  it("should toast entity image generation failures instead of throwing", async () => {
+    mockExecutor.generateEntityFromPrompt.mockRejectedValue(
+      new Error("Daily image generation limit exceeded."),
+    );
+
+    await expect(
+      manager.generateEntityFromPrompt("entity-1", "edited prompt"),
+    ).resolves.toBeUndefined();
+
+    expect(mockStore.notificationStore.notify).toHaveBeenCalledWith(
+      "❌ Daily image generation limit exceeded.",
+      "error",
+    );
+    expect(mockStore.ui.visualizingEntityId).toBeNull();
+  });
+
+  it("should toast message image generation failures instead of throwing", async () => {
+    mockExecutor.generateMessageFromPrompt.mockRejectedValue(
+      new Error("Image generation failed."),
+    );
+
+    await expect(
+      manager.generateMessageFromPrompt("message-1", "message prompt"),
+    ).resolves.toBeUndefined();
+
+    expect(mockStore.notificationStore.notify).toHaveBeenCalledWith(
+      "❌ Image generation failed.",
+      "error",
+    );
+    expect(mockStore.ui.visualizingMessageId).toBeNull();
+  });
+
+  it("should regenerate an entity prompt without opening the review modal", async () => {
+    const context = { uiStore: { activeThemeId: "fantasy" } };
+    mockStore.getExecutionContext.mockReturnValue(context);
+    mockExecutor.prepareEntityPrompt.mockResolvedValue({
+      prompt: "fresh prompt",
+    });
+
+    const result = await manager.regenerateEntityPrompt("entity-1");
+
+    expect(result).toBe("fresh prompt");
+    expect(mockExecutor.prepareEntityPrompt).toHaveBeenCalledWith(
+      "entity-1",
+      context,
+      { ignoreSavedArtDirection: true },
+    );
+    expect(modalUIStore.imagePromptReview.open).toBe(false);
   });
 });

--- a/apps/web/src/lib/stores/oracle/types.ts
+++ b/apps/web/src/lib/stores/oracle/types.ts
@@ -93,6 +93,10 @@ export interface IOracleStore {
   ): Promise<void>;
   drawEntity(entityId: string): Promise<void>;
   drawMessage(messageId: string): Promise<void>;
+  generateEntityFromPrompt(entityId: string, prompt: string): Promise<void>;
+  generateMessageFromPrompt(messageId: string, prompt: string): Promise<void>;
+  regenerateEntityPrompt(entityId: string): Promise<string | null>;
+  regenerateMessagePrompt(messageId: string): Promise<string | null>;
   isVisualizingEntity(entityId: string | null | undefined): boolean;
   isVisualizingMessage(messageId: string | null | undefined): boolean;
   clearMessages(): Promise<void>;

--- a/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
@@ -6,6 +6,10 @@ export type SettingsTab =
   | "about"
   | "help";
 
+export type ImagePromptReviewTarget =
+  | { kind: "entity"; id: string; title: string }
+  | { kind: "message"; id: string; title: string; entityId?: string };
+
 export class ModalUIStore {
   showSettings = $state(false);
   activeSettingsTab = $state<SettingsTab>("vault");
@@ -65,6 +69,16 @@ export class ModalUIStore {
 
   showVaultSwitcher = $state(false);
   showShare = $state(false);
+
+  imagePromptReview = $state<{
+    open: boolean;
+    target: ImagePromptReviewTarget | null;
+    prompt: string;
+  }>({
+    open: false,
+    target: null,
+    prompt: "",
+  });
 
   // Derived properties for backwards compatibility
   get readModeNodeId() {
@@ -147,6 +161,22 @@ export class ModalUIStore {
     this.showShare = false;
   }
 
+  openImagePromptReview(target: ImagePromptReviewTarget, prompt: string) {
+    this.imagePromptReview = {
+      open: true,
+      target,
+      prompt,
+    };
+  }
+
+  closeImagePromptReview() {
+    this.imagePromptReview = {
+      open: false,
+      target: null,
+      prompt: "",
+    };
+  }
+
   openCanvasSelection(pendingEntities: string[]) {
     this.pendingCanvasEntities = pendingEntities;
     this.showCanvasSelector = true;
@@ -214,6 +244,7 @@ export class ModalUIStore {
       this.relatedEntityDialog.open ||
       this.showVaultSwitcher ||
       this.showShare ||
+      this.imagePromptReview.open ||
       this.lightbox.show ||
       this.soundBite.show
     );
@@ -225,6 +256,6 @@ export class ModalUIStore {
 // cached instance that predates the current class definition — which would
 // cause new properties to be undefined and their reactive assignments to be
 // silently dropped.
-const KEY = "__codex_modal_ui_store__v4__";
+const KEY = "__codex_modal_ui_store__v5__";
 export const modalUIStore: ModalUIStore =
   (globalThis as any)[KEY] ?? ((globalThis as any)[KEY] = new ModalUIStore());

--- a/apps/web/src/lib/stores/ui/notification.svelte.ts
+++ b/apps/web/src/lib/stores/ui/notification.svelte.ts
@@ -38,8 +38,12 @@ export class NotificationStore {
       this.notificationTimeoutId = setTimeout(() => {
         this.notification = null;
         this.notificationTimeoutId = null;
-      }, 5000) as unknown as number;
+      }, this.getDisplayDuration(type)) as unknown as number;
     }
+  }
+
+  private getDisplayDuration(type: "success" | "info" | "error"): number {
+    return type === "error" ? 12000 : 5000;
   }
 
   clearNotification() {

--- a/apps/web/src/lib/stores/ui/notification.test.ts
+++ b/apps/web/src/lib/stores/ui/notification.test.ts
@@ -45,8 +45,27 @@ describe("NotificationStore", () => {
     vi.advanceTimersByTime(2500);
     expect(store.notification).not.toBeNull(); // Should not clear yet
 
+    vi.advanceTimersByTime(7000);
+    expect(store.notification).not.toBeNull(); // Error notifications stay visible longer
+
     vi.advanceTimersByTime(2500);
-    expect(store.notification).toBeNull(); // Clears after 5000 total from second notify
+    expect(store.notification).toBeNull(); // Clears after 12000 total from second notify
+  });
+
+  it("keeps error notifications visible longer", () => {
+    const store = new NotificationStore();
+
+    store.notify("Error", "error");
+
+    vi.advanceTimersByTime(5000);
+    expect(store.notification).toEqual({
+      message: "Error",
+      type: "error",
+      persistent: false,
+    });
+
+    vi.advanceTimersByTime(7000);
+    expect(store.notification).toBeNull();
   });
 
   it("handles persistent notifications", () => {

--- a/apps/web/src/lib/utils/markdown.test.ts
+++ b/apps/web/src/lib/utils/markdown.test.ts
@@ -180,6 +180,8 @@ describe("markdown.ts utility", () => {
         content:
           "# Eldrin Shadoweaver\nAn ancient shadow mage who dwells in the keeping of shadows.",
         lore: "He was born before the first moon fell.",
+        artDirection:
+          "Full-body character concept art with sharp focus and weathered robes.",
         image: "images/eldrin.png",
         thumbnail: "images/eldrin_thumb.png",
         date: {
@@ -234,6 +236,7 @@ describe("markdown.ts utility", () => {
       expect(parsedResult.metadata.aliases).toEqual(fullEntity.aliases);
       expect(parsedResult.metadata.connections).toEqual(fullEntity.connections);
       expect(parsedResult.metadata.lore).toBe(fullEntity.lore);
+      expect(parsedResult.metadata.artDirection).toBe(fullEntity.artDirection);
       expect(parsedResult.metadata.image).toBe(fullEntity.image);
       expect(parsedResult.metadata.thumbnail).toBe(fullEntity.thumbnail);
       expect(parsedResult.metadata.date).toEqual(fullEntity.date);

--- a/apps/workers/oracle-proxy/src/index.test.ts
+++ b/apps/workers/oracle-proxy/src/index.test.ts
@@ -133,9 +133,15 @@ describe("Oracle Proxy Worker image generation", () => {
       success: true,
       result: { image: "base64-image" },
     });
-    expect(ai.run).toHaveBeenCalledWith(DEFAULT_CF_IMAGE_MODEL, {
-      prompt: "castle at sunset",
-    });
+    expect(ai.run).toHaveBeenCalledWith(
+      DEFAULT_CF_IMAGE_MODEL,
+      expect.objectContaining({
+        multipart: expect.objectContaining({
+          body: expect.any(Object),
+          contentType: expect.stringContaining("multipart/form-data"),
+        }),
+      }),
+    );
   });
 
   it("uses the requested Cloudflare image model when one is provided", async () => {
@@ -151,8 +157,14 @@ describe("Oracle Proxy Worker image generation", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(ai.run).toHaveBeenCalledWith(model, {
-      prompt: "castle at sunset",
-    });
+    expect(ai.run).toHaveBeenCalledWith(
+      model,
+      expect.objectContaining({
+        multipart: expect.objectContaining({
+          body: expect.any(Object),
+          contentType: expect.stringContaining("multipart/form-data"),
+        }),
+      }),
+    );
   });
 });

--- a/apps/workers/oracle-proxy/src/index.ts
+++ b/apps/workers/oracle-proxy/src/index.ts
@@ -119,8 +119,22 @@ export default {
         console.log(
           `[Oracle Proxy] Generating image using Workers AI model: ${targetModel}`,
         );
-        // Run model through binding. For image models it returns binary.
-        const output = await env.AI.run(targetModel, { prompt });
+        const form = new FormData();
+        form.append("prompt", prompt);
+        form.append("width", String(body.width || 1024));
+        form.append("height", String(body.height || 1024));
+
+        const formResponse = new Response(form);
+        const formBody = formResponse.body || form;
+        const formContentType =
+          formResponse.headers.get("content-type") || "multipart/form-data";
+
+        const output = await env.AI.run(targetModel, {
+          multipart: {
+            body: formBody,
+            contentType: formContentType,
+          },
+        });
 
         let buffer: ArrayBuffer;
         if (output instanceof ArrayBuffer) {

--- a/packages/oracle-engine/src/executors/visualization-executor.test.ts
+++ b/packages/oracle-engine/src/executors/visualization-executor.test.ts
@@ -99,4 +99,59 @@ describe("VisualizationExecutor", () => {
       expect.arrayContaining([expect.objectContaining({ type: "image" })]),
     );
   });
+
+  it("should prepare an entity prompt without generating an image", async () => {
+    const generator = {
+      prepareEntityVisualizationPrompt: vi
+        .fn()
+        .mockResolvedValue({ prompt: "final prompt" }),
+      generateEntityVisualization: vi.fn(),
+    };
+    const executor = new VisualizationExecutor(generator as any);
+    const context = {} as any;
+
+    const result = await executor.prepareEntityPrompt("e1", context);
+
+    expect(result).toEqual({ prompt: "final prompt" });
+    expect(generator.prepareEntityVisualizationPrompt).toHaveBeenCalledWith(
+      "e1",
+      context,
+      {},
+    );
+    expect(generator.generateEntityVisualization).not.toHaveBeenCalled();
+  });
+
+  it("should generate an entity image from an approved prompt", async () => {
+    const blob = new Blob([]);
+    const generator = {
+      generateVisualizationFromPrompt: vi.fn().mockResolvedValue(blob),
+    };
+    const executor = new VisualizationExecutor(generator as any);
+    const saveImageToVault = vi
+      .fn()
+      .mockResolvedValue({ image: "path", thumbnail: "thumb" });
+    const updateEntity = vi.fn();
+
+    const context = {
+      vault: {
+        entities: { e1: { id: "e1", title: "Target" } },
+        saveImageToVault,
+        updateEntity,
+      },
+      chatHistory: { addMessage: vi.fn() },
+      isDemoMode: false,
+    } as any;
+
+    await executor.generateEntityFromPrompt("e1", "edited prompt", context);
+
+    expect(generator.generateVisualizationFromPrompt).toHaveBeenCalledWith(
+      "edited prompt",
+      context,
+    );
+    expect(saveImageToVault).toHaveBeenCalledWith(blob, "e1");
+    expect(updateEntity).toHaveBeenCalledWith("e1", {
+      image: "path",
+      thumbnail: "thumb",
+    });
+  });
 });

--- a/packages/oracle-engine/src/executors/visualization-executor.ts
+++ b/packages/oracle-engine/src/executors/visualization-executor.ts
@@ -64,7 +64,10 @@ export class VisualizationExecutor
     if (!generator) throw new Error("Generator not available in context.");
 
     try {
-      const blob = await generator.generateEntityVisualization(entityId, context);
+      const blob = await generator.generateEntityVisualization(
+        entityId,
+        context,
+      );
 
       if (context.isDemoMode) {
         const imageUrl = URL.createObjectURL(blob);
@@ -104,6 +107,75 @@ export class VisualizationExecutor
     }
   }
 
+  async prepareEntityPrompt(
+    entityId: string,
+    context: OracleExecutionContext,
+    options: { ignoreSavedArtDirection?: boolean } = {},
+  ) {
+    const generator = this.generator || context.generator;
+    if (!generator) throw new Error("Generator not available in context.");
+
+    return generator.prepareEntityVisualizationPrompt(
+      entityId,
+      context,
+      options,
+    );
+  }
+
+  async generateEntityFromPrompt(
+    entityId: string,
+    prompt: string,
+    context: OracleExecutionContext,
+  ) {
+    const entity = context.vault.entities[entityId];
+    if (!entity) return;
+
+    const generator = this.generator || context.generator;
+    if (!generator) throw new Error("Generator not available in context.");
+
+    try {
+      const blob = await generator.generateVisualizationFromPrompt(
+        prompt,
+        context,
+      );
+
+      if (context.isDemoMode) {
+        const imageUrl = URL.createObjectURL(blob);
+        await context.chatHistory.addMessage({
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: "",
+          type: "image",
+          imageUrl,
+          imageBlob: blob,
+          entityId,
+        });
+      } else {
+        const { image, thumbnail } = await context.vault.saveImageToVault(
+          blob,
+          entityId,
+        );
+        await context.vault.updateEntity(entityId, {
+          image,
+          thumbnail,
+        });
+      }
+    } catch (err: any) {
+      if (err.message && err.message.startsWith("MISSING_KEY_PROMPT|")) {
+        await context.chatHistory.addMessage({
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: `Image generation requires an API key. You can copy and paste the generated prompt below into an external image generator:\n\n\`\`\`text\n${prompt}\n\`\`\``,
+        });
+        await context.vault.updateEntity(entityId, {
+          artDirection: prompt,
+        });
+        return;
+      }
+      throw err;
+    }
+  }
+
   async drawMessage(messageId: string, context: OracleExecutionContext) {
     const msgIndex = context.chatHistory.messages.findIndex(
       (m: any) => m.id === messageId,
@@ -115,7 +187,10 @@ export class VisualizationExecutor
     if (!generator) throw new Error("Generator not available in context.");
 
     try {
-      const blob = await generator.generateMessageVisualization(message, context);
+      const blob = await generator.generateMessageVisualization(
+        message,
+        context,
+      );
       const imageUrl = URL.createObjectURL(blob);
       const updatedMsgs = [...context.chatHistory.messages];
       updatedMsgs[msgIndex] = {
@@ -135,8 +210,76 @@ export class VisualizationExecutor
           role: "assistant",
           content: `Image generation requires an API key. You can copy and paste the generated prompt below into an external image generator:\n\n\`\`\`text\n${prompt}\n\`\`\``,
         });
-        
+
         // Update the message state to remove the drawing state
+        const updatedMsgs = [...context.chatHistory.messages];
+        updatedMsgs[msgIndex] = {
+          ...message,
+          isDrawing: false,
+        };
+        context.chatHistory.setMessages(updatedMsgs);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  async prepareMessagePrompt(
+    messageId: string,
+    context: OracleExecutionContext,
+  ) {
+    const msgIndex = context.chatHistory.messages.findIndex(
+      (m: any) => m.id === messageId,
+    );
+    if (msgIndex === -1) return null;
+
+    const generator = this.generator || context.generator;
+    if (!generator) throw new Error("Generator not available in context.");
+
+    return generator.prepareMessageVisualizationPrompt(
+      context.chatHistory.messages[msgIndex],
+      context,
+    );
+  }
+
+  async generateMessageFromPrompt(
+    messageId: string,
+    prompt: string,
+    context: OracleExecutionContext,
+  ) {
+    const msgIndex = context.chatHistory.messages.findIndex(
+      (m: any) => m.id === messageId,
+    );
+    if (msgIndex === -1) return;
+
+    const message = context.chatHistory.messages[msgIndex];
+    const generator = this.generator || context.generator;
+    if (!generator) throw new Error("Generator not available in context.");
+
+    try {
+      const blob = await generator.generateVisualizationFromPrompt(
+        prompt,
+        context,
+      );
+      const imageUrl = URL.createObjectURL(blob);
+      const updatedMsgs = [...context.chatHistory.messages];
+      updatedMsgs[msgIndex] = {
+        ...message,
+        type: "image",
+        imageUrl,
+        imageBlob: blob,
+        isDrawing: false,
+        hasDrawAction: false,
+      };
+      context.chatHistory.setMessages(updatedMsgs);
+    } catch (err: any) {
+      if (err.message && err.message.startsWith("MISSING_KEY_PROMPT|")) {
+        await context.chatHistory.addMessage({
+          id: crypto.randomUUID(),
+          role: "assistant",
+          content: `Image generation requires an API key. You can copy and paste the generated prompt below into an external image generator:\n\n\`\`\`text\n${prompt}\n\`\`\``,
+        });
+
         const updatedMsgs = [...context.chatHistory.messages];
         updatedMsgs[msgIndex] = {
           ...message,

--- a/packages/oracle-engine/src/image-defaults.ts
+++ b/packages/oracle-engine/src/image-defaults.ts
@@ -1,5 +1,4 @@
-export const DEFAULT_CF_IMAGE_MODEL =
-  "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+export const DEFAULT_CF_IMAGE_MODEL = "@cf/black-forest-labs/flux-2-klein-4b";
 
 export const DEFAULT_CUSTOM_IMAGE_MODEL = "black-forest-labs/FLUX.1-schnell";
 export const DEFAULT_CUSTOM_IMAGE_BASE_URL =

--- a/packages/oracle-engine/src/oracle-executor.test.ts
+++ b/packages/oracle-engine/src/oracle-executor.test.ts
@@ -22,6 +22,7 @@ describe("OracleActionExecutor - Detailed", () => {
         .mockResolvedValue({ primaryEntityId: "e1", sourceIds: ["e1"] }),
       generateEntityVisualization: vi.fn().mockResolvedValue(new Blob([])),
       generateMessageVisualization: vi.fn().mockResolvedValue(new Blob([])),
+      generateVisualizationFromPrompt: vi.fn().mockResolvedValue(new Blob([])),
       generateRegenerationResponse: vi.fn().mockResolvedValue(undefined),
       generateCreationResponse: vi
         .fn()
@@ -1063,6 +1064,38 @@ describe("OracleActionExecutor - Detailed", () => {
       mockContext.chatHistory.messages = [{ id: "m1", content: "c" }];
       await executor.drawMessage("m1", mockContext);
       expect(mockContext.chatHistory.setMessages).toHaveBeenCalled();
+    });
+
+    it("should let direct entity image failures bubble to UI callers", async () => {
+      mockContext.vault.entities = { e1: { title: "T" } };
+      mockGenerator.generateEntityVisualization.mockRejectedValue(
+        new Error("Daily image generation limit exceeded."),
+      );
+
+      await expect(executor.drawEntity("e1", mockContext)).rejects.toThrow(
+        "Daily image generation limit exceeded.",
+      );
+      expect(mockContext.chatHistory.addMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("Image generation failed"),
+        }),
+      );
+    });
+
+    it("should let approved prompt image failures bubble to UI callers", async () => {
+      mockContext.vault.entities = { e1: { title: "T" } };
+      mockGenerator.generateVisualizationFromPrompt.mockRejectedValue(
+        new Error("Daily image generation limit exceeded."),
+      );
+
+      await expect(
+        executor.generateEntityFromPrompt("e1", "prompt", mockContext),
+      ).rejects.toThrow("Daily image generation limit exceeded.");
+      expect(mockContext.chatHistory.addMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("Image generation failed"),
+        }),
+      );
     });
   });
 

--- a/packages/oracle-engine/src/oracle-executor.ts
+++ b/packages/oracle-engine/src/oracle-executor.ts
@@ -101,30 +101,57 @@ export class OracleActionExecutor {
    * Public API for direct entity visualization.
    */
   async drawEntity(entityId: string, context: OracleExecutionContext) {
-    try {
-      await this.visualizationExecutor.drawEntity(entityId, context);
-    } catch (err: any) {
-      await context.chatHistory.addMessage({
-        id: crypto.randomUUID(),
-        role: "system",
-        content: `❌ Image generation failed: ${err.message}`,
-      });
-    }
+    await this.visualizationExecutor.drawEntity(entityId, context);
+  }
+
+  async prepareEntityPrompt(
+    entityId: string,
+    context: OracleExecutionContext,
+    options: { ignoreSavedArtDirection?: boolean } = {},
+  ) {
+    return this.visualizationExecutor.prepareEntityPrompt(
+      entityId,
+      context,
+      options,
+    );
+  }
+
+  async generateEntityFromPrompt(
+    entityId: string,
+    prompt: string,
+    context: OracleExecutionContext,
+  ) {
+    await this.visualizationExecutor.generateEntityFromPrompt(
+      entityId,
+      prompt,
+      context,
+    );
   }
 
   /**
    * Public API for direct message visualization.
    */
   async drawMessage(messageId: string, context: OracleExecutionContext) {
-    try {
-      await this.visualizationExecutor.drawMessage(messageId, context);
-    } catch (err: any) {
-      await context.chatHistory.addMessage({
-        id: crypto.randomUUID(),
-        role: "system",
-        content: `❌ Image generation failed: ${err.message}`,
-      });
-    }
+    await this.visualizationExecutor.drawMessage(messageId, context);
+  }
+
+  async prepareMessagePrompt(
+    messageId: string,
+    context: OracleExecutionContext,
+  ) {
+    return this.visualizationExecutor.prepareMessagePrompt(messageId, context);
+  }
+
+  async generateMessageFromPrompt(
+    messageId: string,
+    prompt: string,
+    context: OracleExecutionContext,
+  ) {
+    await this.visualizationExecutor.generateMessageFromPrompt(
+      messageId,
+      prompt,
+      context,
+    );
   }
 
   /**

--- a/packages/oracle-engine/src/oracle-generator.test.ts
+++ b/packages/oracle-engine/src/oracle-generator.test.ts
@@ -112,7 +112,7 @@ describe("OracleGenerator", () => {
         mockContext.imageGeneration.distillVisualPrompt,
       ).toHaveBeenCalledWith(
         "key",
-        expect.stringContaining("full character concept art"),
+        expect.stringContaining("full-body character concept art"),
         "ctx",
         "model",
         false,
@@ -136,6 +136,40 @@ describe("OracleGenerator", () => {
       ).toHaveBeenCalledWith(
         "key",
         expect.stringContaining("Almos. ink wash portrait"),
+        "ctx",
+        "model",
+        false,
+      );
+    });
+
+    it("should ignore saved entity art direction when requested", async () => {
+      mockContext.vault.entities.e1 = {
+        id: "e1",
+        title: "Almos",
+        type: "character",
+        labels: [],
+        artDirection: "old saved prompt",
+      };
+      mockContext.uiStore.activeThemeId = "cyberpunk";
+
+      await generator.prepareEntityVisualizationPrompt("e1", mockContext, {
+        ignoreSavedArtDirection: true,
+      });
+
+      expect(
+        mockContext.imageGeneration.distillVisualPrompt,
+      ).toHaveBeenCalledWith(
+        "key",
+        expect.stringContaining("Cyberpunk digital concept art style"),
+        "ctx",
+        "model",
+        false,
+      );
+      expect(
+        mockContext.imageGeneration.distillVisualPrompt,
+      ).not.toHaveBeenCalledWith(
+        "key",
+        expect.stringContaining("old saved prompt"),
         "ctx",
         "model",
         false,
@@ -189,7 +223,9 @@ describe("OracleGenerator", () => {
         mockContext.imageGeneration.distillVisualPrompt,
       ).toHaveBeenCalledWith(
         "key",
-        expect.stringContaining("Draw the moon gate. flat ink and gold leaf icon"),
+        expect.stringContaining(
+          "Draw the moon gate. flat ink and gold leaf icon",
+        ),
         "ctx",
         "model",
         false,
@@ -206,7 +242,7 @@ describe("OracleGenerator", () => {
         mockContext.imageGeneration.distillVisualPrompt,
       ).toHaveBeenCalledWith(
         "key",
-        expect.stringContaining("Almos, full character concept art"),
+        expect.stringContaining("Almos, full-body character concept art"),
         "ctx",
         "model",
         false,

--- a/packages/oracle-engine/src/oracle-generator.ts
+++ b/packages/oracle-engine/src/oracle-generator.ts
@@ -1,5 +1,9 @@
 import type { ChatMessage, OracleExecutionContext } from "./types";
 import { resolveArtDirection } from "schema";
+import {
+  DEFAULT_CF_IMAGE_MODEL,
+  DEFAULT_CUSTOM_IMAGE_MODEL,
+} from "./image-defaults";
 
 interface VisualEntityLike {
   id?: string;
@@ -12,10 +16,15 @@ interface VisualEntityLike {
   artDirection?: string;
 }
 
+export interface PreparedVisualizationPrompt {
+  prompt: string;
+}
+
 export class OracleGenerator {
   private buildEntityVisualQuery(
     entity: VisualEntityLike,
     context?: OracleExecutionContext,
+    options: { ignoreSavedArtDirection?: boolean } = {},
   ): string {
     const artDirection = resolveArtDirection({
       subject: entity.title,
@@ -25,7 +34,9 @@ export class OracleGenerator {
       categoryLabel: entity.type,
       themeId: context?.uiStore?.activeThemeId,
       surface: "entity",
-      entityArtDirection: this.extractEntityArtDirection(entity),
+      entityArtDirection: options.ignoreSavedArtDirection
+        ? undefined
+        : this.extractEntityArtDirection(entity),
     });
 
     return this.appendVisualLabels(artDirection.prompt, entity.labels);
@@ -292,8 +303,19 @@ Treat these labels as strong visual direction. If they imply mood, genre, attire
     entityId: string,
     context: OracleExecutionContext,
   ): Promise<Blob> {
-    const apiKey = context.effectiveApiKey || "";
+    const { prompt } = await this.prepareEntityVisualizationPrompt(
+      entityId,
+      context,
+    );
+    return this.generateVisualizationFromPrompt(prompt, context);
+  }
 
+  async prepareEntityVisualizationPrompt(
+    entityId: string,
+    context: OracleExecutionContext,
+    options: { ignoreSavedArtDirection?: boolean } = {},
+  ): Promise<PreparedVisualizationPrompt> {
+    const apiKey = context.effectiveApiKey || "";
     const entity = context.vault.entities[entityId];
     const { content: aiContext } =
       await context.contextRetrieval.retrieveContext(
@@ -304,50 +326,15 @@ Treat these labels as strong visual direction. If they imply mood, genre, attire
         true,
       );
 
-    const visualPrompt = await context.imageGeneration.distillVisualPrompt(
-      apiKey,
-      this.buildEntityVisualQuery(entity, context),
-      aiContext,
-      context.modelName,
-      context.isDemoMode,
-    );
-
-    const isCustom = context.imageProvider === "custom";
-    const isCloudflare = context.imageProvider === "cloudflare";
-
-    let targetKey = apiKey;
-    if (isCustom && context.customImageApiKey) {
-      targetKey = context.customImageApiKey;
-    } else if (isCloudflare) {
-      targetKey = "";
-    }
-
-    let targetModel = "gemini-2.5-flash-image";
-    if (isCustom) {
-      targetModel =
-        context.customImageModel || "black-forest-labs/FLUX.1-schnell";
-    } else if (isCloudflare) {
-      targetModel =
-        context.cloudflareModel ||
-        "@cf/stabilityai/stable-diffusion-xl-base-1.0";
-    }
-
-    const needsKey =
-      (isCustom && !targetKey) || (!isCustom && !isCloudflare && !targetKey);
-
-    if (needsKey) {
-      throw new Error(`MISSING_KEY_PROMPT|${visualPrompt}`);
-    }
-
-    return await context.imageGeneration.generateImage(
-      targetKey,
-      visualPrompt,
-      targetModel,
-      {
-        provider: context.imageProvider,
-        baseUrl: context.customImageBaseUrl,
-      },
-    );
+    return {
+      prompt: await context.imageGeneration.distillVisualPrompt(
+        apiKey,
+        this.buildEntityVisualQuery(entity, context, options),
+        aiContext,
+        context.modelName,
+        context.isDemoMode,
+      ),
+    };
   }
 
   /**
@@ -357,8 +344,18 @@ Treat these labels as strong visual direction. If they imply mood, genre, attire
     message: ChatMessage,
     context: OracleExecutionContext,
   ): Promise<Blob> {
-    const apiKey = context.effectiveApiKey || "";
+    const { prompt } = await this.prepareMessageVisualizationPrompt(
+      message,
+      context,
+    );
+    return this.generateVisualizationFromPrompt(prompt, context);
+  }
 
+  async prepareMessageVisualizationPrompt(
+    message: ChatMessage,
+    context: OracleExecutionContext,
+  ): Promise<PreparedVisualizationPrompt> {
+    const apiKey = context.effectiveApiKey || "";
     const entity = message.entityId
       ? context.vault.entities[message.entityId]
       : null;
@@ -373,14 +370,22 @@ Treat these labels as strong visual direction. If they imply mood, genre, attire
         true,
       );
 
-    const visualPrompt = await context.imageGeneration.distillVisualPrompt(
-      apiKey,
-      this.buildMessageVisualQuery(message, entity, context),
-      aiContext,
-      context.modelName,
-      context.isDemoMode,
-    );
+    return {
+      prompt: await context.imageGeneration.distillVisualPrompt(
+        apiKey,
+        this.buildMessageVisualQuery(message, entity, context),
+        aiContext,
+        context.modelName,
+        context.isDemoMode,
+      ),
+    };
+  }
 
+  async generateVisualizationFromPrompt(
+    prompt: string,
+    context: OracleExecutionContext,
+  ): Promise<Blob> {
+    const apiKey = context.effectiveApiKey || "";
     const isCustom = context.imageProvider === "custom";
     const isCloudflare = context.imageProvider === "cloudflare";
 
@@ -393,24 +398,21 @@ Treat these labels as strong visual direction. If they imply mood, genre, attire
 
     let targetModel = "gemini-2.5-flash-image";
     if (isCustom) {
-      targetModel =
-        context.customImageModel || "black-forest-labs/FLUX.1-schnell";
+      targetModel = context.customImageModel || DEFAULT_CUSTOM_IMAGE_MODEL;
     } else if (isCloudflare) {
-      targetModel =
-        context.cloudflareModel ||
-        "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+      targetModel = context.cloudflareModel || DEFAULT_CF_IMAGE_MODEL;
     }
 
     const needsKey =
       (isCustom && !targetKey) || (!isCustom && !isCloudflare && !targetKey);
 
     if (needsKey) {
-      throw new Error(`MISSING_KEY_PROMPT|${visualPrompt}`);
+      throw new Error(`MISSING_KEY_PROMPT|${prompt}`);
     }
 
     return await context.imageGeneration.generateImage(
       targetKey,
-      visualPrompt,
+      prompt,
       targetModel,
       {
         provider: context.imageProvider,

--- a/packages/schema/src/art-direction.test.ts
+++ b/packages/schema/src/art-direction.test.ts
@@ -72,11 +72,150 @@ describe("art direction resolver", () => {
       themeId: "scifi",
     });
 
-    expect(result.prompt).toContain("Mara, full character concept art");
+    expect(result.prompt).toContain("Mara, full-body character concept art");
     expect(result.prompt).toContain("Mara. Digital concept art style");
     expect(result.prompt).toContain(
       "Mara, illustrated worldbuilding reference",
     );
+  });
+
+  it("keeps character defaults concrete without overriding themed or vault art styles", () => {
+    const result = resolveArtDirection({
+      subject: "Tymora",
+      surface: "entity",
+      categoryId: "character",
+      themeId: "fantasy",
+    });
+
+    expect(result.prompt).toContain("clear face");
+    expect(result.prompt).toContain("visible hands");
+    expect(result.prompt).toContain("sharp focus on the full figure");
+    expect(result.prompt).toContain("body language");
+    expect(result.prompt).toContain("signature attire");
+    expect(result.prompt).toContain(
+      "hand-held props or environmental contact points",
+    );
+    expect(result.prompt).toContain("wearable technology or accessories");
+    expect(result.prompt).toContain("surface finish");
+    expect(result.prompt).toContain("weathering");
+    expect(result.prompt).toContain("asymmetry");
+    expect(result.prompt).toContain(
+      "presentation lighting frames the character",
+    );
+    expect(result.prompt).toContain("Oil painting style");
+    expect(result.prompt).toContain("warm earth palette");
+    expect(result.prompt).toContain(
+      "Tymora, illustrated worldbuilding reference",
+    );
+  });
+
+  it("keeps cyberpunk characters material-specific and environment-aware", () => {
+    const result = resolveArtDirection({
+      subject: "Architect-Class Figure",
+      surface: "entity",
+      categoryId: "character",
+      themeId: "cyberpunk",
+    });
+
+    expect(result.prompt).toContain("role, status, temperament");
+    expect(result.prompt).toContain("wearable technology or accessories");
+    expect(result.prompt).toContain("seams, fasteners, surface finish");
+    expect(result.prompt).toContain("practical wear");
+    expect(result.prompt).toContain("hand gesture");
+    expect(result.prompt).toContain("surrounding environment");
+    expect(result.prompt).toContain("urban surfaces and environmental texture");
+    expect(result.prompt).toContain("high-contrast neon palette");
+  });
+
+  it("keeps item defaults tactile and specific without overriding themed art styles", () => {
+    const result = resolveArtDirection({
+      subject: "Synapse-Bridge",
+      surface: "entity",
+      categoryId: "item",
+      themeId: "cyberpunk",
+    });
+
+    expect(result.prompt).toContain("close-up detailed prop concept art");
+    expect(result.prompt).toContain("clear scale cues");
+    expect(result.prompt).toContain("functional seams");
+    expect(result.prompt).toContain("contact points");
+    expect(result.prompt).toContain("worn surfaces");
+    expect(result.prompt).toContain(
+      "physical consequences of repeated handling",
+    );
+    expect(result.prompt).toContain("urban surfaces and environmental texture");
+    expect(result.prompt).toContain(
+      "Synapse-Bridge, illustrated worldbuilding reference",
+    );
+  });
+
+  it("keeps faction defaults identity-focused without overriding themed art styles", () => {
+    const result = resolveArtDirection({
+      subject: "Arasaka Security Detachment",
+      surface: "entity",
+      categoryId: "faction",
+      themeId: "cyberpunk",
+    });
+
+    expect(result.prompt).toContain("wide-angle eye-level faction concept art");
+    expect(result.prompt).toContain("cohesive group composition");
+    expect(result.prompt).toContain("clear visual anchor");
+    expect(result.prompt).toContain("clear hierarchy");
+    expect(result.prompt).toContain("readable insignia or subtle heraldry");
+    expect(result.prompt).toContain("controlled patrol halt");
+    expect(result.prompt).toContain("mirrored functional arrangement");
+    expect(result.prompt).toContain("distinct uniform language");
+    expect(result.prompt).toContain("restricted faction palette");
+    expect(result.prompt).toContain("role-specific equipment");
+    expect(result.prompt).toContain("specialist visual cues");
+    expect(result.prompt).toContain("equipment readiness");
+    expect(result.prompt).toContain("faces or masks where appropriate");
+    expect(result.prompt).toContain("authority, ideology, resources");
+    expect(result.prompt).toContain(
+      "background landscape or ambient color that stays secondary",
+    );
+    expect(result.prompt).toContain("recognizable faction identity");
+    expect(result.prompt).toContain("tactile material contrast");
+    expect(result.prompt).toContain("cohesive silhouette");
+    expect(result.prompt).toContain("controlled palette hierarchy");
+    expect(result.prompt).toContain(
+      "readable faction marks on practical gear or regalia",
+    );
+    expect(result.prompt).toContain("natural or crafted material weight");
+    expect(result.prompt).toContain("rhythmic group spacing");
+    expect(result.prompt).toContain("neon clutter");
+    expect(result.prompt).toContain("modern gear unless setting-appropriate");
+    expect(result.prompt).toContain("ornate generic armor");
+    expect(result.prompt).toContain("Cyberpunk digital concept art style");
+    expect(result.prompt).toContain("urban surfaces and environmental texture");
+    expect(result.prompt).toContain(
+      "Arasaka Security Detachment, illustrated worldbuilding reference",
+    );
+  });
+
+  it("keeps fantasy faction defaults grounded and material-focused", () => {
+    const result = resolveArtDirection({
+      subject: "Stormber Patrol Unit",
+      surface: "entity",
+      categoryId: "faction",
+      themeId: "fantasy",
+    });
+
+    expect(result.prompt).toContain("subtle heraldry");
+    expect(result.prompt).toContain("clear visual anchor");
+    expect(result.prompt).toContain("mirrored functional arrangement");
+    expect(result.prompt).toContain("restricted faction palette");
+    expect(result.prompt).toContain("repeated motifs");
+    expect(result.prompt).toContain("background landscape");
+    expect(result.prompt).toContain("natural or crafted material weight");
+    expect(result.prompt).toContain("rhythmic group spacing");
+    expect(result.prompt).toContain(
+      "readable faction marks on practical gear or regalia",
+    );
+    expect(result.prompt).toContain("ornate generic armor");
+    expect(result.prompt).toContain("modern gear unless setting-appropriate");
+    expect(result.prompt).toContain("Oil painting style");
+    expect(result.prompt).toContain("handcrafted materials");
   });
 
   it("inserts the subject when the template has no placeholder", () => {
@@ -215,7 +354,10 @@ describe("art direction resolver", () => {
     const testCases: Array<{ themeId: string; expectedSubstring: string }> = [
       { themeId: "fantasy", expectedSubstring: "Oil painting style" },
       { themeId: "scifi", expectedSubstring: "Digital concept art style" },
-      { themeId: "cyberpunk", expectedSubstring: "wet streets" },
+      {
+        themeId: "cyberpunk",
+        expectedSubstring: "Cyberpunk digital concept art style",
+      },
       { themeId: "modern", expectedSubstring: "Photographic" },
       {
         themeId: "apocalyptic",

--- a/packages/schema/src/art-direction.ts
+++ b/packages/schema/src/art-direction.ts
@@ -67,7 +67,7 @@ export const CATEGORY_ART_DIRECTION_DEFAULTS: Record<
     label: "Character Default",
     source: "category-default",
     template:
-      "{subject}, full character concept art with readable silhouette, expressive pose, distinctive clothing, equipment, and clear face and body language.",
+      "{subject}, full-body character concept art with a clean readable silhouette, sharp focus on the full figure, clear face, visible hands, balanced anatomy, expressive stance, and body language that communicates role, status, temperament, and current intent. Give the figure distinctive clothing layers or signature attire, personal equipment, hand-held props or environmental contact points where useful, wearable technology or accessories where appropriate, and concrete material details such as seams, fasteners, surface finish, weathering, repairs, stains, and crafted ornament. Emphasize asymmetry, practical wear, facial expression, hand gesture, and how the surrounding environment or presentation lighting frames the character without overpowering them. Avoid name repetition, generic armor, vague heroic phrasing, stiff poses, and unreadable effects.",
   },
   creature: {
     id: "category.creature",
@@ -88,14 +88,14 @@ export const CATEGORY_ART_DIRECTION_DEFAULTS: Record<
     label: "Item Default",
     source: "category-default",
     template:
-      "{subject}, detailed prop design on a simple presentation background, emphasizing materials, craftsmanship, wear, symbols, and readable silhouette.",
+      "{subject}, close-up detailed prop concept art on a plain unobtrusive presentation background, with a readable silhouette, clear scale cues, visible construction logic, functional seams, fasteners, contact points, and worn surfaces. Emphasize tactile material craftsmanship, age, repairs, inscriptions or symbols, use-specific details, and the physical consequences of repeated handling. Use sharp focus and concrete visual details; avoid floating UI effects, vague magic glow, and generic treasure styling.",
   },
   faction: {
     id: "category.faction",
     label: "Faction Default",
     source: "category-default",
     template:
-      "{subject}, faction visual identity with banners, colors, uniforms or regalia, symbolic motifs, and an organized group composition.",
+      "{subject}, wide-angle eye-level faction concept art with a cohesive group composition, clear visual anchor, clear hierarchy, readable insignia or subtle heraldry, synchronized movement, disciplined formation, mirrored functional arrangement, or controlled patrol halt, and distinct uniform language, regalia, restricted faction palette, banners, tools, weapons, or symbols. Show how the faction expresses authority, ideology, resources, and internal roles through posture, role-specific equipment, specialist visual cues, equipment readiness, faces or masks where appropriate, material quality, repeated motifs, environmental control, and background landscape or ambient color that stays secondary to the faction identity. Emphasize recognizable faction identity, grounded proportions, sharp focus on the group, tactile material contrast, cohesive silhouette, controlled palette hierarchy, readable faction marks on practical gear or regalia, natural or crafted material weight, rhythmic group spacing, and organized visual rhythm; avoid random crowds, generic soldiers, oversized logos, superhero posing, excessive holograms, neon clutter, ornate generic armor, modern gear unless setting-appropriate, and unreadable background clutter.",
   },
   event: {
     id: "category.event",
@@ -141,7 +141,7 @@ const cyberpunk: ArtDirectionTemplate = {
   label: "Cyberpunk Default",
   source: "theme-default",
   template:
-    "{subject}. Digital concept art style, wet streets, dense signage, layered technology, hard shadows, high-contrast neon palette with hot pink and electric blue accents.",
+    "{subject}. Cyberpunk digital concept art style, dense signage, layered technology, hard shadows, high-contrast neon palette with hot pink and electric blue accents, urban surfaces and environmental texture that suit the scene.",
 };
 
 const modern: ArtDirectionTemplate = {


### PR DESCRIPTION
## Summary
- Adds a two-step image generation flow so generated prompts can be reviewed, edited, regenerated, saved, and reused.
- Persists image prompts on entities through existing vault/markdown/IndexedDB flows for more consistent character/entity images.
- Updates art-direction defaults for characters, items, factions, and cyberpunk/fantasy themes.
- Switches default Cloudflare image generation to `@cf/black-forest-labs/flux-2-klein-4b` and updates proxy/direct Cloudflare payload handling.
- Improves image-generation error handling with clearer rate-limit messages and longer dismissible error toasts.

## Validation
- `bun run --filter '*' lint:types`
- `bun run --filter '*' lint -- --cache --cache-strategy content`
- Push hook changed-test run passed
- Focused web/oracle/schema/worker tests were run during implementation