### PR TITLE
[codex] Add category grouping to Entity Explorer

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -42,6 +42,12 @@
   const activeVaultId = $derived(vault.activeVaultId);
   const labelFilters = $derived(explorerUIStore.labelFilters);
   const viewMode = $derived(explorerUIStore.explorerViewMode);
+  const effectiveViewMode = $derived(
+    viewMode === "category" && typeFilters.size === 1 ? "list" : viewMode,
+  );
+  const collapsedCategoryGroups = $derived(
+    explorerUIStore.getCollapsedCategoryGroups(activeVaultId),
+  );
   const collapsedLabelGroups = $derived(
     explorerUIStore.getCollapsedLabelGroups(activeVaultId),
   );
@@ -64,7 +70,7 @@
   );
 
   const groupedEntities = $derived(
-    groupEntitiesForExplorer(filteredEntities, viewMode),
+    groupEntitiesForExplorer(filteredEntities, effectiveViewMode),
   );
 
   const collapsedEntities = $derived(
@@ -112,6 +118,10 @@
     } finally {
       isCreatingChild = false;
     }
+  }
+
+  function getCategoryLabel(categoryId: string) {
+    return categories.getCategory(categoryId)?.label ?? categoryId;
   }
 </script>
 
@@ -209,7 +219,7 @@
                 aria-label="New entity category"
                 disabled={isCreatingChild}
               >
-                {#each categories.list as cat}
+                {#each categories.list as cat (cat.id)}
                   <option value={cat.id}>{cat.label}</option>
                 {/each}
               </select>
@@ -267,7 +277,39 @@
       </div>
     {/snippet}
 
-    {#if viewMode === "list"}
+    {#snippet groupedEntityItem(entity: Entity, _keySuffix: string)}
+      <EntityListItem
+        {entity}
+        {isDragging}
+        isDragSource={entity.id === draggedEntityId}
+        draggable={!!onDragStart}
+        {onSelect}
+        onDragStart={onDragStart
+          ? (e, entityId) => {
+              draggedEntityId = entityId;
+              requestAnimationFrame(() => {
+                if (draggedEntityId === entityId) {
+                  isDragging = true;
+                }
+              });
+              onDragStart?.(e, entityId);
+            }
+          : undefined}
+        onDragEnd={onDragStart
+          ? () => {
+              isDragging = false;
+              draggedEntityId = null;
+              onDragEnd?.();
+            }
+          : undefined}
+        {onOpenZen}
+        {onFindInGraph}
+        {onApproveDraft}
+        {onRejectDraft}
+      />
+    {/snippet}
+
+    {#if effectiveViewMode === "list"}
       {#if isDragging}
         <div
           class="border-2 border-dashed border-theme-border rounded-xl p-3 text-center text-xs text-theme-muted hover:border-theme-primary hover:text-theme-primary transition-all mb-2"
@@ -310,8 +352,8 @@
           {/if}
         </div>
       {/each}
-    {:else if viewMode === "label" && groupedEntities?.type === "label"}
-      {#each groupedEntities.sortedKeys as label}
+    {:else if effectiveViewMode === "label" && groupedEntities?.type === "label"}
+      {#each groupedEntities.sortedKeys as label (label)}
         {@const labelEntities = groupedEntities.groups.get(label) ?? []}
         {@const isCollapsed = collapsedLabelGroups.has(label)}
         <button
@@ -401,6 +443,47 @@
           />
         {/each}
       {/if}
+      {#if filteredEntities.length === 0}
+        <div data-testid="no-entities-found">
+          <EmptyState
+            icon="icon-[lucide--search-x]"
+            headline="No entities found"
+            body="Try adjusting your search or filters."
+          />
+        </div>
+      {/if}
+    {:else if effectiveViewMode === "category" && groupedEntities?.type === "category"}
+      {#each groupedEntities.sortedKeys as categoryId (categoryId)}
+        {@const categoryEntities = groupedEntities.groups.get(categoryId) ?? []}
+        {@const isCollapsed = collapsedCategoryGroups.has(categoryId)}
+        <button
+          type="button"
+          onclick={() =>
+            explorerUIStore.toggleExplorerCategoryGroup(
+              activeVaultId,
+              categoryId,
+            )}
+          aria-expanded={!isCollapsed}
+          class="mt-4 first:mt-0 flex w-full items-center justify-between rounded-lg border border-theme-border/30 px-2 py-1.5 text-left text-[10px] font-bold uppercase tracking-[0.2em] text-theme-muted transition-all hover:border-theme-primary/40 hover:bg-theme-primary/5 hover:text-theme-text focus:border-theme-accent focus:outline-none focus:ring-2 focus:ring-theme-accent/20"
+        >
+          <span class="flex items-center gap-1.5">
+            {#if isCollapsed}
+              <span class="icon-[lucide--chevron-right] h-3 w-3"></span>
+            {:else}
+              <span class="icon-[lucide--chevron-down] h-3 w-3"></span>
+            {/if}
+            <span>{getCategoryLabel(categoryId)}</span>
+          </span>
+          <span class="text-[9px] text-theme-muted/80"
+            >{categoryEntities.length}</span
+          >
+        </button>
+        {#if !isCollapsed}
+          {#each categoryEntities as entity (`${entity.id}:${categoryId}`)}
+            {@render groupedEntityItem(entity, categoryId)}
+          {/each}
+        {/if}
+      {/each}
       {#if filteredEntities.length === 0}
         <div data-testid="no-entities-found">
           <EmptyState

--- a/apps/web/src/lib/components/explorer/EntityList.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityList.test.ts
@@ -49,7 +49,7 @@ const mockVault = vi.hoisted(() => {
       {
         id: "parent-1",
         title: "Parent Entity",
-        type: "npc",
+        type: "location",
         tags: [],
         labels: [],
         connections: [],
@@ -59,7 +59,7 @@ const mockVault = vi.hoisted(() => {
       {
         id: "child-1",
         title: "Child Entity",
-        type: "npc",
+        type: "location",
         tags: [],
         labels: [],
         connections: [],
@@ -87,8 +87,14 @@ vi.mock("$lib/stores/vault.svelte", () => ({
 
 vi.mock("$lib/stores/categories.svelte", () => ({
   categories: {
-    list: [{ id: "npc", label: "NPC", icon: "user", color: "#fff" }],
-    getCategory: () => ({ icon: "user" }),
+    list: [
+      { id: "npc", label: "NPC", icon: "user", color: "#fff" },
+      { id: "location", label: "Locations", icon: "map-pin", color: "#fff" },
+    ],
+    getCategory: (id: string) =>
+      id === "location"
+        ? { label: "Locations", icon: "map-pin" }
+        : { label: "NPC", icon: "user" },
   },
 }));
 
@@ -100,8 +106,10 @@ describe("EntityList", () => {
   beforeEach(() => {
     explorerUIStore.explorerViewMode = "list";
     explorerUIStore.clearLabelFilters();
+    explorerUIStore.explorerCollapsedCategoryGroups = {};
     explorerUIStore.explorerCollapsedLabelGroups = {};
     explorerUIStore.explorerCollapsedEntityIds = {};
+    window.localStorage.removeItem("codex_explorer_collapsed_category_groups");
     window.localStorage.removeItem("codex_explorer_collapsed_label_groups");
     window.localStorage.removeItem("codex_explorer_collapsed_entity_ids");
     sessionModeStore.isGuestMode = false;
@@ -149,6 +157,59 @@ describe("EntityList", () => {
     expect(
       explorerUIStore.getCollapsedLabelGroups("vault-1").has("Quest"),
     ).toBe(false);
+  });
+
+  it("shows and hides entities within a category group", async () => {
+    explorerUIStore.setExplorerViewMode("category");
+
+    render(EntityList);
+
+    expect(screen.getByText("Ava")).not.toBeNull();
+    expect(screen.getByText("Parent Entity")).not.toBeNull();
+
+    const locationToggle = screen
+      .getAllByRole("button")
+      .find(
+        (button) =>
+          button.getAttribute("aria-expanded") === "true" &&
+          button.textContent?.includes("Locations") &&
+          button.textContent?.includes("2"),
+      );
+
+    expect(locationToggle).not.toBeUndefined();
+
+    await fireEvent.click(locationToggle!);
+
+    expect(screen.queryByText("Parent Entity")).toBeNull();
+    expect(screen.queryByText("Child Entity")).toBeNull();
+    expect(screen.getByText("Ava")).not.toBeNull();
+    expect(
+      explorerUIStore.getCollapsedCategoryGroups("vault-1").has("location"),
+    ).toBe(true);
+  });
+
+  it("renders category grouping as a plain list when one category filter is active", async () => {
+    explorerUIStore.setExplorerViewMode("category");
+
+    render(EntityList);
+
+    const npcFilterButton = screen.getByLabelText("Filter by NPC");
+    await fireEvent.click(npcFilterButton);
+    await tick();
+
+    expect(
+      (screen.getByLabelText("Group by Category") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      screen.getByLabelText("List View").getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByLabelText("Group by Category").getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(screen.queryByRole("button", { expanded: true })).toBeNull();
+    expect(screen.getByText("Ava")).not.toBeNull();
+    expect(screen.queryByText("Parent Entity")).toBeNull();
   });
 
   it("clears the search query when the clear button is clicked", async () => {

--- a/apps/web/src/lib/components/explorer/EntityListFilterBar.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListFilterBar.svelte
@@ -15,6 +15,10 @@
 
   const labelFilters = $derived(explorerUIStore.labelFilters);
   const viewMode = $derived(explorerUIStore.explorerViewMode);
+  const categoryGroupingDisabled = $derived(typeFilters.size === 1);
+  const effectiveViewMode = $derived(
+    viewMode === "category" && categoryGroupingDisabled ? "list" : viewMode,
+  );
 
   const allowedTypeSet = $derived.by(() =>
     allowedTypes ? new Set(allowedTypes) : null,
@@ -60,6 +64,14 @@
     return active
       ? "rounded-lg border border-theme-primary bg-theme-primary text-theme-bg shadow-sm transition-all hover:border-theme-secondary hover:bg-theme-secondary"
       : "rounded-lg border border-theme-border bg-theme-bg/50 text-theme-muted transition-all hover:bg-theme-bg hover:text-theme-text";
+  }
+
+  function getCategoryGroupToggleClasses(active: boolean, disabled: boolean) {
+    if (disabled) {
+      return "rounded-lg border border-theme-border/50 bg-theme-bg/30 text-theme-muted/40 cursor-not-allowed";
+    }
+
+    return getIconToggleClasses(active);
   }
 </script>
 
@@ -114,9 +126,9 @@
     onclick={() => explorerUIStore.setExplorerViewMode("list")}
     title="List View"
     aria-label="List View"
-    aria-pressed={viewMode === "list"}
+    aria-pressed={effectiveViewMode === "list"}
     class="flex items-center justify-center p-1.5 {getIconToggleClasses(
-      viewMode === 'list',
+      effectiveViewMode === 'list',
     )}"
   >
     <span class="icon-[lucide--list] w-3.5 h-3.5"></span>
@@ -127,12 +139,29 @@
     onclick={() => explorerUIStore.setExplorerViewMode("label")}
     title="Group by Label"
     aria-label="Group by Label"
-    aria-pressed={viewMode === "label"}
+    aria-pressed={effectiveViewMode === "label"}
     class="flex items-center justify-center p-1.5 {getIconToggleClasses(
-      viewMode === 'label',
+      effectiveViewMode === 'label',
     )}"
   >
     <span class="icon-[lucide--tag] w-3.5 h-3.5"></span>
+  </button>
+
+  <button
+    type="button"
+    onclick={() => explorerUIStore.setExplorerViewMode("category")}
+    title={categoryGroupingDisabled
+      ? "Clear the category filter to group by category"
+      : "Group by Category"}
+    aria-label="Group by Category"
+    aria-pressed={effectiveViewMode === "category"}
+    disabled={categoryGroupingDisabled}
+    class="flex items-center justify-center p-1.5 {getCategoryGroupToggleClasses(
+      effectiveViewMode === 'category',
+      categoryGroupingDisabled,
+    )}"
+  >
+    <span class="icon-[lucide--folder-tree] w-3.5 h-3.5"></span>
   </button>
 </div>
 
@@ -140,7 +169,7 @@
   <div
     class="mt-3 flex flex-wrap gap-1.5 animate-in fade-in slide-in-from-top-1 duration-200"
   >
-    {#each Array.from(labelFilters).sort() as label}
+    {#each Array.from(labelFilters).sort() as label (label)}
       <div
         class="flex items-center gap-1 px-2 py-0.5 rounded-md bg-theme-primary/10 border border-theme-primary/20 text-[9px] font-bold text-theme-primary uppercase tracking-wider"
       >

--- a/apps/web/src/lib/components/explorer/EntityListGrouping.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityListGrouping.test.ts
@@ -31,7 +31,7 @@ describe("EntityList Grouping Logic", () => {
     {
       id: "e3",
       title: "C",
-      type: "npc",
+      type: "location",
       status: "active",
       tags: [],
       labels: [],
@@ -70,5 +70,20 @@ describe("EntityList Grouping Logic", () => {
 
   it("should not group anything in list mode", () => {
     expect(groupEntitiesForExplorer(mockEntities, "list")).toBeNull();
+  });
+
+  it("should group by category while preserving all matching entities", () => {
+    const result = groupEntitiesForExplorer(mockEntities, "category");
+
+    expect(result?.type).toBe("category");
+    expect(result?.sortedKeys).toEqual(["location", "npc"]);
+    expect(result?.groups.get("npc")?.map((entity) => entity.id)).toEqual([
+      "e1",
+      "e2",
+      "e4",
+    ]);
+    expect(result?.groups.get("location")?.map((entity) => entity.id)).toEqual([
+      "e3",
+    ]);
   });
 });

--- a/apps/web/src/lib/components/explorer/entityListGrouping.ts
+++ b/apps/web/src/lib/components/explorer/entityListGrouping.ts
@@ -1,6 +1,6 @@
 import type { Entity } from "schema";
 
-export type ExplorerViewMode = "list" | "label";
+export type ExplorerViewMode = "list" | "label" | "category";
 
 export type LabelGroupedEntities = {
   type: "label";
@@ -9,11 +9,44 @@ export type LabelGroupedEntities = {
   unlabeled: Entity[];
 };
 
+export type CategoryGroupedEntities = {
+  type: "category";
+  groups: Map<string, Entity[]>;
+  sortedKeys: string[];
+};
+
+export type ExplorerGroupedEntities =
+  | LabelGroupedEntities
+  | CategoryGroupedEntities;
+
 export function groupEntitiesForExplorer(
   entities: Entity[],
   viewMode: ExplorerViewMode,
-): LabelGroupedEntities | null {
+): ExplorerGroupedEntities | null {
   if (viewMode === "list") return null;
+
+  if (viewMode === "category") {
+    const groups = new Map<string, Entity[]>();
+
+    for (const entity of entities) {
+      let categoryGroup = groups.get(entity.type);
+      if (!categoryGroup) {
+        categoryGroup = [];
+        groups.set(entity.type, categoryGroup);
+      }
+      categoryGroup.push(entity);
+    }
+
+    const sortedKeys = Array.from(groups.keys()).sort((a, b) =>
+      a.localeCompare(b),
+    );
+
+    return {
+      type: "category",
+      groups,
+      sortedKeys,
+    };
+  }
 
   const groups = new Map<string, Entity[]>();
   const unlabeled: Entity[] = [];

--- a/apps/web/src/lib/stores/ui/explorer-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/explorer-ui.svelte.ts
@@ -5,11 +5,14 @@ import {
 } from "./persistence";
 
 type ExplorerCollapsedLabelGroups = Record<string, string[]>;
+type ExplorerCollapsedCategoryGroups = Record<string, string[]>;
+type ExplorerViewMode = "list" | "label" | "category";
 
 export class ExplorerUIStore {
   private persistence: UIPersistence;
 
-  explorerViewMode = $state<"list" | "label">("list");
+  explorerViewMode = $state<ExplorerViewMode>("list");
+  explorerCollapsedCategoryGroups = $state<ExplorerCollapsedCategoryGroups>({});
   explorerCollapsedLabelGroups = $state<ExplorerCollapsedLabelGroups>({});
   explorerCollapsedEntityIds = $state<Record<string, string[]>>({});
   labelFilters = $state<Set<string>>(new Set());
@@ -25,54 +28,34 @@ export class ExplorerUIStore {
       (v) => v,
       "list",
     );
-    if (explorerMode === "list" || explorerMode === "label") {
+    if (
+      explorerMode === "list" ||
+      explorerMode === "label" ||
+      explorerMode === "category"
+    ) {
       this.explorerViewMode = explorerMode;
     }
 
+    this.explorerCollapsedCategoryGroups = this.persistence.read(
+      UI_STORAGE_KEYS.EXPLORER_COLLAPSED_CATEGORY_GROUPS,
+      (v) => this.parseStringArrayMap(v, "Invalid collapsed category groups"),
+      {},
+    );
+
     this.explorerCollapsedLabelGroups = this.persistence.read(
       UI_STORAGE_KEYS.EXPLORER_COLLAPSED_LABEL_GROUPS,
-      (v) => {
-        const parsed = JSON.parse(v);
-        if (
-          parsed &&
-          typeof parsed === "object" &&
-          !Array.isArray(parsed) &&
-          Object.values(parsed).every(
-            (value) =>
-              Array.isArray(value) &&
-              value.every((item) => typeof item === "string"),
-          )
-        ) {
-          return parsed as ExplorerCollapsedLabelGroups;
-        }
-        throw new Error("Invalid collapsed label groups");
-      },
+      (v) => this.parseStringArrayMap(v, "Invalid collapsed label groups"),
       {},
     );
 
     this.explorerCollapsedEntityIds = this.persistence.read(
       UI_STORAGE_KEYS.EXPLORER_COLLAPSED_ENTITY_IDS,
-      (v) => {
-        const parsed = JSON.parse(v);
-        if (
-          parsed &&
-          typeof parsed === "object" &&
-          !Array.isArray(parsed) &&
-          Object.values(parsed).every(
-            (value) =>
-              Array.isArray(value) &&
-              value.every((item) => typeof item === "string"),
-          )
-        ) {
-          return parsed as Record<string, string[]>;
-        }
-        throw new Error("Invalid collapsed entity IDs");
-      },
+      (v) => this.parseStringArrayMap(v, "Invalid collapsed entity IDs"),
       {},
     );
   }
 
-  setExplorerViewMode(mode: "list" | "label") {
+  setExplorerViewMode(mode: ExplorerViewMode) {
     this.explorerViewMode = mode;
     this.persistence.write(UI_STORAGE_KEYS.EXPLORER_VIEW_MODE, mode, String);
   }
@@ -105,13 +88,42 @@ export class ExplorerUIStore {
     this.labelFilters = new Set();
   }
 
+  getCollapsedCategoryGroups(vaultId: string | null): Set<string> {
+    const scope = this.getExplorerGroupScope(vaultId);
+    return new Set(this.explorerCollapsedCategoryGroups[scope] ?? []);
+  }
+
+  toggleExplorerCategoryGroup(vaultId: string | null, categoryId: string) {
+    const scope = this.getExplorerGroupScope(vaultId);
+    const nextCategories = new Set(
+      this.explorerCollapsedCategoryGroups[scope] ?? [],
+    );
+
+    if (nextCategories.has(categoryId)) {
+      nextCategories.delete(categoryId);
+    } else {
+      nextCategories.add(categoryId);
+    }
+
+    const nextState = this.withUpdatedGroup(
+      this.explorerCollapsedCategoryGroups,
+      scope,
+      nextCategories,
+    );
+    this.explorerCollapsedCategoryGroups = nextState;
+    this.persistence.write(
+      UI_STORAGE_KEYS.EXPLORER_COLLAPSED_CATEGORY_GROUPS,
+      nextState,
+    );
+  }
+
   getCollapsedLabelGroups(vaultId: string | null): Set<string> {
-    const scope = this.getExplorerLabelGroupScope(vaultId);
+    const scope = this.getExplorerGroupScope(vaultId);
     return new Set(this.explorerCollapsedLabelGroups[scope] ?? []);
   }
 
   toggleExplorerLabelGroup(vaultId: string | null, label: string) {
-    const scope = this.getExplorerLabelGroupScope(vaultId);
+    const scope = this.getExplorerGroupScope(vaultId);
     const nextLabels = new Set(this.explorerCollapsedLabelGroups[scope] ?? []);
 
     if (nextLabels.has(label)) {
@@ -120,15 +132,11 @@ export class ExplorerUIStore {
       nextLabels.add(label);
     }
 
-    const nextState = { ...this.explorerCollapsedLabelGroups };
-    if (nextLabels.size === 0) {
-      delete nextState[scope];
-    } else {
-      nextState[scope] = Array.from(nextLabels).sort((a, b) =>
-        a.localeCompare(b),
-      );
-    }
-
+    const nextState = this.withUpdatedGroup(
+      this.explorerCollapsedLabelGroups,
+      scope,
+      nextLabels,
+    );
     this.explorerCollapsedLabelGroups = nextState;
     this.persistence.write(
       UI_STORAGE_KEYS.EXPLORER_COLLAPSED_LABEL_GROUPS,
@@ -137,12 +145,12 @@ export class ExplorerUIStore {
   }
 
   getCollapsedEntities(vaultId: string | null): Set<string> {
-    const scope = this.getExplorerLabelGroupScope(vaultId);
+    const scope = this.getExplorerGroupScope(vaultId);
     return new Set(this.explorerCollapsedEntityIds[scope] ?? []);
   }
 
   toggleExplorerEntityCollapse(vaultId: string | null, entityId: string) {
-    const scope = this.getExplorerLabelGroupScope(vaultId);
+    const scope = this.getExplorerGroupScope(vaultId);
     const nextEntities = new Set(this.explorerCollapsedEntityIds[scope] ?? []);
 
     if (nextEntities.has(entityId)) {
@@ -151,15 +159,11 @@ export class ExplorerUIStore {
       nextEntities.add(entityId);
     }
 
-    const nextState = { ...this.explorerCollapsedEntityIds };
-    if (nextEntities.size === 0) {
-      delete nextState[scope];
-    } else {
-      nextState[scope] = Array.from(nextEntities).sort((a, b) =>
-        a.localeCompare(b),
-      );
-    }
-
+    const nextState = this.withUpdatedGroup(
+      this.explorerCollapsedEntityIds,
+      scope,
+      nextEntities,
+    );
     this.explorerCollapsedEntityIds = nextState;
     this.persistence.write(
       UI_STORAGE_KEYS.EXPLORER_COLLAPSED_ENTITY_IDS,
@@ -167,7 +171,38 @@ export class ExplorerUIStore {
     );
   }
 
-  private getExplorerLabelGroupScope(vaultId: string | null) {
+  private parseStringArrayMap(raw: string, errorMessage: string) {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      Object.values(parsed).every(
+        (value) =>
+          Array.isArray(value) &&
+          value.every((item) => typeof item === "string"),
+      )
+    ) {
+      return parsed as Record<string, string[]>;
+    }
+    throw new Error(errorMessage);
+  }
+
+  private withUpdatedGroup(
+    current: Record<string, string[]>,
+    scope: string,
+    entries: Set<string>,
+  ) {
+    const nextState = { ...current };
+    if (entries.size === 0) {
+      delete nextState[scope];
+    } else {
+      nextState[scope] = Array.from(entries).sort((a, b) => a.localeCompare(b));
+    }
+    return nextState;
+  }
+
+  private getExplorerGroupScope(vaultId: string | null) {
     return vaultId ?? "__default__";
   }
 }

--- a/apps/web/src/lib/stores/ui/explorer-ui.test.ts
+++ b/apps/web/src/lib/stores/ui/explorer-ui.test.ts
@@ -65,6 +65,49 @@ describe("ExplorerUIStore", () => {
     expect(Array.from(store.getCollapsedLabelGroups("v1"))).toEqual([]);
   });
 
+  it("handles collapsed category groups independently from labels", () => {
+    const mockStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    const persistence = new UIPersistence({ storage: mockStorage });
+    const store = new ExplorerUIStore(persistence);
+
+    store.toggleExplorerCategoryGroup("v1", "npc");
+    store.toggleExplorerLabelGroup("v1", "npc");
+
+    expect(Array.from(store.getCollapsedCategoryGroups("v1"))).toEqual(["npc"]);
+    expect(Array.from(store.getCollapsedLabelGroups("v1"))).toEqual(["npc"]);
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      "codex_explorer_collapsed_category_groups",
+      expect.stringContaining("npc"),
+    );
+
+    store.toggleExplorerCategoryGroup("v1", "npc");
+
+    expect(Array.from(store.getCollapsedCategoryGroups("v1"))).toEqual([]);
+    expect(Array.from(store.getCollapsedLabelGroups("v1"))).toEqual(["npc"]);
+  });
+
+  it("persists category view mode", () => {
+    const mockStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    const persistence = new UIPersistence({ storage: mockStorage });
+    const store = new ExplorerUIStore(persistence);
+
+    store.setExplorerViewMode("category");
+
+    expect(store.explorerViewMode).toBe("category");
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      "codex_explorer_view_mode",
+      "category",
+    );
+  });
+
   it("handles collapsed entity states", () => {
     const mockStorage = {
       getItem: vi.fn().mockReturnValue(null),

--- a/apps/web/src/lib/stores/ui/persistence.test.ts
+++ b/apps/web/src/lib/stores/ui/persistence.test.ts
@@ -11,6 +11,7 @@ describe("UIPersistence", () => {
       "codex_connection_discovery_mode",
       "codex_dismissed_landing",
       "codex_entity_discovery_mode",
+      "codex_explorer_collapsed_category_groups",
       "codex_explorer_collapsed_entity_ids",
       "codex_explorer_collapsed_label_groups",
       "codex_explorer_view_mode",

--- a/apps/web/src/lib/stores/ui/persistence.ts
+++ b/apps/web/src/lib/stores/ui/persistence.ts
@@ -11,6 +11,8 @@ export const UI_STORAGE_KEYS = {
   CONNECTION_DISCOVERY_MODE: "codex_connection_discovery_mode",
   DISMISSED_LANDING: "codex_dismissed_landing",
   ENTITY_DISCOVERY_MODE: "codex_entity_discovery_mode",
+  EXPLORER_COLLAPSED_CATEGORY_GROUPS:
+    "codex_explorer_collapsed_category_groups",
   EXPLORER_COLLAPSED_LABEL_GROUPS: "codex_explorer_collapsed_label_groups",
   EXPLORER_COLLAPSED_ENTITY_IDS: "codex_explorer_collapsed_entity_ids",
   EXPLORER_VIEW_MODE: "codex_explorer_view_mode",


### PR DESCRIPTION
## Summary

Adds a new Entity Explorer view mode that groups the currently matching entity list by category/type.

## What changed

- Added `category` as an explorer view mode alongside `list` and `label`.
- Added a Group by Category control using the existing Iconify utility pattern.
- Renders matching entities under collapsible category headers with counts.
- Persists collapsed category groups per vault without changing entity data.
- Falls back to the plain list and disables category grouping when a single category filter is active.

## Why

Issue #1074 asks for a presentation-only way to scan the whole vault by entity category without using the existing category filter, which narrows the result set to one category.

Closes #1074.

## Validation

- `bun run lint`
- `BUN_NUM_THREADS=2 bun run test`
- `bun run --filter web test -- src/lib/components/explorer/EntityList.test.ts src/lib/components/explorer/EntityListGrouping.test.ts src/lib/stores/ui/explorer-ui.test.ts src/lib/stores/ui/persistence.test.ts`
- Pre-push hook: cached lint and changed-file tests