### PR TITLE
:sparkles: feat(explorer): make category filter buttons toggle multi-select by default

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityList.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityList.test.ts
@@ -352,4 +352,33 @@ describe("EntityList", () => {
       .closest("[data-testid='entity-list-item']");
     expect(parentRow?.getAttribute("draggable")).toBe("false");
   });
+
+  it("toggles multiple category filters sequentially to show OR filtered entities", async () => {
+    render(EntityList);
+
+    const npcButton = screen.getByLabelText("Filter by NPC");
+    const locationsButton = screen.getByLabelText("Filter by Locations");
+
+    // Initially, both npc and location entities are visible
+    expect(screen.queryByText("Ava")).not.toBeNull();
+    expect(screen.queryByText("Parent Entity")).not.toBeNull();
+
+    // Click NPC button -> filters to only NPC
+    await fireEvent.click(npcButton);
+    await tick();
+    expect(screen.queryByText("Ava")).not.toBeNull();
+    expect(screen.queryByText("Parent Entity")).toBeNull();
+
+    // Click Locations button -> toggles Locations ON as well (OR filtering: NPC or Location)
+    await fireEvent.click(locationsButton);
+    await tick();
+    expect(screen.queryByText("Ava")).not.toBeNull();
+    expect(screen.queryByText("Parent Entity")).not.toBeNull();
+
+    // Click NPC button again -> toggles NPC OFF (only Locations remains)
+    await fireEvent.click(npcButton);
+    await tick();
+    expect(screen.queryByText("Ava")).toBeNull();
+    expect(screen.queryByText("Parent Entity")).not.toBeNull();
+  });
 });

--- a/apps/web/src/lib/components/explorer/EntityListFilterBar.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListFilterBar.svelte
@@ -30,7 +30,7 @@
     ),
   );
 
-  function toggleTypeFilter(type: string, event: MouseEvent) {
+  function toggleTypeFilter(type: string, _event: MouseEvent) {
     if (type === "all") {
       typeFilters = new Set();
       explorerUIStore.clearLabelFilters();
@@ -41,23 +41,13 @@
       return;
     }
 
-    const isMulti = event.ctrlKey || event.metaKey;
-
-    if (isMulti) {
-      const newFilters = new Set(typeFilters);
-      if (newFilters.has(type)) {
-        newFilters.delete(type);
-      } else {
-        newFilters.add(type);
-      }
-      typeFilters = newFilters;
+    const newFilters = new Set(typeFilters);
+    if (newFilters.has(type)) {
+      newFilters.delete(type);
     } else {
-      if (typeFilters.has(type)) {
-        typeFilters = new Set();
-      } else {
-        typeFilters = new Set([type]);
-      }
+      newFilters.add(type);
     }
+    typeFilters = newFilters;
   }
 
   function getIconToggleClasses(active: boolean) {

--- a/apps/web/src/lib/components/explorer/EntityListFilterBar.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListFilterBar.svelte
@@ -30,7 +30,7 @@
     ),
   );
 
-  function toggleTypeFilter(type: string, _event: MouseEvent) {
+  function toggleTypeFilter(type: string) {
     if (type === "all") {
       typeFilters = new Set();
       explorerUIStore.clearLabelFilters();
@@ -70,7 +70,7 @@
 >
   <button
     type="button"
-    onclick={(e) => toggleTypeFilter("all", e)}
+    onclick={() => toggleTypeFilter("all")}
     title="Show all categories"
     aria-label="Show all categories"
     aria-pressed={typeFilters.size === 0}
@@ -86,7 +86,7 @@
     {#if count > 0 || typeFilters.has(cat.id)}
       <button
         type="button"
-        onclick={(e) => toggleTypeFilter(cat.id, e)}
+        onclick={() => toggleTypeFilter(cat.id)}
         title={cat.label}
         aria-label={`Filter by ${cat.label}`}
         aria-pressed={typeFilters.has(cat.id)}


### PR DESCRIPTION
Closes #1075

Simplifies category filtering in Entity Explorer to toggle on single click instead of requiring Ctrl/Meta modifiers.