### PR TITLE
✨ feat(1096): ship D&D NPC generator page

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -11,14 +11,31 @@
 
   let {
     slug,
+    canonicalPath,
+    pageTitle,
+    metaDescription,
+    eyebrow = "Free RPG Tool",
+    introTitle,
+    introText,
+    relatedLinks = [],
+    faqs = [],
   }: {
     slug: "npc" | "settlement" | "magic-item";
+    canonicalPath?: string;
+    pageTitle?: string;
+    metaDescription?: string;
+    eyebrow?: string;
+    introTitle?: string;
+    introText?: string;
+    relatedLinks?: { href: string; label: string }[];
+    faqs?: { question: string; answer: string }[];
   } = $props();
 
   // Selected parameters
   let npcRace = $state(npcConfig.races[0]);
   let npcRole = $state(npcConfig.roles[0]);
   let npcAlignment = $state(npcConfig.alignments[0]);
+  let npcCampaignContext = $state("");
 
   let settlementSize = $state(settlementConfig.sizes[2].name); // Default to Town
   let settlementEconomy = $state(settlementConfig.economies[0]);
@@ -34,6 +51,37 @@
 
   // Fallback Copy to Clipboard state
   let copied = $state(false);
+  const resolvedTitle = $derived(
+    pageTitle ||
+      `Free RPG ${slug === "npc" ? "NPC" : slug === "settlement" ? "Settlement" : "Magic Item"} Generator | Codex Cryptica`,
+  );
+  const resolvedDescription = $derived(
+    metaDescription ||
+      "Generate high-quality detailed campaign drafts using our interactive local-first generators.",
+  );
+  const resolvedIntroTitle = $derived(
+    introTitle ||
+      (slug === "npc"
+        ? "D&D NPC Generator"
+        : `${slug === "settlement" ? "Settlement" : "Magic Item"} Generator`),
+  );
+  const faqJsonLd = $derived(
+    faqs.length > 0
+      ? JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqs.map((faq) => ({
+            "@type": "Question",
+            name: faq.question,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: faq.answer,
+            },
+          })),
+        })
+      : "",
+  );
+  const formAction = $derived(canonicalPath || `/generators/${slug}`);
 
   async function handleGenerate() {
     isGenerating = true;
@@ -44,6 +92,7 @@
           race: npcRace,
           role: npcRole,
           alignment: npcAlignment,
+          campaignContext: npcCampaignContext,
           useAI,
         });
       } else if (slug === "settlement") {
@@ -136,18 +185,15 @@ ${generatedData.lore}`;
 </script>
 
 <svelte:head>
-  <title
-    >Free RPG {slug === "npc"
-      ? "NPC"
-      : slug === "settlement"
-        ? "Settlement"
-        : "Magic Item"} Generator | Codex Cryptica</title
-  >
-  <meta
-    name="description"
-    content="Generate high-quality detailed campaign drafts using our interactive local-first generators."
-  />
+  <title>{resolvedTitle}</title>
+  <meta name="description" content={resolvedDescription} />
+  {#if canonicalPath}
+    <link rel="canonical" href="https://codexcryptica.com{canonicalPath}" />
+  {/if}
   <link rel="help" href="{base}/llms.txt" />
+  {#if faqJsonLd}
+    {@html `<script type="application/ld+json">${faqJsonLd}</` + "script>"}
+  {/if}
 </svelte:head>
 
 <div
@@ -204,23 +250,33 @@ ${generatedData.lore}`;
       <div
         class="p-6 bg-theme-surface/40 border border-theme-border/60 rounded-2xl shadow-sm"
       >
+        <div
+          class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-mono font-medium bg-theme-primary/10 border border-theme-primary/20 text-theme-primary mb-4"
+        >
+          <span class="icon-[lucide--wand-sparkles] w-3.5 h-3.5"></span>
+          {eyebrow}
+        </div>
         <h1
           class="font-header font-bold text-lg uppercase tracking-wider text-theme-primary mb-4"
           id="generator-title"
         >
-          {#if slug === "npc"}
-            NPC Generator
-          {:else}
-            {slug === "settlement" ? "Settlement" : "Magic Item"} Generator
-          {/if}
+          {resolvedIntroTitle}
         </h1>
         <p class="text-xs text-theme-muted leading-relaxed mb-6">
-          Customize options and instantly generate structured drafts to populate
-          your campaign lore database.
+          {introText ||
+            "Customize options and instantly generate structured drafts to populate your campaign lore database."}
         </p>
 
         <!-- Generation Inputs -->
-        <div class="space-y-4">
+        <form
+          class="space-y-4"
+          action="{base}{formAction}"
+          method="GET"
+          onsubmit={(event) => {
+            event.preventDefault();
+            void handleGenerate();
+          }}
+        >
           {#if slug === "npc"}
             <div class="flex flex-col gap-1.5">
               <label
@@ -271,6 +327,30 @@ ${generatedData.lore}`;
                   <option value={a}>{a}</option>
                 {/each}
               </select>
+            </div>
+
+            <div class="flex flex-col gap-1.5">
+              <label
+                for="campaign-context"
+                class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+                >Optional Campaign Context</label
+              >
+              <textarea
+                id="campaign-context"
+                name="campaign_context"
+                bind:value={npcCampaignContext}
+                maxlength="240"
+                rows="4"
+                aria-describedby="campaign-context-help"
+                class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+              ></textarea>
+              <p
+                id="campaign-context-help"
+                class="text-[10px] text-theme-muted leading-relaxed"
+              >
+                Add a city, faction, dungeon, or current campaign problem to aim
+                the NPC at your table.
+              </p>
             </div>
           {:else}
             {#if slug === "settlement"}
@@ -364,8 +444,7 @@ ${generatedData.lore}`;
           </div>
 
           <button
-            type="button"
-            onclick={handleGenerate}
+            type="submit"
             disabled={isGenerating}
             class="w-full py-3 mt-4 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2 disabled:opacity-50"
             id="generate-button"
@@ -378,13 +457,30 @@ ${generatedData.lore}`;
               ✦ Generate RPG Draft ✦
             {/if}
           </button>
-        </div>
+        </form>
 
         {#if errorMessage}
           <div
             class="mt-4 p-3 border border-red-500/30 bg-red-500/10 rounded-xl text-red-400 text-xs"
           >
             {errorMessage}
+          </div>
+        {/if}
+
+        {#if relatedLinks.length > 0}
+          <div
+            class="mt-5 border-t border-theme-border/60 pt-4 flex flex-col gap-2"
+            aria-label="Related pages"
+          >
+            {#each relatedLinks as link (link.href)}
+              <a
+                href="{base}{link.href}"
+                class="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-theme-muted hover:text-theme-primary transition-colors"
+              >
+                <span class="icon-[lucide--arrow-right] w-3.5 h-3.5"></span>
+                {link.label}
+              </a>
+            {/each}
           </div>
         {/if}
       </div>
@@ -487,6 +583,34 @@ ${generatedData.lore}`;
       </div>
     </div>
   </div>
+
+  {#if faqs.length > 0}
+    <section class="border-t border-theme-border/60 px-6 py-12">
+      <div class="max-w-4xl mx-auto">
+        <h2
+          class="font-header font-bold text-xl uppercase tracking-wider text-theme-primary mb-6"
+        >
+          D&D NPC Generator FAQ
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {#each faqs as faq (faq.question)}
+            <article
+              class="border border-theme-border/60 bg-theme-surface/30 rounded-xl p-5"
+            >
+              <h3
+                class="font-header font-bold text-sm uppercase tracking-wider mb-2"
+              >
+                {faq.question}
+              </h3>
+              <p class="text-sm text-theme-muted leading-relaxed">
+                {faq.answer}
+              </p>
+            </article>
+          {/each}
+        </div>
+      </div>
+    </section>
+  {/if}
 
   <!-- Marketing Footer -->
   <footer

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -253,7 +253,10 @@ ${generatedData.lore}`;
         <div
           class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-mono font-medium bg-theme-primary/10 border border-theme-primary/20 text-theme-primary mb-4"
         >
-          <span class="icon-[lucide--wand-sparkles] w-3.5 h-3.5"></span>
+          <span
+            class="icon-[lucide--wand-sparkles] w-3.5 h-3.5"
+            aria-hidden="true"
+          ></span>
           {eyebrow}
         </div>
         <h1
@@ -477,7 +480,10 @@ ${generatedData.lore}`;
                 href="{base}{link.href}"
                 class="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-theme-muted hover:text-theme-primary transition-colors"
               >
-                <span class="icon-[lucide--arrow-right] w-3.5 h-3.5"></span>
+                <span
+                  class="icon-[lucide--arrow-right] w-3.5 h-3.5"
+                  aria-hidden="true"
+                ></span>
                 {link.label}
               </a>
             {/each}
@@ -590,7 +596,7 @@ ${generatedData.lore}`;
         <h2
           class="font-header font-bold text-xl uppercase tracking-wider text-theme-primary mb-6"
         >
-          D&D NPC Generator FAQ
+          {resolvedIntroTitle} FAQ
         </h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
           {#each faqs as faq (faq.question)}

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -34,7 +34,24 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.content).toContain("Elf");
       expect(res.content).toContain("Mage");
       expect(res.lore).toContain("Neutral Good");
+      expect(res.lore).toContain("Species/Ancestry");
+      expect(res.lore).toContain("Faction Connection");
+      expect(res.lore).toContain("Plot Hook");
+      expect(res.labels).toContain("npc-generator");
       expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should include optional campaign context in local NPC output", async () => {
+      const res = await engine.generateNPC({
+        race: "Human",
+        role: "Guard",
+        alignment: "Lawful Neutral",
+        campaignContext: "a haunted border city under siege",
+        useAI: false,
+      });
+
+      expect(res.content).toContain("Campaign Fit");
+      expect(res.content).toContain("a haunted border city under siege");
     });
 
     it("should call clientManager when useAI is true and succeed", async () => {
@@ -57,11 +74,15 @@ describe("DefaultGeneratorEngine", () => {
         race: "Elf",
         role: "Mage",
         alignment: "Neutral Good",
+        campaignContext: "a ruined elven academy",
         useAI: true,
       });
 
       expect(mockClientManager.getModel).toHaveBeenCalled();
       expect(mockModel.generateContent).toHaveBeenCalled();
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("a ruined elven academy"),
+      );
       expect(res.title).toBe("Aelwen The Wise");
       expect(res.content).toBe("AI Generated Bio");
       expect(res.lore).toBe("AI Generated Stats");

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -140,6 +140,22 @@ export const npcConfig = {
     "To exact revenge on the corrupt noble who exiled them.",
     "To locate a legendary magical spellbook hidden in a nearby ruin.",
   ],
+  factions: [
+    "The Ashen Ledger, a quiet network of debt collectors and informants.",
+    "The Lantern Court, a civic order that keeps public peace after sunset.",
+    "The Red Sash Company, sellswords with a habit of choosing winning sides.",
+    "The Argent Loom, an artisan guild that hides coded messages in its work.",
+    "The Chapel of Last Mercy, a temple faction that knows too many confessions.",
+    "The Blackwater Compact, smugglers moving relics beneath legitimate trade.",
+  ],
+  plotHooks: [
+    "They ask the party to recover a sealed letter before it reaches a rival.",
+    "They recognize one character from a prophecy but refuse to explain in public.",
+    "They can open a locked district gate if the party solves their immediate problem.",
+    "They are being followed by someone who disappears whenever challenged.",
+    "They offer a reward for escort, then reveal the destination is forbidden ground.",
+    "They own a clue that reframes a recent villain as someone else's pawn.",
+  ],
 };
 
 // Settlement Generator Table Config
@@ -262,6 +278,7 @@ export class DefaultGeneratorEngine {
       race?: string;
       role?: string;
       alignment?: string;
+      campaignContext?: string;
       useAI?: boolean;
     } = {},
   ): Promise<GeneratorOutput> {
@@ -276,6 +293,7 @@ export class DefaultGeneratorEngine {
       npcConfig.alignments[
         Math.floor(Math.random() * npcConfig.alignments.length)
       ];
+    const campaignContext = options.campaignContext?.trim();
     const name = this.generateName();
 
     if (options.useAI !== false) {
@@ -286,13 +304,14 @@ Options:
 - Race: ${race}
 - Role: ${role}
 - Alignment: ${alignment}
+${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
 
 You must return a valid JSON object matching the following structure exactly:
 {
   "title": "A single string for the NPC's name",
-  "content": "A detailed multi-paragraph biographical backstory (markdown formatted) describing who they are, their appearance, and their daily life.",
-  "lore": "Structured GM details (markdown formatted) detailing their stats, alignment, personality traits, secrets, and motives.",
-  "labels": ["rpg-character", "imported-draft"]
+  "content": "A detailed multi-paragraph biographical backstory (markdown formatted) describing who they are, their appearance, daily life, and how they fit the campaign context if provided.",
+  "lore": "Structured GM details (markdown formatted) with sections for core fields, personality, secret, motivation, faction connection, and plot hook.",
+  "labels": ["rpg-character", "npc-generator", "imported-draft"]
 }
 Return only the JSON object. Do not include markdown code block formatting like \`\`\`json.`;
 
@@ -317,7 +336,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
           lore: data.lore || "",
           labels: Array.isArray(data.labels)
             ? data.labels
-            : ["rpg-character", "imported-draft"],
+            : ["rpg-character", "npc-generator", "imported-draft"],
           status: "active",
         };
       } catch (err) {
@@ -334,34 +353,57 @@ Return only the JSON object. Do not include markdown code block formatting like 
       npcConfig.secrets[Math.floor(Math.random() * npcConfig.secrets.length)];
     const motive =
       npcConfig.motives[Math.floor(Math.random() * npcConfig.motives.length)];
+    const faction =
+      npcConfig.factions[Math.floor(Math.random() * npcConfig.factions.length)];
+    const plotHook =
+      npcConfig.plotHooks[
+        Math.floor(Math.random() * npcConfig.plotHooks.length)
+      ];
 
     const content = `### Biography
-${name} is a ${race} ${role} who lives a simple but distinct life. Known by peers to be persistent in their endeavors, they spend their days honing their trade and navigating the complex politics of the local district. 
+${name} is a ${race} ${role} whose public reputation is useful, incomplete, and just suspicious enough to matter. Locals know them as someone who gets results, even when the work requires favors, secrets, or a carefully timed lie.
+
+${campaignContext ? `### Campaign Fit\nUse ${name} in ${campaignContext}. Their current problem should pull the party toward the campaign's active locations, factions, or unresolved mysteries.\n` : ""}
 
 ### Appearance
 They carry themselves with a posture reflecting their profession. Their clothes are well-worn, showing the signs of travel and work, but kept with a level of respect.
 
-### Habits
+### Personality
 - ${traits[0]}
-- ${traits[1]}`;
+- ${traits[1]}
+
+### Table Use
+Introduce ${name} when the party needs a social lead, a compromised witness, or a morally complicated ally. They should be helpful immediately, but never free of consequences.`;
 
     const lore = `### GM Reference Information
-- **Race**: ${race}
-- **Role/Class**: ${role}
+- **Name**: ${name}
+- **Species/Ancestry**: ${race}
+- **Role**: ${role}
 - **Alignment**: ${alignment}
+- **Entity Type**: Character
 
-### Core Motivation
-${motive}
+### Personality
+- ${traits[0]}
+- ${traits[1]}
 
 ### Hidden Secret
-${secret}`;
+${secret}
+
+### Motivation
+${motive}
+
+### Faction Connection
+${faction}
+
+### Plot Hook
+${plotHook}`;
 
     return {
       type: "character",
       title: name,
       content,
       lore,
-      labels: ["rpg-character", "imported-draft"],
+      labels: ["rpg-character", "npc-generator", "imported-draft"],
       status: "active",
     };
   }

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  const toolSections = [
+    {
+      title: "RPG Generators",
+      description:
+        "Generate campaign-ready drafts, then copy them or save them into a local Codex Cryptica vault.",
+      links: [
+        {
+          href: "/tools/dnd-npc-generator",
+          label: "D&D NPC Generator",
+          summary:
+            "Create a fantasy NPC with ancestry, role, personality, secret, faction tie, and plot hook.",
+          icon: "icon-[lucide--user-round-plus]",
+        },
+        {
+          href: "/generators/npc",
+          label: "Procedural NPC Generator",
+          summary:
+            "Use the reusable generator interface for local NPC drafts and save-to-Codex imports.",
+          icon: "icon-[lucide--users]",
+        },
+        {
+          href: "/generators/settlement",
+          label: "Settlement Generator",
+          summary:
+            "Draft towns and villages with population, economy, government, locations, and factions.",
+          icon: "icon-[lucide--landmark]",
+        },
+        {
+          href: "/generators/magic-item",
+          label: "Magic Item Generator",
+          summary:
+            "Generate item concepts with rarity, properties, history, and GM-facing lore.",
+          icon: "icon-[lucide--sparkles]",
+        },
+      ],
+    },
+    {
+      title: "Campaign Tools",
+      description:
+        "Core public pages for the local-first campaign manager, worldbuilding workspace, and AI-assisted GM workflows.",
+      links: [
+        {
+          href: "/free-rpg-campaign-manager",
+          label: "Free RPG Campaign Manager",
+          summary:
+            "Explore the first SEO landing page and the main campaign-management pitch.",
+          icon: "icon-[lucide--castle]",
+        },
+        {
+          href: "/worldbuilding-tool",
+          label: "Worldbuilding Tool",
+          summary:
+            "See how Codex Cryptica supports linked lore, timelines, canvases, and local-first vaults.",
+          icon: "icon-[lucide--network]",
+        },
+        {
+          href: "/ai-rpg-campaign-manager",
+          label: "AI RPG Campaign Manager",
+          summary:
+            "Review the AI-assisted campaign workflow built around local notes and BYO Gemini access.",
+          icon: "icon-[lucide--wand-sparkles]",
+        },
+      ],
+    },
+    {
+      title: "Solutions",
+      description:
+        "Focused pages for searchers comparing campaign planning, worldbuilding, AI assistance, and privacy-first storage.",
+      links: [
+        {
+          href: "/solutions/campaign-manager",
+          label: "Campaign Manager Solution",
+          summary:
+            "Campaign organization, graph navigation, maps, timelines, and prep workflows.",
+          icon: "icon-[lucide--clipboard-list]",
+        },
+        {
+          href: "/solutions/worldbuilding-tool",
+          label: "Worldbuilding Solution",
+          summary:
+            "A visual wiki and campaign knowledge base for factions, places, characters, and lore.",
+          icon: "icon-[lucide--book-open]",
+        },
+        {
+          href: "/solutions/ai-gm-assistant",
+          label: "AI GM Assistant Solution",
+          summary:
+            "AI-assisted lore drafting and revision workflows for game masters.",
+          icon: "icon-[lucide--bot]",
+        },
+        {
+          href: "/solutions/local-first-rpg",
+          label: "Local-First RPG Solution",
+          summary:
+            "Privacy-first campaign storage using browser-local vaults and exportable data.",
+          icon: "icon-[lucide--hard-drive]",
+        },
+      ],
+    },
+    {
+      title: "Comparisons",
+      description:
+        "Side-by-side alternatives for creators evaluating campaign and worldbuilding tools.",
+      links: [
+        {
+          href: "/vs/obsidian",
+          label: "Codex Cryptica vs Obsidian",
+          summary:
+            "Compare a purpose-built RPG workspace with a general-purpose note app.",
+          icon: "icon-[lucide--columns-3]",
+        },
+        {
+          href: "/vs/world-anvil",
+          label: "Codex Cryptica vs World Anvil",
+          summary:
+            "Compare local-first privacy with cloud-hosted worldbuilding and subscriptions.",
+          icon: "icon-[lucide--scale]",
+        },
+        {
+          href: "/vs/legendkeeper",
+          label: "Codex Cryptica vs LegendKeeper",
+          summary:
+            "Compare offline-friendly browser storage with closed cloud wiki workflows.",
+          icon: "icon-[lucide--git-compare]",
+        },
+      ],
+    },
+  ];
+</script>
+
+<svelte:head>
+  <title>RPG Tools, Generators, and Comparisons | Codex Cryptica</title>
+  <meta
+    name="description"
+    content="Browse Codex Cryptica's RPG generators, campaign tools, solution pages, and comparison guides from one central tools hub."
+  />
+  <link rel="canonical" href="https://codexcryptica.com/tools" />
+  <link rel="help" href="{base}/llms.txt" />
+</svelte:head>
+
+<main
+  class="min-h-screen bg-theme-bg text-theme-text font-body selection:bg-theme-primary selection:text-theme-bg"
+  style:background-image="var(--bg-texture-overlay)"
+>
+  <section class="border-b border-theme-border/60 px-6 py-14 md:py-18">
+    <div class="max-w-6xl mx-auto">
+      <a
+        href="{base}/"
+        class="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-theme-muted hover:text-theme-primary transition-colors mb-8"
+      >
+        <span class="icon-[lucide--arrow-left] h-4 w-4"></span>
+        Codex Cryptica
+      </a>
+      <div class="max-w-3xl">
+        <p
+          class="text-xs font-mono uppercase tracking-[0.24em] text-theme-primary mb-4"
+        >
+          Tools Directory
+        </p>
+        <h1
+          class="font-header text-4xl md:text-5xl font-extrabold tracking-wide uppercase mb-5"
+        >
+          RPG Tools, Generators, and Comparisons
+        </h1>
+        <p class="text-base md:text-lg text-theme-muted leading-relaxed">
+          A central index for Codex Cryptica's public campaign tools,
+          generators, solution pages, and comparison guides.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <div class="max-w-6xl mx-auto px-6 py-12 md:py-16 space-y-14">
+    {#each toolSections as section (section.title)}
+      <section aria-labelledby={`${section.title}-heading`}>
+        <div class="max-w-3xl mb-6">
+          <h2
+            id={`${section.title}-heading`}
+            class="font-header text-2xl font-bold uppercase tracking-wider text-theme-primary mb-2"
+          >
+            {section.title}
+          </h2>
+          <p class="text-sm text-theme-muted leading-relaxed">
+            {section.description}
+          </p>
+        </div>
+
+        <ul class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {#each section.links as link (link.href)}
+            <li>
+              <a
+                href="{base}{link.href}"
+                class="group block h-full rounded-xl border border-theme-border/60 bg-theme-surface/35 p-5 hover:border-theme-primary/60 hover:bg-theme-surface/55 transition-colors"
+              >
+                <span class="{link.icon} h-5 w-5 text-theme-primary mb-4 block"
+                ></span>
+                <span
+                  class="block font-header text-sm font-bold uppercase tracking-wider mb-2 group-hover:text-theme-primary transition-colors"
+                >
+                  {link.label}
+                </span>
+                <span class="block text-sm text-theme-muted leading-relaxed">
+                  {link.summary}
+                </span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/each}
+  </div>
+</main>

--- a/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
@@ -1,56 +1,43 @@
 <script lang="ts">
-  import { base } from "$app/paths";
+  import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+
+  const relatedLinks = [
+    { href: "/solutions/ai-gm-assistant", label: "AI GM assistant" },
+    { href: "/free-rpg-campaign-manager", label: "Free RPG campaign manager" },
+  ];
+
+  const faqs = [
+    {
+      question: "Does the D&D NPC generator require an account?",
+      answer:
+        "No. You can generate an NPC on the public page without logging in, then copy the result or save it into a local Codex Cryptica vault.",
+    },
+    {
+      question: "What does each generated NPC include?",
+      answer:
+        "Each NPC includes a name, species or ancestry, role, alignment, personality notes, a hidden secret, motivation, faction connection, and a plot hook.",
+    },
+    {
+      question: "Can I use it outside D&D?",
+      answer:
+        "Yes. The output is written for fantasy RPGs and can be adapted for D&D, Pathfinder, OSR games, homebrew campaigns, and other tabletop systems.",
+    },
+    {
+      question: "How does saving to Codex Cryptica work?",
+      answer:
+        "The page stores the generated draft in browser localStorage and opens the app, where the draft is imported as a Character entity in your local vault.",
+    },
+  ];
 </script>
 
-<svelte:head>
-  <title>DnD NPC Generator | Free RPG Game Master Tools | Codex Cryptica</title>
-  <meta
-    name="description"
-    content="Generate complete non-player characters with stats, traits, and background details instantly. Save them straight into your local campaign vault."
-  />
-  <link
-    rel="canonical"
-    href="https://codexcryptica.com/tools/dnd-npc-generator"
-  />
-  <link rel="help" href="{base}/llms.txt" />
-</svelte:head>
-
-<div
-  class="min-h-screen bg-theme-bg text-theme-text font-body selection:bg-theme-primary selection:text-theme-bg flex flex-col items-center justify-center p-6 text-center"
-  style:background-image="var(--bg-texture-overlay)"
->
-  <div
-    class="max-w-2xl bg-theme-surface/50 border border-theme-border p-12 rounded-2xl shadow-xl"
-  >
-    <div
-      class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-mono font-medium bg-theme-primary/10 border border-theme-primary/20 text-theme-primary mb-6 mx-auto"
-    >
-      <span class="w-1.5 h-1.5 rounded-full bg-theme-primary animate-pulse"
-      ></span>
-      Standalone Suite Coming Soon
-    </div>
-    <h1 class="text-4xl font-bold font-header mb-4">
-      DnD <span class="text-theme-primary">NPC Generator</span>
-    </h1>
-    <p class="text-theme-muted mb-8 leading-relaxed">
-      Interactive name generators, settlement builders, and AI-powered NPC
-      creators are currently in development for this standalone page. In the
-      meantime, you can use the fully functional built-in generator templates
-      and the AI Lore Oracle directly inside the campaign workspace.
-    </p>
-    <div class="flex flex-wrap justify-center gap-4">
-      <a
-        href="{base}/"
-        class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-xs rounded-lg hover:brightness-110 transition-all"
-      >
-        Enter Workspace
-      </a>
-      <a
-        href="{base}/free-rpg-campaign-manager"
-        class="px-8 py-3.5 bg-theme-surface border border-theme-border text-theme-text font-bold uppercase font-header tracking-wider text-xs rounded-lg hover:border-theme-primary/60 transition-all"
-      >
-        View Campaign Manager
-      </a>
-    </div>
-  </div>
-</div>
+<SEOGeneratorLayout
+  slug="npc"
+  canonicalPath="/tools/dnd-npc-generator"
+  pageTitle="D&D NPC Generator | Free Fantasy RPG Character Tool | Codex Cryptica"
+  metaDescription="Generate D&D NPCs with ancestry, role, personality, secret, motivation, faction connection, and plot hook. Copy the draft or save it into your local campaign vault."
+  eyebrow="D&D NPC Generator"
+  introTitle="D&D NPC Generator"
+  introText="Create a ready-to-run fantasy NPC with structured GM notes, a secret, faction tie, and plot hook. Works without login, then saves into your local Codex Cryptica campaign vault."
+  {relatedLinks}
+  {faqs}
+/>

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -20,6 +20,7 @@ export async function GET() {
     { path: "/", changefreq: "weekly", priority: "1.0" },
     { path: "/blog", changefreq: "weekly", priority: "0.9" },
     { path: "/features", changefreq: "monthly", priority: "0.8" },
+    { path: "/tools", changefreq: "weekly", priority: "0.9" },
     {
       path: "/free-rpg-campaign-manager",
       changefreq: "monthly",

--- a/apps/web/src/routes/sitemap.xml/sitemap.test.ts
+++ b/apps/web/src/routes/sitemap.xml/sitemap.test.ts
@@ -28,6 +28,7 @@ describe("Sitemap.xml API Endpoint", () => {
     const xml = await response.text();
     expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
     expect(xml).toContain("<urlset");
+    expect(xml).toContain("https://codexcryptica.com/tools");
     expect(xml).toContain("https://codexcryptica.com/solutions/test-sol");
     expect(xml).toContain("https://codexcryptica.com/vs/test-comp");
     expect(xml).toContain("https://codexcryptica.com/generators/npc");

--- a/apps/web/static/llms.txt
+++ b/apps/web/static/llms.txt
@@ -17,6 +17,7 @@
 
 ## Public Marketing & Interactive Generator Routes
 
+- [Tools Hub](tools): Central directory for public RPG tools, generators, solution pages, and comparison guides.
 - [Campaign Manager Solution](solutions/campaign-manager): Interactive features for TTRPG campaign running.
 - [Worldbuilding Tool Solution](solutions/worldbuilding-tool): Interactive features for visual wiki and timeline worldbuilding.
 - [AI GM Assistant Solution](solutions/ai-gm-assistant): Cooperative lore drafting features with AI.
@@ -27,4 +28,3 @@
 - [Procedural NPC Generator](generators/npc): Client-side name, trait, motive, and backstory generator.
 - [Procedural Settlement Generator](generators/settlement): Client-side settlement size, economy, and factions builder.
 - [Procedural Magic Item Generator](generators/magic-item): Client-side magic item types, properties, and histories generator.
-

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -18,6 +18,7 @@ const config = {
         "/privacy",
         "/blog",
         "/sitemap.xml",
+        "/tools",
         "/free-rpg-campaign-manager",
         "/worldbuilding-tool",
         "/ai-rpg-campaign-manager",

--- a/apps/web/tests/seo.spec.ts
+++ b/apps/web/tests/seo.spec.ts
@@ -122,27 +122,64 @@ test.describe("SEO and Prerendering", () => {
 
     test("generator page and import conversion funnel flow", async ({
       page,
+      request,
     }) => {
-      // 1. Navigate to generator
-      await page.goto("/generators/npc");
-      await expect(page.locator("#generator-title")).toContainText(
-        "NPC Generator",
+      const response = await request.get("/tools/dnd-npc-generator");
+      expect(response.ok()).toBe(true);
+      const html = await response.text();
+      expect(html).toContain("D&amp;D NPC Generator");
+      expect(html).toContain("What does each generated NPC include?");
+      expect(html).toContain("/solutions/ai-gm-assistant");
+      expect(html).toContain("/free-rpg-campaign-manager");
+      const jsonLdScripts = [
+        ...html.matchAll(
+          /<script type="application\/ld\+json">([^<]+)<\/script>/g,
+        ),
+      ].map((match) => JSON.parse(match[1]));
+      const faqSchema = jsonLdScripts.find(
+        (schema) => schema["@type"] === "FAQPage",
       );
+      expect(faqSchema).toBeTruthy();
+      expect(faqSchema["@type"]).toBe("FAQPage");
+      expect(faqSchema.mainEntity).toHaveLength(4);
+      expect(faqSchema.mainEntity[0].name).toBe(
+        "Does the D&D NPC generator require an account?",
+      );
+
+      // 1. Navigate to generator
+      await page.goto("/tools/dnd-npc-generator");
+      await expect(page.locator("#generator-title")).toContainText(
+        "D&D NPC Generator",
+      );
+      await expect(page.getByLabel("Optional Campaign Context")).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: /AI GM assistant/i }),
+      ).toHaveAttribute("href", "/solutions/ai-gm-assistant");
 
       // 2. Select AI Mode checkbox to off (so it runs fallback instantly and deterministically offline-friendly in tests)
       const aiToggle = page.locator("#ai-toggle");
       if (await aiToggle.isChecked()) {
         await aiToggle.uncheck();
       }
+      await page
+        .getByLabel("Optional Campaign Context")
+        .fill("a haunted border city under siege");
 
       // 3. Trigger generate
       await page.click("#generate-button");
 
       // 4. Wait for generated element to show up
       await expect(page.locator("#save-to-codex-btn")).toBeVisible();
-      await expect(page.locator("h2")).not.toContainText("No Draft Generated"); // Check that a title is populated
+      await expect(
+        page.getByRole("heading", { name: "Faction Connection" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Plot Hook" }),
+      ).toBeVisible();
+      const generatedTitle = page.locator("h2").first();
+      await expect(generatedTitle).not.toContainText("No Draft Generated"); // Check that a title is populated
 
-      const generatedName = await page.locator("h2").textContent();
+      const generatedName = await generatedTitle.textContent();
       expect(generatedName).toBeTruthy();
 
       // 5. Click Save to Codex
@@ -154,7 +191,7 @@ test.describe("SEO and Prerendering", () => {
       // 7. Verify the new vault is active and the entity is loaded/selected
       // Since it's local-first OPFS or fallback, wait for the imported entity detail panel to open or show up in sidebar
       await expect(
-        page.locator("h3").filter({ hasText: generatedName!.trim() }).first(),
+        page.getByRole("heading", { name: generatedName!.trim(), level: 2 }),
       ).toBeVisible();
     });
   });

--- a/apps/web/tests/seo.spec.ts
+++ b/apps/web/tests/seo.spec.ts
@@ -104,6 +104,14 @@ test.describe("SEO and Prerendering", () => {
     test("solutions and comparison pages prerender correctly", async ({
       request,
     }) => {
+      const toolsResponse = await request.get("/tools");
+      expect(toolsResponse.ok()).toBe(true);
+      const toolsHtml = await toolsResponse.text();
+      expect(toolsHtml).toContain("RPG Tools, Generators, and Comparisons");
+      expect(toolsHtml).toContain("/tools/dnd-npc-generator");
+      expect(toolsHtml).toContain("/solutions/campaign-manager");
+      expect(toolsHtml).toContain("/vs/world-anvil");
+
       // Test Solutions page prerendering
       const response = await request.get("/solutions/campaign-manager");
       expect(response.ok()).toBe(true);


### PR DESCRIPTION
## Summary
- Replaces the `/tools/dnd-npc-generator` placeholder with a real public D&D NPC generator page.
- Expands NPC output with campaign context, personality, secret, motivation, faction connection, and plot hook fields.
- Adds FAQ metadata/JSON-LD coverage and updates SEO e2e coverage for the public tool route and save-to-Codex funnel.

Closes #1096

## Validation
- `bun --filter web test:unit src/lib/services/seo/generator-engine.test.ts`
- `bun --filter web lint:types`
- `bun --filter web lint src/lib/components/seo/SEOGeneratorLayout.svelte tests/seo.spec.ts`
- `bun --filter web test:e2e tests/seo.spec.ts --reporter=list -g "generator page and import conversion funnel flow"`
- `bun --filter web test:e2e tests/seo.spec.ts --reporter=list --workers=1`
- `bun --filter web build`
- pre-push cached lint and changed tests passed