### PR TITLE
:sparkles: feat(1097): add faction generator SEO page

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -7,6 +7,7 @@
     npcConfig,
     settlementConfig,
     magicItemConfig,
+    factionConfig,
   } from "$lib/services/seo/generator-engine";
 
   let {
@@ -20,7 +21,7 @@
     relatedLinks = [],
     faqs = [],
   }: {
-    slug: "npc" | "settlement" | "magic-item";
+    slug: "npc" | "settlement" | "magic-item" | "faction";
     canonicalPath?: string;
     pageTitle?: string;
     metaDescription?: string;
@@ -43,6 +44,11 @@
   let magicItemType = $state(magicItemConfig.types[0]);
   let magicItemRarity = $state(magicItemConfig.rarities[1]); // Default to Uncommon
 
+  let factionType = $state(factionConfig.types[0]);
+  let factionScope = $state(factionConfig.scopes[1]);
+  let factionAlignment = $state(factionConfig.alignments[0]);
+  let factionCampaignContext = $state("");
+
   // Generator UI state
   let isGenerating = $state(false);
   let generatedData = $state<GeneratorOutput | null>(null);
@@ -53,7 +59,7 @@
   let copied = $state(false);
   const resolvedTitle = $derived(
     pageTitle ||
-      `Free RPG ${slug === "npc" ? "NPC" : slug === "settlement" ? "Settlement" : "Magic Item"} Generator | Codex Cryptica`,
+      `Free RPG ${slug === "npc" ? "NPC" : slug === "settlement" ? "Settlement" : slug === "magic-item" ? "Magic Item" : "Faction"} Generator | Codex Cryptica`,
   );
   const resolvedDescription = $derived(
     metaDescription ||
@@ -63,7 +69,7 @@
     introTitle ||
       (slug === "npc"
         ? "D&D NPC Generator"
-        : `${slug === "settlement" ? "Settlement" : "Magic Item"} Generator`),
+        : `${slug === "settlement" ? "Settlement" : slug === "magic-item" ? "Magic Item" : "Faction"} Generator`),
   );
   const faqJsonLd = $derived(
     faqs.length > 0
@@ -105,6 +111,14 @@
         generatedData = await generatorEngine.generateMagicItem({
           type: magicItemType,
           rarity: magicItemRarity,
+          useAI,
+        });
+      } else if (slug === "faction") {
+        generatedData = await generatorEngine.generateFaction({
+          type: factionType,
+          scope: factionScope,
+          alignment: factionAlignment,
+          campaignContext: factionCampaignContext,
           useAI,
         });
       }
@@ -390,7 +404,7 @@ ${generatedData.lore}`;
                   {/each}
                 </select>
               </div>
-            {:else}
+            {:else if slug === "magic-item"}
               <div class="flex flex-col gap-1.5">
                 <label
                   for="item-type-select"
@@ -423,6 +437,84 @@ ${generatedData.lore}`;
                     <option value={r}>{r}</option>
                   {/each}
                 </select>
+              </div>
+            {:else}
+              <div class="flex flex-col gap-1.5">
+                <label
+                  for="faction-type-select"
+                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+                  >Faction Type</label
+                >
+                <select
+                  id="faction-type-select"
+                  name="faction_type"
+                  bind:value={factionType}
+                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+                >
+                  {#each factionConfig.types as type (type)}
+                    <option value={type}>{type}</option>
+                  {/each}
+                </select>
+              </div>
+
+              <div class="flex flex-col gap-1.5">
+                <label
+                  for="faction-scope-select"
+                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+                  >Operating Scope</label
+                >
+                <select
+                  id="faction-scope-select"
+                  name="faction_scope"
+                  bind:value={factionScope}
+                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+                >
+                  {#each factionConfig.scopes as scope (scope)}
+                    <option value={scope}>{scope}</option>
+                  {/each}
+                </select>
+              </div>
+
+              <div class="flex flex-col gap-1.5">
+                <label
+                  for="faction-alignment-select"
+                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+                  >Moral Posture</label
+                >
+                <select
+                  id="faction-alignment-select"
+                  name="faction_alignment"
+                  bind:value={factionAlignment}
+                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+                >
+                  {#each factionConfig.alignments as alignment (alignment)}
+                    <option value={alignment}>{alignment}</option>
+                  {/each}
+                </select>
+              </div>
+
+              <div class="flex flex-col gap-1.5">
+                <label
+                  for="faction-campaign-context"
+                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+                  >Optional Campaign Context</label
+                >
+                <textarea
+                  id="faction-campaign-context"
+                  name="campaign_context"
+                  bind:value={factionCampaignContext}
+                  maxlength="240"
+                  rows="4"
+                  aria-describedby="faction-campaign-context-help"
+                  class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+                ></textarea>
+                <p
+                  id="faction-campaign-context-help"
+                  class="text-[10px] text-theme-muted leading-relaxed"
+                >
+                  Add a city, frontier, villain, war, or campaign tension to aim
+                  the faction at your table.
+                </p>
               </div>
             {/if}
           {/if}

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -106,6 +106,66 @@ describe("DefaultGeneratorEngine", () => {
     });
   });
 
+  describe("generateFaction", () => {
+    it("should generate faction details locally when useAI is false", async () => {
+      const res = await engine.generateFaction({
+        type: "Merchant Guild",
+        scope: "Single city",
+        alignment: "Pragmatic and profit-driven",
+        campaignContext: "a canal city split by old guild rivalries",
+        useAI: false,
+      });
+
+      expect(res.type).toBe("faction");
+      expect(res.title).toBeDefined();
+      expect(res.content).toContain("merchant guild");
+      expect(res.content).toContain("Campaign Fit");
+      expect(res.content).toContain(
+        "a canal city split by old guild rivalries",
+      );
+      expect(res.lore).toContain("Single city");
+      expect(res.lore).toContain("Internal Conflict");
+      expect(res.lore).toContain("Adventure Hook");
+      expect(res.labels).toContain("faction-generator");
+      expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should include faction campaign context in the AI prompt", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "The Argent Loom",
+                content: "AI Generated Faction",
+                lore: "AI Generated Agenda",
+                labels: ["rpg-faction", "faction-generator"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generateFaction({
+        type: "Secret Society",
+        scope: "Kingdom-wide network",
+        alignment: "Idealistic but compromised",
+        campaignContext: "a kingdom recovering from a succession war",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("a kingdom recovering from a succession war"),
+      );
+      expect(res.type).toBe("faction");
+      expect(res.title).toBe("The Argent Loom");
+      expect(res.content).toBe("AI Generated Faction");
+      expect(res.lore).toBe("AI Generated Agenda");
+      expect(res.labels).toContain("faction-generator");
+    });
+  });
+
   describe("generateSettlement", () => {
     it("should generate settlement details locally when useAI is false", async () => {
       const res = await engine.generateSettlement({

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -231,6 +231,59 @@ export const magicItemConfig = {
   ],
 };
 
+// Faction Generator Table Config
+export const factionConfig = {
+  types: [
+    "Merchant Guild",
+    "Secret Society",
+    "Mercenary Company",
+    "Temple Order",
+    "Criminal Syndicate",
+    "Rebel Cell",
+    "Arcane Circle",
+  ],
+  scopes: [
+    "Local district",
+    "Single city",
+    "Border region",
+    "Trade route",
+    "Hidden stronghold",
+    "Kingdom-wide network",
+  ],
+  alignments: [
+    "Publicly lawful, privately ruthless",
+    "Idealistic but compromised",
+    "Pragmatic and profit-driven",
+    "Fanatical and secretive",
+    "Protective of common folk",
+    "Opportunistic and divided",
+  ],
+  goals: [
+    "Control a contested trade route before a rival power does.",
+    "Recover a forbidden relic buried beneath a civic landmark.",
+    "Replace corrupt officials with loyal agents.",
+    "Protect a hidden sanctuary from outside discovery.",
+    "Break an old treaty that limits their expansion.",
+    "Expose a rival faction's crimes without revealing their own.",
+  ],
+  conflicts: [
+    "A splinter leader is selling secrets to an enemy.",
+    "Their public mission conflicts with the methods they use at night.",
+    "A recent victory created debts they cannot repay.",
+    "Their patron has vanished, leaving rival lieutenants in charge.",
+    "A hostage, ledger, or relic could unravel their legitimacy.",
+    "Their members disagree over whether the party is useful or dangerous.",
+  ],
+  hooks: [
+    "They hire the party for a simple delivery that is actually a loyalty test.",
+    "They ask for protection during a meeting with a bitter rival.",
+    "They offer information about a villain in exchange for public help.",
+    "They frame the party to force them into negotiation.",
+    "They need outsiders to enter a place their members are forbidden to visit.",
+    "They ask the party to choose between two bad successors.",
+  ],
+};
+
 export interface GeneratorOutput {
   type:
     | "character"
@@ -404,6 +457,145 @@ ${plotHook}`;
       content,
       lore,
       labels: ["rpg-character", "npc-generator", "imported-draft"],
+      status: "active",
+    };
+  }
+
+  /**
+   * Generates a faction draft.
+   */
+  async generateFaction(
+    options: {
+      type?: string;
+      scope?: string;
+      alignment?: string;
+      campaignContext?: string;
+      useAI?: boolean;
+    } = {},
+  ): Promise<GeneratorOutput> {
+    const factionType =
+      options.type ||
+      factionConfig.types[
+        Math.floor(Math.random() * factionConfig.types.length)
+      ];
+    const scope =
+      options.scope ||
+      factionConfig.scopes[
+        Math.floor(Math.random() * factionConfig.scopes.length)
+      ];
+    const alignment =
+      options.alignment ||
+      factionConfig.alignments[
+        Math.floor(Math.random() * factionConfig.alignments.length)
+      ];
+    const campaignContext = options.campaignContext?.trim();
+    const name = `${this.generateName()} Compact`;
+
+    if (options.useAI !== false) {
+      try {
+        const prompt = `Generate a detailed RPG faction in JSON format.
+Options:
+- Name: ${name}
+- Faction Type: ${factionType}
+- Scope: ${scope}
+- Moral Posture: ${alignment}
+${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
+
+You must return a valid JSON object matching the following structure exactly:
+{
+  "title": "A single string for the faction name",
+  "content": "A detailed multi-paragraph faction overview (markdown formatted) describing its public face, leadership, resources, and how it fits the campaign context if provided.",
+  "lore": "Structured GM details (markdown formatted) with sections for core fields, agenda, internal conflict, notable NPCs, rival faction, and adventure hook.",
+  "labels": ["rpg-faction", "faction-generator", "imported-draft"]
+}
+Return only the JSON object. Do not include markdown code block formatting like \`\`\`json.`;
+
+        const model = await this.clientManager.getModel(
+          "",
+          "gemini-1.5-flash",
+          "You are an assistant that generates detailed RPG campaign elements in JSON format.",
+        );
+        const response = await model.generateContent(prompt);
+        const text = response.response.text().trim();
+        const cleanText = text
+          .replace(/^```json\s*/i, "")
+          .replace(/```$/, "")
+          .trim();
+        const data = JSON.parse(cleanText);
+
+        return {
+          type: "faction",
+          title: data.title || name,
+          content: data.content || "",
+          lore: data.lore || "",
+          labels: Array.isArray(data.labels)
+            ? data.labels
+            : ["rpg-faction", "faction-generator", "imported-draft"],
+          status: "active",
+        };
+      } catch (err) {
+        console.warn(
+          "AI generation failed, falling back to local tables:",
+          err,
+        );
+      }
+    }
+
+    const goal =
+      factionConfig.goals[
+        Math.floor(Math.random() * factionConfig.goals.length)
+      ];
+    const conflict =
+      factionConfig.conflicts[
+        Math.floor(Math.random() * factionConfig.conflicts.length)
+      ];
+    const hook =
+      factionConfig.hooks[
+        Math.floor(Math.random() * factionConfig.hooks.length)
+      ];
+    const rival = `${this.generateName()} Covenant`;
+    const leader = this.generateName();
+    const agent = this.generateName();
+
+    const content = `### Overview
+${name} is a ${factionType.toLowerCase()} operating across the ${scope.toLowerCase()}. Its members present a controlled public face, but every favor, rumor, and private meeting is part of a larger strategy.
+
+${campaignContext ? `### Campaign Fit\nUse ${name} in ${campaignContext}. Their agenda should touch active locations, disputed resources, or unresolved campaign mysteries.\n` : ""}
+
+### Public Face
+Most locals know the faction through useful services, charitable work, guarded trade, or carefully placed rumors. People disagree about whether ${name} is stabilizing the region or quietly taking ownership of it.
+
+### Table Use
+Bring ${name} into play when the party needs leverage, pressure, a sponsor, or a rival that can negotiate before it strikes.`;
+
+    const lore = `### GM Reference Information
+- **Faction Type**: ${factionType}
+- **Scope**: ${scope}
+- **Moral Posture**: ${alignment}
+- **Entity Type**: Faction
+
+### Agenda
+${goal}
+
+### Internal Conflict
+${conflict}
+
+### Notable NPCs
+- **${leader}**: Public leader who insists every deal has a civic purpose.
+- **${agent}**: Field agent who knows where the faction hides its failures.
+
+### Rival Faction
+${rival} wants the same influence, relic, route, or confession before ${name} can secure it.
+
+### Adventure Hook
+${hook}`;
+
+    return {
+      type: "faction",
+      title: name,
+      content,
+      lore,
+      labels: ["rpg-faction", "faction-generator", "imported-draft"],
       status: "active",
     };
   }

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -15,6 +15,13 @@
           icon: "icon-[lucide--user-round-plus]",
         },
         {
+          href: "/tools/faction-generator",
+          label: "Faction Generator",
+          summary:
+            "Create a fantasy faction with an agenda, internal conflict, rival group, notable NPCs, and adventure hook.",
+          icon: "icon-[lucide--flag]",
+        },
+        {
           href: "/generators/npc",
           label: "Procedural NPC Generator",
           summary:

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+
+  const relatedLinks = [
+    { href: "/tools/dnd-npc-generator", label: "D&D NPC generator" },
+    { href: "/solutions/worldbuilding-tool", label: "Worldbuilding tool" },
+    { href: "/free-rpg-campaign-manager", label: "Free RPG campaign manager" },
+  ];
+
+  const faqs = [
+    {
+      question: "What does the faction generator create?",
+      answer:
+        "It creates a fantasy RPG faction with a name, type, operating scope, public face, agenda, internal conflict, rival faction, notable NPCs, and adventure hook.",
+    },
+    {
+      question: "Can I use the faction generator without an account?",
+      answer:
+        "Yes. You can generate and copy faction notes on the public page without logging in, then save the draft into a browser-local Codex Cryptica vault.",
+    },
+    {
+      question: "Can I aim the faction at my current campaign?",
+      answer:
+        "Yes. Add optional campaign context such as a city, war, villain, frontier, or political tension, and the generated faction will include a campaign fit section.",
+    },
+    {
+      question: "How does saving a generated faction work?",
+      answer:
+        "The page stores the generated faction draft in browser localStorage and opens the app, where it imports as a Faction entity in your local vault.",
+    },
+  ];
+</script>
+
+<SEOGeneratorLayout
+  slug="faction"
+  canonicalPath="/tools/faction-generator"
+  pageTitle="Faction Generator | Free Fantasy RPG Organization Tool | Codex Cryptica"
+  metaDescription="Generate fantasy RPG factions with goals, internal conflict, rival groups, notable NPCs, and adventure hooks. Copy the draft or save it into your local campaign vault."
+  eyebrow="Faction Generator"
+  introTitle="Faction Generator"
+  introText="Create a campaign-ready fantasy faction with a public face, agenda, internal conflict, rival group, notable NPCs, and adventure hook. Works without login, then saves into your local Codex Cryptica campaign vault."
+  {relatedLinks}
+  {faqs}
+/>

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -37,6 +37,11 @@ export async function GET() {
       changefreq: "monthly",
       priority: "0.8",
     },
+    {
+      path: "/tools/faction-generator",
+      changefreq: "monthly",
+      priority: "0.8",
+    },
     { path: "/llms.txt", changefreq: "weekly", priority: "0.7" },
     { path: "/llms-full.txt", changefreq: "weekly", priority: "0.7" },
     { path: "/terms", changefreq: "yearly", priority: "0.5" },

--- a/apps/web/src/routes/sitemap.xml/sitemap.test.ts
+++ b/apps/web/src/routes/sitemap.xml/sitemap.test.ts
@@ -29,6 +29,7 @@ describe("Sitemap.xml API Endpoint", () => {
     expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
     expect(xml).toContain("<urlset");
     expect(xml).toContain("https://codexcryptica.com/tools");
+    expect(xml).toContain("https://codexcryptica.com/tools/faction-generator");
     expect(xml).toContain("https://codexcryptica.com/solutions/test-sol");
     expect(xml).toContain("https://codexcryptica.com/vs/test-comp");
     expect(xml).toContain("https://codexcryptica.com/generators/npc");

--- a/apps/web/static/llms.txt
+++ b/apps/web/static/llms.txt
@@ -18,6 +18,7 @@
 ## Public Marketing & Interactive Generator Routes
 
 - [Tools Hub](tools): Central directory for public RPG tools, generators, solution pages, and comparison guides.
+- [Faction Generator](tools/faction-generator): Free fantasy RPG faction generator with agendas, rivals, conflicts, and adventure hooks.
 - [Campaign Manager Solution](solutions/campaign-manager): Interactive features for TTRPG campaign running.
 - [Worldbuilding Tool Solution](solutions/worldbuilding-tool): Interactive features for visual wiki and timeline worldbuilding.
 - [AI GM Assistant Solution](solutions/ai-gm-assistant): Cooperative lore drafting features with AI.

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -23,6 +23,7 @@ const config = {
         "/worldbuilding-tool",
         "/ai-rpg-campaign-manager",
         "/tools/dnd-npc-generator",
+        "/tools/faction-generator",
         "/solutions/campaign-manager",
         "/solutions/worldbuilding-tool",
         "/solutions/ai-gm-assistant",

--- a/apps/web/tests/seo.spec.ts
+++ b/apps/web/tests/seo.spec.ts
@@ -109,6 +109,7 @@ test.describe("SEO and Prerendering", () => {
       const toolsHtml = await toolsResponse.text();
       expect(toolsHtml).toContain("RPG Tools, Generators, and Comparisons");
       expect(toolsHtml).toContain("/tools/dnd-npc-generator");
+      expect(toolsHtml).toContain("/tools/faction-generator");
       expect(toolsHtml).toContain("/solutions/campaign-manager");
       expect(toolsHtml).toContain("/vs/world-anvil");
 
@@ -198,6 +199,74 @@ test.describe("SEO and Prerendering", () => {
 
       // 7. Verify the new vault is active and the entity is loaded/selected
       // Since it's local-first OPFS or fallback, wait for the imported entity detail panel to open or show up in sidebar
+      await expect(
+        page.getByRole("heading", { name: generatedName!.trim(), level: 2 }),
+      ).toBeVisible();
+    });
+
+    test("faction generator page and import conversion funnel flow", async ({
+      page,
+      request,
+    }) => {
+      const response = await request.get("/tools/faction-generator");
+      expect(response.ok()).toBe(true);
+      const html = await response.text();
+      expect(html).toContain("Faction Generator");
+      expect(html).toContain("What does the faction generator create?");
+      expect(html).toContain("/tools/dnd-npc-generator");
+      expect(html).toContain("/solutions/worldbuilding-tool");
+      const jsonLdScripts = [
+        ...html.matchAll(
+          /<script type="application\/ld\+json">([^<]+)<\/script>/g,
+        ),
+      ].map((match) => JSON.parse(match[1]));
+      const faqSchema = jsonLdScripts.find(
+        (schema) => schema["@type"] === "FAQPage",
+      );
+      expect(faqSchema).toBeTruthy();
+      expect(faqSchema.mainEntity).toHaveLength(4);
+      expect(faqSchema.mainEntity[0].name).toBe(
+        "What does the faction generator create?",
+      );
+
+      await page.goto("/tools/faction-generator");
+      await expect(page.locator("#generator-title")).toContainText(
+        "Faction Generator",
+      );
+      await expect(page.getByLabel("Faction Type")).toBeVisible();
+      await expect(page.getByLabel("Operating Scope")).toBeVisible();
+      await expect(page.getByLabel("Moral Posture")).toBeVisible();
+      await expect(page.getByLabel("Optional Campaign Context")).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: /Worldbuilding tool/i }),
+      ).toHaveAttribute("href", "/solutions/worldbuilding-tool");
+
+      const aiToggle = page.locator("#ai-toggle");
+      if (await aiToggle.isChecked()) {
+        await aiToggle.uncheck();
+      }
+      await page.getByLabel("Faction Type").selectOption("Merchant Guild");
+      await page.getByLabel("Operating Scope").selectOption("Single city");
+      await page
+        .getByLabel("Optional Campaign Context")
+        .fill("a canal city split by old guild rivalries");
+
+      await page.click("#generate-button");
+
+      await expect(page.locator("#save-to-codex-btn")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Internal Conflict" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Adventure Hook" }),
+      ).toBeVisible();
+      const generatedTitle = page.locator("h2").first();
+      await expect(generatedTitle).not.toContainText("No Draft Generated");
+      const generatedName = await generatedTitle.textContent();
+      expect(generatedName).toBeTruthy();
+
+      await page.click("#save-to-codex-btn");
+      await expect(page).toHaveURL(/\/$/);
       await expect(
         page.getByRole("heading", { name: generatedName!.trim(), level: 2 }),
       ).toBeVisible();


### PR DESCRIPTION
## Summary
- Add `/tools/faction-generator` as a public SEO generator page linked from the tools hub
- Extend the shared SEO generator layout and generator engine with faction-specific controls and output
- Register the route in prerender, sitemap, llms.txt, and SEO coverage

## Validation
- npx @sveltejs/mcp svelte-autofixer apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte --svelte-version 5 (known raw HTML warnings only)
- npx @sveltejs/mcp svelte-autofixer apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte --svelte-version 5
- bun --filter web test:unit src/lib/services/seo/generator-engine.test.ts src/routes/sitemap.xml/sitemap.test.ts
- bun --filter web lint ...focused files
- bun --filter web test:e2e tests/seo.spec.ts --reporter=list --workers=1
- bun --filter web build

Closes #1097