### PR TITLE
feat(1107): create reusable public generator page template

### DIFF
--- a/apps/web/src/lib/components/seo/FactionFormFields.svelte
+++ b/apps/web/src/lib/components/seo/FactionFormFields.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import { factionConfig } from "$lib/services/seo/generator-engine";
+
+  let {
+    type = $bindable(factionConfig.types[0]),
+    scope = $bindable(factionConfig.scopes[1]),
+    alignment = $bindable(factionConfig.alignments[0]),
+    campaignContext = $bindable(""),
+  }: {
+    type: string;
+    scope: string;
+    alignment: string;
+    campaignContext: string;
+  } = $props();
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+</script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="faction-type-select" class={labelClass}>Faction Type</label>
+  <select
+    id="faction-type-select"
+    name="faction_type"
+    bind:value={type}
+    class={selectClass}
+  >
+    {#each factionConfig.types as t (t)}
+      <option value={t}>{t}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="faction-scope-select" class={labelClass}>Operating Scope</label>
+  <select
+    id="faction-scope-select"
+    name="faction_scope"
+    bind:value={scope}
+    class={selectClass}
+  >
+    {#each factionConfig.scopes as s (s)}
+      <option value={s}>{s}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="faction-alignment-select" class={labelClass}>Moral Posture</label>
+  <select
+    id="faction-alignment-select"
+    name="faction_alignment"
+    bind:value={alignment}
+    class={selectClass}
+  >
+    {#each factionConfig.alignments as a (a)}
+      <option value={a}>{a}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="faction-campaign-context" class={labelClass}
+    >Optional Campaign Context</label
+  >
+  <textarea
+    id="faction-campaign-context"
+    name="campaign_context"
+    bind:value={campaignContext}
+    maxlength="240"
+    rows="4"
+    aria-describedby="faction-campaign-context-help"
+    class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+  ></textarea>
+  <p
+    id="faction-campaign-context-help"
+    class="text-[10px] text-theme-muted leading-relaxed"
+  >
+    Add a city, frontier, villain, war, or campaign tension to aim the faction
+    at your table.
+  </p>
+</div>

--- a/apps/web/src/lib/components/seo/NPCFormFields.svelte
+++ b/apps/web/src/lib/components/seo/NPCFormFields.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { npcConfig } from "$lib/services/seo/generator-engine";
+
+  let {
+    race = $bindable(npcConfig.races[0]),
+    role = $bindable(npcConfig.roles[0]),
+    alignment = $bindable(npcConfig.alignments[0]),
+    campaignContext = $bindable(""),
+  }: {
+    race: string;
+    role: string;
+    alignment: string;
+    campaignContext: string;
+  } = $props();
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+</script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="race-select" class={labelClass}>Race</label>
+  <select id="race-select" bind:value={race} class={selectClass}>
+    {#each npcConfig.races as r (r)}
+      <option value={r}>{r}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="role-select" class={labelClass}>Role / Class</label>
+  <select id="role-select" bind:value={role} class={selectClass}>
+    {#each npcConfig.roles as r (r)}
+      <option value={r}>{r}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="alignment-select" class={labelClass}>Alignment</label>
+  <select id="alignment-select" bind:value={alignment} class={selectClass}>
+    {#each npcConfig.alignments as a (a)}
+      <option value={a}>{a}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="campaign-context" class={labelClass}
+    >Optional Campaign Context</label
+  >
+  <textarea
+    id="campaign-context"
+    name="campaign_context"
+    bind:value={campaignContext}
+    maxlength="240"
+    rows="4"
+    aria-describedby="campaign-context-help"
+    class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+  ></textarea>
+  <p
+    id="campaign-context-help"
+    class="text-[10px] text-theme-muted leading-relaxed"
+  >
+    Add a city, faction, dungeon, or current campaign problem to aim the NPC at
+    your table.
+  </p>
+</div>

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -1,27 +1,21 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import { fade } from "svelte/transition";
-  import {
-    generatorEngine,
-    type GeneratorOutput,
-    npcConfig,
-    settlementConfig,
-    magicItemConfig,
-    factionConfig,
-  } from "$lib/services/seo/generator-engine";
+  import type { GeneratorOutput } from "$lib/services/seo/generator-engine";
+  import type { Snippet } from "svelte";
 
   let {
-    slug,
     canonicalPath,
-    pageTitle,
-    metaDescription,
+    pageTitle = "Free RPG Generator | Codex Cryptica",
+    metaDescription = "Generate high-quality detailed campaign drafts using our interactive local-first generators.",
     eyebrow = "Free RPG Tool",
-    introTitle,
-    introText,
+    introTitle = "RPG Generator",
+    introText = "Customize options and instantly generate structured drafts to populate your campaign lore database.",
     relatedLinks = [],
     faqs = [],
+    generate,
+    formFields,
   }: {
-    slug: "npc" | "settlement" | "magic-item" | "faction";
     canonicalPath?: string;
     pageTitle?: string;
     metaDescription?: string;
@@ -30,47 +24,15 @@
     introText?: string;
     relatedLinks?: { href: string; label: string }[];
     faqs?: { question: string; answer: string }[];
+    generate: () => Promise<GeneratorOutput>;
+    formFields: Snippet;
   } = $props();
 
-  // Selected parameters
-  let npcRace = $state(npcConfig.races[0]);
-  let npcRole = $state(npcConfig.roles[0]);
-  let npcAlignment = $state(npcConfig.alignments[0]);
-  let npcCampaignContext = $state("");
-
-  let settlementSize = $state(settlementConfig.sizes[2].name); // Default to Town
-  let settlementEconomy = $state(settlementConfig.economies[0]);
-
-  let magicItemType = $state(magicItemConfig.types[0]);
-  let magicItemRarity = $state(magicItemConfig.rarities[1]); // Default to Uncommon
-
-  let factionType = $state(factionConfig.types[0]);
-  let factionScope = $state(factionConfig.scopes[1]);
-  let factionAlignment = $state(factionConfig.alignments[0]);
-  let factionCampaignContext = $state("");
-
-  // Generator UI state
   let isGenerating = $state(false);
   let generatedData = $state<GeneratorOutput | null>(null);
   let errorMessage = $state<string | null>(null);
-  let useAI = $state(true);
-
-  // Fallback Copy to Clipboard state
   let copied = $state(false);
-  const resolvedTitle = $derived(
-    pageTitle ||
-      `Free RPG ${slug === "npc" ? "NPC" : slug === "settlement" ? "Settlement" : slug === "magic-item" ? "Magic Item" : "Faction"} Generator | Codex Cryptica`,
-  );
-  const resolvedDescription = $derived(
-    metaDescription ||
-      "Generate high-quality detailed campaign drafts using our interactive local-first generators.",
-  );
-  const resolvedIntroTitle = $derived(
-    introTitle ||
-      (slug === "npc"
-        ? "D&D NPC Generator"
-        : `${slug === "settlement" ? "Settlement" : slug === "magic-item" ? "Magic Item" : "Faction"} Generator`),
-  );
+
   const faqJsonLd = $derived(
     faqs.length > 0
       ? JSON.stringify({
@@ -87,41 +49,12 @@
         })
       : "",
   );
-  const formAction = $derived(canonicalPath || `/generators/${slug}`);
 
   async function handleGenerate() {
     isGenerating = true;
     errorMessage = null;
     try {
-      if (slug === "npc") {
-        generatedData = await generatorEngine.generateNPC({
-          race: npcRace,
-          role: npcRole,
-          alignment: npcAlignment,
-          campaignContext: npcCampaignContext,
-          useAI,
-        });
-      } else if (slug === "settlement") {
-        generatedData = await generatorEngine.generateSettlement({
-          size: settlementSize,
-          economy: settlementEconomy,
-          useAI,
-        });
-      } else if (slug === "magic-item") {
-        generatedData = await generatorEngine.generateMagicItem({
-          type: magicItemType,
-          rarity: magicItemRarity,
-          useAI,
-        });
-      } else if (slug === "faction") {
-        generatedData = await generatorEngine.generateFaction({
-          type: factionType,
-          scope: factionScope,
-          alignment: factionAlignment,
-          campaignContext: factionCampaignContext,
-          useAI,
-        });
-      }
+      generatedData = await generate();
     } catch (err: any) {
       errorMessage = "Failed to generate: " + (err.message || err);
     } finally {
@@ -168,7 +101,6 @@
       };
 
       localStorage.setItem("__codex_pending_import", JSON.stringify(payload));
-      // Redirect to workspace app root
       window.location.href = `${base}/`;
     } catch {
       errorMessage =
@@ -199,8 +131,8 @@ ${generatedData.lore}`;
 </script>
 
 <svelte:head>
-  <title>{resolvedTitle}</title>
-  <meta name="description" content={resolvedDescription} />
+  <title>{pageTitle}</title>
+  <meta name="description" content={metaDescription} />
   {#if canonicalPath}
     <link rel="canonical" href="https://codexcryptica.com{canonicalPath}" />
   {/if}
@@ -277,266 +209,20 @@ ${generatedData.lore}`;
           class="font-header font-bold text-lg uppercase tracking-wider text-theme-primary mb-4"
           id="generator-title"
         >
-          {resolvedIntroTitle}
+          {introTitle}
         </h1>
         <p class="text-xs text-theme-muted leading-relaxed mb-6">
-          {introText ||
-            "Customize options and instantly generate structured drafts to populate your campaign lore database."}
+          {introText}
         </p>
 
-        <!-- Generation Inputs -->
         <form
           class="space-y-4"
-          action="{base}{formAction}"
-          method="GET"
           onsubmit={(event) => {
             event.preventDefault();
             void handleGenerate();
           }}
         >
-          {#if slug === "npc"}
-            <div class="flex flex-col gap-1.5">
-              <label
-                for="race-select"
-                class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                >Race</label
-              >
-              <select
-                id="race-select"
-                bind:value={npcRace}
-                class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-              >
-                {#each npcConfig.races as r (r)}
-                  <option value={r}>{r}</option>
-                {/each}
-              </select>
-            </div>
-
-            <div class="flex flex-col gap-1.5">
-              <label
-                for="role-select"
-                class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                >Role / Class</label
-              >
-              <select
-                id="role-select"
-                bind:value={npcRole}
-                class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-              >
-                {#each npcConfig.roles as r (r)}
-                  <option value={r}>{r}</option>
-                {/each}
-              </select>
-            </div>
-
-            <div class="flex flex-col gap-1.5">
-              <label
-                for="alignment-select"
-                class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                >Alignment</label
-              >
-              <select
-                id="alignment-select"
-                bind:value={npcAlignment}
-                class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-              >
-                {#each npcConfig.alignments as a (a)}
-                  <option value={a}>{a}</option>
-                {/each}
-              </select>
-            </div>
-
-            <div class="flex flex-col gap-1.5">
-              <label
-                for="campaign-context"
-                class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                >Optional Campaign Context</label
-              >
-              <textarea
-                id="campaign-context"
-                name="campaign_context"
-                bind:value={npcCampaignContext}
-                maxlength="240"
-                rows="4"
-                aria-describedby="campaign-context-help"
-                class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
-              ></textarea>
-              <p
-                id="campaign-context-help"
-                class="text-[10px] text-theme-muted leading-relaxed"
-              >
-                Add a city, faction, dungeon, or current campaign problem to aim
-                the NPC at your table.
-              </p>
-            </div>
-          {:else}
-            {#if slug === "settlement"}
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="size-select"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Settlement Size</label
-                >
-                <select
-                  id="size-select"
-                  bind:value={settlementSize}
-                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-                >
-                  {#each settlementConfig.sizes as s (s.name)}
-                    <option value={s.name}>{s.name} ({s.range})</option>
-                  {/each}
-                </select>
-              </div>
-
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="economy-select"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Primary Economy</label
-                >
-                <select
-                  id="economy-select"
-                  bind:value={settlementEconomy}
-                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-                >
-                  {#each settlementConfig.economies as e (e)}
-                    <option value={e}>{e}</option>
-                  {/each}
-                </select>
-              </div>
-            {:else if slug === "magic-item"}
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="item-type-select"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Item Type</label
-                >
-                <select
-                  id="item-type-select"
-                  bind:value={magicItemType}
-                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-                >
-                  {#each magicItemConfig.types as t (t)}
-                    <option value={t}>{t}</option>
-                  {/each}
-                </select>
-              </div>
-
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="rarity-select"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Rarity</label
-                >
-                <select
-                  id="rarity-select"
-                  bind:value={magicItemRarity}
-                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-                >
-                  {#each magicItemConfig.rarities as r (r)}
-                    <option value={r}>{r}</option>
-                  {/each}
-                </select>
-              </div>
-            {:else}
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="faction-type-select"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Faction Type</label
-                >
-                <select
-                  id="faction-type-select"
-                  name="faction_type"
-                  bind:value={factionType}
-                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-                >
-                  {#each factionConfig.types as type (type)}
-                    <option value={type}>{type}</option>
-                  {/each}
-                </select>
-              </div>
-
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="faction-scope-select"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Operating Scope</label
-                >
-                <select
-                  id="faction-scope-select"
-                  name="faction_scope"
-                  bind:value={factionScope}
-                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-                >
-                  {#each factionConfig.scopes as scope (scope)}
-                    <option value={scope}>{scope}</option>
-                  {/each}
-                </select>
-              </div>
-
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="faction-alignment-select"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Moral Posture</label
-                >
-                <select
-                  id="faction-alignment-select"
-                  name="faction_alignment"
-                  bind:value={factionAlignment}
-                  class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-                >
-                  {#each factionConfig.alignments as alignment (alignment)}
-                    <option value={alignment}>{alignment}</option>
-                  {/each}
-                </select>
-              </div>
-
-              <div class="flex flex-col gap-1.5">
-                <label
-                  for="faction-campaign-context"
-                  class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-                  >Optional Campaign Context</label
-                >
-                <textarea
-                  id="faction-campaign-context"
-                  name="campaign_context"
-                  bind:value={factionCampaignContext}
-                  maxlength="240"
-                  rows="4"
-                  aria-describedby="faction-campaign-context-help"
-                  class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
-                ></textarea>
-                <p
-                  id="faction-campaign-context-help"
-                  class="text-[10px] text-theme-muted leading-relaxed"
-                >
-                  Add a city, frontier, villain, war, or campaign tension to aim
-                  the faction at your table.
-                </p>
-              </div>
-            {/if}
-          {/if}
-
-          <!-- AI Toggle Option -->
-          <div class="flex items-center gap-2 pt-2">
-            <input
-              type="checkbox"
-              id="ai-toggle"
-              bind:checked={useAI}
-              class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
-            />
-            <label
-              for="ai-toggle"
-              class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
-            >
-              <span
-                class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
-              ></span>
-              AI Lore Co-Author Mode
-            </label>
-          </div>
+          {@render formFields()}
 
           <button
             type="submit"
@@ -591,7 +277,6 @@ ${generatedData.lore}`;
       >
         {#if generatedData}
           <div in:fade={{ duration: 250 }} class="flex flex-col flex-grow">
-            <!-- Header section of character sheet -->
             <div
               class="border-b border-theme-border/60 pb-4 mb-6 flex flex-wrap items-center justify-between gap-4"
             >
@@ -632,19 +317,16 @@ ${generatedData.lore}`;
               </div>
             </div>
 
-            <!-- Immersive layout with Alegreya typography, borders, subtle textures -->
             <div
               class="grid grid-cols-1 md:grid-cols-12 gap-8 flex-grow"
               data-world-theme="workspace"
             >
-              <!-- Content Story column -->
               <div
                 class="md:col-span-7 space-y-4 text-xs md:text-sm leading-relaxed text-theme-text/90"
               >
                 {@html renderMarkdown(generatedData.content)}
               </div>
 
-              <!-- Lore Stats column (styled like a side sheet) -->
               <div
                 class="md:col-span-5 p-4 border border-theme-border/60 bg-theme-bg/40 rounded-xl space-y-4"
               >
@@ -688,7 +370,7 @@ ${generatedData.lore}`;
         <h2
           class="font-header font-bold text-xl uppercase tracking-wider text-theme-primary mb-6"
         >
-          {resolvedIntroTitle} FAQ
+          {introTitle} FAQ
         </h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
           {#each faqs as faq (faq.question)}

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -24,7 +24,7 @@
     introText?: string;
     relatedLinks?: { href: string; label: string }[];
     faqs?: { question: string; answer: string }[];
-    generate: () => Promise<GeneratorOutput>;
+    generate: (opts: { useAI: boolean }) => Promise<GeneratorOutput>;
     formFields: Snippet;
   } = $props();
 
@@ -32,6 +32,7 @@
   let generatedData = $state<GeneratorOutput | null>(null);
   let errorMessage = $state<string | null>(null);
   let copied = $state(false);
+  let useAI = $state(true);
 
   const faqJsonLd = $derived(
     faqs.length > 0
@@ -54,7 +55,7 @@
     isGenerating = true;
     errorMessage = null;
     try {
-      generatedData = await generate();
+      generatedData = await generate({ useAI });
     } catch (err: any) {
       errorMessage = "Failed to generate: " + (err.message || err);
     } finally {
@@ -217,12 +218,32 @@ ${generatedData.lore}`;
 
         <form
           class="space-y-4"
+          action={canonicalPath ? `${base}${canonicalPath}` : undefined}
+          method={canonicalPath ? "GET" : undefined}
           onsubmit={(event) => {
             event.preventDefault();
             void handleGenerate();
           }}
         >
           {@render formFields()}
+
+          <div class="flex items-center gap-2 pt-2">
+            <input
+              type="checkbox"
+              id="ai-toggle"
+              bind:checked={useAI}
+              class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
+            />
+            <label
+              for="ai-toggle"
+              class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
+            >
+              <span
+                class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
+              ></span>
+              AI Lore Co-Author Mode
+            </label>
+          </div>
 
           <button
             type="submit"

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import NPCFormFields from "$lib/components/seo/NPCFormFields.svelte";
+  import FactionFormFields from "$lib/components/seo/FactionFormFields.svelte";
   import {
     generatorEngine,
     npcConfig,
@@ -10,57 +12,92 @@
 
   let { data } = $props();
 
-  // NPC state
-  let npcRace = $state(npcConfig.races[0]);
-  let npcRole = $state(npcConfig.roles[0]);
-  let npcAlignment = $state(npcConfig.alignments[0]);
-  let npcCampaignContext = $state("");
+  // Per-slug SEO metadata (#1)
+  const slugMeta = {
+    npc: {
+      pageTitle:
+        "D&D NPC Generator | Free Fantasy RPG Character Tool | Codex Cryptica",
+      metaDescription:
+        "Generate D&D NPCs with ancestry, role, personality, secret, motivation, faction connection, and plot hook. Copy the draft or save it into your local campaign vault.",
+      introTitle: "D&D NPC Generator",
+      eyebrow: "D&D NPC Generator",
+      introText:
+        "Create a ready-to-run fantasy NPC with structured GM notes, a secret, faction tie, and plot hook. Works without login.",
+      canonicalPath: "/generators/npc",
+    },
+    settlement: {
+      pageTitle:
+        "Settlement Generator | Free Fantasy RPG Town Tool | Codex Cryptica",
+      metaDescription:
+        "Generate fantasy RPG settlements with economy, geography, power structure, and adventure hooks. Copy the draft or save it into your local campaign vault.",
+      introTitle: "Settlement Generator",
+      eyebrow: "Settlement Generator",
+      introText:
+        "Create a campaign-ready fantasy settlement with an economy, power structure, notable locations, and adventure hook. Works without login.",
+      canonicalPath: "/generators/settlement",
+    },
+    "magic-item": {
+      pageTitle:
+        "Magic Item Generator | Free Fantasy RPG Loot Tool | Codex Cryptica",
+      metaDescription:
+        "Generate fantasy RPG magic items with lore, abilities, quirks, and campaign hooks. Copy the draft or save it into your local campaign vault.",
+      introTitle: "Magic Item Generator",
+      eyebrow: "Magic Item Generator",
+      introText:
+        "Create a campaign-ready magic item with lore, abilities, and quirks. Works without login.",
+      canonicalPath: "/generators/magic-item",
+    },
+    faction: {
+      pageTitle:
+        "Faction Generator | Free Fantasy RPG Organization Tool | Codex Cryptica",
+      metaDescription:
+        "Generate fantasy RPG factions with goals, internal conflict, rival groups, notable NPCs, and adventure hooks. Copy the draft or save it into your local campaign vault.",
+      introTitle: "Faction Generator",
+      eyebrow: "Faction Generator",
+      introText:
+        "Create a campaign-ready fantasy faction with a public face, agenda, internal conflict, and adventure hook. Works without login.",
+      canonicalPath: "/generators/faction",
+    },
+  } as const;
 
-  // Settlement state
-  let settlementSize = $state(settlementConfig.sizes[2].name);
-  let settlementEconomy = $state(settlementConfig.economies[0]);
+  const meta = slugMeta[data.slug];
 
-  // Magic item state
-  let magicItemType = $state(magicItemConfig.types[0]);
-  let magicItemRarity = $state(magicItemConfig.rarities[1]);
+  // State grouped per generator type (#6)
+  let npc = $state({
+    race: npcConfig.races[0],
+    role: npcConfig.roles[0],
+    alignment: npcConfig.alignments[0],
+    campaignContext: "",
+  });
 
-  // Faction state
-  let factionType = $state(factionConfig.types[0]);
-  let factionScope = $state(factionConfig.scopes[1]);
-  let factionAlignment = $state(factionConfig.alignments[0]);
-  let factionCampaignContext = $state("");
+  let settlement = $state({
+    size: settlementConfig.sizes[2].name,
+    economy: settlementConfig.economies[0],
+  });
 
-  let useAI = $state(true);
+  let magicItem = $state({
+    type: magicItemConfig.types[0],
+    rarity: magicItemConfig.rarities[1],
+  });
 
-  async function generate() {
+  let faction = $state({
+    type: factionConfig.types[0],
+    scope: factionConfig.scopes[1],
+    alignment: factionConfig.alignments[0],
+    campaignContext: "",
+  });
+
+  async function generate({ useAI }: { useAI: boolean }) {
     if (data.slug === "npc") {
-      return generatorEngine.generateNPC({
-        race: npcRace,
-        role: npcRole,
-        alignment: npcAlignment,
-        campaignContext: npcCampaignContext,
-        useAI,
-      });
+      return generatorEngine.generateNPC({ ...npc, useAI });
     } else if (data.slug === "settlement") {
-      return generatorEngine.generateSettlement({
-        size: settlementSize,
-        economy: settlementEconomy,
-        useAI,
-      });
+      return generatorEngine.generateSettlement({ ...settlement, useAI });
     } else if (data.slug === "magic-item") {
-      return generatorEngine.generateMagicItem({
-        type: magicItemType,
-        rarity: magicItemRarity,
-        useAI,
-      });
+      return generatorEngine.generateMagicItem({ ...magicItem, useAI });
+    } else if (data.slug === "faction") {
+      return generatorEngine.generateFaction({ ...faction, useAI });
     } else {
-      return generatorEngine.generateFaction({
-        type: factionType,
-        scope: factionScope,
-        alignment: factionAlignment,
-        campaignContext: factionCampaignContext,
-        useAI,
-      });
+      throw new Error(`No generator implemented for slug: ${data.slug}`);
     }
   }
 
@@ -70,59 +107,29 @@
     "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
 </script>
 
-<SEOGeneratorLayout {generate}>
+<SEOGeneratorLayout
+  pageTitle={meta.pageTitle}
+  metaDescription={meta.metaDescription}
+  introTitle={meta.introTitle}
+  eyebrow={meta.eyebrow}
+  introText={meta.introText}
+  canonicalPath={meta.canonicalPath}
+  {generate}
+>
   {#snippet formFields()}
     {#if data.slug === "npc"}
-      <div class="flex flex-col gap-1.5">
-        <label for="race-select" class={labelClass}>Race</label>
-        <select id="race-select" bind:value={npcRace} class={selectClass}>
-          {#each npcConfig.races as r (r)}
-            <option value={r}>{r}</option>
-          {/each}
-        </select>
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <label for="role-select" class={labelClass}>Role / Class</label>
-        <select id="role-select" bind:value={npcRole} class={selectClass}>
-          {#each npcConfig.roles as r (r)}
-            <option value={r}>{r}</option>
-          {/each}
-        </select>
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <label for="alignment-select" class={labelClass}>Alignment</label>
-        <select
-          id="alignment-select"
-          bind:value={npcAlignment}
-          class={selectClass}
-        >
-          {#each npcConfig.alignments as a (a)}
-            <option value={a}>{a}</option>
-          {/each}
-        </select>
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <label for="campaign-context" class={labelClass}
-          >Optional Campaign Context</label
-        >
-        <textarea
-          id="campaign-context"
-          name="campaign_context"
-          bind:value={npcCampaignContext}
-          maxlength="240"
-          rows="4"
-          class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
-        ></textarea>
-      </div>
+      <NPCFormFields
+        bind:race={npc.race}
+        bind:role={npc.role}
+        bind:alignment={npc.alignment}
+        bind:campaignContext={npc.campaignContext}
+      />
     {:else if data.slug === "settlement"}
       <div class="flex flex-col gap-1.5">
         <label for="size-select" class={labelClass}>Settlement Size</label>
         <select
           id="size-select"
-          bind:value={settlementSize}
+          bind:value={settlement.size}
           class={selectClass}
         >
           {#each settlementConfig.sizes as s (s.name)}
@@ -135,7 +142,7 @@
         <label for="economy-select" class={labelClass}>Primary Economy</label>
         <select
           id="economy-select"
-          bind:value={settlementEconomy}
+          bind:value={settlement.economy}
           class={selectClass}
         >
           {#each settlementConfig.economies as e (e)}
@@ -148,7 +155,7 @@
         <label for="item-type-select" class={labelClass}>Item Type</label>
         <select
           id="item-type-select"
-          bind:value={magicItemType}
+          bind:value={magicItem.type}
           class={selectClass}
         >
           {#each magicItemConfig.types as t (t)}
@@ -161,7 +168,7 @@
         <label for="rarity-select" class={labelClass}>Rarity</label>
         <select
           id="rarity-select"
-          bind:value={magicItemRarity}
+          bind:value={magicItem.rarity}
           class={selectClass}
         >
           {#each magicItemConfig.rarities as r (r)}
@@ -169,83 +176,13 @@
           {/each}
         </select>
       </div>
-    {:else}
-      <div class="flex flex-col gap-1.5">
-        <label for="faction-type-select" class={labelClass}>Faction Type</label>
-        <select
-          id="faction-type-select"
-          name="faction_type"
-          bind:value={factionType}
-          class={selectClass}
-        >
-          {#each factionConfig.types as type (type)}
-            <option value={type}>{type}</option>
-          {/each}
-        </select>
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <label for="faction-scope-select" class={labelClass}
-          >Operating Scope</label
-        >
-        <select
-          id="faction-scope-select"
-          name="faction_scope"
-          bind:value={factionScope}
-          class={selectClass}
-        >
-          {#each factionConfig.scopes as scope (scope)}
-            <option value={scope}>{scope}</option>
-          {/each}
-        </select>
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <label for="faction-alignment-select" class={labelClass}
-          >Moral Posture</label
-        >
-        <select
-          id="faction-alignment-select"
-          name="faction_alignment"
-          bind:value={factionAlignment}
-          class={selectClass}
-        >
-          {#each factionConfig.alignments as alignment (alignment)}
-            <option value={alignment}>{alignment}</option>
-          {/each}
-        </select>
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <label for="faction-campaign-context" class={labelClass}
-          >Optional Campaign Context</label
-        >
-        <textarea
-          id="faction-campaign-context"
-          name="campaign_context"
-          bind:value={factionCampaignContext}
-          maxlength="240"
-          rows="4"
-          class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
-        ></textarea>
-      </div>
-    {/if}
-
-    <div class="flex items-center gap-2 pt-2">
-      <input
-        type="checkbox"
-        id="ai-toggle"
-        bind:checked={useAI}
-        class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
+    {:else if data.slug === "faction"}
+      <FactionFormFields
+        bind:type={faction.type}
+        bind:scope={faction.scope}
+        bind:alignment={faction.alignment}
+        bind:campaignContext={faction.campaignContext}
       />
-      <label
-        for="ai-toggle"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
-      >
-        <span class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
-        ></span>
-        AI Lore Co-Author Mode
-      </label>
-    </div>
+    {/if}
   {/snippet}
 </SEOGeneratorLayout>

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -1,6 +1,251 @@
 <script lang="ts">
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import {
+    generatorEngine,
+    npcConfig,
+    settlementConfig,
+    magicItemConfig,
+    factionConfig,
+  } from "$lib/services/seo/generator-engine";
+
   let { data } = $props();
+
+  // NPC state
+  let npcRace = $state(npcConfig.races[0]);
+  let npcRole = $state(npcConfig.roles[0]);
+  let npcAlignment = $state(npcConfig.alignments[0]);
+  let npcCampaignContext = $state("");
+
+  // Settlement state
+  let settlementSize = $state(settlementConfig.sizes[2].name);
+  let settlementEconomy = $state(settlementConfig.economies[0]);
+
+  // Magic item state
+  let magicItemType = $state(magicItemConfig.types[0]);
+  let magicItemRarity = $state(magicItemConfig.rarities[1]);
+
+  // Faction state
+  let factionType = $state(factionConfig.types[0]);
+  let factionScope = $state(factionConfig.scopes[1]);
+  let factionAlignment = $state(factionConfig.alignments[0]);
+  let factionCampaignContext = $state("");
+
+  let useAI = $state(true);
+
+  async function generate() {
+    if (data.slug === "npc") {
+      return generatorEngine.generateNPC({
+        race: npcRace,
+        role: npcRole,
+        alignment: npcAlignment,
+        campaignContext: npcCampaignContext,
+        useAI,
+      });
+    } else if (data.slug === "settlement") {
+      return generatorEngine.generateSettlement({
+        size: settlementSize,
+        economy: settlementEconomy,
+        useAI,
+      });
+    } else if (data.slug === "magic-item") {
+      return generatorEngine.generateMagicItem({
+        type: magicItemType,
+        rarity: magicItemRarity,
+        useAI,
+      });
+    } else {
+      return generatorEngine.generateFaction({
+        type: factionType,
+        scope: factionScope,
+        alignment: factionAlignment,
+        campaignContext: factionCampaignContext,
+        useAI,
+      });
+    }
+  }
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
 </script>
 
-<SEOGeneratorLayout slug={data.slug} />
+<SEOGeneratorLayout {generate}>
+  {#snippet formFields()}
+    {#if data.slug === "npc"}
+      <div class="flex flex-col gap-1.5">
+        <label for="race-select" class={labelClass}>Race</label>
+        <select id="race-select" bind:value={npcRace} class={selectClass}>
+          {#each npcConfig.races as r (r)}
+            <option value={r}>{r}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="role-select" class={labelClass}>Role / Class</label>
+        <select id="role-select" bind:value={npcRole} class={selectClass}>
+          {#each npcConfig.roles as r (r)}
+            <option value={r}>{r}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="alignment-select" class={labelClass}>Alignment</label>
+        <select
+          id="alignment-select"
+          bind:value={npcAlignment}
+          class={selectClass}
+        >
+          {#each npcConfig.alignments as a (a)}
+            <option value={a}>{a}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="campaign-context" class={labelClass}
+          >Optional Campaign Context</label
+        >
+        <textarea
+          id="campaign-context"
+          name="campaign_context"
+          bind:value={npcCampaignContext}
+          maxlength="240"
+          rows="4"
+          class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+        ></textarea>
+      </div>
+    {:else if data.slug === "settlement"}
+      <div class="flex flex-col gap-1.5">
+        <label for="size-select" class={labelClass}>Settlement Size</label>
+        <select
+          id="size-select"
+          bind:value={settlementSize}
+          class={selectClass}
+        >
+          {#each settlementConfig.sizes as s (s.name)}
+            <option value={s.name}>{s.name} ({s.range})</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="economy-select" class={labelClass}>Primary Economy</label>
+        <select
+          id="economy-select"
+          bind:value={settlementEconomy}
+          class={selectClass}
+        >
+          {#each settlementConfig.economies as e (e)}
+            <option value={e}>{e}</option>
+          {/each}
+        </select>
+      </div>
+    {:else if data.slug === "magic-item"}
+      <div class="flex flex-col gap-1.5">
+        <label for="item-type-select" class={labelClass}>Item Type</label>
+        <select
+          id="item-type-select"
+          bind:value={magicItemType}
+          class={selectClass}
+        >
+          {#each magicItemConfig.types as t (t)}
+            <option value={t}>{t}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="rarity-select" class={labelClass}>Rarity</label>
+        <select
+          id="rarity-select"
+          bind:value={magicItemRarity}
+          class={selectClass}
+        >
+          {#each magicItemConfig.rarities as r (r)}
+            <option value={r}>{r}</option>
+          {/each}
+        </select>
+      </div>
+    {:else}
+      <div class="flex flex-col gap-1.5">
+        <label for="faction-type-select" class={labelClass}>Faction Type</label>
+        <select
+          id="faction-type-select"
+          name="faction_type"
+          bind:value={factionType}
+          class={selectClass}
+        >
+          {#each factionConfig.types as type (type)}
+            <option value={type}>{type}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="faction-scope-select" class={labelClass}
+          >Operating Scope</label
+        >
+        <select
+          id="faction-scope-select"
+          name="faction_scope"
+          bind:value={factionScope}
+          class={selectClass}
+        >
+          {#each factionConfig.scopes as scope (scope)}
+            <option value={scope}>{scope}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="faction-alignment-select" class={labelClass}
+          >Moral Posture</label
+        >
+        <select
+          id="faction-alignment-select"
+          name="faction_alignment"
+          bind:value={factionAlignment}
+          class={selectClass}
+        >
+          {#each factionConfig.alignments as alignment (alignment)}
+            <option value={alignment}>{alignment}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="faction-campaign-context" class={labelClass}
+          >Optional Campaign Context</label
+        >
+        <textarea
+          id="faction-campaign-context"
+          name="campaign_context"
+          bind:value={factionCampaignContext}
+          maxlength="240"
+          rows="4"
+          class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+        ></textarea>
+      </div>
+    {/if}
+
+    <div class="flex items-center gap-2 pt-2">
+      <input
+        type="checkbox"
+        id="ai-toggle"
+        bind:checked={useAI}
+        class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
+      />
+      <label
+        for="ai-toggle"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
+      >
+        <span class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
+        ></span>
+        AI Lore Co-Author Mode
+      </label>
+    </div>
+  {/snippet}
+</SEOGeneratorLayout>

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.ts
@@ -3,17 +3,22 @@ import type { EntryGenerator, PageLoad } from "./$types";
 
 export const prerender = true;
 
-const validSlugs = new Set(["npc", "settlement", "magic-item"]);
+const validSlugs = new Set(["npc", "settlement", "magic-item", "faction"]);
 
 export const load: PageLoad = ({ params }) => {
   if (!validSlugs.has(params.slug)) {
     error(404, "Generator not found");
   }
   return {
-    slug: params.slug as "npc" | "settlement" | "magic-item",
+    slug: params.slug as "npc" | "settlement" | "magic-item" | "faction",
   };
 };
 
 export const entries: EntryGenerator = () => {
-  return [{ slug: "npc" }, { slug: "settlement" }, { slug: "magic-item" }];
+  return [
+    { slug: "npc" },
+    { slug: "settlement" },
+    { slug: "magic-item" },
+    { slug: "faction" },
+  ];
 };

--- a/apps/web/src/routes/(marketing)/generators/[slug]/generators.test.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/generators.test.ts
@@ -24,6 +24,7 @@ describe("Generators SvelteKit Route", () => {
         { slug: "npc" },
         { slug: "settlement" },
         { slug: "magic-item" },
+        { slug: "faction" },
       ]);
     });
   });

--- a/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
@@ -1,5 +1,25 @@
 <script lang="ts">
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import {
+    generatorEngine,
+    npcConfig,
+  } from "$lib/services/seo/generator-engine";
+
+  let npcRace = $state(npcConfig.races[0]);
+  let npcRole = $state(npcConfig.roles[0]);
+  let npcAlignment = $state(npcConfig.alignments[0]);
+  let npcCampaignContext = $state("");
+  let useAI = $state(true);
+
+  async function generate() {
+    return generatorEngine.generateNPC({
+      race: npcRace,
+      role: npcRole,
+      alignment: npcAlignment,
+      campaignContext: npcCampaignContext,
+      useAI,
+    });
+  }
 
   const relatedLinks = [
     { href: "/solutions/ai-gm-assistant", label: "AI GM assistant" },
@@ -31,7 +51,6 @@
 </script>
 
 <SEOGeneratorLayout
-  slug="npc"
   canonicalPath="/tools/dnd-npc-generator"
   pageTitle="D&D NPC Generator | Free Fantasy RPG Character Tool | Codex Cryptica"
   metaDescription="Generate D&D NPCs with ancestry, role, personality, secret, motivation, faction connection, and plot hook. Copy the draft or save it into your local campaign vault."
@@ -40,4 +59,99 @@
   introText="Create a ready-to-run fantasy NPC with structured GM notes, a secret, faction tie, and plot hook. Works without login, then saves into your local Codex Cryptica campaign vault."
   {relatedLinks}
   {faqs}
-/>
+  {generate}
+>
+  {#snippet formFields()}
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="race-select"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Race</label
+      >
+      <select
+        id="race-select"
+        bind:value={npcRace}
+        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+      >
+        {#each npcConfig.races as r (r)}
+          <option value={r}>{r}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="role-select"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Role / Class</label
+      >
+      <select
+        id="role-select"
+        bind:value={npcRole}
+        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+      >
+        {#each npcConfig.roles as r (r)}
+          <option value={r}>{r}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="alignment-select"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Alignment</label
+      >
+      <select
+        id="alignment-select"
+        bind:value={npcAlignment}
+        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+      >
+        {#each npcConfig.alignments as a (a)}
+          <option value={a}>{a}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="campaign-context"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Optional Campaign Context</label
+      >
+      <textarea
+        id="campaign-context"
+        name="campaign_context"
+        bind:value={npcCampaignContext}
+        maxlength="240"
+        rows="4"
+        aria-describedby="campaign-context-help"
+        class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+      ></textarea>
+      <p
+        id="campaign-context-help"
+        class="text-[10px] text-theme-muted leading-relaxed"
+      >
+        Add a city, faction, dungeon, or current campaign problem to aim the NPC
+        at your table.
+      </p>
+    </div>
+
+    <div class="flex items-center gap-2 pt-2">
+      <input
+        type="checkbox"
+        id="ai-toggle"
+        bind:checked={useAI}
+        class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
+      />
+      <label
+        for="ai-toggle"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
+      >
+        <span class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
+        ></span>
+        AI Lore Co-Author Mode
+      </label>
+    </div>
+  {/snippet}
+</SEOGeneratorLayout>

--- a/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import NPCFormFields from "$lib/components/seo/NPCFormFields.svelte";
   import {
     generatorEngine,
     npcConfig,
   } from "$lib/services/seo/generator-engine";
 
-  let npcRace = $state(npcConfig.races[0]);
-  let npcRole = $state(npcConfig.roles[0]);
-  let npcAlignment = $state(npcConfig.alignments[0]);
-  let npcCampaignContext = $state("");
-  let useAI = $state(true);
+  let race = $state(npcConfig.races[0]);
+  let role = $state(npcConfig.roles[0]);
+  let alignment = $state(npcConfig.alignments[0]);
+  let campaignContext = $state("");
 
-  async function generate() {
+  async function generate({ useAI }: { useAI: boolean }) {
     return generatorEngine.generateNPC({
-      race: npcRace,
-      role: npcRole,
-      alignment: npcAlignment,
-      campaignContext: npcCampaignContext,
+      race,
+      role,
+      alignment,
+      campaignContext,
       useAI,
     });
   }
@@ -62,96 +62,6 @@
   {generate}
 >
   {#snippet formFields()}
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="race-select"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Race</label
-      >
-      <select
-        id="race-select"
-        bind:value={npcRace}
-        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-      >
-        {#each npcConfig.races as r (r)}
-          <option value={r}>{r}</option>
-        {/each}
-      </select>
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="role-select"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Role / Class</label
-      >
-      <select
-        id="role-select"
-        bind:value={npcRole}
-        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-      >
-        {#each npcConfig.roles as r (r)}
-          <option value={r}>{r}</option>
-        {/each}
-      </select>
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="alignment-select"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Alignment</label
-      >
-      <select
-        id="alignment-select"
-        bind:value={npcAlignment}
-        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-      >
-        {#each npcConfig.alignments as a (a)}
-          <option value={a}>{a}</option>
-        {/each}
-      </select>
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="campaign-context"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Optional Campaign Context</label
-      >
-      <textarea
-        id="campaign-context"
-        name="campaign_context"
-        bind:value={npcCampaignContext}
-        maxlength="240"
-        rows="4"
-        aria-describedby="campaign-context-help"
-        class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
-      ></textarea>
-      <p
-        id="campaign-context-help"
-        class="text-[10px] text-theme-muted leading-relaxed"
-      >
-        Add a city, faction, dungeon, or current campaign problem to aim the NPC
-        at your table.
-      </p>
-    </div>
-
-    <div class="flex items-center gap-2 pt-2">
-      <input
-        type="checkbox"
-        id="ai-toggle"
-        bind:checked={useAI}
-        class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
-      />
-      <label
-        for="ai-toggle"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
-      >
-        <span class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
-        ></span>
-        AI Lore Co-Author Mode
-      </label>
-    </div>
+    <NPCFormFields bind:race bind:role bind:alignment bind:campaignContext />
   {/snippet}
 </SEOGeneratorLayout>

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import FactionFormFields from "$lib/components/seo/FactionFormFields.svelte";
   import {
     generatorEngine,
     factionConfig,
   } from "$lib/services/seo/generator-engine";
 
-  let factionType = $state(factionConfig.types[0]);
-  let factionScope = $state(factionConfig.scopes[1]);
-  let factionAlignment = $state(factionConfig.alignments[0]);
-  let factionCampaignContext = $state("");
-  let useAI = $state(true);
+  let type = $state(factionConfig.types[0]);
+  let scope = $state(factionConfig.scopes[1]);
+  let alignment = $state(factionConfig.alignments[0]);
+  let campaignContext = $state("");
 
-  async function generate() {
+  async function generate({ useAI }: { useAI: boolean }) {
     return generatorEngine.generateFaction({
-      type: factionType,
-      scope: factionScope,
-      alignment: factionAlignment,
-      campaignContext: factionCampaignContext,
+      type,
+      scope,
+      alignment,
+      campaignContext,
       useAI,
     });
   }
@@ -63,99 +63,11 @@
   {generate}
 >
   {#snippet formFields()}
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="faction-type-select"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Faction Type</label
-      >
-      <select
-        id="faction-type-select"
-        name="faction_type"
-        bind:value={factionType}
-        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-      >
-        {#each factionConfig.types as type (type)}
-          <option value={type}>{type}</option>
-        {/each}
-      </select>
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="faction-scope-select"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Operating Scope</label
-      >
-      <select
-        id="faction-scope-select"
-        name="faction_scope"
-        bind:value={factionScope}
-        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-      >
-        {#each factionConfig.scopes as scope (scope)}
-          <option value={scope}>{scope}</option>
-        {/each}
-      </select>
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="faction-alignment-select"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Moral Posture</label
-      >
-      <select
-        id="faction-alignment-select"
-        name="faction_alignment"
-        bind:value={factionAlignment}
-        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
-      >
-        {#each factionConfig.alignments as alignment (alignment)}
-          <option value={alignment}>{alignment}</option>
-        {/each}
-      </select>
-    </div>
-
-    <div class="flex flex-col gap-1.5">
-      <label
-        for="faction-campaign-context"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
-        >Optional Campaign Context</label
-      >
-      <textarea
-        id="faction-campaign-context"
-        name="campaign_context"
-        bind:value={factionCampaignContext}
-        maxlength="240"
-        rows="4"
-        aria-describedby="faction-campaign-context-help"
-        class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
-      ></textarea>
-      <p
-        id="faction-campaign-context-help"
-        class="text-[10px] text-theme-muted leading-relaxed"
-      >
-        Add a city, frontier, villain, war, or campaign tension to aim the
-        faction at your table.
-      </p>
-    </div>
-
-    <div class="flex items-center gap-2 pt-2">
-      <input
-        type="checkbox"
-        id="ai-toggle"
-        bind:checked={useAI}
-        class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
-      />
-      <label
-        for="ai-toggle"
-        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
-      >
-        <span class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
-        ></span>
-        AI Lore Co-Author Mode
-      </label>
-    </div>
+    <FactionFormFields
+      bind:type
+      bind:scope
+      bind:alignment
+      bind:campaignContext
+    />
   {/snippet}
 </SEOGeneratorLayout>

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -1,5 +1,25 @@
 <script lang="ts">
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import {
+    generatorEngine,
+    factionConfig,
+  } from "$lib/services/seo/generator-engine";
+
+  let factionType = $state(factionConfig.types[0]);
+  let factionScope = $state(factionConfig.scopes[1]);
+  let factionAlignment = $state(factionConfig.alignments[0]);
+  let factionCampaignContext = $state("");
+  let useAI = $state(true);
+
+  async function generate() {
+    return generatorEngine.generateFaction({
+      type: factionType,
+      scope: factionScope,
+      alignment: factionAlignment,
+      campaignContext: factionCampaignContext,
+      useAI,
+    });
+  }
 
   const relatedLinks = [
     { href: "/tools/dnd-npc-generator", label: "D&D NPC generator" },
@@ -32,7 +52,6 @@
 </script>
 
 <SEOGeneratorLayout
-  slug="faction"
   canonicalPath="/tools/faction-generator"
   pageTitle="Faction Generator | Free Fantasy RPG Organization Tool | Codex Cryptica"
   metaDescription="Generate fantasy RPG factions with goals, internal conflict, rival groups, notable NPCs, and adventure hooks. Copy the draft or save it into your local campaign vault."
@@ -41,4 +60,102 @@
   introText="Create a campaign-ready fantasy faction with a public face, agenda, internal conflict, rival group, notable NPCs, and adventure hook. Works without login, then saves into your local Codex Cryptica campaign vault."
   {relatedLinks}
   {faqs}
-/>
+  {generate}
+>
+  {#snippet formFields()}
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="faction-type-select"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Faction Type</label
+      >
+      <select
+        id="faction-type-select"
+        name="faction_type"
+        bind:value={factionType}
+        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+      >
+        {#each factionConfig.types as type (type)}
+          <option value={type}>{type}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="faction-scope-select"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Operating Scope</label
+      >
+      <select
+        id="faction-scope-select"
+        name="faction_scope"
+        bind:value={factionScope}
+        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+      >
+        {#each factionConfig.scopes as scope (scope)}
+          <option value={scope}>{scope}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="faction-alignment-select"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Moral Posture</label
+      >
+      <select
+        id="faction-alignment-select"
+        name="faction_alignment"
+        bind:value={factionAlignment}
+        class="w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60"
+      >
+        {#each factionConfig.alignments as alignment (alignment)}
+          <option value={alignment}>{alignment}</option>
+        {/each}
+      </select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <label
+        for="faction-campaign-context"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted"
+        >Optional Campaign Context</label
+      >
+      <textarea
+        id="faction-campaign-context"
+        name="campaign_context"
+        bind:value={factionCampaignContext}
+        maxlength="240"
+        rows="4"
+        aria-describedby="faction-campaign-context-help"
+        class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+      ></textarea>
+      <p
+        id="faction-campaign-context-help"
+        class="text-[10px] text-theme-muted leading-relaxed"
+      >
+        Add a city, frontier, villain, war, or campaign tension to aim the
+        faction at your table.
+      </p>
+    </div>
+
+    <div class="flex items-center gap-2 pt-2">
+      <input
+        type="checkbox"
+        id="ai-toggle"
+        bind:checked={useAI}
+        class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
+      />
+      <label
+        for="ai-toggle"
+        class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
+      >
+        <span class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
+        ></span>
+        AI Lore Co-Author Mode
+      </label>
+    </div>
+  {/snippet}
+</SEOGeneratorLayout>


### PR DESCRIPTION
## Summary
- Refactored `SEOGeneratorLayout.svelte` to be truly generic — it now accepts a `generate: () => Promise<GeneratorOutput>` prop and a `formFields` Svelte 5 snippet instead of a `slug` discriminator
- NPC and faction generator pages now own their form state and pass a `generate` callback to the layout
- The `generators/[slug]` route handles settlement/magic-item/faction form state locally and passes the same interface
- Added `faction` to the prerendered slug list in `+page.ts`
- Updated test to reflect the expanded slug list

**Adding a new generator type now only requires creating a new route file — no changes to `SEOGeneratorLayout`.**

## Test plan
- [ ] `/tools/dnd-npc-generator` generates NPCs correctly
- [ ] `/tools/faction-generator` generates factions correctly
- [ ] `/generators/settlement` and `/generators/magic-item` still work
- [ ] `/generators/faction` now resolves (was 404 before)
- [ ] 18 generator tests pass

Closes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)