### PR TITLE
feat(1095): add fantasy name generator SEO page

### DIFF
--- a/apps/web/src/lib/components/seo/NameFormFields.svelte
+++ b/apps/web/src/lib/components/seo/NameFormFields.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { nameGeneratorConfig } from "$lib/services/seo/generator-engine";
+
+  let {
+    culture = $bindable(nameGeneratorConfig.cultures[0]),
+    gender = $bindable(nameGeneratorConfig.genders[0]),
+    nameType = $bindable(nameGeneratorConfig.nameTypes[0]),
+    count = $bindable(nameGeneratorConfig.counts[1]),
+    context = $bindable(""),
+  }: {
+    culture: string;
+    gender: string;
+    nameType: string;
+    count: string;
+    context: string;
+  } = $props();
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+</script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="culture-select" class={labelClass}>Culture / Style</label>
+  <select id="culture-select" bind:value={culture} class={selectClass}>
+    {#each nameGeneratorConfig.cultures as c (c)}
+      <option value={c}>{c}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="gender-select" class={labelClass}>Gender / Presentation</label>
+  <select id="gender-select" bind:value={gender} class={selectClass}>
+    {#each nameGeneratorConfig.genders as g (g)}
+      <option value={g}>{g}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="name-type-select" class={labelClass}>Name Type</label>
+  <select id="name-type-select" bind:value={nameType} class={selectClass}>
+    {#each nameGeneratorConfig.nameTypes as t (t)}
+      <option value={t}>{t}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="count-select" class={labelClass}>Number of Results</label>
+  <select id="count-select" bind:value={count} class={selectClass}>
+    {#each nameGeneratorConfig.counts as n (n)}
+      <option value={n}>{n} names</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="name-context" class={labelClass}>Optional Context</label>
+  <textarea
+    id="name-context"
+    name="context"
+    bind:value={context}
+    maxlength="240"
+    rows="3"
+    aria-describedby="name-context-help"
+    class="w-full min-h-20 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+  ></textarea>
+  <p
+    id="name-context-help"
+    class="text-[10px] text-theme-muted leading-relaxed"
+  >
+    Describe the character, place, or faction to get more fitting names — e.g.
+    "a reclusive mage" or "a coastal trading city".
+  </p>
+</div>

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -166,6 +166,94 @@ describe("DefaultGeneratorEngine", () => {
     });
   });
 
+  describe("generateNames", () => {
+    it("should generate the correct entity type for each name type", async () => {
+      const cases: Array<[string, string]> = [
+        ["Person", "character"],
+        ["Place", "location"],
+        ["Faction", "faction"],
+        ["Item", "item"],
+      ];
+      for (const [nameType, expected] of cases) {
+        const res = await engine.generateNames({ nameType, useAI: false });
+        expect(res.type).toBe(expected);
+      }
+    });
+
+    it("should generate the requested count of names in local fallback", async () => {
+      const res = await engine.generateNames({ count: "3", useAI: false });
+      const bullets = (res.content.match(/^- /gm) || []).length;
+      expect(bullets).toBe(3);
+      expect(res.title).toBeDefined();
+      expect(res.title!.length).toBeGreaterThan(0);
+    });
+
+    it("should clamp invalid count to a positive integer", async () => {
+      const res = await engine.generateNames({
+        count: "not-a-number",
+        useAI: false,
+      });
+      const bullets = (res.content.match(/^- /gm) || []).length;
+      expect(bullets).toBeGreaterThan(0);
+      expect(res.title).toBeDefined();
+    });
+
+    it("should use culture-specific prefix/suffix tables", async () => {
+      const res = await engine.generateNames({
+        culture: "Dwarven",
+        count: "5",
+        useAI: false,
+      });
+      expect(res.content).toContain("Dwarven");
+      expect(res.labels).toContain("name-generator");
+      expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should call clientManager and return AI output when useAI is true", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "Sylvara",
+                content: "High Elf names.\n- **Sylvara**: graceful archer",
+                lore: "Culture: High Elf",
+                labels: ["fantasy-name", "name-generator"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generateNames({
+        culture: "High Elf",
+        nameType: "Person",
+        count: "3",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(res.type).toBe("character");
+      expect(res.title).toBe("Sylvara");
+      expect(res.content).toContain("Sylvara");
+    });
+
+    it("should fall back to local tables when AI call fails", async () => {
+      mockClientManager.getModel.mockRejectedValue(new Error("Network Error"));
+
+      const res = await engine.generateNames({
+        culture: "Norse / Viking",
+        count: "3",
+        useAI: true,
+      });
+
+      expect(res.type).toBe("character");
+      expect(res.title).toBeDefined();
+      const bullets = (res.content.match(/^- /gm) || []).length;
+      expect(bullets).toBe(3);
+    });
+  });
+
   describe("generateSettlement", () => {
     it("should generate settlement details locally when useAI is false", async () => {
       const res = await engine.generateSettlement({

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -1390,7 +1390,7 @@ ${reward}`;
     const culture = options.culture || nameGeneratorConfig.cultures[0];
     const gender = options.gender || nameGeneratorConfig.genders[0];
     const nameType = options.nameType || nameGeneratorConfig.nameTypes[0];
-    const count = parseInt(options.count || "5", 10);
+    const count = Math.max(1, parseInt(options.count || "5", 10) || 5);
     const context = options.context?.trim();
 
     const entityType: GeneratorOutput["type"] =
@@ -1415,7 +1415,7 @@ ${context ? `- Context: ${context}` : ""}
 You must return a valid JSON object matching the following structure exactly:
 {
   "title": "The single best or most evocative name from the list",
-  "content": "A brief lead sentence describing the naming style, followed by a markdown list of all ${count} names. Format each name as '- **Name** — one-sentence flavour note'.",
+  "content": "A brief lead sentence describing the naming style, followed by a markdown list of all ${count} names. Format each name as '- **Name**: one-sentence flavour note'.",
   "lore": "GM notes (markdown formatted) with sections for Culture, Style, and Usage Suggestions covering how to use these names in a campaign.",
   "labels": ["fantasy-name", "name-generator", "imported-draft"]
 }
@@ -1468,7 +1468,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
     }
 
     const primary = generated[0];
-    const nameList = generated.map((n) => `- **${n}**`).join("\n");
+    const nameList = generated.map((n) => `- ${n}`).join("\n");
 
     const content = `${culture} ${nameType.toLowerCase()} names in a ${gender.toLowerCase()} register.
 

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -78,6 +78,310 @@ export const nameTable = {
   ],
 };
 
+// Fantasy Name Generator Config
+export const nameGeneratorConfig = {
+  cultures: [
+    "Generic Fantasy",
+    "High Elf",
+    "Dark Elf",
+    "Dwarven",
+    "Halfling",
+    "Orcish",
+    "Norse / Viking",
+    "Roman / Latin",
+    "Celtic / Gaelic",
+    "Eastern / Asian-inspired",
+  ],
+  genders: ["Any", "Masculine", "Feminine", "Neutral / Ambiguous"],
+  nameTypes: ["Person", "Place", "Faction", "Item"],
+  counts: ["3", "5", "10"],
+  // Culture-specific local fallback tables
+  culturePrefixes: {
+    "Generic Fantasy": [
+      "Ael",
+      "Bran",
+      "Cael",
+      "Dax",
+      "El",
+      "Fael",
+      "Kael",
+      "Lyr",
+      "Morg",
+      "Nal",
+      "Thor",
+      "Vael",
+    ],
+    "High Elf": [
+      "Aer",
+      "Caer",
+      "El",
+      "Gal",
+      "Ith",
+      "Lae",
+      "Mir",
+      "Sil",
+      "Thal",
+      "Var",
+      "Wyn",
+      "Zin",
+    ],
+    "Dark Elf": [
+      "Driz",
+      "Mal",
+      "Nath",
+      "Riz",
+      "Sol",
+      "Szor",
+      "Ul",
+      "Vir",
+      "Xan",
+      "Zaer",
+      "Zin",
+      "Vy",
+    ],
+    Dwarven: [
+      "Bal",
+      "Dur",
+      "Glor",
+      "Grim",
+      "Kat",
+      "Kaz",
+      "Mag",
+      "Nar",
+      "Thor",
+      "Tor",
+      "Ulf",
+      "Vor",
+    ],
+    Halfling: [
+      "Bil",
+      "Cor",
+      "Del",
+      "Fil",
+      "Gob",
+      "Mer",
+      "Pip",
+      "Rose",
+      "Sam",
+      "Tom",
+      "Wil",
+      "Bun",
+    ],
+    Orcish: [
+      "Druk",
+      "Grak",
+      "Grom",
+      "Krag",
+      "Mog",
+      "Nar",
+      "Rok",
+      "Skul",
+      "Thok",
+      "Urg",
+      "Vrak",
+      "Zug",
+    ],
+    "Norse / Viking": [
+      "Arn",
+      "Bjor",
+      "Dag",
+      "Eil",
+      "Gunn",
+      "Hal",
+      "Ing",
+      "Leif",
+      "Rag",
+      "Sigr",
+      "Thor",
+      "Ulf",
+    ],
+    "Roman / Latin": [
+      "Aem",
+      "Aur",
+      "Bru",
+      "Cal",
+      "Cas",
+      "Cor",
+      "Flav",
+      "Jul",
+      "Marc",
+      "Octa",
+      "Sext",
+      "Val",
+    ],
+    "Celtic / Gaelic": [
+      "Aed",
+      "Bran",
+      "Caill",
+      "Conn",
+      "Donn",
+      "Eoch",
+      "Fearg",
+      "Niall",
+      "Ruad",
+      "Taig",
+      "Uar",
+      "Cunn",
+    ],
+    "Eastern / Asian-inspired": [
+      "Akira",
+      "Chen",
+      "Hiro",
+      "Jin",
+      "Kai",
+      "Li",
+      "Ren",
+      "Ryu",
+      "Shen",
+      "Tao",
+      "Wei",
+      "Zhen",
+    ],
+  } as Record<string, string[]>,
+  cultureSuffixes: {
+    "Generic Fantasy": [
+      "dar",
+      "eth",
+      "gorn",
+      "ius",
+      "mar",
+      "morn",
+      "ra",
+      "ric",
+      "thas",
+      "val",
+      "wen",
+      "thor",
+    ],
+    "High Elf": [
+      "ael",
+      "aith",
+      "ara",
+      "ath",
+      "elan",
+      "iath",
+      "ien",
+      "ira",
+      "is",
+      "ith",
+      "on",
+      "rial",
+    ],
+    "Dark Elf": [
+      "ace",
+      "arn",
+      "bra",
+      "dra",
+      "fein",
+      "ica",
+      "inae",
+      "ra",
+      "rix",
+      "ssa",
+      "tra",
+      "vra",
+    ],
+    Dwarven: [
+      "ak",
+      "ald",
+      "ar",
+      "ek",
+      "im",
+      "in",
+      "kin",
+      "nar",
+      "rek",
+      "rim",
+      "rin",
+      "uk",
+    ],
+    Halfling: [
+      "ble",
+      "boro",
+      "buck",
+      "fast",
+      "foot",
+      "fur",
+      "good",
+      "hill",
+      "penny",
+      "seed",
+      "wise",
+      "wool",
+    ],
+    Orcish: [
+      "ash",
+      "dar",
+      "gash",
+      "grak",
+      "gruk",
+      "kul",
+      "lash",
+      "mok",
+      "rak",
+      "skrag",
+      "thak",
+      "ugh",
+    ],
+    "Norse / Viking": [
+      "ald",
+      "bjorn",
+      "dís",
+      "eit",
+      "gar",
+      "helm",
+      "nar",
+      "rún",
+      "stein",
+      "ulf",
+      "vald",
+      "var",
+    ],
+    "Roman / Latin": [
+      "anus",
+      "ella",
+      "ia",
+      "ianus",
+      "illa",
+      "ina",
+      "inus",
+      "io",
+      "ius",
+      "lia",
+      "ona",
+      "us",
+    ],
+    "Celtic / Gaelic": [
+      "ach",
+      "all",
+      "an",
+      "ard",
+      "as",
+      "dha",
+      "ech",
+      "en",
+      "inn",
+      "on",
+      "ua",
+      "ugh",
+    ],
+    "Eastern / Asian-inspired": [
+      "bo",
+      "fa",
+      "ji",
+      "ko",
+      "lan",
+      "lei",
+      "li",
+      "mei",
+      "na",
+      "ro",
+      "shi",
+      "xia",
+    ],
+  } as Record<string, string[]>,
+};
+
 // NPC Generator Table Config
 export const npcConfig = {
   races: [
@@ -1069,6 +1373,121 @@ ${reward}`;
       content,
       lore,
       labels: ["rpg-quest", "quest-generator", "imported-draft"],
+      status: "active",
+    };
+  }
+
+  async generateNames(
+    options: {
+      culture?: string;
+      gender?: string;
+      nameType?: string;
+      count?: string;
+      context?: string;
+      useAI?: boolean;
+    } = {},
+  ): Promise<GeneratorOutput> {
+    const culture = options.culture || nameGeneratorConfig.cultures[0];
+    const gender = options.gender || nameGeneratorConfig.genders[0];
+    const nameType = options.nameType || nameGeneratorConfig.nameTypes[0];
+    const count = parseInt(options.count || "5", 10);
+    const context = options.context?.trim();
+
+    const entityType: GeneratorOutput["type"] =
+      nameType === "Place"
+        ? "location"
+        : nameType === "Faction"
+          ? "faction"
+          : nameType === "Item"
+            ? "item"
+            : "character";
+
+    if (options.useAI !== false) {
+      try {
+        const prompt = `Generate ${count} fantasy ${nameType.toLowerCase()} names in JSON format.
+Options:
+- Culture / Style: ${culture}
+- Gender / Presentation: ${gender}
+- Name Type: ${nameType}
+- Count: ${count}
+${context ? `- Context: ${context}` : ""}
+
+You must return a valid JSON object matching the following structure exactly:
+{
+  "title": "The single best or most evocative name from the list",
+  "content": "A brief lead sentence describing the naming style, followed by a markdown list of all ${count} names. Format each name as '- **Name** — one-sentence flavour note'.",
+  "lore": "GM notes (markdown formatted) with sections for Culture, Style, and Usage Suggestions covering how to use these names in a campaign.",
+  "labels": ["fantasy-name", "name-generator", "imported-draft"]
+}
+Return only the JSON object. Do not include markdown code block formatting like \`\`\`json.`;
+
+        const model = await this.clientManager.getModel(
+          "",
+          "gemini-1.5-flash",
+          "You are an assistant that generates detailed RPG campaign elements in JSON format.",
+        );
+        const response = await model.generateContent(prompt);
+        const text = response.response.text().trim();
+        const cleanText = text
+          .replace(/^```json\s*/i, "")
+          .replace(/```$/, "")
+          .trim();
+        const data = JSON.parse(cleanText);
+
+        return {
+          type: entityType,
+          title: data.title || "Fantasy Name",
+          content: data.content || "",
+          lore: data.lore || "",
+          labels: Array.isArray(data.labels)
+            ? data.labels
+            : ["fantasy-name", "name-generator", "imported-draft"],
+          status: "active",
+        };
+      } catch (err) {
+        console.warn(
+          "AI generation failed, falling back to local tables:",
+          err,
+        );
+      }
+    }
+
+    // Local fallback: combine culture-specific prefix + suffix
+    const prefixes =
+      nameGeneratorConfig.culturePrefixes[culture] ||
+      nameGeneratorConfig.culturePrefixes["Generic Fantasy"];
+    const suffixes =
+      nameGeneratorConfig.cultureSuffixes[culture] ||
+      nameGeneratorConfig.cultureSuffixes["Generic Fantasy"];
+
+    const generated: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const prefix = prefixes[Math.floor(Math.random() * prefixes.length)];
+      const suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
+      generated.push(prefix.charAt(0).toUpperCase() + prefix.slice(1) + suffix);
+    }
+
+    const primary = generated[0];
+    const nameList = generated.map((n) => `- **${n}**`).join("\n");
+
+    const content = `${culture} ${nameType.toLowerCase()} names in a ${gender.toLowerCase()} register.
+
+${nameList}`;
+
+    const lore = `### Generator Settings
+- **Culture**: ${culture}
+- **Gender / Presentation**: ${gender}
+- **Name Type**: ${nameType}
+
+### Usage Suggestions
+Use these names for any ${nameType.toLowerCase()} in a ${culture.toLowerCase()}-influenced setting. Combine or modify them freely — drop a syllable, add a prefix, or append a title or epithet for variation.`;
+
+    return {
+      type: entityType,
+      title: primary,
+      content,
+      lore,
+      labels: ["fantasy-name", "name-generator", "imported-draft"],
       status: "active",
     };
   }

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -29,6 +29,13 @@
           icon: "icon-[lucide--scroll-text]",
         },
         {
+          href: "/tools/fantasy-name-generator",
+          label: "Fantasy Name Generator",
+          summary:
+            "Generate character, place, faction, and item names across ten cultural styles.",
+          icon: "icon-[lucide--pen-line]",
+        },
+        {
           href: "/generators/npc",
           label: "Procedural NPC Generator",
           summary:

--- a/apps/web/src/routes/(marketing)/tools/fantasy-name-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/fantasy-name-generator/+page.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import NameFormFields from "$lib/components/seo/NameFormFields.svelte";
+  import {
+    generatorEngine,
+    nameGeneratorConfig,
+  } from "$lib/services/seo/generator-engine";
+
+  let culture = $state(nameGeneratorConfig.cultures[0]);
+  let gender = $state(nameGeneratorConfig.genders[0]);
+  let nameType = $state(nameGeneratorConfig.nameTypes[0]);
+  let count = $state(nameGeneratorConfig.counts[1]);
+  let context = $state("");
+
+  async function generate({ useAI }: { useAI: boolean }) {
+    return generatorEngine.generateNames({
+      culture,
+      gender,
+      nameType,
+      count,
+      context,
+      useAI,
+    });
+  }
+
+  const relatedLinks = [
+    { href: "/worldbuilding-tool", label: "Worldbuilding tool" },
+    { href: "/free-rpg-campaign-manager", label: "Free RPG campaign manager" },
+    { href: "/tools/dnd-npc-generator", label: "D&D NPC generator" },
+  ];
+
+  const faqs = [
+    {
+      question: "Does the fantasy name generator require an account?",
+      answer:
+        "No. You can generate names on the public page without logging in, then copy them or save a favourite into a local Codex Cryptica vault.",
+    },
+    {
+      question: "What name types does it support?",
+      answer:
+        "The generator supports person names, place names, faction names, and item names across ten cultural styles from High Elf and Dwarven to Norse, Celtic, and Eastern-inspired.",
+    },
+    {
+      question: "Can I use these names in my campaign or published work?",
+      answer:
+        "Yes. All generated names are free to use in any personal or commercial tabletop RPG work.",
+    },
+    {
+      question: "How does saving a name to Codex Cryptica work?",
+      answer:
+        "The page stores the primary generated name in browser localStorage and opens the app, where it imports as a Character, Location, Faction, or Item entity depending on the selected name type.",
+    },
+  ];
+</script>
+
+<SEOGeneratorLayout
+  canonicalPath="/tools/fantasy-name-generator"
+  pageTitle="Fantasy Name Generator | Free RPG & Worldbuilding Name Tool | Codex Cryptica"
+  metaDescription="Generate fantasy names for characters, places, factions, and items across ten cultural styles. Free for D&D, Pathfinder, worldbuilding, and any tabletop RPG."
+  eyebrow="Fantasy Name Generator"
+  introTitle="Fantasy Name Generator"
+  introText="Generate fantasy names for characters, places, factions, and items across ten cultural styles. Works without login — copy your favourites or save them into your local Codex Cryptica vault."
+  {relatedLinks}
+  {faqs}
+  {generate}
+>
+  {#snippet formFields()}
+    <NameFormFields
+      bind:culture
+      bind:gender
+      bind:nameType
+      bind:count
+      bind:context
+    />
+  {/snippet}
+</SEOGeneratorLayout>

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -47,6 +47,11 @@ export async function GET() {
       changefreq: "monthly",
       priority: "0.8",
     },
+    {
+      path: "/tools/fantasy-name-generator",
+      changefreq: "monthly",
+      priority: "0.8",
+    },
     { path: "/llms.txt", changefreq: "weekly", priority: "0.7" },
     { path: "/llms-full.txt", changefreq: "weekly", priority: "0.7" },
     { path: "/terms", changefreq: "yearly", priority: "0.5" },


### PR DESCRIPTION
## Summary
- Adds `/tools/fantasy-name-generator` using the `SEOGeneratorLayout` template
- New `nameGeneratorConfig` with 10 cultures, 4 name types (person/place/faction/item), gender/presentation, and count (3/5/10)
- Per-culture prefix/suffix tables for the local fallback
- `generateNames()` in the engine with AI generation + local fallback
- `NameFormFields.svelte` shared form component
- Save-to-vault flow maps name type → entity type (character/location/faction/item)
- Added to tools hub and sitemap

## Test plan
- [ ] Visit `/tools/fantasy-name-generator` — all 5 controls render
- [ ] Generate with AI on — returns N names with flavour notes
- [ ] Generate with AI off (local fallback) — returns names from culture tables
- [ ] Name type "Place" saves as a Location entity, "Faction" as Faction, etc.
- [ ] Copy clipboard works
- [ ] Page title and canonical are correct
- [ ] Entry appears in tools hub

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)