### PR TITLE
feat(1104): implement technical SEO foundation for marketing pages

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -134,9 +134,29 @@ ${generatedData.lore}`;
 <svelte:head>
   <title>{pageTitle}</title>
   <meta name="description" content={metaDescription} />
+  <meta name="robots" content="index, follow" />
   {#if canonicalPath}
     <link rel="canonical" href="https://codexcryptica.com{canonicalPath}" />
   {/if}
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Codex Cryptica" />
+  <meta property="og:title" content={pageTitle} />
+  <meta property="og:description" content={metaDescription} />
+  {#if canonicalPath}
+    <meta
+      property="og:url"
+      content="https://codexcryptica.com{canonicalPath}"
+    />
+  {/if}
+  <meta property="og:image" content="https://codexcryptica.com/logo.png" />
+  <meta property="og:image:width" content="1024" />
+  <meta property="og:image:height" content="1024" />
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content={pageTitle} />
+  <meta name="twitter:description" content={metaDescription} />
+  <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
   {#if faqJsonLd}
     {@html `<script type="application/ld+json">${faqJsonLd}</` + "script>"}

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -51,6 +51,40 @@
       `ipt>`,
   );
 
+  const pageUrl = $derived(
+    `https://codexcryptica.com/${type === "comparison" ? "vs" : "solutions"}/${data.slug}`,
+  );
+
+  const breadcrumb = $derived({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://codexcryptica.com",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: type === "comparison" ? "Comparisons" : "Solutions",
+        item: `https://codexcryptica.com/${type === "comparison" ? "vs" : "solutions"}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: data.h1,
+        item: pageUrl,
+      },
+    ],
+  });
+
+  const breadcrumbScript = $derived(
+    `<script type="application/ld+json">${JSON.stringify(breadcrumb)}</scr` +
+      `ipt>`,
+  );
+
   function toggleFaq(index: number) {
     openFaqIndex = openFaqIndex === index ? null : index;
   }
@@ -60,14 +94,35 @@
   <title>{data.title}</title>
   <meta name="description" content={data.description} />
   <meta name="keywords" content={data.keywords.join(", ")} />
+  <meta name="robots" content="index, follow" />
   <link
     rel="canonical"
     href="https://codexcryptica.com/{type === 'comparison'
       ? 'vs'
       : 'solutions'}/{data.slug}"
   />
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Codex Cryptica" />
+  <meta property="og:title" content={data.title} />
+  <meta property="og:description" content={data.description} />
+  <meta
+    property="og:url"
+    content="https://codexcryptica.com/{type === 'comparison'
+      ? 'vs'
+      : 'solutions'}/{data.slug}"
+  />
+  <meta property="og:image" content="https://codexcryptica.com/logo.png" />
+  <meta property="og:image:width" content="1024" />
+  <meta property="og:image:height" content="1024" />
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content={data.title} />
+  <meta name="twitter:description" content={data.description} />
+  <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
   {@html jsonLdScript}
+  {@html breadcrumbScript}
 </svelte:head>
 
 <div

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -95,23 +95,13 @@
   <meta name="description" content={data.description} />
   <meta name="keywords" content={data.keywords.join(", ")} />
   <meta name="robots" content="index, follow" />
-  <link
-    rel="canonical"
-    href="https://codexcryptica.com/{type === 'comparison'
-      ? 'vs'
-      : 'solutions'}/{data.slug}"
-  />
+  <link rel="canonical" href={pageUrl} />
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Codex Cryptica" />
   <meta property="og:title" content={data.title} />
   <meta property="og:description" content={data.description} />
-  <meta
-    property="og:url"
-    content="https://codexcryptica.com/{type === 'comparison'
-      ? 'vs'
-      : 'solutions'}/{data.slug}"
-  />
+  <meta property="og:url" content={pageUrl} />
   <meta property="og:image" content="https://codexcryptica.com/logo.png" />
   <meta property="og:image:width" content="1024" />
   <meta property="og:image:height" content="1024" />

--- a/apps/web/src/routes/(marketing)/ai-rpg-campaign-manager/+page.svelte
+++ b/apps/web/src/routes/(marketing)/ai-rpg-campaign-manager/+page.svelte
@@ -8,10 +8,36 @@
     name="description"
     content="Supercharge your campaign creation. Generate rich NPC backstories, faction secrets, and city layouts using the AI-assisted Lore Oracle."
   />
+  <meta name="robots" content="index, follow" />
   <link
     rel="canonical"
     href="https://codexcryptica.com/ai-rpg-campaign-manager"
   />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Codex Cryptica" />
+  <meta
+    property="og:title"
+    content="AI RPG Campaign Manager & GM Assistant | Codex Cryptica"
+  />
+  <meta
+    property="og:description"
+    content="Supercharge your campaign creation. Generate rich NPC backstories, faction secrets, and city layouts using the AI-assisted Lore Oracle."
+  />
+  <meta
+    property="og:url"
+    content="https://codexcryptica.com/ai-rpg-campaign-manager"
+  />
+  <meta property="og:image" content="https://codexcryptica.com/logo.png" />
+  <meta name="twitter:card" content="summary" />
+  <meta
+    name="twitter:title"
+    content="AI RPG Campaign Manager & GM Assistant | Codex Cryptica"
+  />
+  <meta
+    name="twitter:description"
+    content="Supercharge your campaign creation. Generate rich NPC backstories, faction secrets, and city layouts using the AI-assisted Lore Oracle."
+  />
+  <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
 </svelte:head>
 

--- a/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
+++ b/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
@@ -114,10 +114,36 @@
     name="description"
     content="Codex Cryptica is a free, local-first campaign manager and notes app for game masters. Map campaign lore, linked graphs, interactive maps, and timelines privately."
   />
+  <meta name="robots" content="index, follow" />
   <link
     rel="canonical"
     href="https://codexcryptica.com/free-rpg-campaign-manager"
   />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Codex Cryptica" />
+  <meta
+    property="og:title"
+    content="Free RPG Campaign Manager & Lore Vault | Codex Cryptica"
+  />
+  <meta
+    property="og:description"
+    content="Codex Cryptica is a free, local-first campaign manager and notes app for game masters. Map campaign lore, linked graphs, interactive maps, and timelines privately."
+  />
+  <meta
+    property="og:url"
+    content="https://codexcryptica.com/free-rpg-campaign-manager"
+  />
+  <meta property="og:image" content="https://codexcryptica.com/logo.png" />
+  <meta name="twitter:card" content="summary" />
+  <meta
+    name="twitter:title"
+    content="Free RPG Campaign Manager & Lore Vault | Codex Cryptica"
+  />
+  <meta
+    name="twitter:description"
+    content="Codex Cryptica is a free, local-first campaign manager and notes app for game masters. Map campaign lore, linked graphs, interactive maps, and timelines privately."
+  />
+  <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
   {@html faqSchemaScript}
 </svelte:head>

--- a/apps/web/src/routes/(marketing)/worldbuilding-tool/+page.svelte
+++ b/apps/web/src/routes/(marketing)/worldbuilding-tool/+page.svelte
@@ -8,7 +8,33 @@
     name="description"
     content="Create, link, and organize world maps, history, and factions. Codex Cryptica is a free, local-first worldbuilding tool running 100% in your browser."
   />
+  <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://codexcryptica.com/worldbuilding-tool" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Codex Cryptica" />
+  <meta
+    property="og:title"
+    content="Free Worldbuilding Tool & Lore Database | Codex Cryptica"
+  />
+  <meta
+    property="og:description"
+    content="Create, link, and organize world maps, history, and factions. Codex Cryptica is a free, local-first worldbuilding tool running 100% in your browser."
+  />
+  <meta
+    property="og:url"
+    content="https://codexcryptica.com/worldbuilding-tool"
+  />
+  <meta property="og:image" content="https://codexcryptica.com/logo.png" />
+  <meta name="twitter:card" content="summary" />
+  <meta
+    name="twitter:title"
+    content="Free Worldbuilding Tool & Lore Database | Codex Cryptica"
+  />
+  <meta
+    name="twitter:description"
+    content="Create, link, and organize world maps, history, and factions. Codex Cryptica is a free, local-first worldbuilding tool running 100% in your browser."
+  />
+  <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
 </svelte:head>
 

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -73,11 +73,13 @@ export async function GET() {
   }));
 
   // Generator pages
-  const generatorRoutes = ["npc", "settlement", "magic-item"].map((slug) => ({
-    path: `/generators/${slug}`,
-    changefreq: "monthly",
-    priority: "0.8",
-  }));
+  const generatorRoutes = ["npc", "settlement", "magic-item", "faction"].map(
+    (slug) => ({
+      path: `/generators/${slug}`,
+      changefreq: "monthly",
+      priority: "0.8",
+    }),
+  );
 
   const allStatic = [
     ...staticRoutes,


### PR DESCRIPTION
## Summary

Adds the missing technical SEO layer across all public marketing pages.

### Open Graph + Twitter Card
Added to both shared layouts and all standalone pages:
- `SEOPageLayout.svelte` — all `/solutions/*` and `/vs/*` pages
- `SEOGeneratorLayout.svelte` — all `/tools/*` generator pages
- `free-rpg-campaign-manager`, `ai-rpg-campaign-manager`, `worldbuilding-tool` standalone pages

Tags added: `og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image` (1024×1024 logo), `twitter:card` (summary), `twitter:title`, `twitter:description`, `twitter:image`

### Robots meta
`<meta name="robots" content="index, follow">` added to all marketing pages.

### BreadcrumbList JSON-LD
Added to `SEOPageLayout` with three-level structure:
`Home → Solutions/Comparisons → [Page Title]`

### Sitemap fix
`/generators/faction` was missing from the sitemap — added alongside the existing npc/settlement/magic-item entries.

## What was already in place
- Unique `<title>` and `<meta description>` per page ✓
- `<link rel="canonical">` ✓
- `FAQPage` JSON-LD on both layouts ✓
- `SoftwareApplication` JSON-LD on `SEOPageLayout` ✓
- `robots.txt` with sitemap declaration ✓
- Prerendered static pages ✓

## Test plan
- [ ] View source on `/solutions/ai-dm-assistant` — confirm og:title, og:description, og:url, breadcrumb JSON-LD
- [ ] View source on `/tools/dnd-npc-generator` — confirm og:title, twitter:card
- [ ] Sitemap includes `/generators/faction`
- [ ] All 7 affected tests pass

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)