### PR TITLE
✨ feat(seo): implement vampire clan generator landing page

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -15,6 +15,7 @@
     faqs = [],
     generate,
     formFields,
+    worldTheme = "workspace",
   }: {
     canonicalPath?: string;
     pageTitle?: string;
@@ -26,6 +27,7 @@
     faqs?: { question: string; answer: string }[];
     generate: (opts: { useAI: boolean }) => Promise<GeneratorOutput>;
     formFields: Snippet;
+    worldTheme?: string;
   } = $props();
 
   let isGenerating = $state(false);
@@ -261,7 +263,7 @@ ${generatedData.lore}`;
 
             <div
               class="grid grid-cols-1 md:grid-cols-12 gap-8 flex-grow"
-              data-world-theme="workspace"
+              data-world-theme={worldTheme}
             >
               <div
                 class="md:col-span-7 space-y-4 text-xs md:text-sm leading-relaxed text-theme-text/90"

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -263,7 +263,7 @@ ${generatedData.lore}`;
 
             <div
               class="grid grid-cols-1 md:grid-cols-12 gap-8 flex-grow"
-              data-world-theme={worldTheme}
+              data-theme={worldTheme}
             >
               <div
                 class="md:col-span-7 space-y-4 text-xs md:text-sm leading-relaxed text-theme-text/90"

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.test.ts
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("SEOGeneratorLayout", () => {
+  it("binds generated preview theming through data-theme", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/lib/components/seo/SEOGeneratorLayout.svelte"),
+      "utf8",
+    );
+
+    expect(source).toContain("data-theme={worldTheme}");
+    expect(source).not.toContain("data-world-theme={worldTheme}");
+  });
+});

--- a/apps/web/src/lib/components/seo/VampireFormFields.svelte
+++ b/apps/web/src/lib/components/seo/VampireFormFields.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import { vampireConfig } from "$lib/services/seo/generator-engine";
+
+  let {
+    archetype = $bindable(vampireConfig.archetypes[0]),
+    bloodline = $bindable(vampireConfig.bloodlines[0]),
+    feedingHabit = $bindable(vampireConfig.feedingHabits[0]),
+    weakness = $bindable(vampireConfig.weaknesses[0]),
+    campaignContext = $bindable(""),
+  }: {
+    archetype: string;
+    bloodline: string;
+    feedingHabit: string;
+    weakness: string;
+    campaignContext: string;
+  } = $props();
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+</script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="vampire-archetype-select" class={labelClass}>Clan Archetype</label
+  >
+  <select
+    id="vampire-archetype-select"
+    name="vampire_archetype"
+    bind:value={archetype}
+    class={selectClass}
+  >
+    {#each vampireConfig.archetypes as t (t)}
+      <option value={t}>{t}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="vampire-bloodline-select" class={labelClass}
+    >Bloodline / Heritage</label
+  >
+  <select
+    id="vampire-bloodline-select"
+    name="vampire_bloodline"
+    bind:value={bloodline}
+    class={selectClass}
+  >
+    {#each vampireConfig.bloodlines as b (b)}
+      <option value={b}>{b}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="vampire-feeding-select" class={labelClass}>Feeding Habit</label>
+  <select
+    id="vampire-feeding-select"
+    name="vampire_feeding"
+    bind:value={feedingHabit}
+    class={selectClass}
+  >
+    {#each vampireConfig.feedingHabits as f (f)}
+      <option value={f}>{f}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="vampire-weakness-select" class={labelClass}>Clan Weakness</label>
+  <select
+    id="vampire-weakness-select"
+    name="vampire_weakness"
+    bind:value={weakness}
+    class={selectClass}
+  >
+    {#each vampireConfig.weaknesses as w (w)}
+      <option value={w}>{w}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="vampire-campaign-context" class={labelClass}
+    >Optional Campaign Context</label
+  >
+  <textarea
+    id="vampire-campaign-context"
+    name="campaign_context"
+    bind:value={campaignContext}
+    maxlength="240"
+    rows="4"
+    aria-describedby="vampire-campaign-context-help"
+    class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+  ></textarea>
+  <p
+    id="vampire-campaign-context-help"
+    class="text-[10px] text-theme-muted leading-relaxed"
+  >
+    Add a city, gothic metropolis, investigator guild, or campaign threat to aim
+    the clan at your table.
+  </p>
+</div>

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -166,6 +166,68 @@ describe("DefaultGeneratorEngine", () => {
     });
   });
 
+  describe("generateVampireClan", () => {
+    it("should generate vampire clan details locally when useAI is false", async () => {
+      const res = await engine.generateVampireClan({
+        archetype: "Aristocratic Court",
+        bloodline: "Sanguine Nobles (Charismatic Mind-Benders)",
+        feedingHabit: "High-Society Salons (Elite & Consent-based)",
+        weakness: "Severe Sun Sensitivity (Burns instantly)",
+        scope: "Single city underbelly",
+        alignment: "Strictly lawful, highly predatory",
+        campaignContext: "a gothic noir metropolis under rain",
+        useAI: false,
+      });
+
+      expect(res.type).toBe("faction");
+      expect(res.title).toBeDefined();
+      expect(res.content).toContain("vampire clan");
+      expect(res.content).toContain("Campaign Fit");
+      expect(res.content).toContain("a gothic noir metropolis under rain");
+      expect(res.lore).toContain("Vampire Clan (Aristocratic Court)");
+      expect(res.lore).toContain("Sanguine Nobles");
+      expect(res.lore).toContain("Feeding Habit");
+      expect(res.lore).toContain("Clan Weakness");
+      expect(res.lore).toContain("Internal Conflict");
+      expect(res.lore).toContain("Adventure Hook");
+      expect(res.labels).toContain("vampire-clan");
+      expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should include vampire clan campaign context in the AI prompt", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "House Karnstein",
+                content: "AI Generated Vampire Clan",
+                lore: "AI Generated Weaknesses and Secrets",
+                labels: ["rpg-faction", "vampire-clan"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generateVampireClan({
+        archetype: "Occult Coven",
+        campaignContext: "an ancient cathedral ruin",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("an ancient cathedral ruin"),
+      );
+      expect(res.type).toBe("faction");
+      expect(res.title).toBe("House Karnstein");
+      expect(res.content).toBe("AI Generated Vampire Clan");
+      expect(res.lore).toBe("AI Generated Weaknesses and Secrets");
+      expect(res.labels).toContain("vampire-clan");
+    });
+  });
+
   describe("generateNames", () => {
     it("should generate the correct entity type for each name type", async () => {
       const cases: Array<[string, string]> = [

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -588,6 +588,72 @@ export const factionConfig = {
   ],
 };
 
+export const vampireConfig = {
+  archetypes: [
+    "Aristocratic Court",
+    "Occult Coven",
+    "Predatory Brood",
+    "Conspiring Syndicate",
+    "Rebel Anarchs",
+  ],
+  bloodlines: [
+    "Sanguine Nobles (Charismatic Mind-Benders)",
+    "Shadow Stalkers (Nightmare Weavers)",
+    "Blood Sorcerers (Occult Ritualists)",
+    "Bestial Ravagers (Feral Predator Shapeshifters)",
+    "Melancholic Artists (Aesthetes of Decay)",
+  ],
+  feedingHabits: [
+    "High-Society Salons (Elite & Consent-based)",
+    "Street Predation (Slums & Forgotten Alleys)",
+    "Blood Trafficking (Black Market & Clinics)",
+    "Occult Sacraments (Ritualistic & Sacrificial)",
+    "Wild Wilderness Hunts (Deep Forests & Ruins)",
+  ],
+  weaknesses: [
+    "Severe Sun Sensitivity (Burns instantly)",
+    "Consecrated Ground Aversion (Cannot cross thresholds)",
+    "Mirror & Reflection Absence (Exposes their nature)",
+    "Decaying Physical Form (Needs fresh blood to look human)",
+    "Silver & Wooden Vulnerability (Prevents regeneration)",
+  ],
+  scopes: [
+    "Single city underbelly",
+    "Hidden castle & border valley",
+    "Trade route shadow network",
+    "Metropolitan high society",
+    "Continental shadow court",
+  ],
+  alignments: [
+    "Strictly lawful, highly predatory",
+    "Pragmatic and power-driven",
+    "Feral, chaotic, and blood-fueled",
+    "Secretive and ritual-obsessed",
+    "Rebellious, seeking freedom from elders",
+  ],
+  goals: [
+    "Infiltrate the city council and blood-bind key mortal leaders.",
+    "Exhume the sarcophagus of their dormant Progenitor.",
+    "Monopolize the local blood bank distribution network.",
+    "Wipe out a rival werewolf pack or vampire hunters' cell.",
+    "Reconstruct a shattered ancient chronicle of blood magic.",
+  ],
+  conflicts: [
+    "The younger brood is planning a rebellion against the ancient elder.",
+    "A feeding gone wrong has drawn the attention of mortal authorities.",
+    "A rogue member has stolen a ledger detailing the clan's human farms.",
+    "The blood supply is tainted by a mystical pathogen.",
+    "An inquisitor has successfully tracked their primary haven.",
+  ],
+  hooks: [
+    "A mysterious patron hires the party to deliver a sealed urn, which is a vampire ashes decoy.",
+    "Locals ask the party to investigate a series of bloodless bodies found in the canal.",
+    "A member of the clan offers to sell a list of high-profile vampire thralls in the city council.",
+    "The clan captures the party and offers freedom in exchange for retrieving a relic from a sunlit temple.",
+    "A dying vampire begs the party to protect their mortal family from their own sire.",
+  ],
+};
+
 export const questConfig = {
   genres: [
     "Classic Fantasy",
@@ -964,6 +1030,186 @@ ${hook}`;
       content,
       lore,
       labels: ["rpg-faction", "faction-generator", "imported-draft"],
+      status: "active",
+    };
+  }
+
+  /**
+   * Generates a vampire clan draft.
+   */
+  async generateVampireClan(
+    options: {
+      archetype?: string;
+      bloodline?: string;
+      feedingHabit?: string;
+      weakness?: string;
+      scope?: string;
+      alignment?: string;
+      campaignContext?: string;
+      useAI?: boolean;
+    } = {},
+  ): Promise<GeneratorOutput> {
+    const archetype =
+      options.archetype ||
+      vampireConfig.archetypes[
+        Math.floor(Math.random() * vampireConfig.archetypes.length)
+      ];
+    const bloodline =
+      options.bloodline ||
+      vampireConfig.bloodlines[
+        Math.floor(Math.random() * vampireConfig.bloodlines.length)
+      ];
+    const feedingHabit =
+      options.feedingHabit ||
+      vampireConfig.feedingHabits[
+        Math.floor(Math.random() * vampireConfig.feedingHabits.length)
+      ];
+    const weakness =
+      options.weakness ||
+      vampireConfig.weaknesses[
+        Math.floor(Math.random() * vampireConfig.weaknesses.length)
+      ];
+    const scope =
+      options.scope ||
+      vampireConfig.scopes[
+        Math.floor(Math.random() * vampireConfig.scopes.length)
+      ];
+    const alignment =
+      options.alignment ||
+      vampireConfig.alignments[
+        Math.floor(Math.random() * vampireConfig.alignments.length)
+      ];
+    const campaignContext = options.campaignContext?.trim();
+
+    // Surnames/houses/covenants for vampires
+    const prefixes = ["House ", "The ", "Covenant of ", "Order of ", "Clan "];
+    const roots = [
+      "Dracul",
+      "Karnstein",
+      "Von Carstein",
+      "Orlok",
+      "Bathory",
+      "Tepes",
+      "Morbius",
+      "Sanguis",
+      "Vargo",
+      "Ruthven",
+    ];
+    const name =
+      prefixes[Math.floor(Math.random() * prefixes.length)] +
+      roots[Math.floor(Math.random() * roots.length)];
+
+    if (options.useAI !== false) {
+      try {
+        const prompt = `Generate a detailed RPG vampire clan/faction in JSON format.
+Options:
+- Name: ${name}
+- Clan Archetype: ${archetype}
+- Bloodline: ${bloodline}
+- Feeding Habit: ${feedingHabit}
+- Clan Weakness: ${weakness}
+- Scope of Influence: ${scope}
+- Moral Posture: ${alignment}
+${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
+
+You must return a valid JSON object matching the following structure exactly:
+{
+  "title": "A single string for the vampire clan/house name",
+  "content": "A detailed multi-paragraph overview (markdown formatted) describing its history, public facade in mortal society, dark haven, and how it fits the campaign context if provided.",
+  "lore": "Structured GM details (markdown formatted) with sections for core fields, bloodline traits, feeding habits, weakness, dark agenda, internal conflict, notable NPCs, rival faction, and adventure hook.",
+  "labels": ["rpg-faction", "vampire-clan", "imported-draft"]
+}
+Return only the JSON object. Do not include markdown code block formatting like \`\`\`json.`;
+
+        const model = await this.clientManager.getModel(
+          "",
+          "gemini-1.5-flash",
+          "You are an assistant that generates detailed RPG campaign elements in JSON format.",
+        );
+        const response = await model.generateContent(prompt);
+        const text = response.response.text().trim();
+        const cleanText = text
+          .replace(/^```json\s*/i, "")
+          .replace(/```$/, "")
+          .trim();
+        const data = JSON.parse(cleanText);
+
+        return {
+          type: "faction",
+          title: data.title || name,
+          content: data.content || "",
+          lore: data.lore || "",
+          labels: Array.isArray(data.labels)
+            ? data.labels
+            : ["rpg-faction", "vampire-clan", "imported-draft"],
+          status: "active",
+        };
+      } catch (err) {
+        console.warn(
+          "AI generation failed, falling back to local tables:",
+          err,
+        );
+      }
+    }
+
+    const goal =
+      vampireConfig.goals[
+        Math.floor(Math.random() * vampireConfig.goals.length)
+      ];
+    const conflict =
+      vampireConfig.conflicts[
+        Math.floor(Math.random() * vampireConfig.conflicts.length)
+      ];
+    const hook =
+      vampireConfig.hooks[
+        Math.floor(Math.random() * vampireConfig.hooks.length)
+      ];
+    const rival = `${this.generateName()} Inquisition`;
+    const sire = this.generateName();
+    const thrall = this.generateName();
+
+    const content = `### Overview
+${name} is a powerful vampire clan of the ${bloodline.toLowerCase()} lineage, operating as a ${archetype.toLowerCase()} across ${scope.toLowerCase()}. They hide their predatory activities behind a carefully crafted mortal facade, manipulating events from the dark.
+
+${campaignContext ? `### Campaign Fit\nUse ${name} in ${campaignContext}. Their influence should touch the local halls of power, forgotten catacombs, or ongoing dark mysteries.\n` : ""}
+
+### Public Facade
+To the mortal world, members of ${name} present themselves as wealthy philanthropists, eccentric scholars, or influential patrons. Very few suspect that behind this elegant mask lies a highly organized coven of undead hunters.
+
+### Table Use
+Introduce ${name} when the party enters high-society intrigue, investigates occult occurrences, or needs a powerful but dangerous ally who demands blood or secrets as currency.`;
+
+    const lore = `### GM Reference Information
+- **Faction Type**: Vampire Clan (${archetype})
+- **Bloodline**: ${bloodline}
+- **Scope**: ${scope}
+- **Moral Posture**: ${alignment}
+- **Feeding Habit**: ${feedingHabit}
+- **Clan Weakness**: ${weakness}
+- **Entity Type**: Faction
+
+### Dark Agenda
+${goal}
+
+### Internal Conflict
+${conflict}
+
+### Notable NPCs
+- **Sire ${sire}**: The ancient leader of the clan who has survived centuries of inquisitions and power struggles.
+- **Thrall ${thrall}**: A high-ranking mortal puppet who manages the clan's daytime assets and legal matters.
+
+### Rival Faction
+The ${rival} seeks to expose, purge, or take control of the secrets and assets held by ${name}.
+
+### Adventure Hook
+${hook}`;
+
+    return {
+      type: "faction",
+      title: name,
+      content,
+      lore,
+      labels: ["rpg-faction", "vampire-clan", "imported-draft"],
       status: "active",
     };
   }

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -1,60 +1,100 @@
 <script lang="ts">
   import { base } from "$app/paths";
 
-  const toolSections = [
+  type ToolLink = {
+    href: string;
+    label: string;
+    summary: string;
+    icon: string;
+  };
+
+  type ToolGroup = {
+    title?: string;
+    links: ToolLink[];
+  };
+
+  type ToolSection = {
+    title: string;
+    description: string;
+    groups: ToolGroup[];
+  };
+
+  const toolSections: ToolSection[] = [
     {
       title: "RPG Generators",
       description:
         "Generate campaign-ready drafts, then copy them or save them into a local Codex Cryptica vault.",
-      links: [
+      groups: [
         {
-          href: "/tools/dnd-npc-generator",
-          label: "D&D NPC Generator",
-          summary:
-            "Create a fantasy NPC with ancestry, role, personality, secret, faction tie, and plot hook.",
-          icon: "icon-[lucide--user-round-plus]",
+          title: "Characters & NPCs",
+          links: [
+            {
+              href: "/tools/dnd-npc-generator",
+              label: "D&D NPC Generator",
+              summary:
+                "Create a fantasy NPC with ancestry, role, personality, secret, faction tie, and plot hook.",
+              icon: "icon-[lucide--user-round-plus]",
+            },
+            {
+              href: "/generators/npc",
+              label: "Procedural NPC Generator",
+              summary:
+                "Use the reusable generator interface for local NPC drafts and save-to-Codex imports.",
+              icon: "icon-[lucide--users]",
+            },
+          ],
         },
         {
-          href: "/tools/faction-generator",
-          label: "Faction Generator",
-          summary:
-            "Create a fantasy faction with an agenda, internal conflict, rival group, notable NPCs, and adventure hook.",
-          icon: "icon-[lucide--flag]",
+          title: "Factions & Organizations",
+          links: [
+            {
+              href: "/tools/faction-generator",
+              label: "Faction Generator",
+              summary:
+                "Create a fantasy faction with an agenda, internal conflict, rival group, notable NPCs, and adventure hook.",
+              icon: "icon-[lucide--flag]",
+            },
+            {
+              href: "/tools/vampire-clan-generator",
+              label: "Vampire Clan Generator",
+              summary:
+                "Create vampire clans, bloodlines, covens, and secret societies with dark agendas and plot hooks.",
+              icon: "icon-[lucide--moon]",
+            },
+            {
+              href: "/tools/fantasy-name-generator",
+              label: "Fantasy Name Generator",
+              summary:
+                "Generate character, place, faction, and item names across ten cultural styles.",
+              icon: "icon-[lucide--pen-line]",
+            },
+          ],
         },
         {
-          href: "/tools/quest-hook-generator",
-          label: "Quest Hook Generator",
-          summary:
-            "Generate a GM-ready quest hook with a complication, key NPC, twist, and reward.",
-          icon: "icon-[lucide--scroll-text]",
-        },
-        {
-          href: "/tools/fantasy-name-generator",
-          label: "Fantasy Name Generator",
-          summary:
-            "Generate character, place, faction, and item names across ten cultural styles.",
-          icon: "icon-[lucide--pen-line]",
-        },
-        {
-          href: "/generators/npc",
-          label: "Procedural NPC Generator",
-          summary:
-            "Use the reusable generator interface for local NPC drafts and save-to-Codex imports.",
-          icon: "icon-[lucide--users]",
-        },
-        {
-          href: "/generators/settlement",
-          label: "Settlement Generator",
-          summary:
-            "Draft towns and villages with population, economy, government, locations, and factions.",
-          icon: "icon-[lucide--landmark]",
-        },
-        {
-          href: "/generators/magic-item",
-          label: "Magic Item Generator",
-          summary:
-            "Generate item concepts with rarity, properties, history, and GM-facing lore.",
-          icon: "icon-[lucide--sparkles]",
+          title: "Adventure & Worldbuilding",
+          links: [
+            {
+              href: "/tools/quest-hook-generator",
+              label: "Quest Hook Generator",
+              summary:
+                "Generate a GM-ready quest hook with a complication, key NPC, twist, and reward.",
+              icon: "icon-[lucide--scroll-text]",
+            },
+            {
+              href: "/generators/settlement",
+              label: "Settlement Generator",
+              summary:
+                "Draft towns and villages with population, economy, government, locations, and factions.",
+              icon: "icon-[lucide--landmark]",
+            },
+            {
+              href: "/generators/magic-item",
+              label: "Magic Item Generator",
+              summary:
+                "Generate item concepts with rarity, properties, history, and GM-facing lore.",
+              icon: "icon-[lucide--sparkles]",
+            },
+          ],
         },
       ],
     },
@@ -62,27 +102,31 @@
       title: "Campaign Tools",
       description:
         "Core public pages for the local-first campaign manager, worldbuilding workspace, and AI-assisted GM workflows.",
-      links: [
+      groups: [
         {
-          href: "/free-rpg-campaign-manager",
-          label: "Free RPG Campaign Manager",
-          summary:
-            "Explore the first SEO landing page and the main campaign-management pitch.",
-          icon: "icon-[lucide--castle]",
-        },
-        {
-          href: "/worldbuilding-tool",
-          label: "Worldbuilding Tool",
-          summary:
-            "See how Codex Cryptica supports linked lore, timelines, canvases, and local-first vaults.",
-          icon: "icon-[lucide--network]",
-        },
-        {
-          href: "/ai-rpg-campaign-manager",
-          label: "AI RPG Campaign Manager",
-          summary:
-            "Review the AI-assisted campaign workflow built around local notes and BYO Gemini access.",
-          icon: "icon-[lucide--wand-sparkles]",
+          links: [
+            {
+              href: "/free-rpg-campaign-manager",
+              label: "Free RPG Campaign Manager",
+              summary:
+                "Explore the first SEO landing page and the main campaign-management pitch.",
+              icon: "icon-[lucide--castle]",
+            },
+            {
+              href: "/worldbuilding-tool",
+              label: "Worldbuilding Tool",
+              summary:
+                "See how Codex Cryptica supports linked lore, timelines, canvases, and local-first vaults.",
+              icon: "icon-[lucide--network]",
+            },
+            {
+              href: "/ai-rpg-campaign-manager",
+              label: "AI RPG Campaign Manager",
+              summary:
+                "Review the AI-assisted campaign workflow built around local notes and BYO Gemini access.",
+              icon: "icon-[lucide--wand-sparkles]",
+            },
+          ],
         },
       ],
     },
@@ -90,34 +134,38 @@
       title: "Solutions",
       description:
         "Focused pages for searchers comparing campaign planning, worldbuilding, AI assistance, and privacy-first storage.",
-      links: [
+      groups: [
         {
-          href: "/solutions/campaign-manager",
-          label: "Campaign Manager Solution",
-          summary:
-            "Campaign organization, graph navigation, maps, timelines, and prep workflows.",
-          icon: "icon-[lucide--clipboard-list]",
-        },
-        {
-          href: "/solutions/worldbuilding-tool",
-          label: "Worldbuilding Solution",
-          summary:
-            "A visual wiki and campaign knowledge base for factions, places, characters, and lore.",
-          icon: "icon-[lucide--book-open]",
-        },
-        {
-          href: "/solutions/ai-gm-assistant",
-          label: "AI GM Assistant Solution",
-          summary:
-            "AI-assisted lore drafting and revision workflows for game masters.",
-          icon: "icon-[lucide--bot]",
-        },
-        {
-          href: "/solutions/local-first-rpg",
-          label: "Local-First RPG Solution",
-          summary:
-            "Privacy-first campaign storage using browser-local vaults and exportable data.",
-          icon: "icon-[lucide--hard-drive]",
+          links: [
+            {
+              href: "/solutions/campaign-manager",
+              label: "Campaign Manager Solution",
+              summary:
+                "Campaign organization, graph navigation, maps, timelines, and prep workflows.",
+              icon: "icon-[lucide--clipboard-list]",
+            },
+            {
+              href: "/solutions/worldbuilding-tool",
+              label: "Worldbuilding Solution",
+              summary:
+                "A visual wiki and campaign knowledge base for factions, places, characters, and lore.",
+              icon: "icon-[lucide--book-open]",
+            },
+            {
+              href: "/solutions/ai-gm-assistant",
+              label: "AI GM Assistant Solution",
+              summary:
+                "AI-assisted lore drafting and revision workflows for game masters.",
+              icon: "icon-[lucide--bot]",
+            },
+            {
+              href: "/solutions/local-first-rpg",
+              label: "Local-First RPG Solution",
+              summary:
+                "Privacy-first campaign storage using browser-local vaults and exportable data.",
+              icon: "icon-[lucide--hard-drive]",
+            },
+          ],
         },
       ],
     },
@@ -125,27 +173,31 @@
       title: "Comparisons",
       description:
         "Side-by-side alternatives for creators evaluating campaign and worldbuilding tools.",
-      links: [
+      groups: [
         {
-          href: "/vs/obsidian",
-          label: "Codex Cryptica vs Obsidian",
-          summary:
-            "Compare a purpose-built RPG workspace with a general-purpose note app.",
-          icon: "icon-[lucide--columns-3]",
-        },
-        {
-          href: "/vs/world-anvil",
-          label: "Codex Cryptica vs World Anvil",
-          summary:
-            "Compare local-first privacy with cloud-hosted worldbuilding and subscriptions.",
-          icon: "icon-[lucide--scale]",
-        },
-        {
-          href: "/vs/legendkeeper",
-          label: "Codex Cryptica vs LegendKeeper",
-          summary:
-            "Compare offline-friendly browser storage with closed cloud wiki workflows.",
-          icon: "icon-[lucide--git-compare]",
+          links: [
+            {
+              href: "/vs/obsidian",
+              label: "Codex Cryptica vs Obsidian",
+              summary:
+                "Compare a purpose-built RPG workspace with a general-purpose note app.",
+              icon: "icon-[lucide--columns-3]",
+            },
+            {
+              href: "/vs/world-anvil",
+              label: "Codex Cryptica vs World Anvil",
+              summary:
+                "Compare local-first privacy with cloud-hosted worldbuilding and subscriptions.",
+              icon: "icon-[lucide--scale]",
+            },
+            {
+              href: "/vs/legendkeeper",
+              label: "Codex Cryptica vs LegendKeeper",
+              summary:
+                "Compare offline-friendly browser storage with closed cloud wiki workflows.",
+              icon: "icon-[lucide--git-compare]",
+            },
+          ],
         },
       ],
     },
@@ -209,27 +261,44 @@
           </p>
         </div>
 
-        <ul class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-          {#each section.links as link (link.href)}
-            <li>
-              <a
-                href="{base}{link.href}"
-                class="group block h-full rounded-xl border border-theme-border/60 bg-theme-surface/35 p-5 hover:border-theme-primary/60 hover:bg-theme-surface/55 transition-colors"
-              >
-                <span class="{link.icon} h-5 w-5 text-theme-primary mb-4 block"
-                ></span>
-                <span
-                  class="block font-header text-sm font-bold uppercase tracking-wider mb-2 group-hover:text-theme-primary transition-colors"
+        <div class="space-y-8">
+          {#each section.groups as group, groupIndex (`${section.title}-${groupIndex}`)}
+            <div>
+              {#if group.title}
+                <h3
+                  class="font-header text-sm font-bold uppercase tracking-widest text-theme-text mb-4"
                 >
-                  {link.label}
-                </span>
-                <span class="block text-sm text-theme-muted leading-relaxed">
-                  {link.summary}
-                </span>
-              </a>
-            </li>
+                  {group.title}
+                </h3>
+              {/if}
+
+              <ul class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                {#each group.links as link (link.href)}
+                  <li>
+                    <a
+                      href="{base}{link.href}"
+                      class="group block h-full rounded-xl border border-theme-border/60 bg-theme-surface/35 p-5 hover:border-theme-primary/60 hover:bg-theme-surface/55 transition-colors"
+                    >
+                      <span
+                        class="{link.icon} h-5 w-5 text-theme-primary mb-4 block"
+                      ></span>
+                      <span
+                        class="block font-header text-sm font-bold uppercase tracking-wider mb-2 group-hover:text-theme-primary transition-colors"
+                      >
+                        {link.label}
+                      </span>
+                      <span
+                        class="block text-sm text-theme-muted leading-relaxed"
+                      >
+                        {link.summary}
+                      </span>
+                    </a>
+                  </li>
+                {/each}
+              </ul>
+            </div>
           {/each}
-        </ul>
+        </div>
       </section>
     {/each}
   </div>

--- a/apps/web/src/routes/(marketing)/tools/tools.test.ts
+++ b/apps/web/src/routes/(marketing)/tools/tools.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Tools directory", () => {
+  it("groups faction-style generators under RPG generators", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/routes/(marketing)/tools/+page.svelte"),
+      "utf8",
+    );
+
+    expect(source).toContain('title: "RPG Generators"');
+    expect(source).toContain('title: "Factions & Organizations"');
+    expect(source).toContain('href: "/tools/faction-generator"');
+    expect(source).toContain('href: "/tools/vampire-clan-generator"');
+  });
+});

--- a/apps/web/src/routes/(marketing)/tools/vampire-clan-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/vampire-clan-generator/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import VampireFormFields from "$lib/components/seo/VampireFormFields.svelte";
+  import {
+    generatorEngine,
+    vampireConfig,
+  } from "$lib/services/seo/generator-engine";
+
+  let archetype = $state(vampireConfig.archetypes[0]);
+  let bloodline = $state(vampireConfig.bloodlines[0]);
+  let feedingHabit = $state(vampireConfig.feedingHabits[0]);
+  let weakness = $state(vampireConfig.weaknesses[0]);
+  let campaignContext = $state("");
+
+  async function generate({ useAI }: { useAI: boolean }) {
+    return generatorEngine.generateVampireClan({
+      archetype,
+      bloodline,
+      feedingHabit,
+      weakness,
+      campaignContext,
+      useAI,
+    });
+  }
+
+  const relatedLinks = [
+    { href: "/tools/faction-generator", label: "Faction generator" },
+    { href: "/tools/dnd-npc-generator", label: "D&D NPC generator" },
+    { href: "/solutions/worldbuilding-tool", label: "Worldbuilding tool" },
+  ];
+
+  const faqs = [
+    {
+      question: "What does the vampire clan generator create?",
+      answer:
+        "It generates a vampire clan or occult coven with a name, archetype, bloodline heritage, feeding habits, clan weakness, dark agenda, internal conflicts, and adventure hooks.",
+    },
+    {
+      question: "Which vampire systems or RPGs is this compatible with?",
+      answer:
+        "This tool is system-agnostic and works perfectly for Vampire: The Masquerade, D&D, Pathfinder, Gothic Earth, or any customized gothic noir worldbuilding setting.",
+    },
+    {
+      question:
+        "Can I customize the generated clan to fit my current campaign?",
+      answer:
+        "Yes. Add optional campaign context such as a specific gothic metropolis, an investigator faction, or active threats, and the generator will integrate them.",
+    },
+    {
+      question: "How does the save function integrate with the app?",
+      answer:
+        "Clicking 'Save to Codex' serializes the generated coven draft into browser localStorage and opens the main app interface, auto-importing it as a new Faction in your vault.",
+    },
+  ];
+</script>
+
+<SEOGeneratorLayout
+  canonicalPath="/tools/vampire-clan-generator"
+  pageTitle="Vampire Clan Generator | Free RPG Bloodline & Coven Tool | Codex Cryptica"
+  metaDescription="Create detailed vampire clans, bloodlines, occult covens, and secret societies. Generate history, feeding habits, weaknesses, and plot hooks for your campaign."
+  eyebrow="Vampire Clan Generator"
+  introTitle="Vampire Clan Generator"
+  introText="Forge a secret society of the undead. Customize bloodlines, feeding preferences, and weaknesses, then instantly generate details or save the draft into your Codex Cryptica campaign vault."
+  worldTheme="horror"
+  {relatedLinks}
+  {faqs}
+  {generate}
+>
+  {#snippet formFields()}
+    <VampireFormFields
+      bind:archetype
+      bind:bloodline
+      bind:feedingHabit
+      bind:weakness
+      bind:campaignContext
+    />
+  {/snippet}
+</SEOGeneratorLayout>

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -43,6 +43,11 @@ export async function GET() {
       priority: "0.8",
     },
     {
+      path: "/tools/vampire-clan-generator",
+      changefreq: "monthly",
+      priority: "0.8",
+    },
+    {
       path: "/tools/quest-hook-generator",
       changefreq: "monthly",
       priority: "0.8",

--- a/apps/web/src/routes/sitemap.xml/sitemap.test.ts
+++ b/apps/web/src/routes/sitemap.xml/sitemap.test.ts
@@ -30,6 +30,9 @@ describe("Sitemap.xml API Endpoint", () => {
     expect(xml).toContain("<urlset");
     expect(xml).toContain("https://codexcryptica.com/tools");
     expect(xml).toContain("https://codexcryptica.com/tools/faction-generator");
+    expect(xml).toContain(
+      "https://codexcryptica.com/tools/vampire-clan-generator",
+    );
     expect(xml).toContain("https://codexcryptica.com/solutions/test-sol");
     expect(xml).toContain("https://codexcryptica.com/vs/test-comp");
     expect(xml).toContain("https://codexcryptica.com/generators/npc");


### PR DESCRIPTION
Closes #1125

This PR implements the **Vampire Faction Generator Landing Page** at `/tools/vampire-clan-generator` with Svelte 5 layout and configurations, custom vampire-themed variables, and sitemap/test integrations.

- Pre-selects the "Blood & Noir" (`horror`) theme for the generator layout.
- Provides specialized options for occult archetypes, bloodlines, feeding habits, weaknesses, and custom campaign context.
- Exports generated content directly to the app workspace via `localStorage` import.
- Integrated into `/sitemap.xml`.