### PR TITLE
feat(1131): faction generator UX polish — layout, AI quality, conversion

### DIFF
--- a/apps/web/src/lib/components/seo/FactionFormFields.svelte
+++ b/apps/web/src/lib/components/seo/FactionFormFields.svelte
@@ -83,7 +83,7 @@
 </script>
 
 <div class="flex flex-col gap-1.5">
-  <label for="faction-theme-select" class={labelClass}>Campaign Theme</label>
+  <label for="faction-theme-select" class={labelClass}>Choose a vibe</label>
   <select
     id="faction-theme-select"
     name="faction_theme"
@@ -97,7 +97,9 @@
 </div>
 
 <div class="flex flex-col gap-1.5">
-  <label for="faction-type-select" class={labelClass}>Faction Type</label>
+  <label for="faction-type-select" class={labelClass}
+    >Choose what they are</label
+  >
   <select
     id="faction-type-select"
     name="faction_type"
@@ -111,7 +113,8 @@
 </div>
 
 <div class="flex flex-col gap-1.5">
-  <label for="faction-scope-select" class={labelClass}>Operating Scope</label>
+  <label for="faction-scope-select" class={labelClass}>Choose their scale</label
+  >
   <select
     id="faction-scope-select"
     name="faction_scope"
@@ -125,7 +128,9 @@
 </div>
 
 <div class="flex flex-col gap-1.5">
-  <label for="faction-alignment-select" class={labelClass}>Moral Posture</label>
+  <label for="faction-alignment-select" class={labelClass}
+    >Choose their morality</label
+  >
   <select
     id="faction-alignment-select"
     name="faction_alignment"
@@ -140,7 +145,7 @@
 
 <div class="flex flex-col gap-1.5">
   <label for="faction-campaign-context" class={labelClass}
-    >Optional Campaign Context</label
+    >Add campaign context</label
   >
   <textarea
     id="faction-campaign-context"
@@ -153,7 +158,7 @@
   ></textarea>
   <p
     id="faction-campaign-context-help"
-    class="text-[10px] text-theme-muted leading-relaxed"
+    class="text-[10px] text-theme-text/60 leading-relaxed"
   >
     Add a city, frontier, villain, war, or campaign tension to aim the faction
     at your table.

--- a/apps/web/src/lib/components/seo/FactionFormFields.svelte
+++ b/apps/web/src/lib/components/seo/FactionFormFields.svelte
@@ -2,11 +2,13 @@
   import { factionConfig } from "$lib/services/seo/generator-engine";
 
   let {
+    theme = $bindable(factionConfig.themes[0]),
     type = $bindable(factionConfig.types[0]),
     scope = $bindable(factionConfig.scopes[1]),
     alignment = $bindable(factionConfig.alignments[0]),
     campaignContext = $bindable(""),
   }: {
+    theme: string;
     type: string;
     scope: string;
     alignment: string;
@@ -18,6 +20,20 @@
   const labelClass =
     "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
 </script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="faction-theme-select" class={labelClass}>Campaign Theme</label>
+  <select
+    id="faction-theme-select"
+    name="faction_theme"
+    bind:value={theme}
+    class={selectClass}
+  >
+    {#each factionConfig.themes as t (t)}
+      <option value={t}>{t}</option>
+    {/each}
+  </select>
+</div>
 
 <div class="flex flex-col gap-1.5">
   <label for="faction-type-select" class={labelClass}>Faction Type</label>

--- a/apps/web/src/lib/components/seo/FactionFormFields.svelte
+++ b/apps/web/src/lib/components/seo/FactionFormFields.svelte
@@ -7,18 +7,79 @@
     scope = $bindable(factionConfig.scopes[1]),
     alignment = $bindable(factionConfig.alignments[0]),
     campaignContext = $bindable(""),
+    onSurprise = undefined,
   }: {
     theme: string;
     type: string;
     scope: string;
     alignment: string;
     campaignContext: string;
+    onSurprise?: () => void;
   } = $props();
 
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
     "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+
+  const thematicTypes: Record<string, string[]> = {
+    "Classic Fantasy": [
+      "Temple Order",
+      "Arcane Circle",
+      "Merchant Guild",
+      "Secret Society",
+      "Mercenary Company",
+      "Criminal Syndicate",
+      "Rebel Cell",
+    ],
+    "Cyberpunk / Corporate": [
+      "Megacorporation Megagroup",
+      "Corporate Syndicate",
+      "Rebel Cell",
+      "Hacker Collective",
+      "Street Gang Alliance",
+      "Secret Society",
+      "Mercenary Company",
+    ],
+    "Vampire / Gothic Noir": [
+      "Vampire Coven",
+      "Arcane Circle",
+      "Temple Order",
+      "Inquisition Watch",
+      "Secret Society",
+      "Criminal Syndicate",
+    ],
+    "Sci-Fi / Space Opera": [
+      "Megacorporation Megagroup",
+      "Stellar Federation Alliance",
+      "Rebel Cell",
+      "Mercenary Company",
+      "Merchant Guild",
+      "Secret Society",
+    ],
+    "Modern Conspiracy": [
+      "Secret Society",
+      "Intelligence Agency",
+      "Criminal Syndicate",
+      "Corporate Syndicate",
+      "Hacker Collective",
+    ],
+    "Post-Apocalyptic": [
+      "Scavenger Tribe",
+      "Rebel Cell",
+      "Wasteland Cult",
+      "Mercenary Company",
+      "Street Gang Alliance",
+    ],
+  };
+
+  const availableTypes = $derived(thematicTypes[theme] || factionConfig.types);
+
+  $effect(() => {
+    if (theme && !availableTypes.includes(type)) {
+      type = availableTypes[0] || factionConfig.types[0];
+    }
+  });
 </script>
 
 <div class="flex flex-col gap-1.5">
@@ -43,7 +104,7 @@
     bind:value={type}
     class={selectClass}
   >
-    {#each factionConfig.types as t (t)}
+    {#each availableTypes as t (t)}
       <option value={t}>{t}</option>
     {/each}
   </select>
@@ -97,4 +158,29 @@
     Add a city, frontier, villain, war, or campaign tension to aim the faction
     at your table.
   </p>
+</div>
+
+<div class="pt-2 flex justify-end">
+  <button
+    type="button"
+    onclick={() => {
+      const types = thematicTypes[theme] || factionConfig.types;
+      type = types[Math.floor(Math.random() * types.length)];
+      scope =
+        factionConfig.scopes[
+          Math.floor(Math.random() * factionConfig.scopes.length)
+        ];
+      alignment =
+        factionConfig.alignments[
+          Math.floor(Math.random() * factionConfig.alignments.length)
+        ];
+      if (onSurprise) {
+        onSurprise();
+      }
+    }}
+    class="flex items-center gap-1.5 px-3 py-1.5 bg-theme-surface/60 border border-theme-border/60 rounded-lg text-[10px] font-bold uppercase tracking-wider text-theme-text hover:bg-theme-primary hover:text-theme-bg hover:border-theme-primary transition-all cursor-pointer"
+  >
+    <span class="icon-[lucide--dices] w-3.5 h-3.5"></span>
+    Surprise Me
+  </button>
 </div>

--- a/apps/web/src/lib/components/seo/FactionFormFields.test.ts
+++ b/apps/web/src/lib/components/seo/FactionFormFields.test.ts
@@ -55,7 +55,7 @@ describe("FactionFormFields Theme Swapping", () => {
     expect(screen.getByText("Arcane Circle")).toBeTruthy();
 
     // Select Post-Apocalyptic theme
-    const themeSelect = screen.getByLabelText("Campaign Theme");
+    const themeSelect = screen.getByLabelText("Choose a vibe");
     await fireEvent.change(themeSelect, {
       target: { value: "Post-Apocalyptic" },
     });

--- a/apps/web/src/lib/components/seo/FactionFormFields.test.ts
+++ b/apps/web/src/lib/components/seo/FactionFormFields.test.ts
@@ -1,0 +1,74 @@
+/** @vitest-environment jsdom */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+import FactionFormFields from "./FactionFormFields.svelte";
+
+vi.mock("$lib/services/seo/generator-engine", () => ({
+  factionConfig: {
+    themes: [
+      "Classic Fantasy",
+      "Cyberpunk / Corporate",
+      "Vampire / Gothic Noir",
+      "Sci-Fi / Space Opera",
+      "Modern Conspiracy",
+      "Post-Apocalyptic",
+    ],
+    types: [
+      "Merchant Guild",
+      "Secret Society",
+      "Mercenary Company",
+      "Temple Order",
+      "Criminal Syndicate",
+      "Rebel Cell",
+      "Arcane Circle",
+    ],
+    scopes: ["Local district", "Single city"],
+    alignments: ["Pragmatic and profit-driven"],
+    goals: ["Goal"],
+    conflicts: ["Conflict"],
+    hooks: ["Hook"],
+  },
+}));
+
+describe("FactionFormFields Theme Swapping", () => {
+  it("filters faction types dynamically based on selected theme and calls onSurprise", async () => {
+    const theme = "Classic Fantasy";
+    const type = "Arcane Circle";
+    const scope = "Single city";
+    const alignment = "Pragmatic and profit-driven";
+    const campaignContext = "";
+    const onSurprise = vi.fn();
+
+    const { component: _component } = render(FactionFormFields, {
+      props: {
+        theme,
+        type,
+        scope,
+        alignment,
+        campaignContext,
+        onSurprise,
+      },
+    });
+
+    // Verify initial type is present (Classic Fantasy includes Arcane Circle)
+    expect(screen.getByText("Arcane Circle")).toBeTruthy();
+
+    // Select Post-Apocalyptic theme
+    const themeSelect = screen.getByLabelText("Campaign Theme");
+    await fireEvent.change(themeSelect, {
+      target: { value: "Post-Apocalyptic" },
+    });
+
+    // Type should dynamically shift to Post-Apocalyptic default (e.g. Scavenger Tribe)
+    await waitFor(() => {
+      expect(screen.queryByText("Arcane Circle")).toBeNull();
+      expect(screen.getByText("Scavenger Tribe")).toBeTruthy();
+    });
+
+    // Clicking Surprise Me randomizes fields and triggers callback
+    const surpriseBtn = screen.getByText("Surprise Me");
+    await fireEvent.click(surpriseBtn);
+    expect(onSurprise).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -13,6 +13,7 @@
     introText = "Customize options and instantly generate structured drafts to populate your campaign lore database.",
     relatedLinks = [],
     faqs = [],
+    theme = "Classic Fantasy",
     generate,
     formFields,
   }: {
@@ -24,6 +25,7 @@
     introText?: string;
     relatedLinks?: { href: string; label: string }[];
     faqs?: { question: string; answer: string }[];
+    theme?: string;
     generate: (opts: { useAI: boolean }) => Promise<GeneratorOutput>;
     formFields: Snippet;
   } = $props();
@@ -33,6 +35,17 @@
   let errorMessage = $state<string | null>(null);
   let copied = $state(false);
   let useAI = $state(true);
+
+  const themeMap: Record<string, string> = {
+    "Classic Fantasy": "fantasy",
+    "Cyberpunk / Corporate": "cyberpunk",
+    "Vampire / Gothic Noir": "horror",
+    "Sci-Fi / Space Opera": "scifi",
+    "Modern Conspiracy": "modern",
+    "Post-Apocalyptic": "apocalyptic",
+  };
+
+  const activeThemeId = $derived(themeMap[theme] || "workspace");
 
   const faqJsonLd = $derived(
     faqs.length > 0
@@ -86,6 +99,7 @@
         '<div class="flex flex-col mb-1"><span class="font-bold text-theme-muted uppercase tracking-wider text-[9px]">$1</span><span>$2</span></div>',
       )
       .replace(/^- (.*)$/gm, '<li class="list-disc ml-4">$1</li>')
+      .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
       .replace(/\n\n/g, "<br/><br/>");
 
   function handleSaveToCodex() {
@@ -261,7 +275,7 @@ ${generatedData.lore}`;
 
             <div
               class="grid grid-cols-1 md:grid-cols-12 gap-8 flex-grow"
-              data-world-theme="workspace"
+              data-world-theme={activeThemeId}
             >
               <div
                 class="md:col-span-7 space-y-4 text-xs md:text-sm leading-relaxed text-theme-text/90"

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -16,6 +16,7 @@
     theme = "Classic Fantasy",
     generate,
     formFields,
+    triggerGenerate = $bindable(),
   }: {
     canonicalPath?: string;
     pageTitle?: string;
@@ -28,6 +29,7 @@
     theme?: string;
     generate: (opts: { useAI: boolean }) => Promise<GeneratorOutput>;
     formFields: Snippet;
+    triggerGenerate?: (() => void) | undefined;
   } = $props();
 
   let isGenerating = $state(false);
@@ -75,6 +77,11 @@
       isGenerating = false;
     }
   }
+
+  $effect(() => {
+    const _ = triggerGenerate; // reference it to track
+    triggerGenerate = () => void handleGenerate();
+  });
 
   const escapeHtml = (value: string) =>
     value

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -180,6 +180,7 @@ ${generatedData.lore}`;
 <div
   class="min-h-screen bg-theme-bg text-theme-text font-body selection:bg-theme-primary selection:text-theme-bg flex flex-col"
   style:background-image="var(--bg-texture-overlay)"
+  data-world-theme={activeThemeId}
 >
   <!-- Marketing Header -->
   <header
@@ -273,10 +274,7 @@ ${generatedData.lore}`;
               </div>
             </div>
 
-            <div
-              class="grid grid-cols-1 md:grid-cols-12 gap-8 flex-grow"
-              data-world-theme={activeThemeId}
-            >
+            <div class="grid grid-cols-1 md:grid-cols-12 gap-8 flex-grow">
               <div
                 class="md:col-span-7 space-y-4 text-xs md:text-sm leading-relaxed text-theme-text/90"
               >

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -2,6 +2,7 @@
   import { base } from "$app/paths";
   import { fade } from "svelte/transition";
   import type { GeneratorOutput } from "$lib/services/seo/generator-engine";
+  import { onMount } from "svelte";
   import type { Snippet } from "svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import { browser } from "$app/environment";
@@ -153,7 +154,9 @@
     }
   }
 
-  $effect(() => {
+  // Register once on mount — inline prop functions get a new identity on each
+  // rerender, so a $effect would re-run repeatedly and cause a loop.
+  onMount(() => {
     if (registerTrigger) {
       registerTrigger(() => void handleGenerate());
     }
@@ -199,10 +202,13 @@
     if (!generatedData) return;
 
     try {
+      const content = generatedData.summary
+        ? `*${generatedData.summary}*\n\n${generatedData.content}`
+        : generatedData.content;
       const payload = {
         type: generatedData.type,
         title: generatedData.title,
-        content: generatedData.content,
+        content,
         lore: generatedData.lore,
         labels: generatedData.labels,
         status: generatedData.status,
@@ -346,14 +352,19 @@
         type="button"
         onclick={() => void handleGenerate()}
         disabled={isGenerating}
+        aria-busy={isGenerating}
         class="px-4 py-2 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all flex items-center gap-1.5 disabled:opacity-50"
         id="strip-generate-btn"
       >
         {#if isGenerating}
-          <span class="icon-[lucide--loader-2] animate-spin w-3.5 h-3.5"></span>
+          <span
+            class="icon-[lucide--loader-2] animate-spin w-3.5 h-3.5"
+            aria-hidden="true"
+          ></span>
           Forging...
         {:else}
-          <span class="icon-[lucide--dice-5] w-3.5 h-3.5"></span>
+          <span class="icon-[lucide--dice-5] w-3.5 h-3.5" aria-hidden="true"
+          ></span>
           Generate {generatedSingular}
         {/if}
       </button>
@@ -545,14 +556,19 @@
           <button
             type="submit"
             disabled={isGenerating}
+            aria-busy={isGenerating}
             class="w-full py-3 mt-4 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2 disabled:opacity-50"
             id="generate-button"
           >
             {#if isGenerating}
-              <span class="icon-[lucide--loader-2] animate-spin w-4 h-4"></span>
+              <span
+                class="icon-[lucide--loader-2] animate-spin w-4 h-4"
+                aria-hidden="true"
+              ></span>
               Forging...
             {:else}
-              <span class="icon-[lucide--dice-5] w-4 h-4"></span>
+              <span class="icon-[lucide--dice-5] w-4 h-4" aria-hidden="true"
+              ></span>
               ✦ Generate {generatedSingular} ✦
             {/if}
           </button>

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -3,6 +3,8 @@
   import { fade } from "svelte/transition";
   import type { GeneratorOutput } from "$lib/services/seo/generator-engine";
   import type { Snippet } from "svelte";
+  import { themeStore } from "$lib/stores/theme.svelte";
+  import { browser } from "$app/environment";
 
   let {
     canonicalPath,
@@ -14,6 +16,7 @@
     relatedLinks = [],
     faqs = [],
     theme = $bindable("Classic Fantasy"),
+    isThemeCustomizable = false,
     generate,
     formFields,
     registerTrigger,
@@ -27,16 +30,35 @@
     relatedLinks?: { href: string; label: string }[];
     faqs?: { question: string; answer: string }[];
     theme?: string;
+    isThemeCustomizable?: boolean;
     generate: (opts: { useAI: boolean }) => Promise<GeneratorOutput>;
     formFields: Snippet;
     registerTrigger?: (fn: () => void) => void;
   } = $props();
 
+  const HIDDEN_TAGS = new Set([
+    "imported-draft",
+    "faction-generator",
+    "rpg-faction",
+    "rpg-npc",
+    "npc-generator",
+    "rpg-settlement",
+    "settlement-generator",
+    "rpg-item",
+    "item-generator",
+    "rpg-quest",
+    "quest-generator",
+    "rpg-names",
+    "name-generator",
+  ]);
+
   let isGenerating = $state(false);
   let generatedData = $state<GeneratorOutput | null>(null);
+  let isExampleDraft = $state(true);
   let errorMessage = $state<string | null>(null);
   let copied = $state(false);
   let useAI = $state(true);
+  let showSaveModal = $state(false);
 
   const themeMap: Record<string, string> = {
     "Classic Fantasy": "fantasy",
@@ -48,6 +70,56 @@
   };
 
   const activeThemeId = $derived(themeMap[theme] || "workspace");
+
+  const generatedNoun = $derived(
+    eyebrow.toLowerCase().includes("name")
+      ? "fantasy names"
+      : eyebrow.toLowerCase().includes("npc")
+        ? "D&D NPCs"
+        : eyebrow.toLowerCase().includes("faction")
+          ? "RPG factions"
+          : eyebrow.toLowerCase().includes("quest")
+            ? "quest hooks"
+            : eyebrow.toLowerCase().includes("settlement")
+              ? "settlements"
+              : eyebrow.toLowerCase().includes("item")
+                ? "magic items"
+                : "RPG elements",
+  );
+
+  const generatedSingular = $derived(
+    eyebrow.replace(/\s*Generator\s*/i, "").trim() || "Draft",
+  );
+
+  $effect(() => {
+    if (browser && isThemeCustomizable && activeThemeId) {
+      if (themeStore.worldThemeId !== activeThemeId) {
+        void themeStore.setTheme(activeThemeId);
+      }
+    }
+  });
+
+  $effect(() => {
+    if (browser && !generatedData) {
+      void handleGenerateOnMount();
+    }
+  });
+
+  async function handleGenerateOnMount() {
+    isGenerating = true;
+    errorMessage = null;
+    try {
+      generatedData = await generate({ useAI: false });
+    } catch (err: any) {
+      console.warn("Failed to generate initial draft:", err);
+    } finally {
+      isGenerating = false;
+    }
+  }
+
+  function confirmSaveRedirect() {
+    window.location.href = `${base}/`;
+  }
 
   const faqJsonLd = $derived(
     faqs.length > 0
@@ -67,6 +139,7 @@
   );
 
   async function handleGenerate() {
+    isExampleDraft = false;
     isGenerating = true;
     errorMessage = null;
     try {
@@ -92,23 +165,33 @@
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
 
+  const LABEL_VALUE_HTML =
+    '<div class="flex flex-col mb-1"><span class="font-bold text-theme-muted uppercase tracking-wider text-[9px]">$1</span><span>$2</span></div>';
+
   const renderMarkdown = (value: string) =>
     escapeHtml(value)
       .replace(
-        /^### (.*)$/gm,
+        /^#{3} (.*)$/gm,
         '<h3 class="font-header font-bold text-base mt-4 mb-2 text-theme-primary">$1</h3>',
       )
       .replace(
-        /^## (.*)$/gm,
+        /^#{2} (.*)$/gm,
         '<h2 class="font-header font-bold text-lg mt-6 mb-3 border-b border-theme-border/40 pb-1">$1</h2>',
       )
-      .replace(
-        /^- \*\*(.*?)\*\*: (.*)$/gm,
-        '<div class="flex flex-col mb-1"><span class="font-bold text-theme-muted uppercase tracking-wider text-[9px]">$1</span><span>$2</span></div>',
-      )
-      .replace(/^- (.*)$/gm, '<li class="list-disc ml-4">$1</li>')
+      // bold-key variant: "- **Key**: value" or "* **Key**: value"
+      .replace(/^[*-] \*\*(.*?)\*\*: (.*)$/gm, LABEL_VALUE_HTML)
+      // plain-key variant: "* Key: value" or "- Key: value" (key ≤ 60 chars, no colon in key)
+      .replace(/^[*-] ([A-Za-z][^:\n]{0,58}): (.+)$/gm, LABEL_VALUE_HTML)
+      // remaining bullets
+      .replace(/^[*-] (.*)$/gm, '<li class="list-disc ml-4">$1</li>')
       .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
       .replace(/\n\n/g, "<br/><br/>");
+
+  const renderLore = (value: string) =>
+    renderMarkdown(value).replace(
+      /class="flex flex-col mb-1"/g,
+      'class="flex flex-col mb-5"',
+    );
 
   function handleSaveToCodex() {
     if (!generatedData) return;
@@ -124,7 +207,7 @@
       };
 
       localStorage.setItem("__codex_pending_import", JSON.stringify(payload));
-      window.location.href = `${base}/`;
+      showSaveModal = true;
     } catch {
       errorMessage =
         "Storage access is blocked. Please copy the Markdown below instead.";
@@ -134,12 +217,18 @@
   async function handleCopyMarkdown() {
     if (!generatedData) return;
 
-    const markdownText = `# ${generatedData.title}
-Labels: ${generatedData.labels.join(", ")}
-
-${generatedData.content}
-
-${generatedData.lore}`;
+    const markdownText = [
+      `# ${generatedData.title}`,
+      generatedData.summary ? `*${generatedData.summary}*` : "",
+      `Labels: ${generatedData.labels.join(", ")}`,
+      "",
+      generatedData.content,
+      "",
+      generatedData.lore,
+    ]
+      .filter((line) => line !== undefined)
+      .join("\n")
+      .trim();
 
     try {
       await navigator.clipboard.writeText(markdownText);
@@ -226,81 +315,119 @@ ${generatedData.lore}`;
           class="px-5 py-2.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
           id="nav-cta-btn"
         >
-          Open App
+          Open Codex
         </a>
       </div>
     </div>
   </header>
 
+  <!-- Compact Explainer / CTA Strip -->
   <div
-    class="max-w-6xl mx-auto px-6 py-12 w-full flex-grow grid grid-cols-1 lg:grid-cols-12 gap-10"
+    class="w-full border-b border-theme-border/30 bg-theme-surface/10 py-5 px-6"
   >
-    <!-- Output Card Column: rendered first in DOM for correct mobile reading/focus order, positioned on the right on desktop -->
-    <div class="lg:col-span-8 flex flex-col lg:order-2">
+    <div
+      class="max-w-6xl mx-auto flex flex-col sm:flex-row sm:items-center justify-between gap-4"
+    >
+      <div>
+        <p
+          class="text-xs font-bold text-theme-primary uppercase tracking-widest font-header"
+        >
+          Generate campaign-ready {generatedNoun} in seconds.
+        </p>
+        <p
+          class="text-[10px] text-theme-text/85 tracking-wider uppercase font-header mt-1"
+        >
+          No account required. Results save directly to your local Codex vault.
+        </p>
+      </div>
+      <button
+        type="button"
+        onclick={() => void handleGenerate()}
+        disabled={isGenerating}
+        class="px-4 py-2 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all flex items-center gap-1.5 disabled:opacity-50"
+        id="strip-generate-btn"
+      >
+        {#if isGenerating}
+          <span class="icon-[lucide--loader-2] animate-spin w-3.5 h-3.5"></span>
+          Forging...
+        {:else}
+          <span class="icon-[lucide--dice-5] w-3.5 h-3.5"></span>
+          Generate {generatedSingular}
+        {/if}
+      </button>
+    </div>
+  </div>
+
+  <div
+    class="max-w-6xl mx-auto px-6 py-12 w-full flex-grow grid grid-cols-1 lg:grid-cols-12 gap-8"
+  >
+    <!-- Output Card Column: controls first on mobile, middle column on desktop -->
+    <div class="lg:col-span-6 flex flex-col order-2 lg:order-2">
       <div
         class="flex-grow p-6 md:p-8 bg-theme-surface/30 border border-theme-border/60 rounded-2xl shadow-sm flex flex-col min-h-[400px]"
       >
         {#if generatedData}
           <div in:fade={{ duration: 250 }} class="flex flex-col flex-grow">
-            <div
-              class="border-b border-theme-border/60 pb-4 mb-6 flex flex-wrap items-center justify-between gap-4"
-            >
-              <div>
+            <div class="border-b border-theme-border/60 pb-4 mb-6">
+              <div class="flex items-start gap-3 flex-wrap">
                 <h2
                   class="font-header font-extrabold text-2xl md:text-3xl tracking-wide uppercase text-theme-primary"
                 >
                   {generatedData.title}
                 </h2>
-                <div class="flex gap-2 mt-2">
-                  {#each generatedData.labels as label (label)}
+                {#if isExampleDraft}
+                  <span
+                    class="mt-1.5 px-2 py-0.5 rounded-full border border-theme-border/70 text-theme-text/60 text-[9px] font-mono uppercase tracking-wider flex-shrink-0"
+                  >
+                    Example
+                  </span>
+                {/if}
+              </div>
+              {#if generatedData.summary}
+                <p
+                  class="text-xs text-theme-text/65 leading-relaxed mt-2 italic"
+                >
+                  {generatedData.summary}
+                </p>
+              {/if}
+              <div
+                class="flex flex-wrap items-center justify-between gap-2 mt-3"
+              >
+                <div class="flex flex-wrap gap-1.5">
+                  {#each (generatedData.labels ?? []).filter((l) => !HIDDEN_TAGS.has(l)) as label (label)}
                     <span
-                      class="rounded-full border border-theme-primary/20 bg-theme-primary/10 px-2.5 py-0.5 text-[9px] uppercase tracking-wider font-mono font-bold text-theme-primary"
+                      class="rounded-full border border-theme-border/60 bg-theme-surface/20 px-2 py-0.5 text-[8px] uppercase tracking-wider font-mono font-bold text-theme-text/55"
                     >
                       {label}
                     </span>
                   {/each}
                 </div>
-              </div>
-              <div class="flex gap-2">
-                <button
-                  type="button"
-                  onclick={handleSaveToCodex}
-                  class="px-4 py-2 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
-                  id="save-to-codex-btn"
-                >
-                  Save to Codex
-                </button>
-                <button
-                  type="button"
-                  onclick={handleCopyMarkdown}
-                  class="px-4 py-2 bg-theme-surface border border-theme-border/80 text-theme-text font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:border-theme-primary/60 transition-all flex items-center gap-1.5"
-                  id="copy-markdown-btn"
-                >
-                  <span class="icon-[lucide--copy] w-3.5 h-3.5"></span>
-                  {copied ? "Copied!" : "Copy"}
-                </button>
+                <div class="flex gap-2 flex-shrink-0">
+                  <button
+                    type="button"
+                    onclick={handleSaveToCodex}
+                    class="px-4 py-2 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
+                    id="save-to-codex-btn"
+                  >
+                    Save to Codex
+                  </button>
+                  <button
+                    type="button"
+                    onclick={handleCopyMarkdown}
+                    class="px-4 py-2 bg-theme-surface border border-theme-border/80 text-theme-text font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:border-theme-primary/60 transition-all flex items-center gap-1.5"
+                    id="copy-markdown-btn"
+                  >
+                    <span class="icon-[lucide--copy] w-3.5 h-3.5"></span>
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
               </div>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-12 gap-8 flex-grow">
-              <div
-                class="md:col-span-7 space-y-4 text-xs md:text-sm leading-relaxed text-theme-text/90"
-              >
-                {@html renderMarkdown(generatedData.content)}
-              </div>
-
-              <div
-                class="md:col-span-5 p-4 border border-theme-border/60 bg-theme-bg/40 rounded-xl space-y-4"
-              >
-                <h4
-                  class="font-header font-bold text-xs uppercase tracking-widest text-theme-primary"
-                >
-                  GM Stats & Info
-                </h4>
-                <div class="text-xs space-y-3 leading-relaxed">
-                  {@html renderMarkdown(generatedData.lore)}
-                </div>
-              </div>
+            <div
+              class="space-y-4 text-xs md:text-sm leading-relaxed text-theme-text/90 flex-grow"
+            >
+              {@html renderMarkdown(generatedData.content || "")}
             </div>
           </div>
         {:else}
@@ -325,8 +452,36 @@ ${generatedData.lore}`;
       </div>
     </div>
 
-    <!-- Parameters Column: rendered second in DOM, positioned on the left on desktop -->
-    <div class="lg:col-span-4 space-y-6 lg:order-1">
+    <!-- At the Table Column: rendered third in DOM, positioned on the right on desktop -->
+    <div class="lg:col-span-3 order-3 lg:order-3">
+      <div
+        class="p-5 bg-theme-surface/20 border border-theme-border/40 rounded-2xl shadow-sm sticky top-24"
+      >
+        {#if generatedData}
+          <div
+            in:fade={{ duration: 250 }}
+            class="text-xs leading-relaxed text-theme-text/80"
+          >
+            {@html renderLore(generatedData.lore || "")}
+          </div>
+        {:else}
+          <div
+            class="flex flex-col items-center text-center text-theme-muted/40 py-8"
+          >
+            <span class="icon-[lucide--scroll] w-8 h-8 mb-3"></span>
+            <p class="text-[10px] uppercase tracking-widest font-header">
+              At the Table
+            </p>
+            <p class="text-[10px] mt-2 leading-relaxed">
+              GM utility details appear here after generation.
+            </p>
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Parameters Column: rendered last in DOM, positioned on the left on desktop -->
+    <div class="lg:col-span-3 space-y-6 order-1 lg:order-1">
       <div
         class="p-6 bg-theme-surface/40 border border-theme-border/60 rounded-2xl shadow-sm"
       >
@@ -345,8 +500,14 @@ ${generatedData.lore}`;
         >
           {introTitle}
         </h1>
-        <p class="text-xs text-theme-muted leading-relaxed mb-6">
+        <p class="text-xs text-theme-text/70 leading-relaxed mb-4">
           {introText}
+        </p>
+        <p
+          class="text-[9px] text-theme-text/45 uppercase tracking-widest font-header mb-4 flex items-center gap-1.5"
+        >
+          <span class="icon-[lucide--arrow-right] w-3 h-3"></span>
+          Set your inputs — your draft updates to the right
         </p>
 
         <form
@@ -386,10 +547,10 @@ ${generatedData.lore}`;
           >
             {#if isGenerating}
               <span class="icon-[lucide--loader-2] animate-spin w-4 h-4"></span>
-              Forging Lore...
+              Forging...
             {:else}
               <span class="icon-[lucide--dice-5] w-4 h-4"></span>
-              ✦ Generate RPG Draft ✦
+              ✦ Generate {generatedSingular} ✦
             {/if}
           </button>
         </form>
@@ -402,25 +563,7 @@ ${generatedData.lore}`;
           </div>
         {/if}
 
-        {#if relatedLinks.length > 0}
-          <div
-            class="mt-5 border-t border-theme-border/60 pt-4 flex flex-col gap-2"
-            aria-label="Related pages"
-          >
-            {#each relatedLinks as link (link.href)}
-              <a
-                href="{base}{link.href}"
-                class="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-theme-muted hover:text-theme-primary transition-colors"
-              >
-                <span
-                  class="icon-[lucide--arrow-right] w-3.5 h-3.5"
-                  aria-hidden="true"
-                ></span>
-                {link.label}
-              </a>
-            {/each}
-          </div>
-        {/if}
+        <!-- Related links moved to bottom discover section -->
       </div>
     </div>
   </div>
@@ -451,6 +594,85 @@ ${generatedData.lore}`;
         </div>
       </div>
     </section>
+  {/if}
+
+  {#if relatedLinks.length > 0}
+    <section
+      class="border-t border-theme-border/40 px-6 py-12 text-center bg-theme-surface/5"
+    >
+      <div class="max-w-4xl mx-auto">
+        <h2
+          class="font-header font-bold text-xs uppercase tracking-widest text-theme-muted mb-6"
+        >
+          More RPG Worldbuilding Tools
+        </h2>
+        <div class="flex flex-wrap justify-center gap-3">
+          {#each relatedLinks as link (link.href)}
+            <a
+              href="{base}{link.href}"
+              class="px-4 py-2 bg-theme-surface/30 border border-theme-border/40 hover:border-theme-primary/60 text-xs font-bold uppercase tracking-wider text-theme-text rounded-full shadow-sm hover:bg-theme-surface/50 transition-all flex items-center gap-1.5"
+            >
+              <span>{link.label}</span>
+              <span
+                class="icon-[lucide--arrow-right] w-3.5 h-3.5"
+                aria-hidden="true"
+              ></span>
+            </a>
+          {/each}
+        </div>
+      </div>
+    </section>
+  {/if}
+
+  <!-- Save to Codex Transition Modal -->
+  {#if showSaveModal}
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/75 backdrop-blur-sm"
+      transition:fade={{ duration: 150 }}
+    >
+      <div
+        class="bg-theme-surface border border-theme-border max-w-md w-full p-6 rounded-2xl shadow-xl flex flex-col gap-4 text-center animate-in fade-in zoom-in-95 duration-200"
+      >
+        <div
+          class="mx-auto w-12 h-12 rounded-full bg-theme-primary/10 border border-theme-primary/30 flex items-center justify-center text-theme-primary mb-2"
+        >
+          <span class="icon-[lucide--check-circle-2] w-6 h-6"></span>
+        </div>
+
+        <h3
+          class="font-header font-bold text-xl uppercase tracking-wider text-theme-primary"
+        >
+          Saved to your local Codex vault.
+        </h3>
+
+        <p class="text-xs text-theme-text/70 leading-relaxed">
+          Open Codex to link this faction to NPCs, locations, maps, and campaign
+          notes. Your vault lives in the browser — no account, no sync, no
+          cloud.
+        </p>
+
+        <div class="flex flex-col gap-2 mt-4">
+          <button
+            type="button"
+            onclick={confirmSaveRedirect}
+            class="w-full py-3 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 transition-all flex items-center justify-center gap-2"
+          >
+            <span class="icon-[lucide--external-link] w-4 h-4"></span>
+            Open Codex
+          </button>
+
+          <button
+            type="button"
+            onclick={() => {
+              showSaveModal = false;
+            }}
+            class="w-full py-3 bg-theme-surface/50 border border-theme-border/60 text-theme-text font-bold uppercase font-header tracking-widest text-xs rounded-xl hover:bg-theme-surface transition-all"
+          >
+            Back to Generator
+          </button>
+        </div>
+      </div>
+    </div>
   {/if}
 
   <!-- Marketing Footer -->

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -13,10 +13,10 @@
     introText = "Customize options and instantly generate structured drafts to populate your campaign lore database.",
     relatedLinks = [],
     faqs = [],
-    theme = "Classic Fantasy",
+    theme = $bindable("Classic Fantasy"),
     generate,
     formFields,
-    triggerGenerate = $bindable(),
+    registerTrigger,
   }: {
     canonicalPath?: string;
     pageTitle?: string;
@@ -29,7 +29,7 @@
     theme?: string;
     generate: (opts: { useAI: boolean }) => Promise<GeneratorOutput>;
     formFields: Snippet;
-    triggerGenerate?: (() => void) | undefined;
+    registerTrigger?: (fn: () => void) => void;
   } = $props();
 
   let isGenerating = $state(false);
@@ -79,8 +79,9 @@
   }
 
   $effect(() => {
-    const _ = triggerGenerate; // reference it to track
-    triggerGenerate = () => void handleGenerate();
+    if (registerTrigger) {
+      registerTrigger(() => void handleGenerate());
+    }
   });
 
   const escapeHtml = (value: string) =>

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.test.ts
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.test.ts
@@ -1,0 +1,112 @@
+/** @vitest-environment jsdom */
+
+import { render } from "@testing-library/svelte";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Snippet } from "svelte";
+import SEOGeneratorLayout from "./SEOGeneratorLayout.svelte";
+import { themeStore } from "$lib/stores/theme.svelte";
+
+const noopSnippet = (() => {}) as unknown as Snippet;
+
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
+
+vi.mock("$app/paths", () => ({
+  base: "",
+}));
+
+// Stub Element.prototype.animate for JSDOM / Svelte 5 transitions compatibility
+if (typeof Element !== "undefined" && !Element.prototype.animate) {
+  Element.prototype.animate = () => {
+    return {
+      cancel: () => {},
+      finish: () => {},
+      pause: () => {},
+      play: () => {},
+      reverse: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    } as any;
+  };
+}
+
+describe("SEOGeneratorLayout Theming Sync", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls themeStore.setTheme when isThemeCustomizable is true and theme changes", async () => {
+    const setThemeSpy = vi
+      .spyOn(themeStore, "setTheme")
+      .mockResolvedValue(undefined);
+
+    // Set themeStore initial value
+    themeStore.currentThemeId = "workspace";
+
+    // Set up a mock generate function
+    const mockGenerate = vi.fn().mockResolvedValue({
+      title: "Test Title",
+      type: "Faction",
+      content: "Test Content",
+      lore: "Test Lore",
+      labels: [],
+      status: "draft",
+    });
+
+    const { rerender } = render(SEOGeneratorLayout, {
+      props: {
+        theme: "Classic Fantasy",
+        isThemeCustomizable: true,
+        generate: mockGenerate,
+        formFields: noopSnippet,
+      },
+    });
+
+    // Initial check: activeThemeId for "Classic Fantasy" is "fantasy"
+    // Since themeStore.worldThemeId was "workspace", it should trigger setTheme("fantasy")
+    expect(setThemeSpy).toHaveBeenCalledWith("fantasy");
+
+    setThemeSpy.mockClear();
+
+    // Rerender with a new theme: "Cyberpunk / Corporate" (maps to "cyberpunk")
+    await rerender({
+      theme: "Cyberpunk / Corporate",
+      isThemeCustomizable: true,
+      generate: mockGenerate,
+      formFields: noopSnippet,
+    });
+
+    expect(setThemeSpy).toHaveBeenCalledWith("cyberpunk");
+  });
+
+  it("does NOT call themeStore.setTheme when isThemeCustomizable is false", async () => {
+    themeStore.currentThemeId = "workspace";
+    const setThemeSpy = vi
+      .spyOn(themeStore, "setTheme")
+      .mockResolvedValue(undefined);
+
+    const mockGenerate = vi.fn().mockResolvedValue({});
+
+    const { rerender } = render(SEOGeneratorLayout, {
+      props: {
+        theme: "Classic Fantasy",
+        isThemeCustomizable: false,
+        generate: mockGenerate,
+        formFields: noopSnippet,
+      },
+    });
+
+    expect(setThemeSpy).not.toHaveBeenCalled();
+
+    // Rerender with a new theme
+    await rerender({
+      theme: "Cyberpunk / Corporate",
+      isThemeCustomizable: false,
+      generate: mockGenerate,
+      formFields: noopSnippet,
+    });
+
+    expect(setThemeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -175,7 +175,7 @@
           class="px-5 py-2.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
           id="nav-cta-btn"
         >
-          Open App
+          Open Codex
         </a>
       </div>
     </div>

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -166,7 +166,7 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.labels).toContain("faction-generator");
     });
 
-    it("should include campaign theme in the AI prompt and fallback content", async () => {
+    it("should include campaign theme in the AI prompt (fallback content is not theme-specific)", async () => {
       const mockModel = {
         generateContent: vi.fn().mockResolvedValue({
           response: {

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -118,14 +118,15 @@ describe("DefaultGeneratorEngine", () => {
 
       expect(res.type).toBe("faction");
       expect(res.title).toBeDefined();
+      expect(res.summary).toBeDefined();
       expect(res.content).toContain("merchant guild");
-      expect(res.content).toContain("Campaign Fit");
+      expect(res.content).toContain("What they control");
+      expect(res.content).toContain("What they want");
       expect(res.content).toContain(
         "a canal city split by old guild rivalries",
       );
-      expect(res.lore).toContain("Single city");
       expect(res.lore).toContain("Internal Conflict");
-      expect(res.lore).toContain("Adventure Hook");
+      expect(res.lore).toContain("At the Table");
       expect(res.labels).toContain("faction-generator");
       expect(res.labels).toContain("imported-draft");
     });
@@ -190,7 +191,7 @@ describe("DefaultGeneratorEngine", () => {
       });
 
       expect(mockModel.generateContent).toHaveBeenCalledWith(
-        expect.stringContaining("Campaign Theme/Genre: Cyberpunk / Corporate"),
+        expect.stringContaining("Theme/Genre: Cyberpunk / Corporate"),
       );
       expect(res.title).toBe("Cyberdine Corp");
 
@@ -202,10 +203,9 @@ describe("DefaultGeneratorEngine", () => {
         theme: "Cyberpunk / Corporate",
         useAI: false,
       });
-      expect(fallbackRes.content).toContain("cyberpunk / corporate themed");
-      expect(fallbackRes.lore).toContain(
-        "**Campaign Theme**: Cyberpunk / Corporate",
-      );
+      expect(fallbackRes.content).toContain("criminal syndicate");
+      expect(fallbackRes.content).toContain("What they control");
+      expect(fallbackRes.lore).toContain("At the Table");
     });
   });
 

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -164,6 +164,49 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.lore).toBe("AI Generated Agenda");
       expect(res.labels).toContain("faction-generator");
     });
+
+    it("should include campaign theme in the AI prompt and fallback content", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "Cyberdine Corp",
+                content: "AI Cyberpunk Faction",
+                lore: "AI Cyberpunk Agenda",
+                labels: ["rpg-faction", "cyberpunk"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generateFaction({
+        type: "Criminal Syndicate",
+        scope: "Single city",
+        alignment: "Pragmatic",
+        theme: "Cyberpunk / Corporate",
+        useAI: true,
+      });
+
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("Campaign Theme/Genre: Cyberpunk / Corporate"),
+      );
+      expect(res.title).toBe("Cyberdine Corp");
+
+      // Test local fallback path for theme awareness
+      const fallbackRes = await engine.generateFaction({
+        type: "Criminal Syndicate",
+        scope: "Single city",
+        alignment: "Pragmatic",
+        theme: "Cyberpunk / Corporate",
+        useAI: false,
+      });
+      expect(fallbackRes.content).toContain("cyberpunk / corporate themed");
+      expect(fallbackRes.lore).toContain(
+        "**Campaign Theme**: Cyberpunk / Corporate",
+      );
+    });
   });
 
   describe("generateNames", () => {

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -670,6 +670,7 @@ export interface GeneratorOutput {
     | "faction"
     | "note";
   title: string;
+  summary?: string;
   content: string;
   lore: string;
   labels: string[];
@@ -837,6 +838,92 @@ ${plotHook}`;
     };
   }
 
+  private pickFrom<T>(arr: T[]): T {
+    return arr[Math.floor(Math.random() * arr.length)];
+  }
+
+  private factionBase(type: string): string {
+    const map: Record<string, string[]> = {
+      "Merchant Guild": [
+        "A bonded counting house whose ledgers are sealed by city charter",
+        "A licensed exchange hall at the centre of the trade district",
+        "A warehouse compound that no sheriff may enter without a writ",
+      ],
+      "Secret Society": [
+        "A private dining club whose membership list is never committed to paper",
+        "A decommissioned observatory reached through a hidden press in the library stacks",
+        "Rotating safe houses connected by messenger-drop protocols",
+      ],
+      "Mercenary Company": [
+        "A fortified barracks compound outside the city walls",
+        "A charted garrison holding neutral ground between two rival lords",
+        "A licensed inn that doubles as a staging ground for contract work",
+      ],
+      "Temple Order": [
+        "A sanctified compound built above the sealed catacombs",
+        "A pilgrimage waystation that doubles as an intelligence hub",
+        "A charitable hospice whose basement holds restricted archives",
+      ],
+      "Criminal Syndicate": [
+        "A legitimate bathhouse with soundproofed rooms below street level",
+        "A moneylender's office whose public ledgers contain a second set of books",
+        "A district of connected properties linked by sealed passages",
+      ],
+      "Rebel Cell": [
+        "A print-house running two sets of accounts",
+        "A disused chapel in a contested neighbourhood where records are rarely checked",
+        "A network of sympathiser homes linked by a rotating code phrase",
+      ],
+      "Arcane Circle": [
+        "A registered scholar's hall with warded inner chambers",
+        "A cartographer's guild whose maps contain hidden notation systems",
+        "A canal barge anchored in a dock district where manifests go uninspected",
+      ],
+    };
+    return this.pickFrom(map[type] ?? map["Merchant Guild"]);
+  }
+
+  private factionResource(type: string): string {
+    const map: Record<string, string[]> = {
+      "Merchant Guild": [
+        "Exclusive trade licences, bonded debts, and letters of introduction that open every city gate",
+        "Commodity price information days before it reaches the open market",
+        "Certified seals of provenance that determine what goods may legally change hands",
+      ],
+      "Secret Society": [
+        "Compromising knowledge distributed in sealed fragments held by separate members",
+        "A curated register of favours owed by officials, merchants, and clergy",
+        "Access to a network of false identities and safe-passage routes",
+      ],
+      "Mercenary Company": [
+        "Contractual access to trained soldiers who ask no political questions",
+        "Neutral enforcement services hired by every side of every dispute",
+        "An archive of battlefield contracts that constitute decades of political leverage",
+      ],
+      "Temple Order": [
+        "Exclusive rights over burial rites, confessions, and civic oaths",
+        "A pharmaceutical supply chain running through the charitable district",
+        "Institutional immunity protecting their premises from search or seizure",
+      ],
+      "Criminal Syndicate": [
+        "Control over the city's informal credit markets and enforcement ecosystem",
+        "Detailed knowledge of every patrol route, informant, and magistrate's price",
+        "A distribution network for restricted goods running through legitimate storefronts",
+      ],
+      "Rebel Cell": [
+        "A verified printing and distribution network for prohibited materials",
+        "Contacts embedded in the guard, the census office, and the merchant registry",
+        "Secure courier routes that move people, messages, and contraband past checkpoints",
+      ],
+      "Arcane Circle": [
+        "Proprietary ritual techniques licensed to no outside practitioner",
+        "A sealed archive of magical precedents that defines what is legally permitted",
+        "Controlled access to rare components that no other supplier will touch",
+      ],
+    };
+    return this.pickFrom(map[type] ?? map["Merchant Guild"]);
+  }
+
   /**
    * Generates a faction draft.
    */
@@ -869,33 +956,81 @@ ${plotHook}`;
     const campaignContext = options.campaignContext?.trim();
     const name = `${this.generateName()} Compact`;
 
+    const namingStyles = [
+      "Name this faction after a material, substance, or natural phenomenon twisted to their purpose.",
+      "Name this faction after an abstract concept, virtue, or doctrine — not a person or place.",
+      "Use a short stark one-word name or a tight two-word compound (e.g. 'The Writ', 'Iron Accord').",
+      "Base the faction name on a specific local landmark, street, district, or geographic feature.",
+      "Name the faction after their founding secret, hidden method, or signature act.",
+      "Use a name that sounds like a legitimate civic institution but carries a sinister undertone.",
+      "Name the faction after a historical event, failed uprising, or forgotten figure from the setting.",
+      "Give the faction a name derived from an unusual profession, trade, or craft.",
+      "Use an archaic or invented word that evokes the faction's cultural roots.",
+      "Name the faction after a symbol, emblem, or recurring motif associated with their work.",
+    ];
+    const npcNamingStyles = [
+      "Give each NPC a name that sounds distinctly local — not generic fantasy.",
+      "Each NPC name should have an unusual phonetic texture. Avoid Kael, Zara, Theron, and similar overused patterns.",
+      "Give each NPC a short street name or title that hints at their role (e.g. 'The Ledger', 'Pale Maren').",
+      "Use names that suggest a specific cultural or ethnic origin consistent with the setting.",
+      "Each NPC should have a name that is easy to say aloud at a gaming table.",
+    ];
+    const chosenNamingStyle =
+      namingStyles[Math.floor(Math.random() * namingStyles.length)];
+    const chosenNpcStyle =
+      npcNamingStyles[Math.floor(Math.random() * npcNamingStyles.length)];
+    const varianceSeed = Math.floor(Math.random() * 99991) + 10;
+
     if (options.useAI !== false) {
       try {
-        const prompt = `Generate a detailed RPG faction in JSON format.
-Options:
-- Campaign Theme/Genre: ${theme}
+        const themeVoice: Record<string, string> = {
+          "Classic Fantasy":
+            "medieval fantasy — guilds, nobles, arcane orders, political intrigue in a world of swords and sorcery",
+          "Cyberpunk / Corporate":
+            "near-future cyberpunk — megacorporations, street gangs, hackers, corporate espionage, neon-lit dystopia",
+          "Vampire / Gothic Noir":
+            "gothic horror — vampire covens, inquisitions, decadent aristocracy, forbidden rites, candlelit conspiracies",
+          "Sci-Fi / Space Opera":
+            "science fiction space opera — stellar federations, alien factions, interstellar trade, colony politics, advanced technology",
+          "Modern Conspiracy":
+            "modern-day thriller — intelligence agencies, secret societies, corporate conspiracies, hidden influence networks",
+          "Post-Apocalyptic":
+            "post-apocalyptic survival — scavenger tribes, wasteland cults, resource wars, collapsed civilisation, desperate factions",
+        };
+        const voice = themeVoice[theme] ?? "tabletop RPG";
+
+        const systemInstruction = `You are an expert RPG campaign writer specialising in ${voice}. You generate detailed, original faction drafts for that setting in JSON format.
+
+OUTPUT FORMAT — return ONLY a valid JSON object, no markdown fences:
+{
+  "title": "Faction name (follow the naming directive in the user message)",
+  "summary": "One sentence: what this faction is and what makes them interesting (e.g. 'A sanitation cult-technocracy that controls clean water in a poisoned city.').",
+  "content": "Markdown. Use exactly these four section headers in order: '### What they control', '### What they want', '### Why they are dangerous', '### How to use them at the table'. Each section: 2-4 tight sentences. Include campaign context if provided.",
+  "lore": "Markdown. Use EXACTLY this structure with ### headers and '- **Label**: Value' list items:\\n### At the Table\\n- **Base**: specific named location\\n- **Resource**: what they control that others need\\n- **Symbol**: identifying mark or emblem\\n- **Secret**: hidden truth that would destroy them\\n- **Immediate Hook**: one-sentence GM hook\\n### Notable NPCs\\n- **Name**: one-line description (2-3 NPCs)\\n### Internal Conflict\\none paragraph\\n### Rival Faction\\n- **Name**: one-line rivalry",
+  "labels": ["2-5 lowercase tags for the faction's theme and activities, plus 'rpg-faction', 'faction-generator', 'imported-draft'"]
+}
+
+QUALITY RULES:
+- Every generation must feel like a completely different faction — avoid repeating names, concepts, or structures from prior outputs.
+- Avoid generic RPG naming clichés (no 'Gilded Ledger', 'Iron Brotherhood', 'Shadow Hand', etc.).
+- NPC names must feel culturally specific and phonetically varied — avoid Kael, Zara, Theron, and similar overused patterns.
+- Place names (bases, districts, landmarks) must be specific and invented — never use 'the old district', 'the lower city', or other generic geography. Every location should have a proper name.
+- Before finalising, silently critique for: name originality, internal consistency (NPCs don't contradict each other), logical alignment between public face and secret agenda. Rewrite if issues found.`;
+
+        const userMessage = `Generate a faction. Variation seed: ${varianceSeed}.
+- Theme/Genre: ${theme}
 - Faction Type: ${factionType}
 - Scope: ${scope}
-- Moral Posture: ${alignment}
-${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
-- Style Guideline: Avoid generic RPG naming clichés and tropes (e.g. do not default to "Gilded Ledger" or similar repetitive names for merchant guilds). Focus on highly original, evocative, and distinctive names and lore.
-- Self-Assessment: Critique your entire generated draft (including name, public face, agenda, conflicts, and NPCs) before finalizing it. Ensure that the name and concept are highly original, and that the entire output is completely internally consistent with no contradictions (e.g. ensuring NPCs described as dead are not active elsewhere, and the faction's goals align logically with its public face, secrets, and activities). If any issues are found, refine and rewrite the draft before returning it.
-
-You must return a valid JSON object matching the following structure exactly:
-{
-  "title": "A single string for the faction name",
-  "content": "A detailed multi-paragraph faction overview (markdown formatted) describing its public face, leadership, resources, and how it fits the campaign context and campaign theme if provided.",
-  "lore": "Structured GM details (markdown formatted) with sections for core fields, agenda, internal conflict, notable NPCs, rival faction, and adventure hook.",
-  "labels": ["An array of descriptive tags representing the faction's theme, type, and activities (e.g. 'cult', 'underground', 'mercenaries') along with 'rpg-faction', 'faction-generator', and 'imported-draft'"]
-}
-Return only the JSON object. Do not include markdown code block formatting like \`\`\`json.`;
+- Moral Posture: ${alignment}${campaignContext ? `\n- Campaign Context: ${campaignContext}` : ""}
+- Faction Naming Directive: ${chosenNamingStyle}
+- NPC Naming Directive: ${chosenNpcStyle}`;
 
         const model = await this.clientManager.getModel(
           "",
           "gemini-3.1-flash-lite",
-          "You are an assistant that generates detailed RPG campaign elements in JSON format.",
+          systemInstruction,
         );
-        const response = await model.generateContent(prompt);
+        const response = await model.generateContent(userMessage);
         const text = response.response.text().trim();
         const cleanText = text
           .replace(/^```json\s*/i, "")
@@ -906,6 +1041,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
         return {
           type: "faction",
           title: data.title || name,
+          summary: data.summary || "",
           content: data.content || "",
           lore: data.lore || "",
           labels: Array.isArray(data.labels)
@@ -937,43 +1073,41 @@ Return only the JSON object. Do not include markdown code block formatting like 
     const leader = this.generateName();
     const agent = this.generateName();
 
-    const content = `### Overview
-${name} is a ${theme.toLowerCase()} themed ${factionType.toLowerCase()} operating across the ${scope.toLowerCase()}. Its members present a controlled public face, but every favor, rumor, and private meeting is part of a larger strategy.
- 
-${campaignContext ? `### Campaign Fit\nUse ${name} in ${campaignContext}. Their agenda should touch active locations, disputed resources, or unresolved campaign mysteries.\n` : ""}
- 
-### Public Face
-Most locals know the faction through useful services, charitable work, guarded trade, or carefully placed rumors. People disagree about whether ${name} is stabilizing the region or quietly taking ownership of it.
- 
-### Table Use
-Bring ${name} into play when the party needs leverage, pressure, a sponsor, or a rival that can negotiate before it strikes.`;
+    const summary = `A ${alignment.toLowerCase()} ${factionType.toLowerCase()} operating at the ${scope.toLowerCase()} level.`;
 
-    const lore = `### GM Reference Information
-- **Campaign Theme**: ${theme}
-- **Faction Type**: ${factionType}
-- **Scope**: ${scope}
-- **Moral Posture**: ${alignment}
-- **Entity Type**: Faction
+    const content = `### What they control
+${name} is a ${factionType.toLowerCase()} with a firm grip on key resources across the ${scope.toLowerCase()}. Their reach is felt in every trade deal, guarded rumor, and carefully placed favor.${campaignContext ? ` In ${campaignContext}, they already have fingers in the most contested disputes.` : ""}
 
-### Agenda
-${goal}
+### What they want
+${goal} Every action the faction takes, however charitable it appears, serves this underlying drive.
+
+### Why they are dangerous
+${conflict} Beyond their internal tensions, they will negotiate before striking — but they do not forget.
+
+### How to use them at the table
+Bring ${name} into play when the party needs leverage, pressure, a sponsor, or a rival who can operate in daylight. They reward players who deal in favors and punish those who make public enemies.`;
+
+    const lore = `### At the Table
+- **Base**: ${this.factionBase(factionType)}
+- **Resource**: ${this.factionResource(factionType)}
+- **Symbol**: ${name.split(" ")[0]} iconography worn by inner-circle members
+- **Secret**: ${conflict}
+- **Immediate hook**: ${hook}
+
+### Notable NPCs
+- **${leader}**: Public face who insists every deal serves the common good.
+- **${agent}**: Field operative who knows where the faction buries its failures.
 
 ### Internal Conflict
 ${conflict}
 
-### Notable NPCs
-- **${leader}**: Public leader who insists every deal has a civic purpose.
-- **${agent}**: Field agent who knows where the faction hides its failures.
-
 ### Rival Faction
-${rival} wants the same influence, relic, route, or confession before ${name} can secure it.
-
-### Adventure Hook
-${hook}`;
+${rival} is pursuing the same influence, relic, or route — and will reach it first if the party does nothing.`;
 
     return {
       type: "faction",
       title: name,
+      summary,
       content,
       lore,
       labels: ["rpg-faction", "faction-generator", "imported-draft"],

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -945,8 +945,69 @@ ${plotHook}`;
         "A cartographer's guild whose maps contain hidden notation systems",
         "A canal barge anchored in a dock district where manifests go uninspected",
       ],
+      // Cyberpunk types
+      "Megacorporation Megagroup": [
+        "A sealed corporate tower whose lower floors are open to the public and upper floors are not on any map",
+        "A campus of linked facilities connected by private transit lines that bypass city checkpoints",
+        "A data-centre compound in a legally ambiguous special economic zone",
+      ],
+      "Corporate Syndicate": [
+        "A registered LLC with rotating directors and no fixed address",
+        "A licensed private security firm that maintains offices in three jurisdictions simultaneously",
+        "A shell company whose registered seat is a post-box in a compliant offshore district",
+      ],
+      "Hacker Collective": [
+        "A distributed mesh of rented server nodes and anonymous relay points",
+        "A legitimate ISP whose routing infrastructure doubles as a covert comms layer",
+        "Rotating physical dead-drops in public infrastructure — lockers, charging stations, transit hubs",
+      ],
+      "Street Gang Alliance": [
+        "A block of contested commercial units enforced by informal tax agreements",
+        "A series of interconnected basement spaces beneath a market district",
+        "A community centre operating with city permits while the basement handles other business",
+      ],
+      // Gothic types
+      "Vampire Coven": [
+        "A sealed private estate whose deed has not changed hands in three centuries",
+        "A licensed sanatorium whose patient records are never released to outside authorities",
+        "A labyrinthine wine cellar beneath a respectable merchant's townhouse",
+      ],
+      "Inquisition Watch": [
+        "A fortified chapter-house adjacent to the civil courthouse",
+        "A mobile tribunal that establishes temporary jurisdiction wherever the investigation leads",
+        "A warded archive annexed to the city's oldest cathedral",
+      ],
+      // Sci-Fi types
+      "Stellar Federation Alliance": [
+        "A neutral space station positioned at a strategically contested transit point",
+        "A diplomatic compound on a contested colony world with extraterritorial status",
+        "A fleet of registered humanitarian vessels that doubles as a mobile command structure",
+      ],
+      // Modern types
+      "Intelligence Agency": [
+        "A nondescript government office building whose basement floors are not on the building plan",
+        "A chain of legitimate consulting firms that share encrypted back-office infrastructure",
+        "An embassy annex operating under diplomatic immunity",
+      ],
+      // Post-apocalyptic types
+      "Scavenger Tribe": [
+        "A fortified salvage yard at the edge of a collapsed industrial zone",
+        "A mobile convoy that claims no fixed territory but controls key supply corridors",
+        "A series of hidden caches spread across a hundred kilometres of dead highway",
+      ],
+      "Wasteland Cult": [
+        "A sealed compound built inside a pre-collapse water treatment facility",
+        "A fortified hilltop site with sightlines across three days of travel in every direction",
+        "A network of underground bunkers connected by service tunnels from before the collapse",
+      ],
     };
-    return this.pickFrom(map[type] ?? map["Merchant Guild"]);
+    return this.pickFrom(
+      map[type] ?? [
+        "A neutral facility whose access is controlled and whose records are not shared",
+        "A licensed premises that provides cover for activities conducted elsewhere",
+        "A distributed network of locations with no single point of failure",
+      ],
+    );
   }
 
   private factionResource(type: string): string {
@@ -986,8 +1047,69 @@ ${plotHook}`;
         "A sealed archive of magical precedents that defines what is legally permitted",
         "Controlled access to rare components that no other supplier will touch",
       ],
+      // Cyberpunk types
+      "Megacorporation Megagroup": [
+        "Patent portfolios, regulatory capture, and the ability to rewrite local law through lobbying",
+        "A private security force larger than the city police and legally permitted to operate with fewer constraints",
+        "Exclusive contracts with critical infrastructure — power, water, data, transit",
+      ],
+      "Corporate Syndicate": [
+        "Shell-company ownership of key residential and commercial properties across the district",
+        "Leveraged debt held against every small business in the target sector",
+        "Proprietary logistics infrastructure that competitors cannot access without their permission",
+      ],
+      "Hacker Collective": [
+        "Zero-day exploits, surveillance backdoors, and access to every networked system in the city",
+        "A distributed archive of intercepted communications from every major institution",
+        "The ability to make anyone's digital identity disappear — or reappear differently",
+      ],
+      "Street Gang Alliance": [
+        "Control of informal economies: protection, distribution, and dispute resolution in three districts",
+        "Detailed knowledge of every surveillance blind spot, patrol schedule, and officer price",
+        "Loyalty networks that extend into city maintenance, transit, and low-level civil service",
+      ],
+      // Gothic types
+      "Vampire Coven": [
+        "Centuries of accumulated wealth, property, and blackmail material on every notable family",
+        "The ability to alter memory, compel testimony, and move unseen through any social tier",
+        "A network of thralls embedded in the city's legal, medical, and religious institutions",
+      ],
+      "Inquisition Watch": [
+        "Legal authority to detain, interrogate, and seize assets without civil court oversight",
+        "An archive of confessions, heresies, and crimes dating back three generations",
+        "Jurisdiction that supersedes local law in matters defined — broadly — as spiritual threat",
+      ],
+      // Sci-Fi types
+      "Stellar Federation Alliance": [
+        "Trade route licensing, customs authority, and the right to impose blockades under federation charter",
+        "A shared military asset pool that member states cannot individually match",
+        "Diplomatic recognition that determines which colonies and stations are treated as sovereign",
+      ],
+      // Modern types
+      "Intelligence Agency": [
+        "Surveillance infrastructure covering communications, financial transactions, and physical movement",
+        "Classified leverage on every significant political, corporate, and criminal actor in the region",
+        "The legal authority to classify, redact, and deny — which is effectively the power to erase events",
+      ],
+      // Post-apocalyptic types
+      "Scavenger Tribe": [
+        "Access to pre-collapse technology caches and the knowledge to operate what others cannot",
+        "Control of the only reliable route through a stretch of dead territory",
+        "A repair and fabrication capability that no other group in the region can match",
+      ],
+      "Wasteland Cult": [
+        "Clean water, food stockpiles, and medical supplies — distributed exclusively to the faithful",
+        "A coherent ideology that provides meaning in a world without institutions",
+        "Armed enforcers who believe completely in what they are protecting",
+      ],
     };
-    return this.pickFrom(map[type] ?? map["Merchant Guild"]);
+    return this.pickFrom(
+      map[type] ?? [
+        "Specialised knowledge or access that no other group in the region controls",
+        "A network of obligations, debts, and dependencies too entangled to cut cleanly",
+        "Control of a single critical resource that everyone else needs to function",
+      ],
+    );
   }
 
   /**

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -537,6 +537,14 @@ export const magicItemConfig = {
 
 // Faction Generator Table Config
 export const factionConfig = {
+  themes: [
+    "Classic Fantasy",
+    "Cyberpunk / Corporate",
+    "Vampire / Gothic Noir",
+    "Sci-Fi / Space Opera",
+    "Modern Conspiracy",
+    "Post-Apocalyptic",
+  ],
   types: [
     "Merchant Guild",
     "Secret Society",
@@ -738,7 +746,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
 
         const model = await this.clientManager.getModel(
           "",
-          "gemini-1.5-flash",
+          "gemini-3.1-flash-lite",
           "You are an assistant that generates detailed RPG campaign elements in JSON format.",
         );
         const response = await model.generateContent(prompt);
@@ -838,9 +846,11 @@ ${plotHook}`;
       scope?: string;
       alignment?: string;
       campaignContext?: string;
+      theme?: string;
       useAI?: boolean;
     } = {},
   ): Promise<GeneratorOutput> {
+    const theme = options.theme || factionConfig.themes[0];
     const factionType =
       options.type ||
       factionConfig.types[
@@ -863,24 +873,26 @@ ${plotHook}`;
       try {
         const prompt = `Generate a detailed RPG faction in JSON format.
 Options:
-- Name: ${name}
+- Campaign Theme/Genre: ${theme}
 - Faction Type: ${factionType}
 - Scope: ${scope}
 - Moral Posture: ${alignment}
 ${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
+- Style Guideline: Avoid generic RPG naming clichés and tropes (e.g. do not default to "Gilded Ledger" or similar repetitive names for merchant guilds). Focus on highly original, evocative, and distinctive names and lore.
+- Self-Assessment: Critique your entire generated draft (including name, public face, agenda, conflicts, and NPCs) before finalizing it. Ensure that the name and concept are highly original, and that the entire output is completely internally consistent with no contradictions (e.g. ensuring NPCs described as dead are not active elsewhere, and the faction's goals align logically with its public face, secrets, and activities). If any issues are found, refine and rewrite the draft before returning it.
 
 You must return a valid JSON object matching the following structure exactly:
 {
   "title": "A single string for the faction name",
-  "content": "A detailed multi-paragraph faction overview (markdown formatted) describing its public face, leadership, resources, and how it fits the campaign context if provided.",
+  "content": "A detailed multi-paragraph faction overview (markdown formatted) describing its public face, leadership, resources, and how it fits the campaign context and campaign theme if provided.",
   "lore": "Structured GM details (markdown formatted) with sections for core fields, agenda, internal conflict, notable NPCs, rival faction, and adventure hook.",
-  "labels": ["rpg-faction", "faction-generator", "imported-draft"]
+  "labels": ["An array of descriptive tags representing the faction's theme, type, and activities (e.g. 'cult', 'underground', 'mercenaries') along with 'rpg-faction', 'faction-generator', and 'imported-draft'"]
 }
 Return only the JSON object. Do not include markdown code block formatting like \`\`\`json.`;
 
         const model = await this.clientManager.getModel(
           "",
-          "gemini-1.5-flash",
+          "gemini-3.1-flash-lite",
           "You are an assistant that generates detailed RPG campaign elements in JSON format.",
         );
         const response = await model.generateContent(prompt);
@@ -926,17 +938,18 @@ Return only the JSON object. Do not include markdown code block formatting like 
     const agent = this.generateName();
 
     const content = `### Overview
-${name} is a ${factionType.toLowerCase()} operating across the ${scope.toLowerCase()}. Its members present a controlled public face, but every favor, rumor, and private meeting is part of a larger strategy.
-
+${name} is a ${theme.toLowerCase()} themed ${factionType.toLowerCase()} operating across the ${scope.toLowerCase()}. Its members present a controlled public face, but every favor, rumor, and private meeting is part of a larger strategy.
+ 
 ${campaignContext ? `### Campaign Fit\nUse ${name} in ${campaignContext}. Their agenda should touch active locations, disputed resources, or unresolved campaign mysteries.\n` : ""}
-
+ 
 ### Public Face
 Most locals know the faction through useful services, charitable work, guarded trade, or carefully placed rumors. People disagree about whether ${name} is stabilizing the region or quietly taking ownership of it.
-
+ 
 ### Table Use
 Bring ${name} into play when the party needs leverage, pressure, a sponsor, or a rival that can negotiate before it strikes.`;
 
     const lore = `### GM Reference Information
+- **Campaign Theme**: ${theme}
 - **Faction Type**: ${factionType}
 - **Scope**: ${scope}
 - **Moral Posture**: ${alignment}
@@ -1035,7 +1048,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
 
         const model = await this.clientManager.getModel(
           "",
-          "gemini-1.5-flash",
+          "gemini-3.1-flash-lite",
           "You are an assistant that generates detailed RPG campaign elements in JSON format.",
         );
         const response = await model.generateContent(prompt);
@@ -1172,7 +1185,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
 
         const model = await this.clientManager.getModel(
           "",
-          "gemini-1.5-flash",
+          "gemini-3.1-flash-lite",
           "You are an assistant that generates detailed RPG campaign elements in JSON format.",
         );
         const response = await model.generateContent(prompt);
@@ -1301,7 +1314,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
 
         const model = await this.clientManager.getModel(
           "",
-          "gemini-1.5-flash",
+          "gemini-3.1-flash-lite",
           "You are an assistant that generates detailed RPG campaign elements in JSON format.",
         );
         const response = await model.generateContent(prompt);
@@ -1423,7 +1436,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
 
         const model = await this.clientManager.getModel(
           "",
-          "gemini-1.5-flash",
+          "gemini-3.1-flash-lite",
           "You are an assistant that generates detailed RPG campaign elements in JSON format.",
         );
         const response = await model.generateContent(prompt);

--- a/apps/web/src/lib/stores/oracle/settings-manager.svelte.ts
+++ b/apps/web/src/lib/stores/oracle/settings-manager.svelte.ts
@@ -21,7 +21,7 @@ export class OracleSettingsManager {
   }
 
   get modelName() {
-    return this.settings?.modelName || "gemini-1.5-flash";
+    return this.settings?.modelName || "gemini-3.1-flash-lite";
   }
 
   get isLoading() {

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -111,6 +111,8 @@
     }
   });
 
+  let triggerGen = $state<(() => void) | undefined>(undefined);
+
   async function generate({ useAI }: { useAI: boolean }) {
     if (data.slug === "npc") {
       return generatorEngine.generateNPC({ ...npc, useAI });
@@ -140,6 +142,7 @@
   canonicalPath={meta.canonicalPath}
   theme={data.slug === "faction" ? faction.theme : undefined}
   {generate}
+  bind:triggerGenerate={triggerGen}
 >
   {#snippet formFields()}
     {#if data.slug === "npc"}
@@ -208,6 +211,7 @@
         bind:scope={faction.scope}
         bind:alignment={faction.alignment}
         bind:campaignContext={faction.campaignContext}
+        onSurprise={triggerGen}
       />
     {/if}
   {/snippet}

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
   import NPCFormFields from "$lib/components/seo/NPCFormFields.svelte";
   import FactionFormFields from "$lib/components/seo/FactionFormFields.svelte";
@@ -86,6 +87,28 @@
     scope: factionConfig.scopes[1],
     alignment: factionConfig.alignments[0],
     campaignContext: "",
+  });
+
+  const reverseThemeMap: Record<string, string> = {
+    fantasy: "Classic Fantasy",
+    fantasy_dark: "Classic Fantasy",
+    cyberpunk: "Cyberpunk / Corporate",
+    cyberpunk_light: "Cyberpunk / Corporate",
+    horror: "Vampire / Gothic Noir",
+    horror_light: "Vampire / Gothic Noir",
+    scifi: "Sci-Fi / Space Opera",
+    scifi_light: "Sci-Fi / Space Opera",
+    modern: "Modern Conspiracy",
+    modern_dark: "Modern Conspiracy",
+    apocalyptic: "Post-Apocalyptic",
+    apocalyptic_light: "Post-Apocalyptic",
+  };
+
+  onMount(() => {
+    const activeTheme = localStorage.getItem("codex-cryptica-active-theme");
+    if (activeTheme && reverseThemeMap[activeTheme]) {
+      faction.theme = reverseThemeMap[activeTheme];
+    }
   });
 
   async function generate({ useAI }: { useAI: boolean }) {

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -49,13 +49,13 @@
     },
     faction: {
       pageTitle:
-        "Faction Generator | Free Fantasy RPG Organization Tool | Codex Cryptica",
+        "RPG Faction Generator | Fantasy Guilds, Cyberpunk Megacorps & Vampire Clans | Codex Cryptica",
       metaDescription:
-        "Generate fantasy RPG factions with goals, internal conflict, rival groups, notable NPCs, and adventure hooks. Copy the draft or save it into your local campaign vault.",
-      introTitle: "Faction Generator",
+        "Generate detailed RPG factions. Perfect as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator. Save drafts to your vault.",
+      introTitle: "RPG Faction Generator",
       eyebrow: "Faction Generator",
       introText:
-        "Create a campaign-ready fantasy faction with a public face, agenda, internal conflict, and adventure hook. Works without login.",
+        "Forge campaign-ready organizations across any genre. Use it as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator with distinct agendas, conflicts, and NPCs.",
       canonicalPath: "/generators/faction",
     },
   } as const;

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -81,6 +81,7 @@
   });
 
   let faction = $state({
+    theme: factionConfig.themes[0],
     type: factionConfig.types[0],
     scope: factionConfig.scopes[1],
     alignment: factionConfig.alignments[0],
@@ -114,6 +115,7 @@
   eyebrow={meta.eyebrow}
   introText={meta.introText}
   canonicalPath={meta.canonicalPath}
+  theme={data.slug === "faction" ? faction.theme : undefined}
   {generate}
 >
   {#snippet formFields()}
@@ -178,6 +180,7 @@
       </div>
     {:else if data.slug === "faction"}
       <FactionFormFields
+        bind:theme={faction.theme}
         bind:type={faction.type}
         bind:scope={faction.scope}
         bind:alignment={faction.alignment}

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -140,9 +140,11 @@
   eyebrow={meta.eyebrow}
   introText={meta.introText}
   canonicalPath={meta.canonicalPath}
-  theme={data.slug === "faction" ? faction.theme : "Classic Fantasy"}
+  bind:theme={faction.theme}
   {generate}
-  bind:triggerGenerate={triggerGen}
+  registerTrigger={(fn) => {
+    triggerGen = fn;
+  }}
 >
   {#snippet formFields()}
     {#if data.slug === "npc"}

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -141,6 +141,7 @@
   introText={meta.introText}
   canonicalPath={meta.canonicalPath}
   bind:theme={faction.theme}
+  isThemeCustomizable={data.slug === "faction"}
   {generate}
   registerTrigger={(fn) => {
     triggerGen = fn;

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -140,7 +140,7 @@
   eyebrow={meta.eyebrow}
   introText={meta.introText}
   canonicalPath={meta.canonicalPath}
-  theme={data.slug === "faction" ? faction.theme : undefined}
+  theme={data.slug === "faction" ? faction.theme : "Classic Fantasy"}
   {generate}
   bind:triggerGenerate={triggerGen}
 >

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -55,11 +55,11 @@
 
 <SEOGeneratorLayout
   canonicalPath="/tools/faction-generator"
-  pageTitle="Faction Generator | Free Fantasy RPG Organization Tool | Codex Cryptica"
-  metaDescription="Generate fantasy RPG factions with goals, internal conflict, rival groups, notable NPCs, and adventure hooks. Copy the draft or save it into your local campaign vault."
+  pageTitle="RPG Faction Generator | Fantasy Guilds, Cyberpunk Megacorps & Vampire Clans | Codex Cryptica"
+  metaDescription="Generate detailed RPG factions. Perfect as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator. Save drafts to your vault."
   eyebrow="Faction Generator"
-  introTitle="Faction Generator"
-  introText="Create a campaign-ready fantasy faction with a public face, agenda, internal conflict, rival group, notable NPCs, and adventure hook. Works without login, then saves into your local Codex Cryptica campaign vault."
+  introTitle="RPG Faction Generator"
+  introText="Forge campaign-ready organizations across any genre. Use it as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator with distinct agendas, conflicts, and NPCs. Works instantly without login, then imports to your local campaign database."
   {relatedLinks}
   {faqs}
   {theme}

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -87,9 +87,11 @@
   introText="Forge campaign-ready organizations across any genre. Use it as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator with distinct agendas, conflicts, and NPCs. Works instantly without login, then imports to your local campaign database."
   {relatedLinks}
   {faqs}
-  {theme}
+  bind:theme
   {generate}
-  bind:triggerGenerate={triggerGen}
+  registerTrigger={(fn) => {
+    triggerGen = fn;
+  }}
 >
   {#snippet formFields()}
     <FactionFormFields

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
   import FactionFormFields from "$lib/components/seo/FactionFormFields.svelte";
   import {
@@ -7,6 +8,28 @@
   } from "$lib/services/seo/generator-engine";
 
   let theme = $state(factionConfig.themes[0]);
+
+  const reverseThemeMap: Record<string, string> = {
+    fantasy: "Classic Fantasy",
+    fantasy_dark: "Classic Fantasy",
+    cyberpunk: "Cyberpunk / Corporate",
+    cyberpunk_light: "Cyberpunk / Corporate",
+    horror: "Vampire / Gothic Noir",
+    horror_light: "Vampire / Gothic Noir",
+    scifi: "Sci-Fi / Space Opera",
+    scifi_light: "Sci-Fi / Space Opera",
+    modern: "Modern Conspiracy",
+    modern_dark: "Modern Conspiracy",
+    apocalyptic: "Post-Apocalyptic",
+    apocalyptic_light: "Post-Apocalyptic",
+  };
+
+  onMount(() => {
+    const activeTheme = localStorage.getItem("codex-cryptica-active-theme");
+    if (activeTheme && reverseThemeMap[activeTheme]) {
+      theme = reverseThemeMap[activeTheme];
+    }
+  });
   let type = $state(factionConfig.types[0]);
   let scope = $state(factionConfig.scopes[1]);
   let alignment = $state(factionConfig.alignments[0]);

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -56,22 +56,27 @@
     {
       question: "What does the faction generator create?",
       answer:
-        "It creates a fantasy RPG faction with a name, type, operating scope, public face, agenda, internal conflict, rival faction, notable NPCs, and adventure hook.",
+        "It generates a complete RPG faction across any genre — fantasy guilds, cyberpunk megacorps, vampire covens, space federations, and more. Each result includes a name, agenda, internal conflict, rival faction, notable NPCs, and a ready-to-use GM hook.",
     },
     {
-      question: "Can I use the faction generator without an account?",
+      question: "Can I use it without an account?",
       answer:
-        "Yes. You can generate and copy faction notes on the public page without logging in, then save the draft into a browser-local Codex Cryptica vault.",
+        "Yes. Generate and copy faction notes on this page without logging in. When you're ready, save the draft directly into a browser-local Codex Cryptica vault — no sign-up required.",
     },
     {
       question: "Can I aim the faction at my current campaign?",
       answer:
-        "Yes. Add optional campaign context such as a city, war, villain, frontier, or political tension, and the generated faction will include a campaign fit section.",
+        "Yes. Add optional campaign context — a location, villain, ongoing conflict, or political tension — and the generator will fit the faction to your table rather than producing a generic result.",
+    },
+    {
+      question: "How do I change the genre or tone?",
+      answer:
+        "Use the 'Choose a vibe' selector in the left panel. Switching between Classic Fantasy, Cyberpunk, Gothic Noir, Sci-Fi, Modern Conspiracy, and Post-Apocalyptic changes the faction's language, naming, and setting details throughout.",
     },
     {
       question: "How does saving a generated faction work?",
       answer:
-        "The page stores the generated faction draft in browser localStorage and opens the app, where it imports as a Faction entity in your local vault.",
+        "Clicking 'Save to Codex' stores the faction draft in your browser's local storage. Open Codex Cryptica and it imports automatically as a Faction entity, ready to link to NPCs, locations, and campaign notes.",
     },
   ];
 
@@ -84,10 +89,11 @@
   metaDescription="Generate detailed RPG factions. Perfect as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator. Save drafts to your vault."
   eyebrow="Faction Generator"
   introTitle="RPG Faction Generator"
-  introText="Forge campaign-ready organizations across any genre. Use it as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator with distinct agendas, conflicts, and NPCs. Works instantly without login, then imports to your local campaign database."
+  introText="Create organisations with agendas, conflicts, NPCs, and table-ready hooks. Works without login, then imports into your local Codex vault."
   {relatedLinks}
   {faqs}
   bind:theme
+  isThemeCustomizable={true}
   {generate}
   registerTrigger={(fn) => {
     triggerGen = fn;

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -74,6 +74,8 @@
         "The page stores the generated faction draft in browser localStorage and opens the app, where it imports as a Faction entity in your local vault.",
     },
   ];
+
+  let triggerGen = $state<(() => void) | undefined>(undefined);
 </script>
 
 <SEOGeneratorLayout
@@ -87,6 +89,7 @@
   {faqs}
   {theme}
   {generate}
+  bind:triggerGenerate={triggerGen}
 >
   {#snippet formFields()}
     <FactionFormFields
@@ -95,6 +98,7 @@
       bind:scope
       bind:alignment
       bind:campaignContext
+      onSurprise={triggerGen}
     />
   {/snippet}
 </SEOGeneratorLayout>

--- a/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/faction-generator/+page.svelte
@@ -6,6 +6,7 @@
     factionConfig,
   } from "$lib/services/seo/generator-engine";
 
+  let theme = $state(factionConfig.themes[0]);
   let type = $state(factionConfig.types[0]);
   let scope = $state(factionConfig.scopes[1]);
   let alignment = $state(factionConfig.alignments[0]);
@@ -13,6 +14,7 @@
 
   async function generate({ useAI }: { useAI: boolean }) {
     return generatorEngine.generateFaction({
+      theme,
       type,
       scope,
       alignment,
@@ -60,10 +62,12 @@
   introText="Create a campaign-ready fantasy faction with a public face, agenda, internal conflict, rival group, notable NPCs, and adventure hook. Works without login, then saves into your local Codex Cryptica campaign vault."
   {relatedLinks}
   {faqs}
+  {theme}
   {generate}
 >
   {#snippet formFields()}
     <FactionFormFields
+      bind:theme
       bind:type
       bind:scope
       bind:alignment

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -102,11 +102,7 @@ export default defineConfig({
     include: ["src/**/*.{test,spec}.{js,ts}"],
     environment: "jsdom",
     globals: true,
-    pool: "threads",
-    threads: {
-      maxThreads: 2,
-      minThreads: 1,
-    },
+    pool: "forks",
     setupFiles: ["tests/setup.ts"],
     environmentMatchGlobs: [
       ["src/lib/utils/**", "node"],


### PR DESCRIPTION
## Summary

Implements issue #1131 (improve landing generator first-time visitor flow) across layout, AI generation quality, rendering, and conversion copy.

**Layout & navigation**
- True 3-column layout on desktop: controls | faction output | At the Table
- Mobile order corrected: controls first, output below (configure → see result)
- CTA deduplication: single "Generate Faction" in the strip, "Open Codex" only in top nav
- "Example" pill on auto-loaded draft; disappears on first user-triggered generation
- Flow cue: "→ Set your inputs — your draft updates to the right"

**AI generation quality**
- System/user message split: format schema and quality rules in `system_instruction`, only variable inputs in the user message
- Theme-aware system instruction — cyberpunk, gothic horror, sci-fi, fantasy voices set at the model level
- Per-call variation: random seed + 10 rotating faction naming directives + 5 NPC naming directives
- Place name uniqueness rule: all locations must have proper invented names
- Concrete fallback `Base` and `Resource` per faction type (7 types × 3 options each)

**Rendering**
- `renderMarkdown` now handles `*`, `-`, bold-key, and plain-key bullet variants from AI
- `renderLore` applies `mb-5` spacing between At the Table label-value rows
- Duplicate "At the Table" h4 removed; lore h3 acts as the panel heading
- Internal system tags (`imported-draft`, `faction-generator`, `rpg-faction`, etc.) hidden from UI pills; present in saved data

**Content & copy**
- FAQ rewritten theme-agnostically; new entry explaining the genre selector
- Intro paragraph shortened to 2 sentences
- Save modal: "Saved to your local Codex vault. Open Codex to link this faction to NPCs, locations, maps..." 
- Local-first subline bumped to `text-theme-text/85`
- Text contrast fixed across intro text, summary, flow cue, campaign context help (switched from `text-theme-muted` to `text-theme-text` with opacity)
- Background SVG texture restored (`var(--bg-texture-overlay)`)

## Test plan

- [x] Generate faction 4+ times with same settings — names and NPCs should vary meaningfully each time
- [x] Switch theme (Classic Fantasy → Cyberpunk) — generation voice and faction type list update
- [x] Mobile (≤640px): controls panel appears above output card
- [x] "Example" pill visible on page load; disappears after clicking Generate Faction
- [x] Copy button output includes title, summary, labels, content, and lore
- [x] Save to Codex → modal shows conversion copy → Open Codex redirects to app
- [x] Internal tags (imported-draft, rpg-faction, faction-generator) not visible in tag pills
- [x] At the Table panel: label rows have clear spacing, no duplicate "At the Table" heading
- [x] All 19 unit tests pass: `npx vitest run src/lib/components/seo/ src/lib/services/seo/generator-engine.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)