### PR TITLE
perf(proposals): replace Object.values().map() with for..in loop

### DIFF
--- a/apps/web/src/lib/components/entity-detail/EntityProposals.svelte
+++ b/apps/web/src/lib/components/entity-detail/EntityProposals.svelte
@@ -9,10 +9,16 @@
     isEditing?: boolean;
   }>();
 
-  // The Set of existing entity titles
-  const existingTitles = $derived(
-    new Set(Object.values(vault.entities || {}).map((e) => e.title)),
-  );
+  // The Set of existing entity titles — for..in avoids two intermediate array
+  // allocations per reactive evaluation (Object.values + .map)
+  const existingTitles = $derived.by(() => {
+    const titles = new Set<string>();
+    const entities = vault.entities || {};
+    for (const key in entities) {
+      titles.add(entities[key].title);
+    }
+    return titles;
+  });
 
   // The list of proposed entity titles
   const proposals = $derived(


### PR DESCRIPTION
Closes #1105

## What

Replaces `Object.values(vault.entities || {}).map((e) => e.title)` with a `for..in` loop in `EntityProposals.svelte`.

## Why

Inside a Svelte 5 `$derived.by` block, `Object.values()` allocates an intermediate array of entity values, then `.map()` allocates a second array of titles, before the `Set` constructor finally consumes it. Both intermediate arrays are immediately discarded — pure GC pressure.

The `for..in` loop writes directly into the `Set`, producing zero intermediate allocations. This is a hot path that re-runs on every vault entity change.

## Note

PR #1105 (created by Jules/Bolt) contained the same fix but accumulated 96 commits from months of staging→main promotions, making it unreviable. This PR extracts just the actual change onto a clean branch from staging.

## Test plan
- [ ] EntityProposals renders correctly in the app (no console errors)
- [ ] Proposed entity titles are still correctly deduplicated against existing vault entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)