### PR TITLE
perf(importer): load pdfjs-dist from CDN instead of bundling

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,7 +61,6 @@
     "markdown-it-task-lists": "^2.1.1",
     "marked": "^18.0.4",
     "marked-gfm-heading-id": "^4.1.4",
-    "pdfjs-dist": "^5.6.205",
     "peerjs": "^1.5.5",
     "schema": "workspace:*",
     "svelte-tiptap": "^3.0.1",

--- a/apps/web/src/lib/components/settings/ImportSettings.svelte
+++ b/apps/web/src/lib/components/settings/ImportSettings.svelte
@@ -24,7 +24,6 @@
   import type { DiscoveredEntity } from "@codex/importer";
   import { sanitizeId } from "$lib/utils/markdown";
   import { slide, fade } from "svelte/transition";
-  import pdfWorker from "pdfjs-dist/build/pdf.worker.mjs?url";
   import { aiClientManager } from "$lib/services/ai/client-manager";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { connectionModeStore } from "$lib/stores/ui/connection-mode.svelte";
@@ -65,7 +64,7 @@
     new TextParser(),
     new DocxParser(),
     new JsonParser(),
-    new PdfParser(pdfWorker),
+    new PdfParser(),
   ];
 
   let markdownFrontmatterValidator: MarkdownFrontmatterValidator | null = null;

--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,6 @@
         "markdown-it-task-lists": "^2.1.1",
         "marked": "^18.0.4",
         "marked-gfm-heading-id": "^4.1.4",
-        "pdfjs-dist": "^5.6.205",
         "peerjs": "^1.5.5",
         "schema": "workspace:*",
         "svelte-tiptap": "^3.0.1",
@@ -215,7 +214,6 @@
         "@types/turndown": "^5.0.6",
         "idb": "^8.0.3",
         "mammoth": "^1.12.0",
-        "pdfjs-dist": "^5.6.205",
         "turndown": "^7.2.4",
       },
       "devDependencies": {
@@ -651,30 +649,6 @@
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@2.8.0", "", {}, "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ=="],
-
-    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.100", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.100", "@napi-rs/canvas-darwin-arm64": "0.1.100", "@napi-rs/canvas-darwin-x64": "0.1.100", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100", "@napi-rs/canvas-linux-arm64-gnu": "0.1.100", "@napi-rs/canvas-linux-arm64-musl": "0.1.100", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-gnu": "0.1.100", "@napi-rs/canvas-linux-x64-musl": "0.1.100", "@napi-rs/canvas-win32-arm64-msvc": "0.1.100", "@napi-rs/canvas-win32-x64-msvc": "0.1.100" } }, "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA=="],
-
-    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.100", "", { "os": "android", "cpu": "arm64" }, "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ=="],
-
-    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.100", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A=="],
-
-    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.100", "", { "os": "darwin", "cpu": "x64" }, "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw=="],
-
-    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.100", "", { "os": "linux", "cpu": "arm" }, "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA=="],
-
-    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw=="],
-
-    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ=="],
-
-    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.100", "", { "os": "linux", "cpu": "none" }, "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw=="],
-
-    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg=="],
-
-    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.100", "", { "os": "linux", "cpu": "x64" }, "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA=="],
-
-    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
-
-    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "0.10.2" }, "peerDependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1631,8 +1605,6 @@
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "pdfjs-dist": ["pdfjs-dist@5.7.284", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.100" } }, "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw=="],
 
     "peerjs": ["peerjs@1.5.5", "", { "dependencies": { "@msgpack/msgpack": "^2.8.0", "eventemitter3": "^4.0.7", "peerjs-js-binarypack": "^2.1.0", "webrtc-adapter": "^9.0.0" } }, "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ=="],
 

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -15,7 +15,6 @@
     "@types/turndown": "^5.0.6",
     "idb": "^8.0.3",
     "mammoth": "^1.12.0",
-    "pdfjs-dist": "^5.6.205",
     "turndown": "^7.2.4"
   },
   "devDependencies": {

--- a/packages/importer/src/parsers/pdf.ts
+++ b/packages/importer/src/parsers/pdf.ts
@@ -1,8 +1,8 @@
 import type { FileParser, ParseResult } from "../types";
 
-const PDFJS_VERSION = "5.6.205";
-const PDFJS_CDN = `https://unpkg.com/pdfjs-dist@${PDFJS_VERSION}/build/pdf.min.mjs`;
-const PDFJS_WORKER_CDN = `https://unpkg.com/pdfjs-dist@${PDFJS_VERSION}/build/pdf.worker.min.mjs`;
+const PDFJS_VERSION = "5.7.284";
+export const PDFJS_CDN = `https://unpkg.com/pdfjs-dist@${PDFJS_VERSION}/build/pdf.min.mjs`;
+export const PDFJS_WORKER_CDN = `https://unpkg.com/pdfjs-dist@${PDFJS_VERSION}/build/pdf.worker.min.mjs`;
 
 export class PdfParser implements FileParser {
   private workerSrc: string;

--- a/packages/importer/src/parsers/pdf.ts
+++ b/packages/importer/src/parsers/pdf.ts
@@ -1,16 +1,14 @@
 import type { FileParser, ParseResult } from "../types";
 
-// Ensure worker is set up (though in browser env this might need CDN or local build)
-// For Node/Test env we might skip this or polyfill.
-// pdfjs.GlobalWorkerOptions.workerSrc = '...';
+const PDFJS_VERSION = "5.6.205";
+const PDFJS_CDN = `https://unpkg.com/pdfjs-dist@${PDFJS_VERSION}/build/pdf.min.mjs`;
+const PDFJS_WORKER_CDN = `https://unpkg.com/pdfjs-dist@${PDFJS_VERSION}/build/pdf.worker.min.mjs`;
 
 export class PdfParser implements FileParser {
   private workerSrc: string;
 
   constructor(workerSrc?: string) {
-    // Default to a local path that the app should provide.
-    // If not provided, we expect it to be set globally or via this property.
-    this.workerSrc = workerSrc || "";
+    this.workerSrc = workerSrc || PDFJS_WORKER_CDN;
   }
 
   accepts(file: File): boolean {
@@ -18,15 +16,10 @@ export class PdfParser implements FileParser {
   }
 
   async parse(file: File): Promise<ParseResult> {
-    const pdfjs = await import("pdfjs-dist");
+    const pdfjs = await import(/* @vite-ignore */ PDFJS_CDN);
 
     if (typeof window !== "undefined") {
-      if (this.workerSrc) {
-        pdfjs.GlobalWorkerOptions.workerSrc = this.workerSrc;
-      } else if (!pdfjs.GlobalWorkerOptions.workerSrc) {
-        // Fallback to a standard local path if nothing is set
-        pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
-      }
+      pdfjs.GlobalWorkerOptions.workerSrc = this.workerSrc;
     }
 
     const arrayBuffer = await new Promise<ArrayBuffer>((resolve, reject) => {
@@ -44,19 +37,15 @@ export class PdfParser implements FileParser {
       numPages: pdf.numPages,
     };
 
-    // Sequential page extraction to maintain order
     for (let i = 1; i <= pdf.numPages; i++) {
       const page = await pdf.getPage(i);
       const textContent = await page.getTextContent();
-
-      const pageText = textContent.items.map((item: any) => item.str).join(" ");
-
-      text += pageText + "\n\n";
+      text += textContent.items.map((item: any) => item.str).join(" ") + "\n\n";
     }
 
     return {
       text: text.trim(),
-      assets: [], // PDF image extraction is complex, skipped for MVP as per plan/research (text layer only)
+      assets: [],
       metadata,
     };
   }

--- a/packages/importer/tests/parsers/pdf.spec.ts
+++ b/packages/importer/tests/parsers/pdf.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
-import { PdfParser } from "../../src/parsers/pdf";
-import * as pdfjs from "pdfjs-dist";
+import { PdfParser, PDFJS_CDN } from "../../src/parsers/pdf";
 
-vi.mock("pdfjs-dist", () => ({
-  getDocument: vi.fn(),
+const mockGetDocument = vi.fn();
+
+vi.mock(PDFJS_CDN, () => ({
+  getDocument: mockGetDocument,
   GlobalWorkerOptions: {
     workerSrc: "",
   },
-  version: "mock-version",
 }));
 
 describe("PdfParser", () => {
@@ -32,7 +32,7 @@ describe("PdfParser", () => {
       getPage: vi.fn().mockResolvedValue(mockPage),
     };
 
-    (pdfjs.getDocument as any).mockReturnValue({
+    mockGetDocument.mockReturnValue({
       promise: Promise.resolve(mockPdf),
     });
 


### PR DESCRIPTION
Closes #1146

## Summary
- Removes `pdfjs-dist` (~3MB) from the bundle entirely
- PDF parser now fetches pdfjs and its worker from unpkg at the moment a PDF is parsed
- Drops `pdfjs-dist` from `dependencies` in both `apps/web` and `packages/importer`
- Removes the static `?url` worker import from `ImportSettings.svelte` (was the root cause of Vite including it in the build)

## Test plan
- [ ] Import a PDF file via the import settings UI and verify text extraction still works
- [ ] Verify no `pdfjs` chunk appears in the Vite bundle report
- [ ] Verify the network tab shows pdfjs loaded from unpkg only when a PDF is actually parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)