### PR TITLE
:mag: perf(seo): cache llms.txt and llms-full.txt on Cloudflare Pages

### DIFF
--- a/apps/web/static/_headers
+++ b/apps/web/static/_headers
@@ -1,0 +1,5 @@
+# Cache-Control headers for LLM discovery files
+/llms.txt
+  Cache-Control: public, max-age=3600, must-revalidate
+/llms-full.txt
+  Cache-Control: public, max-age=3600, must-revalidate


### PR DESCRIPTION
Sets Cache-Control headers for the LLM crawlability files so they are cached by Cloudflare Pages.