### PR TITLE
feat: implement Phase 6 Structured Data & Schema schemas

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -394,10 +394,14 @@
   <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
   {#if faqJsonLd}
-    {@html `<script type="application/ld+json">${faqJsonLd}</` + "script>"}
+    <script type="application/ld+json">
+{faqJsonLd}
+    </script>
   {/if}
   {#if resultJsonLd}
-    {@html `<script type="application/ld+json">${resultJsonLd}</` + "script>"}
+    <script type="application/ld+json">
+{resultJsonLd}
+    </script>
   {/if}
 </svelte:head>
 

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -6,6 +6,7 @@
   import type { Snippet } from "svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import { browser } from "$app/environment";
+  import { safeJsonLd } from "$lib/utils/json-ld";
 
   let {
     canonicalPath,
@@ -128,7 +129,7 @@
 
   const faqJsonLd = $derived(
     faqs.length > 0
-      ? JSON.stringify({
+      ? safeJsonLd({
           "@context": "https://schema.org",
           "@type": "FAQPage",
           mainEntity: faqs.map((faq) => ({
@@ -146,7 +147,7 @@
   const resultJsonLd = $derived(
     generatedData
       ? generatedData.type === "character"
-        ? JSON.stringify({
+        ? safeJsonLd({
             "@context": "https://schema.org",
             "@type": "Person",
             name: generatedData.title,
@@ -157,7 +158,7 @@
             jobTitle: "Fictional Character",
           })
         : generatedData.type === "location"
-          ? JSON.stringify({
+          ? safeJsonLd({
               "@context": "https://schema.org",
               "@type": "Place",
               name: generatedData.title,
@@ -166,7 +167,7 @@
                 generatedData.content?.slice(0, 150) ||
                 "",
             })
-          : JSON.stringify({
+          : safeJsonLd({
               "@context": "https://schema.org",
               "@type": "CreativeWork",
               name: generatedData.title,
@@ -394,14 +395,14 @@
   <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
   {#if faqJsonLd}
-    <script type="application/ld+json">
-{faqJsonLd}
-    </script>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html `<scr` + `ipt type="application/ld+json">${faqJsonLd}</scr` + `ipt>`}
   {/if}
   {#if resultJsonLd}
-    <script type="application/ld+json">
-{resultJsonLd}
-    </script>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html `<scr` +
+      `ipt type="application/ld+json">${resultJsonLd}</scr` +
+      `ipt>`}
   {/if}
 </svelte:head>
 

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -143,6 +143,42 @@
       : "",
   );
 
+  const resultJsonLd = $derived(
+    generatedData
+      ? generatedData.type === "character"
+        ? JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Person",
+            name: generatedData.title,
+            description:
+              generatedData.summary ||
+              generatedData.content?.slice(0, 150) ||
+              "",
+            jobTitle: "Fictional Character",
+          })
+        : generatedData.type === "location"
+          ? JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "Place",
+              name: generatedData.title,
+              description:
+                generatedData.summary ||
+                generatedData.content?.slice(0, 150) ||
+                "",
+            })
+          : JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "CreativeWork",
+              name: generatedData.title,
+              description:
+                generatedData.summary ||
+                generatedData.content?.slice(0, 150) ||
+                "",
+              genre: "Fantasy / RPG Campaign Lore",
+            })
+      : null,
+  );
+
   async function handleGenerate() {
     isExampleDraft = false;
     isGenerating = true;
@@ -359,6 +395,9 @@
   <link rel="help" href="{base}/llms.txt" />
   {#if faqJsonLd}
     {@html `<script type="application/ld+json">${faqJsonLd}</` + "script>"}
+  {/if}
+  {#if resultJsonLd}
+    {@html `<script type="application/ld+json">${resultJsonLd}</` + "script>"}
   {/if}
 </svelte:head>
 

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -49,6 +49,7 @@
     },
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const jsonLdString = $derived(JSON.stringify(jsonLd));
 
   const pageUrl = $derived(
@@ -97,15 +98,12 @@
         ],
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const breadcrumbString = $derived(JSON.stringify(breadcrumb));
 
   function toggleFaq(index: number) {
     openFaqIndex = openFaqIndex === index ? null : index;
   }
-
-  // Mark reactive variables as used to satisfy eslint no-unused-vars
-  void jsonLdString;
-  void breadcrumbString;
 </script>
 
 <svelte:head>

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -49,10 +49,7 @@
     },
   });
 
-  const jsonLdScript = $derived(
-    `<script type="application/ld+json">${JSON.stringify(jsonLd)}</scr` +
-      `ipt>`,
-  );
+  const jsonLdString = $derived(JSON.stringify(jsonLd));
 
   const pageUrl = $derived(
     canonicalUrl
@@ -100,14 +97,15 @@
         ],
   });
 
-  const breadcrumbScript = $derived(
-    `<script type="application/ld+json">${JSON.stringify(breadcrumb)}</scr` +
-      `ipt>`,
-  );
+  const breadcrumbString = $derived(JSON.stringify(breadcrumb));
 
   function toggleFaq(index: number) {
     openFaqIndex = openFaqIndex === index ? null : index;
   }
+
+  // Mark reactive variables as used to satisfy eslint no-unused-vars
+  void jsonLdString;
+  void breadcrumbString;
 </script>
 
 <svelte:head>
@@ -131,8 +129,12 @@
   <meta name="twitter:description" content={data.description} />
   <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
-  {@html jsonLdScript}
-  {@html breadcrumbScript}
+  <script type="application/ld+json">
+{jsonLdString}
+  </script>
+  <script type="application/ld+json">
+{breadcrumbString}
+  </script>
 </svelte:head>
 
 <div

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { base } from "$app/paths";
+  import { safeJsonLd } from "$lib/utils/json-ld";
   import type {
     SEOPageData,
     SEOComparisonPageData,
@@ -49,8 +50,7 @@
     },
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const jsonLdString = $derived(JSON.stringify(jsonLd));
+  const jsonLdString = $derived(safeJsonLd(jsonLd));
 
   const pageUrl = $derived(
     canonicalUrl
@@ -98,8 +98,7 @@
         ],
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const breadcrumbString = $derived(JSON.stringify(breadcrumb));
+  const breadcrumbString = $derived(safeJsonLd(breadcrumb));
 
   function toggleFaq(index: number) {
     openFaqIndex = openFaqIndex === index ? null : index;
@@ -127,12 +126,14 @@
   <meta name="twitter:description" content={data.description} />
   <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
-  <script type="application/ld+json">
-{jsonLdString}
-  </script>
-  <script type="application/ld+json">
-{breadcrumbString}
-  </script>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${jsonLdString}</scr` +
+    `ipt>`}
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${breadcrumbString}</scr` +
+    `ipt>`}
 </svelte:head>
 
 <div

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -42,7 +42,7 @@ export const SCHEMA_ORG = {
       ],
       storageRequirements: "Origin Private File System (OPFS)",
       softwareVersion: VERSION,
-      isAccessibleForFree: "True",
+      isAccessibleForFree: true,
       offers: {
         "@type": "Offer",
         price: "0",

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -24,30 +24,51 @@ export const IS_STAGING =
 
 export const SCHEMA_ORG = {
   "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: APP_NAME,
-  applicationCategory: "Tabletop RPG Utility",
-  operatingSystem: "Web, Local-First",
-  featureList: [
-    "AI Lore Oracle",
-    "Interactive Knowledge Graphs",
-    "Tactical Map Mode",
-    "Spatial Canvas & Flowcharts",
-    "Era-based Timelines",
-    "Local-First Privacy",
-    "Google Drive Syncing",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://codexcryptica.com/#software",
+      name: APP_NAME,
+      applicationCategory: "Tabletop RPG Utility",
+      operatingSystem: "Web, Local-First, macOS, Windows, Linux",
+      featureList: [
+        "AI Lore Oracle",
+        "Interactive Knowledge Graphs",
+        "Tactical Map Mode",
+        "Spatial Canvas & Flowcharts",
+        "Era-based Timelines",
+        "Local-First Privacy",
+        "Google Drive Syncing",
+      ],
+      storageRequirements: "Origin Private File System (OPFS)",
+      softwareVersion: VERSION,
+      isAccessibleForFree: "True",
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
+      author: {
+        "@type": "Organization",
+        "@id": "https://codexcryptica.com/#organization",
+      },
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://codexcryptica.com/#organization",
+      name: "Codex Cryptica",
+      url: "https://codexcryptica.com",
+      logo: "https://codexcryptica.com/logo.png",
+      sameAs: ["https://github.com/eserlan/Codex-Cryptica"],
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://codexcryptica.com/#website",
+      url: "https://codexcryptica.com",
+      name: "Codex Cryptica",
+      publisher: {
+        "@id": "https://codexcryptica.com/#organization",
+      },
+    },
   ],
-  storageRequirements: "Origin Private File System (OPFS)",
-  softwareVersion: VERSION,
-  isAccessibleForFree: "True",
-  offers: {
-    "@type": "Offer",
-    price: "0",
-    priceCurrency: "USD",
-  },
-  author: {
-    "@type": "Organization",
-    name: "Eserlan",
-    url: "https://github.com/eserlan",
-  },
 };

--- a/apps/web/src/lib/utils/json-ld.test.ts
+++ b/apps/web/src/lib/utils/json-ld.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { safeJsonLd } from "./json-ld";
+
+describe("safeJsonLd", () => {
+  it("produces valid, round-trippable JSON", () => {
+    const data = {
+      "@type": "Person",
+      name: "Bob",
+      url: "https://x.test?a=1&b=2",
+    };
+    expect(JSON.parse(safeJsonLd(data))).toEqual(data);
+  });
+
+  it("escapes < so a </script> breakout is impossible", () => {
+    const out = safeJsonLd({ name: "</script><img src=x onerror=alert(1)>" });
+    expect(out).not.toContain("<");
+    expect(out).toContain("\\u003c");
+    // still parses back to the original, dangerous-looking string
+    expect(JSON.parse(out).name).toBe("</script><img src=x onerror=alert(1)>");
+  });
+
+  it("escapes every occurrence of <", () => {
+    const out = safeJsonLd({ a: "<<<", b: "x<y<z" });
+    expect(out.match(/\\u003c/g)).toHaveLength(5);
+  });
+});

--- a/apps/web/src/lib/utils/json-ld.ts
+++ b/apps/web/src/lib/utils/json-ld.ts
@@ -1,0 +1,14 @@
+/**
+ * Serialize a value into a JSON-LD string that is safe to inject into a
+ * `<script type="application/ld+json">` element via Svelte's `{@html}`.
+ *
+ * A literal `<script>` element in a Svelte template treats its contents as
+ * raw text and never interpolates `{...}`, so JSON-LD must be injected with
+ * `{@html}`. To do that safely we escape `<` to its `<` unicode form,
+ * which is still valid JSON but cannot break out of the script element (e.g.
+ * a `</script>` sequence appearing inside user-generated content). This is the
+ * standard XSS-safe JSON-embedding technique.
+ */
+export function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -8,6 +8,7 @@
   import { demoService } from "$lib/services/demo";
   import { building, browser } from "$app/environment";
   import { SCHEMA_ORG } from "$lib/config";
+  import { safeJsonLd } from "$lib/utils/json-ld";
   import { onboardingStore } from "$lib/stores/ui/onboarding.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
   import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
@@ -63,8 +64,7 @@
     "starwars",
     "startrek",
   ];
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const schemaOrgString = $derived(JSON.stringify(SCHEMA_ORG));
+  const schemaOrgString = $derived(safeJsonLd(SCHEMA_ORG));
 
   const logChunkError = (name: string, error: any) => {
     if (isSpecialEnv) {
@@ -203,9 +203,10 @@
 
 <svelte:head>
   {#if !isGuestMode && onboardingStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
-    <script type="application/ld+json">
-{schemaOrgString}
-    </script>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html `<scr` +
+      `ipt type="application/ld+json">${schemaOrgString}</scr` +
+      `ipt>`}
   {/if}
 </svelte:head>
 

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -63,8 +63,8 @@
     "starwars",
     "startrek",
   ];
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const schemaOrgString = $derived(JSON.stringify(SCHEMA_ORG));
-  void schemaOrgString;
 
   const logChunkError = (name: string, error: any) => {
     if (isSpecialEnv) {

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -63,8 +63,8 @@
     "starwars",
     "startrek",
   ];
-  const schemaOrg = SCHEMA_ORG;
-  void schemaOrg;
+  const schemaOrgString = $derived(JSON.stringify(SCHEMA_ORG));
+  void schemaOrgString;
 
   const logChunkError = (name: string, error: any) => {
     if (isSpecialEnv) {
@@ -204,7 +204,7 @@
 <svelte:head>
   {#if !isGuestMode && onboardingStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
     <script type="application/ld+json">
-      {JSON.stringify(schemaOrg)}
+      {schemaOrgString}
     </script>
   {/if}
 </svelte:head>

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -204,7 +204,7 @@
 <svelte:head>
   {#if !isGuestMode && onboardingStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
     <script type="application/ld+json">
-      {schemaOrgString}
+{schemaOrgString}
     </script>
   {/if}
 </svelte:head>

--- a/apps/web/src/routes/(marketing)/+layout.svelte
+++ b/apps/web/src/routes/(marketing)/+layout.svelte
@@ -4,10 +4,8 @@
   import { SCHEMA_ORG } from "$lib/config";
   let { children } = $props();
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const schemaOrgString = $derived(JSON.stringify(SCHEMA_ORG));
-
-  // Mark reactive variable as used to satisfy eslint no-unused-vars
-  void schemaOrgString;
 </script>
 
 <svelte:head>

--- a/apps/web/src/routes/(marketing)/+layout.svelte
+++ b/apps/web/src/routes/(marketing)/+layout.svelte
@@ -4,15 +4,17 @@
   import { SCHEMA_ORG } from "$lib/config";
   let { children } = $props();
 
-  const jsonLdScript = $derived(
-    `<script type="application/ld+json">${JSON.stringify(SCHEMA_ORG)}</scr` +
-      `ipt>`,
-  );
+  const schemaOrgString = $derived(JSON.stringify(SCHEMA_ORG));
+
+  // Mark reactive variable as used to satisfy eslint no-unused-vars
+  void schemaOrgString;
 </script>
 
 <svelte:head>
   <link rel="help" href="{base}/llms.txt" />
-  {@html jsonLdScript}
+  <script type="application/ld+json">
+{schemaOrgString}
+  </script>
 </svelte:head>
 
 {@render children()}

--- a/apps/web/src/routes/(marketing)/+layout.svelte
+++ b/apps/web/src/routes/(marketing)/+layout.svelte
@@ -2,17 +2,18 @@
   import "../../app.css";
   import { base } from "$app/paths";
   import { SCHEMA_ORG } from "$lib/config";
+  import { safeJsonLd } from "$lib/utils/json-ld";
   let { children } = $props();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const schemaOrgString = $derived(JSON.stringify(SCHEMA_ORG));
+  const schemaOrgString = $derived(safeJsonLd(SCHEMA_ORG));
 </script>
 
 <svelte:head>
   <link rel="help" href="{base}/llms.txt" />
-  <script type="application/ld+json">
-{schemaOrgString}
-  </script>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${schemaOrgString}</scr` +
+    `ipt>`}
 </svelte:head>
 
 {@render children()}

--- a/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
+++ b/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
@@ -50,10 +50,8 @@
     ],
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const faqSchemaString = $derived(JSON.stringify(faqSchema));
-
-  // Mark reactive variable as used to satisfy eslint no-unused-vars
-  void faqSchemaString;
 
   const capabilities = [
     {

--- a/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
+++ b/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
@@ -2,6 +2,7 @@
   import { base } from "$app/paths";
   import { browser } from "$app/environment";
   import { fly } from "svelte/transition";
+  import { safeJsonLd } from "$lib/utils/json-ld";
 
   async function startDemo(theme: string) {
     if (browser) {
@@ -50,8 +51,7 @@
     ],
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const faqSchemaString = $derived(JSON.stringify(faqSchema));
+  const faqSchemaString = $derived(safeJsonLd(faqSchema));
 
   const capabilities = [
     {
@@ -143,9 +143,10 @@
   />
   <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
-  <script type="application/ld+json">
-{faqSchemaString}
-  </script>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${faqSchemaString}</scr` +
+    `ipt>`}
 </svelte:head>
 
 <div

--- a/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
+++ b/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
@@ -50,10 +50,10 @@
     ],
   };
 
-  const faqSchemaScript = $derived(
-    `<script type="application/ld+json">${JSON.stringify(faqSchema)}</scr` +
-      `ipt>`,
-  );
+  const faqSchemaString = $derived(JSON.stringify(faqSchema));
+
+  // Mark reactive variable as used to satisfy eslint no-unused-vars
+  void faqSchemaString;
 
   const capabilities = [
     {
@@ -145,7 +145,9 @@
   />
   <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
   <link rel="help" href="{base}/llms.txt" />
-  {@html faqSchemaScript}
+  <script type="application/ld+json">
+{faqSchemaString}
+  </script>
 </svelte:head>
 
 <div

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import { fade } from "svelte/transition";
+  import { safeJsonLd } from "$lib/utils/json-ld";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -312,7 +313,7 @@
 
   const faqSchema = $derived(
     pageData.faq && pageData.faq.length > 0
-      ? JSON.stringify({
+      ? safeJsonLd({
           "@context": "https://schema.org",
           "@type": "FAQPage",
           mainEntity: pageData.faq.map((f) => ({
@@ -328,9 +329,8 @@
   );
 
   // Breadcrumb Schema
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const breadcrumbSchema = $derived(
-    JSON.stringify({
+    safeJsonLd({
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       itemListElement: [
@@ -358,13 +358,13 @@
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href={pageUrl} />
   {#if faqSchema}
-    <script type="application/ld+json">
-{faqSchema}
-    </script>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+    {@html `<scr` + `ipt type="application/ld+json">${faqSchema}</scr` + `ipt>`}
   {/if}
-  <script type="application/ld+json">
-{breadcrumbSchema}
-  </script>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${breadcrumbSchema}</scr` +
+    `ipt>`}
 </svelte:head>
 
 <div

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -309,6 +309,7 @@
   const pageUrl = $derived(`https://codexcryptica.com/import/${pageData.slug}`);
 
   // FAQ Schema
+
   const faqSchema = $derived(
     pageData.faq && pageData.faq.length > 0
       ? JSON.stringify({
@@ -327,6 +328,7 @@
   );
 
   // Breadcrumb Schema
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const breadcrumbSchema = $derived(
     JSON.stringify({
       "@context": "https://schema.org",
@@ -347,10 +349,6 @@
       ],
     }),
   );
-
-  // Mark reactive variables as used to satisfy eslint no-unused-vars
-  void faqSchema;
-  void breadcrumbSchema;
 </script>
 
 <svelte:head>

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -305,16 +305,60 @@
         "Failed to store import data. Please check localStorage permissions.";
     }
   }
+
+  const pageUrl = $derived(`https://codexcryptica.com/import/${pageData.slug}`);
+
+  // FAQ Schema
+  const faqSchema = $derived(
+    pageData.faq && pageData.faq.length > 0
+      ? JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: pageData.faq.map((f: any) => ({
+            "@type": "Question",
+            name: f.question,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: f.answer,
+            },
+          })),
+        })
+      : null,
+  );
+
+  // Breadcrumb Schema
+  const breadcrumbSchema = $derived(
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: "https://codexcryptica.com",
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: pageData.h1,
+          item: pageUrl,
+        },
+      ],
+    }),
+  );
 </script>
 
 <svelte:head>
   <title>{pageData.title}</title>
   <meta name="description" content={pageData.description} />
+  <meta name="keywords" content={pageData.keywords?.join(", ")} />
   <meta name="robots" content="index, follow" />
-  <link
-    rel="canonical"
-    href="https://codexcryptica.com/import/{pageData.slug}"
-  />
+  <link rel="canonical" href={pageUrl} />
+  {#if faqSchema}
+    {@html `<script type="application/ld+json">${faqSchema}</` + "script>"}
+  {/if}
+  {@html `<script type="application/ld+json">${breadcrumbSchema}</` + "script>"}
 </svelte:head>
 
 <div

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -314,7 +314,7 @@
       ? JSON.stringify({
           "@context": "https://schema.org",
           "@type": "FAQPage",
-          mainEntity: pageData.faq.map((f: any) => ({
+          mainEntity: pageData.faq.map((f) => ({
             "@type": "Question",
             name: f.question,
             acceptedAnswer: {
@@ -347,6 +347,10 @@
       ],
     }),
   );
+
+  // Mark reactive variables as used to satisfy eslint no-unused-vars
+  void faqSchema;
+  void breadcrumbSchema;
 </script>
 
 <svelte:head>
@@ -356,9 +360,13 @@
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href={pageUrl} />
   {#if faqSchema}
-    {@html `<script type="application/ld+json">${faqSchema}</` + "script>"}
+    <script type="application/ld+json">
+{faqSchema}
+    </script>
   {/if}
-  {@html `<script type="application/ld+json">${breadcrumbSchema}</` + "script>"}
+  <script type="application/ld+json">
+{breadcrumbSchema}
+  </script>
 </svelte:head>
 
 <div

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -208,6 +208,45 @@
         },
       ],
     },
+    {
+      title: "Migration & Importer Hubs",
+      description:
+        "Migrate your campaign notes, wikis, and databases from other worldbuilding tools into local Codex Cryptica vaults.",
+      groups: [
+        {
+          links: [
+            {
+              href: "/import/obsidian-vault",
+              label: "Obsidian Vault Importer",
+              summary:
+                "Import your Obsidian campaign vault. Convert Markdown files, wiki-links, and YAML frontmatter into Codex.",
+              icon: "icon-[lucide--folder-down]",
+            },
+            {
+              href: "/import/world-anvil-export",
+              label: "World Anvil Importer",
+              summary:
+                "Extract your campaign lore from World Anvil backup JSON exports and preview them offline.",
+              icon: "icon-[lucide--download-cloud]",
+            },
+            {
+              href: "/import/kanka-json",
+              label: "Kanka Importer",
+              summary:
+                "Upload your Kanka campaign JSON export to import characters, locations, factions, and items.",
+              icon: "icon-[lucide--download]",
+            },
+            {
+              href: "/import/legendkeeper-json",
+              label: "LegendKeeper Importer",
+              summary:
+                "Convert your LegendKeeper JSON project backups into offline campaign notes.",
+              icon: "icon-[lucide--file-archive]",
+            },
+          ],
+        },
+      ],
+    },
   ];
 </script>
 


### PR DESCRIPTION
This PR implements Phase 6 of the SEO plan, providing 100% structured data schema maturity:
1. Generates and injects BreadcrumbList and FAQPage schemas into competitor /import/[slug] pages.
2. Updates global SCHEMA_ORG configuration to a clean, multi-schema @graph layout containing SoftwareApplication, Organization, and WebSite schemas.
3. Maps generated NPCs, Locations, and generic CreativeWork items dynamically to their respective Person, Place, and CreativeWork schema.org JSON-LD scripts in SEOGeneratorLayout.