### PR TITLE
feat(vs/world-anvil): migration-first hero, pipeline strip, mobile matrix cards

### DIFF
--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -204,7 +204,7 @@
   <!-- Hero Section -->
   <section class="max-w-4xl mx-auto px-6 pt-16 pb-12 text-center flex-grow">
     <div
-      class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-mono font-bold bg-theme-primary/10 border border-theme-primary/20 text-theme-primary mb-6 uppercase tracking-wider"
+      class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-mono font-bold bg-theme-primary/10 border border-theme-primary/20 text-theme-primary mb-10 uppercase tracking-wider"
     >
       <span class="w-1.5 h-1.5 rounded-full bg-theme-primary"></span>
       {data.eyebrow ??
@@ -218,17 +218,28 @@
     >
       {data.h1}
     </h1>
+    {#if data.tagline}
+      <p
+        class="text-3xl md:text-4xl font-extrabold font-header leading-tight mb-6 tracking-wide"
+      >
+        {#each data.tagline.split("\n") as line}
+          <span class="block">{line}</span>
+        {/each}
+      </p>
+    {/if}
     <p
       class="text-lg md:text-xl text-theme-primary/80 font-header italic mb-8 max-w-2xl mx-auto"
     >
       {data.subheading}
     </p>
-    <p
-      class="text-theme-muted text-sm md:text-base leading-relaxed mb-10 max-w-3xl mx-auto"
-    >
-      {data.introText}
-    </p>
-    <div class="flex flex-wrap justify-center gap-4">
+    {#each data.introText.split("\n\n") as paragraph}
+      <p
+        class="text-theme-text/75 text-sm md:text-base leading-relaxed mb-4 last:mb-10 max-w-3xl mx-auto"
+      >
+        {paragraph}
+      </p>
+    {/each}
+    <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
       <a
         href="{base}/"
         class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 hover:-translate-y-0.5 transition-all duration-200"
@@ -246,6 +257,37 @@
         </a>
       {/if}
     </div>
+
+    {#if comparisonData?.migrationStrip}
+      <div
+        class="flex flex-col md:flex-row items-center justify-center gap-2 md:gap-3 mt-10"
+      >
+        {#each comparisonData.migrationStrip as step, idx}
+          {#if idx > 0}
+            <span
+              class="icon-[lucide--arrow-down] md:hidden text-theme-primary/65 w-4 h-4"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="icon-[lucide--arrow-right] hidden md:block self-center text-theme-primary/65 w-4 h-4"
+              aria-hidden="true"
+            ></span>
+          {/if}
+          <div
+            class="flex flex-row md:flex-col items-center gap-2 md:gap-1.5 px-5 py-3 bg-theme-surface/30 border border-theme-border/40 rounded-xl min-w-[160px] md:min-w-0"
+          >
+            <span
+              class="{step.icon} text-theme-primary w-5 h-5 shrink-0"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="text-xs font-bold uppercase tracking-wider font-header text-theme-text text-center"
+              >{step.label}</span
+            >
+          </div>
+        {/each}
+      </div>
+    {/if}
   </section>
 
   <!-- Features Grid -->
@@ -270,7 +312,7 @@
             >
               {feat.title}
             </h3>
-            <p class="text-theme-muted text-xs leading-relaxed">
+            <p class="text-theme-text/70 text-sm leading-relaxed">
               {feat.description}
             </p>
           </div>
@@ -288,22 +330,88 @@
         >
           Feature Matrix: Codex vs {comparisonData.competitorName}
         </h2>
+        <!-- Mobile: stacked cards -->
+        <div class="md:hidden space-y-3" id="comparison-table">
+          {#each comparisonData.comparisonTable as row, idx}
+            <div
+              class="border border-theme-border/60 rounded-xl bg-theme-surface/20 overflow-hidden"
+              id="feat-{idx}"
+            >
+              <div
+                class="px-4 py-2.5 bg-theme-surface/60 border-b border-theme-border/40 font-header font-bold text-xs uppercase tracking-wider"
+              >
+                {row.feature}
+              </div>
+              <div
+                class="grid grid-cols-2 divide-x divide-theme-border/30 text-xs"
+              >
+                <div class="p-3">
+                  <span
+                    class="block font-header font-bold text-[9px] uppercase tracking-wider text-theme-muted mb-1"
+                    >{comparisonData.competitorName}</span
+                  >
+                  {#if typeof row.competitorHas === "boolean"}
+                    {#if row.competitorHas}
+                      <span
+                        class="icon-[lucide--check] text-emerald-500 w-4 h-4"
+                        aria-label="Yes"
+                      ></span>
+                    {:else}
+                      <span
+                        class="icon-[lucide--x] text-rose-500 w-4 h-4"
+                        aria-label="No"
+                      ></span>
+                    {/if}
+                  {:else}
+                    <span class="text-theme-text/70 leading-snug"
+                      >{row.competitorHas}</span
+                    >
+                  {/if}
+                </div>
+                <div class="p-3">
+                  <span
+                    class="block font-header font-bold text-[9px] uppercase tracking-wider text-theme-primary mb-1"
+                    >Codex Cryptica</span
+                  >
+                  {#if typeof row.codexHas === "boolean"}
+                    {#if row.codexHas}
+                      <span
+                        class="icon-[lucide--check] text-emerald-400 w-4 h-4"
+                        aria-label="Yes"
+                      ></span>
+                    {:else}
+                      <span
+                        class="icon-[lucide--x] text-rose-500 w-4 h-4"
+                        aria-label="No"
+                      ></span>
+                    {/if}
+                  {:else}
+                    <span class="font-semibold text-theme-primary leading-snug"
+                      >{row.codexHas}</span
+                    >
+                  {/if}
+                </div>
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <!-- Desktop: table -->
         <div
-          class="overflow-x-auto border border-theme-border/60 rounded-2xl shadow-sm"
+          class="hidden md:block overflow-x-auto border border-theme-border/60 rounded-2xl shadow-sm"
         >
-          <table
-            class="w-full text-left border-collapse bg-theme-surface/20"
-            id="comparison-table"
-          >
+          <table class="w-full text-left border-collapse bg-theme-surface/20">
             <thead>
               <tr
                 class="border-b border-theme-border/60 bg-theme-surface/60 font-header text-xs uppercase tracking-wider"
               >
-                <th class="p-4 font-bold">Feature</th>
-                <th class="p-4 font-bold text-theme-muted"
+                <th class="px-4 py-4 pl-5 font-bold">Feature</th>
+                <th class="px-4 py-4 pl-5 font-bold text-theme-muted"
                   >{comparisonData.competitorName}</th
                 >
-                <th class="p-4 font-bold text-theme-primary">Codex Cryptica</th>
+                <th class="px-4 py-4 pl-5 font-bold text-theme-primary"
+                  >Codex Cryptica</th
+                >
               </tr>
             </thead>
             <tbody class="text-xs">
@@ -352,16 +460,26 @@
           </table>
         </div>
         <div
-          class="mt-8 p-6 bg-theme-surface/40 border border-theme-border/60 rounded-2xl shadow-sm text-center"
+          class="mt-8 p-8 md:p-10 bg-theme-surface/40 border border-theme-border/60 rounded-2xl shadow-sm text-center"
         >
           <h3
-            class="font-header font-bold text-sm uppercase tracking-wider text-theme-primary mb-2"
+            class="font-header font-bold text-sm uppercase tracking-wider text-theme-primary mb-4"
           >
             The Verdict
           </h3>
-          <p class="text-xs leading-relaxed text-theme-muted">
-            {comparisonData.verdict}
-          </p>
+          <div class="space-y-3">
+            {#each comparisonData.verdict.split("\n\n") as para, idx}
+              <p
+                class="leading-relaxed text-theme-text/80"
+                class:text-base={idx === 0}
+                class:font-semibold={idx === 0}
+                class:text-sm={idx > 0}
+                class:text-theme-muted={idx > 0}
+              >
+                {para}
+              </p>
+            {/each}
+          </div>
         </div>
       </div>
     </section>

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -382,7 +382,7 @@
                     {:else}
                       <span
                         class="icon-[lucide--x] text-rose-500 w-4 h-4"
-                        aria-label="No"
+                        role="img" aria-label="No"
                       ></span>
                     {/if}
                   {:else}

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -354,7 +354,7 @@
                     {#if row.competitorHas}
                       <span
                         class="icon-[lucide--check] text-emerald-500 w-4 h-4"
-                        aria-label="Yes"
+                        role="img" aria-label="Yes"
                       ></span>
                     {:else}
                       <span

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -359,7 +359,7 @@
                     {:else}
                       <span
                         class="icon-[lucide--x] text-rose-500 w-4 h-4"
-                        aria-label="No"
+                        role="img" aria-label="No"
                       ></span>
                     {/if}
                   {:else}

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -377,7 +377,7 @@
                     {#if row.codexHas}
                       <span
                         class="icon-[lucide--check] text-emerald-400 w-4 h-4"
-                        aria-label="Yes"
+                        role="img" aria-label="Yes"
                       ></span>
                     {:else}
                       <span

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -335,7 +335,7 @@
           {#each comparisonData.comparisonTable as row, idx}
             <div
               class="border border-theme-border/60 rounded-xl bg-theme-surface/20 overflow-hidden"
-              id="feat-{idx}"
+              id="feat-mobile-{idx}"
             >
               <div
                 class="px-4 py-2.5 bg-theme-surface/60 border-b border-theme-border/40 font-header font-bold text-xs uppercase tracking-wider"

--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -18,6 +18,8 @@ export interface SEOPageData {
   }>;
   /** Hero badge text. Defaults to "100% Local-First Campaign Wiki". */
   eyebrow?: string;
+  /** Large emotional tagline rendered between h1 and subheading. Use \n to split lines. */
+  tagline?: string;
   /** Optional second button in the hero. */
   secondaryCtaText?: string;
   secondaryCtaHref?: string;
@@ -33,6 +35,8 @@ export interface SEOComparisonPageData extends SEOPageData {
     codexHas: boolean | string;
   }>;
   verdict: string;
+  /** Optional migration path strip shown below the hero CTAs. */
+  migrationStrip?: Array<{ icon: string; label: string }>;
 }
 
 export const solutions: Record<string, SEOPageData> = {
@@ -689,12 +693,14 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     title: "Codex Cryptica vs World Anvil: Private vs Cloud Worldbuilding",
     description:
       "Compare Codex Cryptica and World Anvil. Discover the differences between local-first privacy and online subscription-based worldbuilding.",
-    h1: "Codex Cryptica vs World Anvil",
-    subheading:
-      "Choose between private local vaults and online cloud worldbuilding.",
+    eyebrow: "Codex Cryptica vs World Anvil",
+    h1: "Your World Is Yours.",
+    subheading: "No subscriptions. No cloud lock-in.",
     introText:
-      "World Anvil is a cloud-based suite for worldbuilding, but it stores all your notes on remote servers and locks advanced features behind monthly paywalls. Codex Cryptica provides a modern local-first alternative that is 100% free, private, and runs entirely in your browser with offline support.",
+      "Import your World Anvil export and keep building. Your lore lives as local Markdown files — yours to keep, edit, and explore as a connected graph.",
     ctaText: "Get Free Local Vault",
+    secondaryCtaText: "Import World Anvil Export",
+    secondaryCtaHref: "/import/world-anvil-export",
     keywords: [
       "codex cryptica vs world anvil",
       "world anvil alternative",
@@ -702,63 +708,83 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     ],
     features: [
       {
-        title: "100% Client-Side Privacy",
+        title: "Bring Your World Anvil Export",
         description:
-          "Your campaign notes remain fully private, encrypted by the sandbox, and are never sent to remote databases.",
-        icon: "icon-[lucide--shield-alert]",
+          "Already have years of lore in World Anvil? Import your export and pick up where you left off — no copy-pasting, no rebuilding from scratch.",
+        icon: "icon-[lucide--package-open]",
       },
       {
-        title: "Offline Autonomy",
+        title: "Your Lore, Your Files",
         description:
-          "Work on your campaign at the gaming table, on a plane, or in cabin retreats without requiring internet connection.",
-        icon: "icon-[lucide--wifi-off]",
-      },
-      {
-        title: "Standard Markdown Files",
-        description:
-          "Your world wiki is saved as readable files on your computer. No vendor lock-in or database extraction limits.",
+          "Your world wiki is saved as plain Markdown files on your own device. No vendor lock-in, no export gatekeeping, no account required.",
         icon: "icon-[lucide--file-text]",
       },
+      {
+        title: "Core Vault Works Offline",
+        description:
+          "Write, search, and explore your campaign graph without an internet connection. No server latency at the game table.",
+        icon: "icon-[lucide--wifi-off]",
+      },
+    ],
+    migrationStrip: [
+      { icon: "icon-[lucide--cloud-download]", label: "World Anvil Export" },
+      { icon: "icon-[lucide--file-text]", label: "Plain Markdown Vault" },
+      { icon: "icon-[lucide--network]", label: "Interactive Entity Graph" },
     ],
     comparisonTable: [
       {
-        feature: "Offline Compatibility",
-        competitorHas: "No (Cloud only)",
-        codexHas: "Yes",
+        feature: "Storage location",
+        competitorHas: "Remote hosted platform",
+        codexHas: "Browser storage / local Markdown vault",
       },
       {
-        feature: "Data Privacy & Local Storage",
-        competitorHas: "No (Hosted)",
-        codexHas: "Yes",
+        feature: "Offline core workflow",
+        competitorHas: "Cloud-dependent",
+        codexHas: "Yes — core vault works offline",
       },
       {
-        feature: "Price",
-        competitorHas: "Paid tier for privacy/large assets",
-        codexHas: "100% Free & Open Source",
-      },
-      {
-        feature: "Page Load Speed",
-        competitorHas: "Slow (Server dependent)",
-        codexHas: "Instant (Zero-lag local)",
-      },
-      {
-        feature: "No-Setup AI Assistance",
-        competitorHas: "No (Behind paywall)",
-        codexHas: "Yes",
-      },
-      {
-        feature: "Markdown & Folder Sync",
+        feature: "Native local Markdown vault",
         competitorHas: "No",
         codexHas: "Yes",
       },
+      {
+        feature: "World export",
+        competitorHas: "Guild feature for full world export",
+        codexHas: "Local files by default",
+      },
+      {
+        feature: "Private worlds",
+        competitorHas: "Guild (paid) feature",
+        codexHas: "Private by default",
+      },
+      {
+        feature: "AI assistance",
+        competitorHas: "External AI tools / not local-vault focused",
+        codexHas: "Optional BYO-key vault-aware assistance",
+      },
+      {
+        feature: "Graph-based lore exploration",
+        competitorHas: "Wiki-link/article based",
+        codexHas: "Core feature",
+      },
+      {
+        feature: "Price",
+        competitorHas: "Freemium / paid tiers",
+        codexHas: "Free, source-available",
+      },
     ],
     verdict:
-      "For creators who want total control over their creative property, fast load times, and offline access, Codex Cryptica is the ideal choice. Choose World Anvil if you prefer hosting collaborative wikis directly on their web servers.",
+      "Your world should not feel trapped.\n\nChoose Codex Cryptica if you want full ownership of your lore, offline-first access, plain Markdown files, and no subscription fees.\n\nChoose World Anvil if hosted publishing, subscriber features, public presentation, and community wikis are your priority.",
     faq: [
       {
         question: "Is Codex Cryptica completely free?",
         answer:
           "Yes, Codex is free and open-source. There are no paywalls or storage restrictions on your local campaigns.",
+      },
+      {
+        question: "Can I import my World Anvil content?",
+        answer:
+          "Yes. Export your world from World Anvil and import it directly into Codex Cryptica. Your articles become local Markdown files you own outright.",
       },
       {
         question: "How do players access my Codex campaign?",


### PR DESCRIPTION
## Summary

- **Hero reframe**: H1 is now "Your World Is Yours." — competitor name moved to eyebrow badge. Collapses three stacked slogans into a clean badge → h1 → subheading → one body line → CTAs hierarchy
- **Migration pipeline strip**: World Anvil Export → Plain Markdown Vault → Interactive Entity Graph flow diagram below hero CTAs; horizontal on desktop, vertical on mobile
- **Mobile matrix**: feature comparison switches to stacked cards below `md` — each row becomes its own card with a feature header and two-column value split, eliminating the cramped three-column table on small screens
- **Polish**: verdict box multi-paragraph rendering with opening line styled larger/bolder; card body text contrast improved; pipeline arrows brighter; badge margin increased for headline breathing room; table header alignment nudged

## New data fields

- `SEOPageData.tagline?: string` — optional large emotional headline between h1 and subheading
- `SEOComparisonPageData.migrationStrip?: Array<{ icon, label }>` — optional pipeline strip below hero CTAs

## Test plan

- [ ] `/vs/world-anvil` — verify hero hierarchy, pipeline strip, both CTAs, mobile card matrix
- [ ] Other `/vs/*` and `/solutions/*` pages — verify no regressions (tagline/migrationStrip are optional)
- [ ] Mobile viewport (~375px) — matrix stacked cards readable, pipeline strip vertical

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)