### PR TITLE
Blog keyword chips: title case, Topics heading, fix CTA copy

### DIFF
--- a/.agents/skills/codex-review
+++ b/.agents/skills/codex-review
@@ -1,0 +1,1 @@
+../../.agent/skills/codex-review

--- a/.github/workflows/deploy-blog-content.yml
+++ b/.github/workflows/deploy-blog-content.yml
@@ -2,7 +2,7 @@ name: Deploy Blog Content
 
 on:
   push:
-    branches: ["main", "staging"]
+    branches: ["main", "staging", "blog"]
     paths:
       - "apps/web/src/lib/content/blog/**"
       - "scripts/publish-blog-content.mjs"

--- a/.github/workflows/deploy-blog-content.yml
+++ b/.github/workflows/deploy-blog-content.yml
@@ -2,7 +2,7 @@ name: Deploy Blog Content
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "staging"]
     paths:
       - "apps/web/src/lib/content/blog/**"
       - "scripts/publish-blog-content.mjs"

--- a/.github/workflows/deploy-blog-content.yml
+++ b/.github/workflows/deploy-blog-content.yml
@@ -70,4 +70,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run deploy.yml --ref ${{ github.ref_name }}
+          gh workflow run deploy.yml --ref main

--- a/.github/workflows/deploy-blog-content.yml
+++ b/.github/workflows/deploy-blog-content.yml
@@ -2,7 +2,7 @@ name: Deploy Blog Content
 
 on:
   push:
-    branches: ["main", "staging", "blog"]
+    branches: ["main", "staging"]
     paths:
       - "apps/web/src/lib/content/blog/**"
       - "scripts/publish-blog-content.mjs"

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{ "feature_directory": "specs/125-entity-auto-link" }
+{
+  "feature_directory": "specs/130-editable-time-graph"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ This file is the Codex-facing instruction layer for this repository.
 <!-- SPECKIT START -->
 
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the [current plan](./specs/127-context-aware-entity-generator/plan.md).
+shell commands, and other important information, read the [current plan](./specs/130-editable-time-graph/plan.md).
 
 <!-- SPECKIT END -->
 

--- a/apps/web/.github/workflows/deploy-blog-content.yml
+++ b/apps/web/.github/workflows/deploy-blog-content.yml
@@ -1,0 +1,55 @@
+name: Deploy Blog Content
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/src/lib/content/blog/**'
+      - 'scripts/publish-blog-content.mjs'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Generate blog output
+        run: node scripts/publish-blog-content.mjs --out /tmp/blog-out
+        working-directory: apps/web
+
+      - name: Publish to blog-content branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin blog-content 2>/dev/null || true
+
+          # Check out or create the blog-content branch in a worktree
+          if git ls-remote --exit-code origin blog-content; then
+            git worktree add /tmp/blog-branch blog-content
+          else
+            git worktree add --orphan -b blog-content /tmp/blog-branch
+          fi
+
+          # Sync blog files
+          rm -f /tmp/blog-branch/blog/*.md /tmp/blog-branch/blog/index.json
+          mkdir -p /tmp/blog-branch/blog
+          cp /tmp/blog-out/*.md /tmp/blog-branch/blog/
+          cp /tmp/blog-out/index.json /tmp/blog-branch/blog/
+
+          cd /tmp/blog-branch
+          git add blog/
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+          git commit --no-verify -m "chore: publish blog content [skip ci]"
+          git push origin blog-content

--- a/apps/web/scripts/publish-blog-content.mjs
+++ b/apps/web/scripts/publish-blog-content.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Reads blog .md files, parses frontmatter, and writes:
+ *   - out/<slug>.md  (each article)
+ *   - out/index.json (index of all articles sorted by publishedAt desc)
+ *
+ * Usage: node scripts/publish-blog-content.mjs [--out <dir>]
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const outIdx = args.indexOf("--out");
+const outDir =
+  outIdx !== -1
+    ? path.resolve(args[outIdx + 1])
+    : path.join(root, "blog-out");
+
+const blogDir = path.join(root, "src", "lib", "content", "blog");
+
+function parseFrontmatter(raw) {
+  const match = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fm = {};
+  for (const line of match[1].split("\n")) {
+    const colon = line.indexOf(":");
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const val = line.slice(colon + 1).trim().replace(/^"|"$/g, "");
+    if (key && val && !val.startsWith("[")) fm[key] = val;
+  }
+  return fm;
+}
+
+const files = fs
+  .readdirSync(blogDir)
+  .filter((f) => f.endsWith(".md") && f !== "front-page.md");
+
+const index = [];
+
+fs.mkdirSync(outDir, { recursive: true });
+
+for (const file of files) {
+  const raw = fs.readFileSync(path.join(blogDir, file), "utf8");
+  const fm = parseFrontmatter(raw);
+  if (!fm.id || !fm.slug || !fm.title || !fm.description || !fm.publishedAt) {
+    console.warn(`Skipping ${file}: missing required frontmatter fields`);
+    continue;
+  }
+  fs.copyFileSync(path.join(blogDir, file), path.join(outDir, file));
+  index.push({
+    id: fm.id,
+    slug: fm.slug,
+    title: fm.title,
+    description: fm.description,
+    publishedAt: fm.publishedAt,
+  });
+}
+
+index.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
+fs.writeFileSync(path.join(outDir, "index.json"), JSON.stringify(index, null, 2));
+
+console.log(`Published ${index.length} articles to ${outDir}`);
+console.log(index.map((a) => `  ${a.slug}`).join("\n"));

--- a/apps/web/src/lib/app/init/app-init.ts
+++ b/apps/web/src/lib/app/init/app-init.ts
@@ -448,7 +448,6 @@ export function registerServiceWorker(deps?: {
               console.log(
                 "[SW] Unregistered active service worker in development mode.",
               );
-              win.location.reload();
             }
           });
         }

--- a/apps/web/src/lib/app/init/app-init.ts
+++ b/apps/web/src/lib/app/init/app-init.ts
@@ -435,7 +435,25 @@ export function registerServiceWorker(deps?: {
   const win = deps?.window ?? window;
   const isDev = deps?.isDev ?? import.meta.env.DEV;
 
-  if (!browser || !("serviceWorker" in nav) || isDev) {
+  if (!browser || !("serviceWorker" in nav)) {
+    return;
+  }
+
+  if (isDev) {
+    if (nav.serviceWorker.getRegistrations) {
+      nav.serviceWorker.getRegistrations().then((registrations) => {
+        for (const registration of registrations) {
+          registration.unregister().then((unregistered) => {
+            if (unregistered) {
+              console.log(
+                "[SW] Unregistered active service worker in development mode.",
+              );
+              win.location.reload();
+            }
+          });
+        }
+      });
+    }
     return;
   }
 

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -454,6 +454,7 @@
                     entity={activeEntity}
                     {isEditing}
                     {editType}
+                    bind:editDate
                     bind:editContent
                     bind:editLore
                     bind:editStartDate

--- a/apps/web/src/lib/components/EntityDetailPanel.svelte
+++ b/apps/web/src/lib/components/EntityDetailPanel.svelte
@@ -92,10 +92,11 @@
         editType !== entity.type ||
         editImage !== (entity.image ?? "") ||
         JSON.stringify(editAliases) !== JSON.stringify(entity.aliases ?? []) ||
-        JSON.stringify(editDate) !== JSON.stringify(entity.date ?? null) ||
-        JSON.stringify(editStartDate) !==
+        JSON.stringify(editDate ?? null) !==
+          JSON.stringify(entity.date ?? null) ||
+        JSON.stringify(editStartDate ?? null) !==
           JSON.stringify(entity.start_date ?? null) ||
-        JSON.stringify(editEndDate) !==
+        JSON.stringify(editEndDate ?? null) !==
           JSON.stringify(entity.end_date ?? null) ||
         JSON.stringify(editGuestChatConfig) !==
           JSON.stringify(

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -100,7 +100,10 @@
   });
 
   const handleKeyDown = async (e: KeyboardEvent) => {
-    if (e.key === "Escape" && chronologyEdit.pendingIntent) {
+    if (
+      e.key === "Escape" &&
+      (chronologyEdit.pendingIntent || chronologyEdit.drag)
+    ) {
       controller.restoreChronologyDragOrigin();
       chronologyEdit.cancel();
       return;

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -474,14 +474,24 @@
 
   function handleCanvasDragover(event: DragEvent) {
     if (!graph.chronologyEditMode) return;
-    if (!event.dataTransfer?.types.includes("application/codex-entity")) return;
+    const types = event.dataTransfer?.types ?? [];
+    if (
+      !types.includes("application/x-codex-entity-id") &&
+      !types.includes("application/codex-entity") &&
+      !types.includes("text/plain")
+    ) {
+      return;
+    }
     event.preventDefault();
-    event.dataTransfer.dropEffect = "copy";
+    event.dataTransfer!.dropEffect = "copy";
   }
 
   function handleCanvasDrop(event: DragEvent) {
     if (!graph.chronologyEditMode) return;
-    const entityId = event.dataTransfer?.getData("application/codex-entity");
+    const entityId =
+      event.dataTransfer?.getData("application/x-codex-entity-id") ||
+      event.dataTransfer?.getData("application/codex-entity") ||
+      event.dataTransfer?.getData("text/plain");
     if (!entityId) return;
     event.preventDefault();
     controller.beginExplorerChronologyPlacement(entityId, {

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -14,6 +14,7 @@
   import EdgeEditorModal from "./graph/EdgeEditorModal.svelte";
   import GraphHUD from "./graph/GraphHUD.svelte";
   import GraphToolbar from "./graph/GraphToolbar.svelte";
+  import TimelineOverlay from "./graph/TimelineOverlay.svelte";
   import ChronologyDragIndicator from "./graph/ChronologyDragIndicator.svelte";
   import SemanticPlacementPopover from "./graph/SemanticPlacementPopover.svelte";
   import { handleGraphDeleteShortcut } from "./graph/graph-keyboard";
@@ -487,17 +488,23 @@
   }
 
   function handleCanvasDrop(event: DragEvent) {
-    if (!graph.chronologyEditMode) return;
+    console.log("[GraphView] drop event received");
+    if (!graph.chronologyEditMode) {
+      console.log("[GraphView] drop ignored: chronologyEditMode is false");
+      return;
+    }
     const entityId =
       event.dataTransfer?.getData("application/x-codex-entity-id") ||
       event.dataTransfer?.getData("application/codex-entity") ||
       event.dataTransfer?.getData("text/plain");
+    console.log("[GraphView] drop entityId resolved:", entityId);
     if (!entityId) return;
     event.preventDefault();
-    controller.beginExplorerChronologyPlacement(entityId, {
+    const result = controller.beginExplorerChronologyPlacement(entityId, {
       x: event.clientX,
       y: event.clientY,
     });
+    console.log("[GraphView] beginExplorerChronologyPlacement result:", result);
   }
 </script>
 
@@ -566,6 +573,7 @@
   {#if controller.cy}
     <ContextMenu cy={controller.cy} />
     <SelectionConnector cy={controller.cy} />
+    <TimelineOverlay cy={controller.cy} />
   {/if}
   {#if hasNoEntities}
     <div

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -14,6 +14,8 @@
   import EdgeEditorModal from "./graph/EdgeEditorModal.svelte";
   import GraphHUD from "./graph/GraphHUD.svelte";
   import GraphToolbar from "./graph/GraphToolbar.svelte";
+  import ChronologyDragIndicator from "./graph/ChronologyDragIndicator.svelte";
+  import SemanticPlacementPopover from "./graph/SemanticPlacementPopover.svelte";
   import { handleGraphDeleteShortcut } from "./graph/graph-keyboard";
   import { DEFAULT_SEARCH_ENTITY_ZOOM } from "./search/search-focus";
   import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
@@ -24,6 +26,21 @@
   import { GraphViewController } from "./graph/graph-view-controller.svelte";
   import { createHoverContentLoader } from "./graph/hover-content-loader";
   import EmptyState from "$lib/components/ui/EmptyState.svelte";
+  import { chronologyEdit } from "$lib/stores/chronology-edit.svelte";
+  import type { TemporalMeaning } from "chronology-engine";
+  import type { TemporalMetadata } from "schema";
+
+  type ChronologyPlacementSave = {
+    meaning: TemporalMeaning;
+    date?: TemporalMetadata;
+    start_date?: TemporalMetadata;
+    end_date?: TemporalMetadata;
+    customLabel?: string;
+    existingAnchorId?: string;
+    createNewAnchor?: boolean;
+    createEvent?: boolean;
+    eventTitle?: string;
+  };
 
   let { selectedId = $bindable(null) } = $props<{
     selectedId: string | null;
@@ -83,6 +100,12 @@
   });
 
   const handleKeyDown = async (e: KeyboardEvent) => {
+    if (e.key === "Escape" && chronologyEdit.pendingIntent) {
+      controller.restoreChronologyDragOrigin();
+      chronologyEdit.cancel();
+      return;
+    }
+
     const handledDelete = await handleGraphDeleteShortcut(e, {
       cy: controller.cy,
       selectedId: controller.selectedId,
@@ -392,6 +415,77 @@
       vault.status !== "loading" &&
       vault.allEntities.length === 0,
   );
+
+  let pendingPlacementEntity = $derived(
+    chronologyEdit.pendingEntity
+      ? (vault.entities[chronologyEdit.pendingEntity.id] ??
+          chronologyEdit.pendingEntity)
+      : null,
+  );
+  let pendingPlacementAnchor = $derived(
+    pendingPlacementEntity && chronologyEdit.drag?.anchorId
+      ? pendingPlacementEntity.temporalAnchors?.find(
+          (anchor) => anchor.id === chronologyEdit.drag?.anchorId,
+        )
+      : undefined,
+  );
+  let pendingLinkedEntityTitle = $derived(
+    pendingPlacementAnchor?.linkedEntityId
+      ? (vault.entities[pendingPlacementAnchor.linkedEntityId]?.title ?? null)
+      : null,
+  );
+  let chronologyPopoverPosition = $derived(
+    controller.getChronologyPopoverPosition(),
+  );
+
+  async function saveChronologyPlacement(detail: ChronologyPlacementSave) {
+    const entity = pendingPlacementEntity;
+    if (!entity) return;
+    chronologyEdit.buildSemanticIntent({
+      ...detail,
+      entity,
+    });
+    const saved = await chronologyEdit.confirm(entity);
+    if (saved) {
+      await controller.applyCurrentLayout(false, true, "Chronology Edit Save");
+    }
+  }
+
+  function cancelChronologyPlacement() {
+    controller.restoreChronologyDragOrigin();
+    chronologyEdit.cancel();
+  }
+
+  async function removeChronologyAnchor(anchorId: string) {
+    const entity = pendingPlacementEntity;
+    if (!entity) return;
+    const removed = await chronologyEdit.removeAnchor(entity, anchorId);
+    if (removed) {
+      await controller.applyCurrentLayout(
+        false,
+        true,
+        "Chronology Anchor Remove",
+      );
+    }
+  }
+
+  function handleCanvasDragover(event: DragEvent) {
+    if (!graph.chronologyEditMode) return;
+    if (!event.dataTransfer?.types.includes("application/codex-entity")) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }
+
+  function handleCanvasDrop(event: DragEvent) {
+    if (!graph.chronologyEditMode) return;
+    const entityId = event.dataTransfer?.getData("application/codex-entity");
+    if (!entityId) return;
+    event.preventDefault();
+    controller.beginExplorerChronologyPlacement(entityId, {
+      x: event.clientX,
+      y: event.clientY,
+    });
+  }
 </script>
 
 <div
@@ -423,13 +517,38 @@
   <div
     bind:this={container}
     data-testid="graph-canvas"
+    role="application"
+    aria-label="Graph canvas"
+    ondragover={handleCanvasDragover}
+    ondrop={handleCanvasDrop}
     class="w-full h-full {controller.graphVisible
       ? 'opacity-100'
       : 'opacity-0'} transition-opacity duration-1000"
   ></div>
 
   <GraphTooltip {hoveredEntity} hoverPosition={controller.hoverPosition} />
+  <ChronologyDragIndicator
+    service={chronologyEdit}
+    x={controller.hoverPosition?.x ?? 24}
+    y={(controller.hoverPosition?.y ?? 24) + 32}
+  />
   <EdgeEditorModal bind:editingEdge={controller.editingEdge} />
+
+  {#if chronologyEdit.pendingIntent && pendingPlacementEntity && chronologyEdit.drag}
+    <div class="pointer-events-auto">
+      <SemanticPlacementPopover
+        entity={pendingPlacementEntity}
+        targetYear={chronologyEdit.drag.targetYear}
+        existingAnchorId={chronologyEdit.drag.anchorId}
+        anchorPosition={chronologyPopoverPosition}
+        linkedEntityTitle={pendingLinkedEntityTitle}
+        conflict={chronologyEdit.conflict}
+        onSave={saveChronologyPlacement}
+        onRemove={removeChronologyAnchor}
+        onCancel={cancelChronologyPlacement}
+      />
+    </div>
+  {/if}
 
   {#if controller.cy}
     <ContextMenu cy={controller.cy} />
@@ -456,6 +575,9 @@
   {/if}
   {#if connectionModeStore.isConnecting}
     <FeatureHint hintId="connect-mode" />
+  {/if}
+  {#if graph.chronologyEditMode}
+    <FeatureHint hintId="edit-chronology" />
   {/if}
 </div>
 

--- a/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailHeader.svelte
@@ -63,6 +63,13 @@
     entity?.parent ? vault.entities[entity.parent] : null,
   );
 
+  // Only treat the sound bite as "active" (stronger accent + play affordance)
+  // when an actual audio file/data is attached - not when only a voice config
+  // or transcript exists without generated audio.
+  const hasSoundFile = $derived(
+    !!(entity?.soundBite?.audioFile || entity?.soundBite?.audioData),
+  );
+
   const handleOpenParent = () => {
     if (parentEntity) {
       vault.selectedEntityId = parentEntity.id;
@@ -127,15 +134,15 @@
           if (!alreadyOpen) soundBiteService.loadFromEntity(entity);
           modalUIStore.openSoundBite(entity.id);
         }}
-        class="transition flex items-center justify-center p-1 {entity.soundBite
+        class="transition flex items-center justify-center p-1 {hasSoundFile
           ? 'text-theme-accent hover:opacity-85'
           : 'text-[color:var(--theme-icon-default)] hover:text-[color:var(--theme-icon-active)]'}"
         aria-label="Sound bite"
-        title={entity.soundBite ? "Play sound bite" : "Generate sound bite"}
+        title={hasSoundFile ? "Play sound bite" : "Generate sound bite"}
         data-testid="sound-bite-button"
       >
         <span
-          class="{entity.soundBite
+          class="{hasSoundFile
             ? 'icon-[lucide--volume-2]'
             : 'icon-[lucide--mic]'} w-5 h-5"
         ></span>
@@ -186,9 +193,11 @@
     </div>
   </div>
 
-  <div class="md:flex md:justify-between md:items-center mb-2">
+  <div
+    class="flex flex-wrap items-start md:items-center justify-between gap-x-2 gap-y-3 mb-2"
+  >
     <div
-      class="flex items-start md:items-center gap-3 md:gap-4 md:flex-1 min-w-0 w-full"
+      class="flex items-start md:items-center gap-3 md:gap-4 flex-1 min-w-0 basis-[180px]"
     >
       {#if isEditing}
         <div class="flex flex-col gap-2 w-full mr-4">
@@ -205,7 +214,7 @@
           <h2
             class="{isFantasyTheme
               ? 'text-xl md:text-3xl font-header tracking-wider'
-              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold whitespace-normal break-words overflow-visible w-full md:truncate"
+              : 'text-xl md:text-3xl font-body tracking-wide'} font-bold break-words line-clamp-2 w-full"
             style:color={isFantasyTheme ? "var(--theme-title-ink)" : undefined}
           >
             {entity.title}{#if entity.labels?.some((l: string) => l.toLowerCase() === "past")}<sup
@@ -251,9 +260,7 @@
       {/if}
     </div>
 
-    <div
-      class="hidden md:flex items-center gap-1.5 md:gap-2 shrink-0 ml-2 md:ml-4"
-    >
+    <div class="hidden md:flex items-center gap-1.5 md:gap-2 shrink-0 ml-auto">
       {@render headerActions()}
 
       <!-- Desktop-only close button -->

--- a/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
+++ b/apps/web/src/lib/components/entity-detail/DetailStatusTab.svelte
@@ -114,6 +114,7 @@ Do not include a heading, preamble, summary, stat block, lore rewrite, secrets, 
     editType,
     editContent = $bindable(),
     editLore = $bindable(),
+    editDate = $bindable(),
     editStartDate = $bindable(),
     editEndDate = $bindable(),
     editGuestChatConfig = $bindable(),
@@ -123,6 +124,7 @@ Do not include a heading, preamble, summary, stat block, lore rewrite, secrets, 
     editType: string;
     editContent: string;
     editLore?: string;
+    editDate?: Entity["date"];
     editStartDate: Entity["start_date"];
     editEndDate: Entity["end_date"];
     editGuestChatConfig?: GuestChatConfig;
@@ -311,18 +313,22 @@ Do not include a heading, preamble, summary, stat block, lore rewrite, secrets, 
   <!-- Temporal Metadata -->
   {#if isEditing}
     <div class="space-y-4">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <TemporalEditor
-          bind:value={editStartDate}
-          label={getTemporalLabel(editType, "start")}
-          referenceValue={editEndDate}
-        />
-        <TemporalEditor
-          bind:value={editEndDate}
-          label={getTemporalLabel(editType, "end")}
-          referenceValue={editStartDate}
-        />
-      </div>
+      {#if editDate?.year !== undefined || (!editStartDate && !editEndDate)}
+        <TemporalEditor bind:value={editDate} label="Date" />
+      {:else}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <TemporalEditor
+            bind:value={editStartDate}
+            label={getTemporalLabel(editType, "start")}
+            referenceValue={editEndDate}
+          />
+          <TemporalEditor
+            bind:value={editEndDate}
+            label={getTemporalLabel(editType, "end")}
+            referenceValue={editStartDate}
+          />
+        </div>
+      {/if}
     </div>
   {/if}
 

--- a/apps/web/src/lib/components/graph/ChronologyDragIndicator.svelte
+++ b/apps/web/src/lib/components/graph/ChronologyDragIndicator.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { calendarStore } from "$lib/stores/calendar.svelte";
+  import { chronologyEdit } from "$lib/stores/chronology-edit.svelte";
+
+  let {
+    service = chronologyEdit,
+    x = 0,
+    y = 0,
+  }: {
+    service?: typeof chronologyEdit;
+    x?: number;
+    y?: number;
+  } = $props();
+
+  const label = $derived.by(() => {
+    const year = service.drag?.targetYear;
+    if (year === undefined) return "";
+    const suffix = calendarStore.config.epochLabel;
+    return suffix ? `${year} ${suffix}` : String(year);
+  });
+</script>
+
+{#if service.drag}
+  <div
+    class="pointer-events-none fixed z-50 rounded border border-feedback-warning/60 bg-theme-surface px-3 py-1 text-xs font-bold text-theme-text shadow-lg"
+    style:left={`${x}px`}
+    style:top={`${y}px`}
+    aria-live="polite"
+  >
+    <span
+      class="icon-[lucide--calendar-clock] mr-1 inline-block h-3.5 w-3.5 text-feedback-warning"
+    ></span>
+    {label}
+  </div>
+{/if}

--- a/apps/web/src/lib/components/graph/ChronologyEditToggle.svelte
+++ b/apps/web/src/lib/components/graph/ChronologyEditToggle.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { graph } from "$lib/stores/graph.svelte";
+
+  let {
+    onToggle,
+  }: {
+    onToggle?: () => void;
+  } = $props();
+
+  function toggle() {
+    graph.toggleChronologyEditMode();
+    onToggle?.();
+  }
+</script>
+
+<button
+  type="button"
+  onclick={toggle}
+  class={[
+    "inline-flex items-center gap-2 rounded border px-3 py-1.5 text-xs font-bold tracking-widest transition",
+    graph.chronologyEditMode
+      ? "border-feedback-warning/60 bg-feedback-warning/15 text-feedback-warning"
+      : "border-theme-border bg-theme-surface/90 text-theme-muted hover:border-theme-primary hover:text-theme-primary",
+  ]}
+  aria-pressed={graph.chronologyEditMode}
+  aria-label="Toggle edit chronology mode"
+  title="Edit Chronology"
+>
+  <span class="icon-[lucide--move-horizontal] h-3.5 w-3.5"></span>
+  EDIT CHRONOLOGY
+</button>

--- a/apps/web/src/lib/components/graph/GraphHUD.svelte
+++ b/apps/web/src/lib/components/graph/GraphHUD.svelte
@@ -178,16 +178,24 @@
   >
     {#if graph.timelineMode}
       <div
-        class="bg-timeline-dark/40 backdrop-blur border border-timeline-primary/30 px-3 py-1 flex items-center gap-2 text-[10px] font-mono tracking-[0.2em] text-timeline-primary shadow-lg uppercase pointer-events-auto mb-10 md:mb-0"
+        class="{graph.chronologyEditMode
+          ? 'bg-feedback-warning/15 border-feedback-warning/50 text-feedback-warning'
+          : 'bg-timeline-dark/40 border-timeline-primary/30 text-timeline-primary'} backdrop-blur border px-3 py-1 flex items-center gap-2 text-[10px] font-mono tracking-[0.2em] shadow-lg uppercase pointer-events-auto mb-10 md:mb-0"
         transition:fade
       >
-        <span class="icon-[lucide--history] w-3 h-3 animate-pulse"></span>
+        <span
+          class="{graph.chronologyEditMode
+            ? 'icon-[lucide--move-horizontal]'
+            : 'icon-[lucide--history]'} w-3 h-3 animate-pulse"
+        ></span>
         <span class="hidden md:inline"
-          >Chronological Synchrony Active ({graph.timelineAxis === "x"
-            ? "Horizontal"
-            : "Vertical"})</span
+          >{graph.chronologyEditMode
+            ? "Editing Lore Chronology"
+            : `Chronological Synchrony Active (${graph.timelineAxis === "x" ? "Horizontal" : "Vertical"})`}</span
         >
-        <span class="md:hidden">Timeline Active</span>
+        <span class="md:hidden"
+          >{graph.chronologyEditMode ? "Editing Time" : "Timeline Active"}</span
+        >
       </div>
     {/if}
 

--- a/apps/web/src/lib/components/graph/GraphHUD.svelte
+++ b/apps/web/src/lib/components/graph/GraphHUD.svelte
@@ -174,13 +174,13 @@
   {/if}
 
   <div
-    class="absolute bottom-0 left-0 flex flex-col items-start gap-2 md:gap-3"
+    class="absolute bottom-8 left-2 md:bottom-12 md:left-4 flex flex-col items-start gap-2 md:gap-3"
   >
     {#if graph.timelineMode}
       <div
         class="{graph.chronologyEditMode
           ? 'bg-feedback-warning/15 border-feedback-warning/50 text-feedback-warning'
-          : 'bg-timeline-dark/40 border-timeline-primary/30 text-timeline-primary'} backdrop-blur border px-3 py-1 flex items-center gap-2 text-[10px] font-mono tracking-[0.2em] shadow-lg uppercase pointer-events-auto mb-10 md:mb-0"
+          : 'bg-timeline-dark/40 border-timeline-primary/30 text-timeline-primary'} backdrop-blur border px-3 py-1 flex items-center gap-2 text-[10px] font-mono tracking-[0.2em] shadow-lg uppercase pointer-events-auto"
         transition:fade
       >
         <span
@@ -191,7 +191,7 @@
         <span class="hidden md:inline"
           >{graph.chronologyEditMode
             ? "Editing Lore Chronology"
-            : `Chronological Synchrony Active (${graph.timelineAxis === "x" ? "Horizontal" : "Vertical"})`}</span
+            : `Timeline Active (${graph.timelineAxis === "x" ? "Horizontal" : "Vertical"})`}</span
         >
         <span class="md:hidden"
           >{graph.chronologyEditMode ? "Editing Time" : "Timeline Active"}</span
@@ -201,7 +201,7 @@
 
     {#if isLayoutRunning}
       <div
-        class="bg-blue-900/40 backdrop-blur border border-blue-500/30 px-3 py-1 flex items-center gap-2 text-[10px] font-mono tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto mb-10 md:mb-0"
+        class="bg-blue-900/40 backdrop-blur border border-blue-500/30 px-3 py-1 flex items-center gap-2 text-[10px] font-mono tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto"
         transition:fade
       >
         <span class="icon-[lucide--cpu] w-3 h-3 animate-spin"></span>
@@ -214,7 +214,7 @@
 
     {#if connectionModeStore.isConnecting}
       <div
-        class="bg-blue-500/20 border border-blue-500/50 backdrop-blur-md px-4 py-2 rounded flex items-center gap-3 text-xs font-bold tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto mb-10 md:mb-0"
+        class="bg-blue-500/20 border border-blue-500/50 backdrop-blur-md px-4 py-2 rounded flex items-center gap-3 text-xs font-bold tracking-[0.2em] text-blue-300 shadow-lg uppercase pointer-events-auto"
         transition:fade
       >
         <span class="icon-[lucide--link] w-3.5 h-3.5 animate-pulse"></span>

--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -6,6 +6,7 @@
   import { guestStore } from "$lib/stores/guest.svelte";
   import Minimap from "./Minimap.svelte";
   import TimelineControls from "./TimelineControls.svelte";
+  import ChronologyEditToggle from "./ChronologyEditToggle.svelte";
   import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
   import { connectionModeStore } from "$lib/stores/ui/connection-mode.svelte";
   import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
@@ -98,6 +99,13 @@
       closeMenuIfMobile();
     }}
   />
+  {#if graph.timelineMode && !sessionModeStore.isGuestMode}
+    <ChronologyEditToggle
+      onToggle={() => {
+        closeMenuIfMobile();
+      }}
+    />
+  {/if}
   <div class="h-6 w-px bg-theme-border/30 mx-2 flex-shrink-0"></div>
   <div class="flex gap-1 items-center">
     <button

--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -110,14 +110,14 @@
   <div class="flex gap-1 items-center">
     <button
       class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
-      onclick={() => cy?.zoom(cy.zoom() * 1.2)}
+      onclick={() => cy?.zoom(cy.zoom() * 1.1)}
       title="Zoom In"
       aria-label="Zoom In"
       ><span class="icon-[lucide--zoom-in] w-4 h-4"></span></button
     >
     <button
       class="w-8 h-8 flex-shrink-0 flex items-center justify-center border border-theme-border bg-theme-surface/80 text-theme-primary hover:bg-theme-primary/20 hover:text-theme-text transition"
-      onclick={() => cy?.zoom(cy.zoom() / 1.2)}
+      onclick={() => cy?.zoom(cy.zoom() / 1.1)}
       title="Zoom Out"
       aria-label="Zoom Out"
       ><span class="icon-[lucide--zoom-out] w-4 h-4"></span></button

--- a/apps/web/src/lib/components/graph/GraphTooltip.svelte
+++ b/apps/web/src/lib/components/graph/GraphTooltip.svelte
@@ -24,8 +24,9 @@
 
 {#if hoveredEntity && hoverPosition}
   <div
-    class="fixed z-50 pointer-events-none bg-theme-surface/90 backdrop-blur-md border border-theme-primary/30 p-4 shadow-2xl max-w-[calc(100vw-2rem)] sm:max-w-xs overflow-hidden rounded-xl"
-    style="left: {hoverPosition.x + 20}px; top: {hoverPosition.y - 20}px;"
+    class="absolute z-50 pointer-events-none bg-theme-surface/90 backdrop-blur-md border border-theme-primary/30 p-4 shadow-2xl max-w-[calc(100vw-2rem)] sm:max-w-xs overflow-hidden rounded-xl"
+    style="left: {hoverPosition.x}px; top: {hoverPosition.y +
+      28}px; transform: translateX(-50%);"
     transition:fly={{ y: 10, duration: 200 }}
   >
     <div class="flex flex-col gap-2">

--- a/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
+++ b/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
@@ -1,0 +1,348 @@
+<script lang="ts">
+  import { computePosition, flip, offset, shift } from "@floating-ui/dom";
+  import { onMount, tick, untrack } from "svelte";
+  import TemporalEditor from "$lib/components/timeline/TemporalEditor.svelte";
+  import {
+    getMeanings,
+    validateRange,
+    type TemporalMeaning,
+  } from "chronology-engine";
+  import type { Entity, TemporalMetadata } from "schema";
+
+  let {
+    entity,
+    targetYear,
+    existingAnchorId,
+    anchorPosition,
+    linkedEntityTitle,
+    conflict = false,
+    onSave,
+    onRemove,
+    onCancel,
+  }: {
+    entity: Entity;
+    targetYear: number;
+    existingAnchorId?: string;
+    anchorPosition?: { x: number; y: number };
+    linkedEntityTitle?: string | null;
+    conflict?: boolean;
+    onSave: (detail: {
+      meaning: TemporalMeaning;
+      date?: TemporalMetadata;
+      start_date?: TemporalMetadata;
+      end_date?: TemporalMetadata;
+      customLabel?: string;
+      existingAnchorId?: string;
+      createNewAnchor?: boolean;
+      createEvent?: boolean;
+      eventTitle?: string;
+    }) => void | Promise<void>;
+    onRemove?: (anchorId: string) => void | Promise<void>;
+    onCancel: () => void;
+  } = $props();
+
+  const initialMeanings = untrack(() => getMeanings(entity.type));
+  const initialIsPrimaryRangeStart = untrack(
+    () => existingAnchorId === "primary-range-start",
+  );
+  const initialIsPrimaryRangeEnd = untrack(
+    () => existingAnchorId === "primary-range-end",
+  );
+  const initialAnchor = untrack(() =>
+    existingAnchorId
+      ? entity.temporalAnchors?.find((anchor) => anchor.id === existingAnchorId)
+      : undefined,
+  );
+  const initialSelectedId = untrack(() => {
+    if (
+      existingAnchorId === "primary-range-start" ||
+      existingAnchorId === "primary-range-end"
+    ) {
+      return initialMeanings.find((meaning) => meaning.kind === "span")?.id;
+    }
+    if (initialAnchor) {
+      return initialMeanings.find(
+        (meaning) => meaning.id === initialAnchor.type,
+      )?.id;
+    }
+    return undefined;
+  });
+  const meanings = $derived(getMeanings(entity.type));
+  const existingAnchor = $derived(
+    existingAnchorId
+      ? entity.temporalAnchors?.find((anchor) => anchor.id === existingAnchorId)
+      : undefined,
+  );
+  const isPrimaryRangeStart = $derived(
+    existingAnchorId === "primary-range-start",
+  );
+  const isPrimaryRangeEnd = $derived(existingAnchorId === "primary-range-end");
+  const editsSinglePrimaryRangeSide = $derived(
+    isPrimaryRangeStart || isPrimaryRangeEnd,
+  );
+  let selectedId = $state(
+    initialSelectedId ?? initialMeanings[0]?.id ?? "date",
+  );
+  let customLabel = $state("");
+  let startDate = $state<TemporalMetadata | undefined>(
+    (initialIsPrimaryRangeStart
+      ? untrack(() => entity.start_date)
+      : undefined) ??
+      initialAnchor?.date ??
+      initialAnchor?.start_date ??
+      untrack(() => ({ year: targetYear })),
+  );
+  let endDate = $state<TemporalMetadata | undefined>(
+    (initialIsPrimaryRangeEnd ? untrack(() => entity.end_date) : undefined) ??
+      initialAnchor?.end_date ??
+      untrack(() => ({ year: targetYear })),
+  );
+  let createNewAnchor = $state(false);
+  let createEvent = $state(false);
+  let eventTitle = $state(untrack(() => `${entity.title} - ${targetYear}`));
+  let isSaving = $state(false);
+  let popoverElement = $state<HTMLElement>();
+  let x = $state(0);
+  let y = $state(0);
+
+  const selectedMeaning = $derived(
+    meanings.find((meaning) => meaning.id === selectedId) ?? meanings[0],
+  );
+  const isSpan = $derived(selectedMeaning?.kind === "span");
+  const rangeState = $derived(
+    isSpan ? validateRange(startDate, endDate) : { valid: true as const },
+  );
+  const linkedStatus = $derived.by(() => {
+    if (!existingAnchor?.linkedEntityId) return "";
+    if (linkedEntityTitle) return `Linked event: ${linkedEntityTitle}`;
+    return "Linked event is missing. The anchor will remain editable.";
+  });
+  const writeTarget = $derived.by(() => {
+    if (createEvent) return "A new linked Event will be created.";
+    if (!selectedMeaning) return "";
+    if (selectedMeaning.target === "date")
+      return "This will update the entity date.";
+    if (
+      selectedMeaning.target === "start_date" ||
+      selectedMeaning.target === "end_date"
+    ) {
+      return "This will update the entity range.";
+    }
+    if (existingAnchorId && !createNewAnchor)
+      return "This will update the selected anchor.";
+    return "This will create a temporal anchor.";
+  });
+
+  async function save() {
+    if (isSaving || !selectedMeaning || !rangeState.valid) return;
+    isSaving = true;
+    try {
+      await onSave({
+        meaning: selectedMeaning,
+        date: isSpan || editsSinglePrimaryRangeSide ? undefined : startDate,
+        start_date: isSpan || isPrimaryRangeStart ? startDate : undefined,
+        end_date:
+          (isSpan && !editsSinglePrimaryRangeSide) || isPrimaryRangeEnd
+            ? endDate
+            : undefined,
+        customLabel: selectedMeaning.id === "custom" ? customLabel : undefined,
+        existingAnchorId,
+        createNewAnchor,
+        createEvent,
+        eventTitle,
+      });
+    } finally {
+      isSaving = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") onCancel();
+  }
+
+  function remove() {
+    if (existingAnchorId) onRemove?.(existingAnchorId);
+  }
+
+  const updatePosition = async () => {
+    if (!popoverElement || !anchorPosition) return;
+    const virtualReference = {
+      getBoundingClientRect: () =>
+        ({
+          x: anchorPosition.x,
+          y: anchorPosition.y,
+          top: anchorPosition.y,
+          left: anchorPosition.x,
+          right: anchorPosition.x,
+          bottom: anchorPosition.y,
+          width: 0,
+          height: 0,
+        }) as DOMRect,
+    };
+    const next = await computePosition(virtualReference, popoverElement, {
+      placement: "right-start",
+      middleware: [offset(12), flip(), shift({ padding: 12 })],
+    });
+    x = next.x;
+    y = next.y;
+  };
+
+  onMount(() => {
+    tick().then(updatePosition);
+  });
+
+  $effect(() => {
+    void anchorPosition?.x;
+    void anchorPosition?.y;
+    tick().then(updatePosition);
+  });
+</script>
+
+<div
+  bind:this={popoverElement}
+  class="fixed z-[70] w-80 rounded border border-theme-border bg-theme-surface p-4 text-theme-text shadow-xl"
+  role="dialog"
+  aria-labelledby="chronology-placement-title"
+  tabindex="-1"
+  onkeydown={handleKeydown}
+  style:left="{x}px"
+  style:top="{y}px"
+>
+  <div class="mb-3 flex items-start justify-between gap-3">
+    <div>
+      <h2
+        id="chronology-placement-title"
+        class="text-sm font-bold text-theme-primary"
+      >
+        Place {entity.title}
+      </h2>
+      <p class="text-xs text-theme-muted">Target year: {targetYear}</p>
+    </div>
+    <button
+      type="button"
+      class="rounded p-1 text-theme-muted hover:text-theme-primary"
+      aria-label="Cancel placement"
+      title="Cancel"
+      onclick={onCancel}
+    >
+      <span class="icon-[lucide--x] h-4 w-4"></span>
+    </button>
+  </div>
+
+  {#if entity.type === "event" && selectedMeaning?.target === "date"}
+    <p class="mb-3 text-sm">Set event date to {targetYear}?</p>
+  {:else}
+    <fieldset class="mb-3 space-y-2">
+      <legend
+        class="mb-2 text-xs font-bold uppercase tracking-widest text-theme-muted"
+      >
+        Meaning
+      </legend>
+      {#each meanings as meaning (meaning.id)}
+        <label class="flex items-center gap-2 text-sm">
+          <input type="radio" bind:group={selectedId} value={meaning.id} />
+          <span>{meaning.label}</span>
+        </label>
+      {/each}
+    </fieldset>
+  {/if}
+
+  {#if selectedMeaning?.id === "custom"}
+    <label class="mb-3 block text-xs font-bold text-theme-muted">
+      Custom label
+      <input
+        class="mt-1 w-full rounded border border-theme-border bg-theme-bg px-2 py-1 text-sm text-theme-text"
+        bind:value={customLabel}
+      />
+    </label>
+  {/if}
+
+  <div class="mb-3 space-y-2">
+    <TemporalEditor
+      bind:value={startDate}
+      label={isSpan ? "Start date" : "Date"}
+    />
+    {#if isSpan}
+      <TemporalEditor
+        bind:value={endDate}
+        label="End date"
+        referenceValue={startDate}
+      />
+    {/if}
+  </div>
+
+  {#if existingAnchorId}
+    <label class="mb-3 flex items-center gap-2 text-sm">
+      <input type="checkbox" bind:checked={createNewAnchor} />
+      <span>Create a new anchor instead</span>
+    </label>
+  {/if}
+
+  <label class="mb-3 flex items-center gap-2 text-sm">
+    <input type="checkbox" bind:checked={createEvent} />
+    <span>Create an event here</span>
+  </label>
+
+  {#if createEvent}
+    <label class="mb-3 block text-xs font-bold text-theme-muted">
+      Event title
+      <input
+        class="mt-1 w-full rounded border border-theme-border bg-theme-bg px-2 py-1 text-sm text-theme-text"
+        bind:value={eventTitle}
+      />
+    </label>
+  {/if}
+
+  {#if linkedStatus}
+    <p
+      class="mb-3 rounded border border-theme-border/60 bg-theme-bg/60 p-2 text-xs text-theme-muted"
+      data-testid="linked-anchor-status"
+    >
+      {linkedStatus}
+    </p>
+  {/if}
+
+  <p class="mb-3 text-xs text-theme-muted">{writeTarget}</p>
+  {#if conflict}
+    <p
+      class="mb-3 rounded border border-feedback-warning/50 bg-feedback-warning/10 p-2 text-xs text-feedback-warning"
+    >
+      This entity changed while the placement was open. Review it before saving.
+    </p>
+  {/if}
+  {#if !rangeState.valid}
+    <p
+      class="mb-3 rounded border border-feedback-error/50 bg-feedback-error/10 p-2 text-xs text-feedback-error"
+    >
+      {rangeState.reason}
+    </p>
+  {/if}
+
+  <div class="flex justify-end gap-2">
+    {#if existingAnchorId && onRemove}
+      <button
+        type="button"
+        class="mr-auto rounded border border-feedback-error/50 px-3 py-1.5 text-xs font-bold text-feedback-error hover:bg-feedback-error/10"
+        onclick={remove}
+      >
+        Remove
+      </button>
+    {/if}
+    <button
+      type="button"
+      class="rounded border border-theme-border px-3 py-1.5 text-xs font-bold text-theme-muted hover:text-theme-primary"
+      onclick={onCancel}
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="rounded bg-theme-primary px-3 py-1.5 text-xs font-bold text-theme-bg disabled:opacity-50"
+      disabled={isSaving || !rangeState.valid}
+      aria-busy={isSaving}
+      onclick={save}
+    >
+      Save
+    </button>
+  </div>
+</div>

--- a/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
+++ b/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
@@ -213,6 +213,27 @@
     );
     tick().then(updatePosition);
   });
+
+  $effect(() => {
+    const currentYear = targetYear;
+    const currentEntity = entity;
+    const currentAnchorId = existingAnchorId;
+
+    untrack(() => {
+      const isStart = currentAnchorId === "primary-range-start";
+      const isEnd = currentAnchorId === "primary-range-end";
+      const anchor = currentAnchorId
+        ? currentEntity.temporalAnchors?.find((a) => a.id === currentAnchorId)
+        : undefined;
+
+      startDate = (isStart ? currentEntity.start_date : undefined) ??
+        anchor?.date ??
+        anchor?.start_date ?? { year: currentYear };
+
+      endDate = (isEnd ? currentEntity.end_date : undefined) ??
+        anchor?.end_date ?? { year: currentYear };
+    });
+  });
 </script>
 
 <div

--- a/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
+++ b/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
@@ -112,6 +112,9 @@
   const rangeState = $derived(
     isSpan ? validateRange(startDate, endDate) : { valid: true as const },
   );
+  const isCustomLabelInvalid = $derived(
+    selectedMeaning?.id === "custom" && customLabel.trim() === "",
+  );
   const linkedStatus = $derived.by(() => {
     if (!existingAnchor?.linkedEntityId) return "";
     if (linkedEntityTitle) return `Linked event: ${linkedEntityTitle}`;
@@ -134,7 +137,13 @@
   });
 
   async function save() {
-    if (isSaving || !selectedMeaning || !rangeState.valid) return;
+    if (
+      isSaving ||
+      !selectedMeaning ||
+      !rangeState.valid ||
+      isCustomLabelInvalid
+    )
+      return;
     isSaving = true;
     try {
       await onSave({
@@ -317,6 +326,13 @@
       {rangeState.reason}
     </p>
   {/if}
+  {#if isCustomLabelInvalid}
+    <p
+      class="mb-3 rounded border border-feedback-error/50 bg-feedback-error/10 p-2 text-xs text-feedback-error"
+    >
+      Custom anchor label cannot be empty.
+    </p>
+  {/if}
 
   <div class="flex justify-end gap-2">
     {#if existingAnchorId && onRemove}
@@ -338,7 +354,7 @@
     <button
       type="button"
       class="rounded bg-theme-primary px-3 py-1.5 text-xs font-bold text-theme-bg disabled:opacity-50"
-      disabled={isSaving || !rangeState.valid}
+      disabled={isSaving || !rangeState.valid || isCustomLabelInvalid}
       aria-busy={isSaving}
       onclick={save}
     >

--- a/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
+++ b/apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte
@@ -197,12 +197,20 @@
   };
 
   onMount(() => {
+    console.log(
+      "[SemanticPlacementPopover] onMount, anchorPosition:",
+      anchorPosition,
+    );
     tick().then(updatePosition);
   });
 
   $effect(() => {
     void anchorPosition?.x;
     void anchorPosition?.y;
+    console.log(
+      "[SemanticPlacementPopover] position update effect, anchorPosition:",
+      anchorPosition,
+    );
     tick().then(updatePosition);
   });
 </script>

--- a/apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts
+++ b/apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts
@@ -1,0 +1,226 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+import SemanticPlacementPopover from "./SemanticPlacementPopover.svelte";
+import type { Entity } from "schema";
+
+function entity(type: string): Entity {
+  return {
+    id: `${type}-1`,
+    type,
+    title: type === "character" ? "Avel" : "The Ember Court",
+    tags: [],
+    labels: [],
+    aliases: [],
+    connections: [],
+    content: "",
+    status: "active",
+  };
+}
+
+describe("SemanticPlacementPopover", () => {
+  it("renders character meanings with begin meaning selected and write disclosure", async () => {
+    const onSave = vi.fn();
+    render(SemanticPlacementPopover, {
+      entity: entity("character"),
+      targetYear: 580,
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    expect(await screen.findByText("Born")).toBeTruthy();
+    expect(screen.getByText("Died")).toBeTruthy();
+    expect(screen.getByText("Active period")).toBeTruthy();
+    expect(screen.getByText("Reign")).toBeTruthy();
+    expect(screen.getByText("Major appearance")).toBeTruthy();
+    expect(screen.getByText("Custom anchor")).toBeTruthy();
+    expect((screen.getByLabelText("Born") as HTMLInputElement).checked).toBe(
+      true,
+    );
+    expect(screen.getByText("This will update the entity date.")).toBeTruthy();
+  });
+
+  it("renders faction-specific meanings that differ from characters", async () => {
+    render(SemanticPlacementPopover, {
+      entity: entity("faction"),
+      targetYear: 610,
+      onSave: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    expect(await screen.findByText("Founded")).toBeTruthy();
+    expect(screen.getByText("Dissolved")).toBeTruthy();
+    expect(screen.getByText("Schism")).toBeTruthy();
+    expect(screen.queryByText("Born")).toBeNull();
+  });
+
+  it("saves a selected anchor meaning and cancels on Escape without saving", async () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    const { container } = render(SemanticPlacementPopover, {
+      entity: entity("character"),
+      targetYear: 621,
+      onSave,
+      onCancel,
+    });
+
+    await fireEvent.click(await screen.findByLabelText("Major appearance"));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meaning: expect.objectContaining({ id: "majorAppearance" }),
+        date: { year: 621 },
+      }),
+    );
+
+    await fireEvent.keyDown(container.firstElementChild as HTMLElement, {
+      key: "Escape",
+    });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("blocks inverted ranges with an explanation", async () => {
+    const onSave = vi.fn();
+    render(SemanticPlacementPopover, {
+      entity: entity("note"),
+      targetYear: 600,
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    await fireEvent.click(await screen.findByLabelText("Associated period"));
+
+    expect(screen.getByText("Start date")).toBeTruthy();
+    expect(screen.getByText("End date")).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Save" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
+  it("shows linked anchor status and removes an existing anchor", async () => {
+    const onRemove = vi.fn();
+    const linkedEntity = {
+      ...entity("character"),
+      temporalAnchors: [
+        {
+          id: "appearance",
+          type: "majorAppearance",
+          date: { year: 621 },
+          linkedEntityId: "missing-event",
+        },
+      ],
+    } as Entity;
+
+    render(SemanticPlacementPopover, {
+      entity: linkedEntity,
+      targetYear: 621,
+      existingAnchorId: "appearance",
+      linkedEntityTitle: null,
+      onSave: vi.fn(),
+      onRemove,
+      onCancel: vi.fn(),
+    });
+
+    expect(
+      await screen.findByText(
+        "Linked event is missing. The anchor will remain editable.",
+      ),
+    ).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(onRemove).toHaveBeenCalledWith("appearance");
+  });
+
+  it("preselects the existing anchor meaning when editing an anchor", async () => {
+    const onSave = vi.fn();
+    const linkedEntity = {
+      ...entity("character"),
+      temporalAnchors: [
+        {
+          id: "death",
+          type: "died",
+          date: { year: 640 },
+        },
+      ],
+    } as Entity;
+
+    render(SemanticPlacementPopover, {
+      entity: linkedEntity,
+      targetYear: 641,
+      existingAnchorId: "death",
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    expect(
+      ((await screen.findByLabelText("Died")) as HTMLInputElement).checked,
+    ).toBe(true);
+    expect((screen.getByLabelText("Born") as HTMLInputElement).checked).toBe(
+      false,
+    );
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meaning: expect.objectContaining({ id: "died" }),
+        existingAnchorId: "death",
+      }),
+    );
+  });
+
+  it("saves only the edited primary range side", async () => {
+    const onSave = vi.fn();
+    const rangeEntity = {
+      ...entity("note"),
+      start_date: { year: 500 },
+      end_date: { year: 510 },
+    } as Entity;
+
+    render(SemanticPlacementPopover, {
+      entity: rangeEntity,
+      targetYear: 505,
+      existingAnchorId: "primary-range-start",
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        existingAnchorId: "primary-range-start",
+        start_date: { year: 500 },
+        end_date: undefined,
+        date: undefined,
+      }),
+    );
+  });
+
+  it("guards against duplicate saves while a save is pending", async () => {
+    let resolveSave: (() => void) | undefined;
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    render(SemanticPlacementPopover, {
+      entity: entity("character"),
+      targetYear: 580,
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    await fireEvent.click(saveButton);
+    await fireEvent.click(saveButton);
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+
+    resolveSave?.();
+  });
+});

--- a/apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts
+++ b/apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts
@@ -223,4 +223,47 @@ describe("SemanticPlacementPopover", () => {
 
     resolveSave?.();
   });
+
+  it("blocks saving and disables Save button when custom anchor label is empty", async () => {
+    const onSave = vi.fn();
+    render(SemanticPlacementPopover, {
+      entity: entity("character"),
+      targetYear: 580,
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    await fireEvent.click(await screen.findByLabelText("Custom anchor"));
+    const saveButton = screen.getByRole("button", {
+      name: "Save",
+    }) as HTMLButtonElement;
+
+    // Initially customLabel is empty, so it should be disabled
+    expect(saveButton.disabled).toBe(true);
+    expect(
+      screen.getByText("Custom anchor label cannot be empty."),
+    ).toBeTruthy();
+
+    // Fill in the label
+    const customLabelInput = screen.getByLabelText(
+      "Custom label",
+    ) as HTMLInputElement;
+    await fireEvent.input(customLabelInput, {
+      target: { value: "My Custom Anchor" },
+    });
+
+    // Now it should be enabled
+    expect(saveButton.disabled).toBe(false);
+    expect(
+      screen.queryByText("Custom anchor label cannot be empty."),
+    ).toBeNull();
+
+    // Click save
+    await fireEvent.click(saveButton);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customLabel: "My Custom Anchor",
+      }),
+    );
+  });
 });

--- a/apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts
+++ b/apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts
@@ -266,4 +266,28 @@ describe("SemanticPlacementPopover", () => {
       }),
     );
   });
+
+  it("updates local state dynamically when targetYear prop changes", async () => {
+    const onSave = vi.fn();
+    const { rerender } = render(SemanticPlacementPopover, {
+      entity: entity("character"),
+      targetYear: 580,
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    await rerender({
+      entity: entity("character"),
+      targetYear: 610,
+      onSave,
+      onCancel: vi.fn(),
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        date: { year: 610 },
+      }),
+    );
+  });
 });

--- a/apps/web/src/lib/components/graph/TimelineControls.svelte
+++ b/apps/web/src/lib/components/graph/TimelineControls.svelte
@@ -51,6 +51,7 @@
 
   const applyRange = () => {
     graph.timelineRange = { start: filterStart, end: filterEnd };
+    if (onApply) onApply(false, true, "Timeline Range Change");
   };
 </script>
 
@@ -113,7 +114,10 @@
         max="1000"
         step="50"
         bind:value={graph.timelineScale}
-        onchange={onApply}
+        onchange={() => {
+          graph.setTimelineScale(graph.timelineScale);
+          if (onApply) onApply();
+        }}
         aria-label="Timeline Scale"
         class="w-16 sm:w-20 h-1 bg-theme-border rounded-lg appearance-none cursor-pointer accent-timeline-primary focus:outline-none focus:ring-2 focus:ring-theme-primary focus:ring-offset-1 focus:ring-offset-theme-surface"
       />

--- a/apps/web/src/lib/components/graph/TimelineOverlay.svelte
+++ b/apps/web/src/lib/components/graph/TimelineOverlay.svelte
@@ -46,9 +46,26 @@
       if (year !== undefined) {
         years.push(year);
       }
+      if (e.temporalAnchors) {
+        const anchorCount = e.temporalAnchors.length;
+        for (let j = 0; j < anchorCount; j++) {
+          const anchor = e.temporalAnchors[j];
+          const aYear =
+            anchor.date?.year ??
+            anchor.start_date?.year ??
+            anchor.end_date?.year;
+          if (aYear !== undefined) {
+            years.push(aYear);
+          }
+        }
+      }
     }
 
-    return getSequentialYearPositions(years, graph.timelineScale);
+    const fallbackYear = new Date().getFullYear();
+    return getSequentialYearPositions(
+      years.length > 0 ? years : [fallbackYear],
+      graph.timelineScale,
+    );
   });
 
   let ticks = $derived(getRulerTicks(yearPositions));
@@ -126,7 +143,7 @@
           {/if}
         {/each}
 
-        <!-- Ruler Ticks -->
+        <!-- Ruler Ticks Gridlines -->
         {#each ticks as tick}
           {#if graph.timelineAxis === "x"}
             <line
@@ -138,15 +155,6 @@
               stroke-opacity={tick.isMajor ? 0.1 : 0.03}
               stroke-dasharray={tick.isMajor ? "" : "5,5"}
             />
-            <text
-              x={tick.pos + 5}
-              y="20"
-              fill="var(--color-theme-accent)"
-              fill-opacity="0.2"
-              class="text-[12px] font-mono font-bold"
-            >
-              {tick.year}
-            </text>
           {:else}
             <line
               x1="-10000"
@@ -157,15 +165,6 @@
               stroke-opacity={tick.isMajor ? 0.1 : 0.03}
               stroke-dasharray={tick.isMajor ? "" : "5,5"}
             />
-            <text
-              x="20"
-              y={tick.pos - 5}
-              fill="var(--color-theme-accent)"
-              fill-opacity="0.2"
-              class="text-[12px] font-mono font-bold"
-            >
-              {tick.year}
-            </text>
           {/if}
         {/each}
 
@@ -206,6 +205,39 @@
           {/each}
         {/if}
       </g>
+
+      <!-- Sticky Screen-Space Ruler Year Labels -->
+      {#each ticks as tick}
+        {#if graph.timelineAxis === "x"}
+          {@const screenX = tick.pos * transform.k + transform.x}
+          {#if screenX >= 0 && screenX <= (cy?.width() ?? window.innerWidth)}
+            <text
+              x={screenX + 6}
+              y="24"
+              fill="var(--color-theme-accent)"
+              fill-opacity="0.85"
+              class="text-[11px] font-mono font-bold select-none tracking-wider pointer-events-none"
+              style="text-shadow: 0 1px 3px rgba(0,0,0,0.8), 0 0 2px rgba(0,0,0,0.5);"
+            >
+              {tick.year}
+            </text>
+          {/if}
+        {:else}
+          {@const screenY = tick.pos * transform.k + transform.y}
+          {#if screenY >= 0 && screenY <= (cy?.height() ?? window.innerHeight)}
+            <text
+              x="16"
+              y={screenY - 4}
+              fill="var(--color-theme-accent)"
+              fill-opacity="0.85"
+              class="text-[11px] font-mono font-bold select-none tracking-wider pointer-events-none"
+              style="text-shadow: 0 1px 3px rgba(0,0,0,0.8), 0 0 2px rgba(0,0,0,0.5);"
+            >
+              {tick.year}
+            </text>
+          {/if}
+        {/if}
+      {/each}
     </svg>
   </div>
 {/if}

--- a/apps/web/src/lib/components/graph/TimelineOverlay.svelte
+++ b/apps/web/src/lib/components/graph/TimelineOverlay.svelte
@@ -5,6 +5,8 @@
     getRulerTicks,
     getEraRegions,
     getSequentialYearPositions,
+    getFractionalYear,
+    getQuantizedYear,
   } from "graph-engine";
   import type { Core, NodeSingular } from "cytoscape";
   import { onMount } from "svelte";
@@ -42,20 +44,20 @@
 
     for (let i = 0; i < count; i++) {
       const e = allEntities[i];
-      const year = e.date?.year ?? e.start_date?.year ?? e.end_date?.year;
+      const dateObj = e.date ?? e.start_date ?? e.end_date;
+      const year = getFractionalYear(dateObj);
       if (year !== undefined) {
-        years.push(year);
+        years.push(getQuantizedYear(year, transform.k));
       }
       if (e.temporalAnchors) {
         const anchorCount = e.temporalAnchors.length;
         for (let j = 0; j < anchorCount; j++) {
           const anchor = e.temporalAnchors[j];
-          const aYear =
-            anchor.date?.year ??
-            anchor.start_date?.year ??
-            anchor.end_date?.year;
+          const anchorDateObj =
+            anchor.date ?? anchor.start_date ?? anchor.end_date;
+          const aYear = getFractionalYear(anchorDateObj);
           if (aYear !== undefined) {
-            years.push(aYear);
+            years.push(getQuantizedYear(aYear, transform.k));
           }
         }
       }
@@ -68,7 +70,7 @@
     );
   });
 
-  let ticks = $derived(getRulerTicks(yearPositions));
+  let ticks = $derived(getRulerTicks(yearPositions, transform.k));
   let eraRegions = $derived(getEraRegions(graph.eras, yearPositions));
 
   // Extract nodes with dates for label rendering
@@ -152,8 +154,20 @@
               x2={tick.pos}
               y2="10000"
               stroke="var(--color-theme-accent)"
-              stroke-opacity={tick.isMajor ? 0.1 : 0.03}
-              stroke-dasharray={tick.isMajor ? "" : "5,5"}
+              stroke-opacity={tick.type === "year"
+                ? tick.isMajor
+                  ? 0.15
+                  : 0.08
+                : tick.type === "month"
+                  ? tick.isMajor
+                    ? 0.08
+                    : 0.04
+                  : 0.02}
+              stroke-dasharray={tick.type === "year" && tick.isMajor
+                ? ""
+                : tick.type === "month"
+                  ? "3,3"
+                  : "1,5"}
             />
           {:else}
             <line
@@ -162,8 +176,20 @@
               x2="10000"
               y2={tick.pos}
               stroke="var(--color-theme-accent)"
-              stroke-opacity={tick.isMajor ? 0.1 : 0.03}
-              stroke-dasharray={tick.isMajor ? "" : "5,5"}
+              stroke-opacity={tick.type === "year"
+                ? tick.isMajor
+                  ? 0.15
+                  : 0.08
+                : tick.type === "month"
+                  ? tick.isMajor
+                    ? 0.08
+                    : 0.04
+                  : 0.02}
+              stroke-dasharray={tick.type === "year" && tick.isMajor
+                ? ""
+                : tick.type === "month"
+                  ? "3,3"
+                  : "1,5"}
             />
           {/if}
         {/each}
@@ -213,27 +239,61 @@
           {#if screenX >= 0 && screenX <= (cy?.width() ?? window.innerWidth)}
             <text
               x={screenX + 6}
-              y="24"
+              y={tick.type === "year"
+                ? "24"
+                : tick.type === "month"
+                  ? "36"
+                  : "46"}
               fill="var(--color-theme-accent)"
-              fill-opacity="0.85"
-              class="text-[11px] font-mono font-bold select-none tracking-wider pointer-events-none"
+              fill-opacity={tick.type === "year"
+                ? tick.isMajor
+                  ? 0.85
+                  : 0.6
+                : tick.type === "month"
+                  ? tick.isMajor
+                    ? 0.7
+                    : 0.5
+                  : 0.35}
+              class="font-mono select-none tracking-wider pointer-events-none {tick.type ===
+              'year'
+                ? 'text-[11px] font-bold'
+                : tick.type === 'month'
+                  ? 'text-[9.5px] font-medium'
+                  : 'text-[8.5px] font-light'}"
               style="text-shadow: 0 1px 3px rgba(0,0,0,0.8), 0 0 2px rgba(0,0,0,0.5);"
             >
-              {tick.year}
+              {tick.label}
             </text>
           {/if}
         {:else}
           {@const screenY = tick.pos * transform.k + transform.y}
           {#if screenY >= 0 && screenY <= (cy?.height() ?? window.innerHeight)}
             <text
-              x="16"
+              x={tick.type === "year"
+                ? "16"
+                : tick.type === "month"
+                  ? "30"
+                  : "42"}
               y={screenY - 4}
               fill="var(--color-theme-accent)"
-              fill-opacity="0.85"
-              class="text-[11px] font-mono font-bold select-none tracking-wider pointer-events-none"
+              fill-opacity={tick.type === "year"
+                ? tick.isMajor
+                  ? 0.85
+                  : 0.6
+                : tick.type === "month"
+                  ? tick.isMajor
+                    ? 0.7
+                    : 0.5
+                  : 0.35}
+              class="font-mono select-none tracking-wider pointer-events-none {tick.type ===
+              'year'
+                ? 'text-[11px] font-bold'
+                : tick.type === 'month'
+                  ? 'text-[9.5px] font-medium'
+                  : 'text-[8.5px] font-light'}"
               style="text-shadow: 0 1px 3px rgba(0,0,0,0.8), 0 0 2px rgba(0,0,0,0.5);"
             >
-              {tick.year}
+              {tick.label}
             </text>
           {/if}
         {/if}

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -21,6 +21,12 @@ import {
   markSearchEntityFocusHandled,
 } from "../search/search-focus";
 import type { LocalEntity } from "$lib/stores/vault/types";
+import {
+  chronologyEdit as defaultChronologyEdit,
+  type ChronologyEditService,
+} from "$lib/stores/chronology-edit.svelte";
+import { getSequentialYearPositions } from "graph-engine";
+import type { Entity } from "schema";
 
 export interface GraphViewDependencies {
   graph: typeof graphStore;
@@ -29,6 +35,7 @@ export interface GraphViewDependencies {
   layoutUIStore: typeof layoutUIStoreType;
   connectionModeStore: typeof connectionModeStoreType;
   modalUIStore: typeof modalUIStoreType;
+  chronologyEdit?: ChronologyEditService;
 }
 
 export class GraphViewController {
@@ -75,6 +82,7 @@ export class GraphViewController {
   private searchFocusListener: ((event: Event) => void) | null = null;
 
   private deps: GraphViewDependencies;
+  private chronologyEdit: ChronologyEditService;
 
   constructor(
     options: { selectedId: string | null },
@@ -82,6 +90,7 @@ export class GraphViewController {
   ) {
     this.selectedId = options.selectedId;
     this.deps = deps;
+    this.chronologyEdit = deps.chronologyEdit ?? defaultChronologyEdit;
   }
 
   init = async (container: HTMLElement, graphStyle: any) => {
@@ -202,10 +211,89 @@ export class GraphViewController {
         "[GraphViewController] Init successful, graphVisible set to true",
       );
       this.setupEventListeners();
+      this.setupChronologyDragHandlers(instance);
     } catch (err) {
       this.deps.debugStore.error("Graph Init Failed", err);
     }
   };
+
+  private setupChronologyDragHandlers(instance: Core) {
+    instance.on("grab", "node", (_event: any) => {
+      if (
+        !this.deps.graph.timelineMode ||
+        !this.deps.graph.chronologyEditMode
+      ) {
+        return;
+      }
+      const node = _event.target;
+      const entity = this.getEntityForNode(node.id());
+      if (!entity) return;
+      const position = node.position();
+      this.chronologyEdit.beginDrag({
+        entity,
+        source: "graph",
+        anchorId: node.data("anchorId") ?? undefined,
+        originPosition: position,
+        pressPosition: position,
+        context: this.getTimelineYearContext(),
+      });
+    });
+
+    instance.on("drag", "node", (_event: any) => {
+      if (!this.deps.graph.chronologyEditMode) return;
+      const node = _event.target;
+      const position = node.position();
+      const drag = this.chronologyEdit.drag;
+      const pixelDelta =
+        this.deps.graph.timelineAxis === "y"
+          ? Math.abs(position.y - (drag?.originPosition?.y ?? position.y))
+          : Math.abs(position.x - (drag?.originPosition?.x ?? position.x));
+      this.chronologyEdit.updateDrag(
+        position,
+        this.getTimelineYearContext(),
+        pixelDelta,
+      );
+    });
+
+    instance.on("dragfree", "node", (_event: any) => {
+      if (!this.deps.graph.chronologyEditMode) return;
+      const node = _event.target;
+      const entity = this.getEntityForNode(node.id());
+      if (!entity) return;
+      this.chronologyEdit.prepareDrop(entity);
+    });
+  }
+
+  private getEntityForNode(nodeId: string): Entity | undefined {
+    const entityId = nodeId.includes("::") ? nodeId.split("::")[0] : nodeId;
+    return (this.deps.vault.entities?.[entityId] ?? undefined) as
+      | Entity
+      | undefined;
+  }
+
+  private getTimelineYearContext() {
+    const years = (this.deps.vault.allEntities as Entity[])
+      .flatMap((entity) => [
+        entity.date?.year,
+        entity.start_date?.year,
+        entity.end_date?.year,
+        ...(entity.temporalAnchors ?? []).flatMap((anchor) => [
+          anchor.date?.year,
+          anchor.start_date?.year,
+          anchor.end_date?.year,
+        ]),
+      ])
+      .filter((year): year is number => typeof year === "number");
+
+    const fallbackYear = new Date().getFullYear();
+    return {
+      yearPositions: getSequentialYearPositions(
+        years.length > 0 ? years : [fallbackYear],
+        this.deps.graph.timelineScale,
+      ),
+      axis: this.deps.graph.timelineAxis,
+    };
+  }
 
   private setupEventListeners = () => {
     window.addEventListener("resize", this.handleResize);
@@ -491,5 +579,70 @@ export class GraphViewController {
     if (this.cy && this.didFinalizeLoad) {
       this.applyCurrentLayout(false, true, "Mode Change Effect");
     }
+  };
+
+  restoreChronologyDragOrigin = () => {
+    const drag = this.chronologyEdit.drag;
+    if (!this.cy || !drag?.originPosition) return;
+    const nodeId = drag.anchorId
+      ? `${drag.entityId}::${drag.anchorId}`
+      : drag.entityId;
+    const node = this.cy.$id(nodeId);
+    if (node.length > 0) {
+      node.position(drag.originPosition);
+    }
+  };
+
+  getChronologyPopoverPosition = (): { x: number; y: number } | undefined => {
+    const drag = this.chronologyEdit.drag;
+    if (!this.cy || !drag) return undefined;
+    const nodeId = drag.anchorId
+      ? `${drag.entityId}::${drag.anchorId}`
+      : drag.entityId;
+    const node = this.cy.$id(nodeId);
+    if (node.length > 0) {
+      const rendered = node.renderedPosition();
+      const rect = this.cy.container()?.getBoundingClientRect();
+      return {
+        x: (rect?.left ?? 0) + rendered.x,
+        y: (rect?.top ?? 0) + rendered.y,
+      };
+    }
+    const rect = this.cy.container()?.getBoundingClientRect();
+    return rect ? { x: rect.left + 24, y: rect.top + 24 } : undefined;
+  };
+
+  beginExplorerChronologyPlacement = (
+    entityId: string,
+    clientPosition: { x: number; y: number },
+  ): boolean => {
+    if (
+      !this.cy ||
+      !this.deps.graph.timelineMode ||
+      !this.deps.graph.chronologyEditMode
+    ) {
+      return false;
+    }
+    const entity = this.getEntityForNode(entityId);
+    if (!entity) return false;
+
+    const container = this.cy.container();
+    if (!container) return false;
+    const rect = container.getBoundingClientRect();
+    const pan = this.cy.pan();
+    const zoom = this.cy.zoom();
+    const modelPosition = {
+      x: (clientPosition.x - rect.left - pan.x) / zoom,
+      y: (clientPosition.y - rect.top - pan.y) / zoom,
+    };
+
+    const began = this.chronologyEdit.beginDrag({
+      entity,
+      source: "explorer",
+      pressPosition: modelPosition,
+      context: this.getTimelineYearContext(),
+    });
+    if (!began) return false;
+    return this.chronologyEdit.prepareDrop(entity) !== null;
   };
 }

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -6,6 +6,7 @@ import {
   GraphImageManager,
   setupGraphEvents,
   syncGraphElements,
+  type YearPositionContext,
 } from "graph-engine";
 import { isTemporalMetadataEqual } from "$lib/utils/comparison";
 import type { graph as graphStore } from "$lib/stores/graph.svelte";
@@ -71,6 +72,7 @@ export class GraphViewController {
   private lastOrientation: "landscape" | "portrait" | null = null;
 
   private isDestroyed = false;
+  private activeDragContext: YearPositionContext | null = null;
 
   pendingSearchFocus: {
     entityId: string;
@@ -229,18 +231,20 @@ export class GraphViewController {
       const entity = this.getEntityForNode(node.id());
       if (!entity) return;
       const position = node.position();
+      this.activeDragContext = this.getTimelineYearContext();
       this.chronologyEdit.beginDrag({
         entity,
         source: "graph",
         anchorId: node.data("anchorId") ?? undefined,
         originPosition: position,
         pressPosition: position,
-        context: this.getTimelineYearContext(),
+        context: this.activeDragContext,
       });
     });
 
     instance.on("drag", "node", (_event: any) => {
-      if (!this.deps.graph.chronologyEditMode) return;
+      if (!this.deps.graph.chronologyEditMode || !this.activeDragContext)
+        return;
       const node = _event.target;
       const position = node.position();
       const drag = this.chronologyEdit.drag;
@@ -250,7 +254,7 @@ export class GraphViewController {
           : Math.abs(position.x - (drag?.originPosition?.x ?? position.x));
       this.chronologyEdit.updateDrag(
         position,
-        this.getTimelineYearContext(),
+        this.activeDragContext,
         pixelDelta,
       );
     });
@@ -261,6 +265,7 @@ export class GraphViewController {
       const entity = this.getEntityForNode(node.id());
       if (!entity) return;
       this.chronologyEdit.prepareDrop(entity);
+      this.activeDragContext = null;
     });
   }
 

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -6,6 +6,8 @@ import {
   GraphImageManager,
   setupGraphEvents,
   syncGraphElements,
+  TIMELINE_DAY_ZOOM_THRESHOLD,
+  TIMELINE_MONTH_ZOOM_THRESHOLD,
   type YearPositionContext,
 } from "graph-engine";
 import { isTemporalMetadataEqual } from "$lib/utils/comparison";
@@ -26,7 +28,11 @@ import {
   chronologyEdit as defaultChronologyEdit,
   type ChronologyEditService,
 } from "$lib/stores/chronology-edit.svelte";
-import { getSequentialYearPositions } from "graph-engine";
+import {
+  getSequentialYearPositions,
+  getFractionalYear,
+  getQuantizedYear,
+} from "graph-engine";
 import type { Entity } from "schema";
 
 export interface GraphViewDependencies {
@@ -119,6 +125,28 @@ export class GraphViewController {
         this.selectedCount = instance.$("node:selected").length;
       };
       instance.on("select unselect", "node", updateSelectionCount);
+      let lastZoomCategory = "year";
+      instance.on("zoom", () => {
+        if (!this.deps.graph.timelineMode) return;
+        const currentZoom = instance.zoom();
+        const currentCategory =
+          currentZoom < TIMELINE_MONTH_ZOOM_THRESHOLD
+            ? "year"
+            : currentZoom < TIMELINE_DAY_ZOOM_THRESHOLD
+              ? "month"
+              : "day";
+        if (currentCategory !== lastZoomCategory) {
+          lastZoomCategory = currentCategory;
+          this.applyCurrentLayout(
+            false,
+            false,
+            "Zoom Category Change",
+            false,
+            false,
+            false,
+          );
+        }
+      });
       instance.on("grab", "node", () => {
         this.hoveredEntityId = null;
         this.hoverPosition = null;
@@ -235,7 +263,7 @@ export class GraphViewController {
       const entity = this.getEntityForNode(node.id());
       if (!entity) return;
       const position = node.position();
-      this.activeDragContext = this.getTimelineYearContext();
+      this.activeDragContext = this.getTimelineYearContext(instance.zoom());
       this.chronologyEdit.beginDrag({
         entity,
         source: "graph",
@@ -280,19 +308,18 @@ export class GraphViewController {
       | undefined;
   }
 
-  private getTimelineYearContext() {
+  private getTimelineYearContext(zoom: number = 1.0) {
     const years = (this.deps.vault.allEntities as Entity[])
       .flatMap((entity) => [
-        entity.date?.year,
-        entity.start_date?.year,
-        entity.end_date?.year,
+        getFractionalYear(entity.date ?? entity.start_date ?? entity.end_date),
         ...(entity.temporalAnchors ?? []).flatMap((anchor) => [
-          anchor.date?.year,
-          anchor.start_date?.year,
-          anchor.end_date?.year,
+          getFractionalYear(
+            anchor.date ?? anchor.start_date ?? anchor.end_date,
+          ),
         ]),
       ])
-      .filter((year): year is number => typeof year === "number");
+      .filter((year): year is number => typeof year === "number")
+      .map((y) => getQuantizedYear(y, zoom));
 
     const fallbackYear = new Date().getFullYear();
     return {
@@ -382,6 +409,7 @@ export class GraphViewController {
     caller = "unknown",
     randomizeForced = false,
     hasNewNodes = false,
+    fit = true,
   ) => {
     if (!this.layoutManager) return;
 
@@ -390,11 +418,13 @@ export class GraphViewController {
         timelineMode: this.deps.graph.timelineMode,
         timelineAxis: this.deps.graph.timelineAxis,
         timelineScale: this.deps.graph.timelineScale,
-        yearPositions: this.getTimelineYearContext().yearPositions,
+        yearPositions: this.getTimelineYearContext(this.cy?.zoom() ?? 1.0)
+          .yearPositions,
         orbitMode: this.deps.graph.orbitMode,
         centralNodeId: this.deps.graph.centralNodeId,
         stableLayout: this.deps.graph.stableLayout,
         isGuest: this.deps.vault.isGuest,
+        fit,
         onLayoutStart: () => {
           this.isLayoutRunning = true;
         },

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -119,6 +119,10 @@ export class GraphViewController {
         this.selectedCount = instance.$("node:selected").length;
       };
       instance.on("select unselect", "node", updateSelectionCount);
+      instance.on("grab", "node", () => {
+        this.hoveredEntityId = null;
+        this.hoverPosition = null;
+      });
       updateSelectionCount();
 
       if (import.meta.env.DEV || (window as any).__E2E__) {
@@ -386,6 +390,7 @@ export class GraphViewController {
         timelineMode: this.deps.graph.timelineMode,
         timelineAxis: this.deps.graph.timelineAxis,
         timelineScale: this.deps.graph.timelineScale,
+        yearPositions: this.getTimelineYearContext().yearPositions,
         orbitMode: this.deps.graph.orbitMode,
         centralNodeId: this.deps.graph.centralNodeId,
         stableLayout: this.deps.graph.stableLayout,
@@ -601,6 +606,9 @@ export class GraphViewController {
   getChronologyPopoverPosition = (): { x: number; y: number } | undefined => {
     const drag = this.chronologyEdit.drag;
     if (!this.cy || !drag) return undefined;
+    if (drag.source === "explorer" && drag.dropPosition) {
+      return drag.dropPosition;
+    }
     const nodeId = drag.anchorId
       ? `${drag.entityId}::${drag.anchorId}`
       : drag.entityId;
@@ -621,14 +629,28 @@ export class GraphViewController {
     entityId: string,
     clientPosition: { x: number; y: number },
   ): boolean => {
+    console.log(
+      "[GraphViewController] beginExplorerChronologyPlacement for:",
+      entityId,
+      clientPosition,
+    );
     if (
       !this.cy ||
       !this.deps.graph.timelineMode ||
       !this.deps.graph.chronologyEditMode
     ) {
+      console.log(
+        "[GraphViewController] placement rejected: cy, timelineMode, or chronologyEditMode is missing/false",
+        {
+          cy: !!this.cy,
+          timelineMode: this.deps.graph.timelineMode,
+          chronologyEditMode: this.deps.graph.chronologyEditMode,
+        },
+      );
       return false;
     }
     const entity = this.getEntityForNode(entityId);
+    console.log("[GraphViewController] entity resolved from node ID:", entity);
     if (!entity) return false;
 
     const container = this.cy.container();
@@ -640,14 +662,23 @@ export class GraphViewController {
       x: (clientPosition.x - rect.left - pan.x) / zoom,
       y: (clientPosition.y - rect.top - pan.y) / zoom,
     };
+    console.log(
+      "[GraphViewController] modelPosition calculated:",
+      modelPosition,
+    );
 
     const began = this.chronologyEdit.beginDrag({
       entity,
       source: "explorer",
       pressPosition: modelPosition,
       context: this.getTimelineYearContext(),
+      dropPosition: clientPosition,
     });
+    console.log("[GraphViewController] beginDrag began:", began);
     if (!began) return false;
-    return this.chronologyEdit.prepareDrop(entity) !== null;
+
+    const dropIntent = this.chronologyEdit.prepareDrop(entity);
+    console.log("[GraphViewController] prepareDrop dropIntent:", dropIntent);
+    return dropIntent !== null;
   };
 }

--- a/apps/web/src/lib/components/graph/graph-view-controller.test.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.test.ts
@@ -93,6 +93,32 @@ vi.mock("graph-engine", () => {
     syncGraphElements: vi.fn(),
     getSequentialYearPositions: (years: number[], scale: number) =>
       Object.fromEntries(years.map((year, index) => [year, index * scale])),
+    getFractionalYear: (date?: {
+      year: number;
+      month?: number;
+      day?: number;
+    }) => {
+      if (!date) return undefined;
+      let val = date.year;
+      if (date.month !== undefined) {
+        val += (date.month - 1) / 12;
+        if (date.day !== undefined) {
+          val += (date.day - 1) / 365;
+        }
+      }
+      return val;
+    },
+    getQuantizedYear: (val: number, zoom: number = 1.0) => {
+      if (zoom < 3.0) {
+        return Math.floor(val);
+      } else if (zoom < 8.0) {
+        return Math.floor(val * 12) / 12;
+      } else {
+        return Math.floor(val * 365) / 365;
+      }
+    },
+    TIMELINE_MONTH_ZOOM_THRESHOLD: 3.0,
+    TIMELINE_DAY_ZOOM_THRESHOLD: 8.0,
   };
 });
 

--- a/apps/web/src/lib/components/graph/graph-view-controller.test.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.test.ts
@@ -4,8 +4,17 @@ import { GraphViewController } from "./graph-view-controller.svelte";
 
 // Mock graph-engine
 vi.mock("graph-engine", () => {
+  const handlers: Array<{
+    event: string;
+    selector: string;
+    callback: (event: any) => void;
+  }> = [];
   const mockCy = {
-    on: vi.fn(),
+    on: vi.fn((event, selector, callback) => {
+      if (typeof selector === "string" && typeof callback === "function") {
+        handlers.push({ event, selector, callback });
+      }
+    }),
     off: vi.fn(),
     destroy: vi.fn(),
     batch: vi.fn((cb) => cb?.()),
@@ -50,6 +59,11 @@ vi.mock("graph-engine", () => {
     }),
     width: vi.fn().mockReturnValue(100),
     height: vi.fn().mockReturnValue(100),
+    container: vi.fn().mockReturnValue({
+      getBoundingClientRect: vi.fn().mockReturnValue({ left: 10, top: 20 }),
+    }),
+    pan: vi.fn().mockReturnValue({ x: 5, y: 6 }),
+    zoom: vi.fn().mockReturnValue(2),
     resize: vi.fn(),
     animate: vi.fn().mockResolvedValue(undefined),
     center: vi.fn(),
@@ -71,13 +85,25 @@ vi.mock("graph-engine", () => {
   }
 
   return {
+    __handlers: handlers,
     initGraph: vi.fn().mockResolvedValue(mockCy),
     LayoutManager: vi.fn().mockImplementation(MockLayoutManager),
     GraphImageManager: vi.fn().mockImplementation(MockGraphImageManager),
     setupGraphEvents: vi.fn().mockReturnValue(vi.fn()),
     syncGraphElements: vi.fn(),
+    getSequentialYearPositions: (years: number[], scale: number) =>
+      Object.fromEntries(years.map((year, index) => [year, index * scale])),
   };
 });
+
+vi.mock("$lib/stores/chronology-edit.svelte", () => ({
+  chronologyEdit: {
+    drag: null,
+    beginDrag: vi.fn().mockReturnValue(true),
+    updateDrag: vi.fn(),
+    prepareDrop: vi.fn().mockReturnValue({ writes: {} }),
+  },
+}));
 
 describe("GraphViewController", () => {
   let deps: any;
@@ -88,6 +114,7 @@ describe("GraphViewController", () => {
       graph: {
         elements: [],
         timelineMode: false,
+        chronologyEditMode: false,
         timelineAxis: "x",
         timelineScale: 1,
         orbitMode: false,
@@ -100,6 +127,7 @@ describe("GraphViewController", () => {
         isGuest: false,
         status: "idle",
         allEntities: [],
+        entities: {},
         releaseImageUrl: vi.fn(),
         resolveImageUrl: vi.fn(),
         batchUpdate: vi.fn(),
@@ -184,5 +212,91 @@ describe("GraphViewController", () => {
 
     expect(controller.didFinalizeLoad).toBe(true);
     expect(applySpy).toHaveBeenCalledWith(true, true, "Load Finalized");
+  });
+
+  it("gates chronology drags behind timeline edit mode", async () => {
+    const { __handlers } = (await import("graph-engine")) as any;
+    const { chronologyEdit } =
+      await import("$lib/stores/chronology-edit.svelte");
+    const container = document.createElement("div");
+    await controller.init(container, {});
+
+    const grab = (__handlers as any[])
+      .filter((handler) => handler.event === "grab")
+      .at(-1);
+    grab.callback({
+      target: {
+        id: () => "e1",
+        position: () => ({ x: 0, y: 0 }),
+      },
+    });
+
+    expect(chronologyEdit.beginDrag).not.toHaveBeenCalled();
+  });
+
+  it("routes edit-mode node drops into chronology placement", async () => {
+    const { __handlers } = (await import("graph-engine")) as any;
+    const { chronologyEdit } =
+      await import("$lib/stores/chronology-edit.svelte");
+    const entity = {
+      id: "e1",
+      type: "event",
+      title: "Founding",
+      date: { year: 600 },
+    };
+    deps.graph.timelineMode = true;
+    deps.graph.chronologyEditMode = true;
+    deps.graph.timelineScale = 100;
+    deps.vault.allEntities = [entity];
+    deps.vault.entities = { e1: entity };
+    const container = document.createElement("div");
+    await controller.init(container, {});
+
+    const grab = (__handlers as any[])
+      .filter((handler) => handler.event === "grab")
+      .at(-1);
+    const dragfree = (__handlers as any[])
+      .filter((handler) => handler.event === "dragfree")
+      .at(-1);
+    const node = {
+      id: () => "e1",
+      data: () => undefined,
+      position: () => ({ x: 0, y: 0 }),
+    };
+    grab.callback({ target: node });
+    dragfree.callback({ target: node });
+
+    expect(chronologyEdit.beginDrag).toHaveBeenCalled();
+    expect(chronologyEdit.prepareDrop).toHaveBeenCalledWith(entity);
+  });
+
+  it("routes explorer drops through model-position year resolution when edit mode is active", async () => {
+    const { chronologyEdit } =
+      await import("$lib/stores/chronology-edit.svelte");
+    const entity = {
+      id: "u1",
+      type: "note",
+      title: "Undated",
+    };
+    deps.graph.timelineMode = true;
+    deps.graph.chronologyEditMode = true;
+    deps.graph.timelineScale = 100;
+    deps.vault.allEntities = [{ ...entity, date: { year: 600 } }];
+    deps.vault.entities = { u1: entity };
+    const container = document.createElement("div");
+    await controller.init(container, {});
+
+    expect(
+      controller.beginExplorerChronologyPlacement("u1", { x: 115, y: 226 }),
+    ).toBe(true);
+
+    expect(chronologyEdit.beginDrag).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity,
+        source: "explorer",
+        pressPosition: { x: 50, y: 100 },
+      }),
+    );
+    expect(chronologyEdit.prepareDrop).toHaveBeenCalledWith(entity);
   });
 });

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -283,6 +283,35 @@
   {#if type === "comparison" && comparisonData}
     <section class="border-t border-theme-border/30 py-16">
       <div class="max-w-4xl mx-auto px-6">
+        {#if data.slug === "world-anvil"}
+          <div
+            class="mb-16 p-8 border border-theme-primary/30 bg-theme-primary/5 rounded-3xl text-center max-w-2xl mx-auto"
+          >
+            <span
+              class="icon-[lucide--folder-input] text-theme-primary w-10 h-10 mb-4 block mx-auto"
+            ></span>
+            <h3
+              class="font-header font-bold text-lg uppercase tracking-wider mb-2 text-theme-primary"
+            >
+              Already have a world in World Anvil?
+            </h3>
+            <p
+              class="text-xs text-theme-muted leading-relaxed mb-6 max-w-lg mx-auto"
+            >
+              Bring it with you. Codex Cryptica can import structured
+              worldbuilding content from exported files and rebuild your lore as
+              a private local vault. Keep your articles, preserve your world
+              structure, and continue working without starting from scratch.
+            </p>
+            <a
+              href="{base}/import/world-anvil-export"
+              class="inline-flex px-6 py-3 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-md transition-all"
+            >
+              Import World Anvil Export
+            </a>
+          </div>
+        {/if}
+
         <h2
           class="text-center font-header text-2xl uppercase tracking-widest text-theme-primary mb-10"
         >

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -293,16 +293,27 @@
             <h3
               class="font-header font-bold text-lg uppercase tracking-wider mb-2 text-theme-primary"
             >
-              Already have a world in World Anvil?
+              Already have a world in World Anvil? Bring it with you.
             </h3>
-            <p
-              class="text-xs text-theme-muted leading-relaxed mb-6 max-w-lg mx-auto"
+            <div
+              class="text-xs text-theme-muted leading-relaxed mb-6 max-w-lg mx-auto space-y-4"
             >
-              Bring it with you. Codex Cryptica can import structured
-              worldbuilding content from exported files and rebuild your lore as
-              a private local vault. Keep your articles, preserve your world
-              structure, and continue working without starting from scratch.
-            </p>
+              <p>
+                Codex Cryptica can import structured worldbuilding content from
+                exported files and rebuild your lore as a private local vault.
+                Keep your articles, preserve your world structure, and continue
+                working without starting from scratch.
+              </p>
+              <p>
+                <strong>Step 1:</strong> Upload your export. &nbsp;&bull;&nbsp;
+                <strong>Step 2:</strong>
+                Review the detected entities. &nbsp;&bull;&nbsp;
+                <strong>Step 3:</strong> Start exploring your world as a graph.
+              </p>
+              <p class="font-bold text-theme-primary">
+                Your world should not feel trapped.
+              </p>
+            </div>
             <a
               href="{base}/import/world-anvil-export"
               class="inline-flex px-6 py-3 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-md transition-all"
@@ -481,13 +492,24 @@
           ? "No account required. No subscription. All your campaign notes stay on your own device."
           : "No account. No server database leaks. Just quick, private, local-first worldbuilding."}
       </p>
-      <a
-        href="{base}/"
-        class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 transition-all"
-        id="footer-cta-btn"
-      >
-        {type === "comparison" ? "Try Free Now" : "Launch Codex Cryptica"}
-      </a>
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a
+          href="{base}/"
+          class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 transition-all"
+          id="footer-cta-btn"
+        >
+          {type === "comparison" ? "Try Free Now" : "Launch Codex Cryptica"}
+        </a>
+        {#if data.slug === "world-anvil"}
+          <a
+            href="{base}/import/world-anvil-export"
+            class="px-8 py-3.5 border border-theme-primary text-theme-primary font-bold uppercase font-header tracking-widest text-xs rounded-xl hover:bg-theme-primary/10 transition-all duration-200"
+            id="footer-migration-cta"
+          >
+            Migrating from World Anvil? Import your world
+          </a>
+        {/if}
+      </div>
     </div>
   </section>
 

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -204,7 +204,7 @@
   <!-- Hero Section -->
   <section class="max-w-4xl mx-auto px-6 pt-16 pb-12 text-center flex-grow">
     <div
-      class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-mono font-bold bg-theme-primary/10 border border-theme-primary/20 text-theme-primary mb-6 uppercase tracking-wider"
+      class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-mono font-bold bg-theme-primary/10 border border-theme-primary/20 text-theme-primary mb-10 uppercase tracking-wider"
     >
       <span class="w-1.5 h-1.5 rounded-full bg-theme-primary"></span>
       {data.eyebrow ??
@@ -218,17 +218,28 @@
     >
       {data.h1}
     </h1>
+    {#if data.tagline}
+      <p
+        class="text-3xl md:text-4xl font-extrabold font-header leading-tight mb-6 tracking-wide"
+      >
+        {#each data.tagline.split("\n") as line}
+          <span class="block">{line}</span>
+        {/each}
+      </p>
+    {/if}
     <p
       class="text-lg md:text-xl text-theme-primary/80 font-header italic mb-8 max-w-2xl mx-auto"
     >
       {data.subheading}
     </p>
-    <p
-      class="text-theme-muted text-sm md:text-base leading-relaxed mb-10 max-w-3xl mx-auto"
-    >
-      {data.introText}
-    </p>
-    <div class="flex flex-wrap justify-center gap-4">
+    {#each data.introText.split("\n\n") as paragraph}
+      <p
+        class="text-theme-text/75 text-sm md:text-base leading-relaxed mb-4 last:mb-10 max-w-3xl mx-auto"
+      >
+        {paragraph}
+      </p>
+    {/each}
+    <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
       <a
         href="{base}/"
         class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 hover:-translate-y-0.5 transition-all duration-200"
@@ -246,6 +257,37 @@
         </a>
       {/if}
     </div>
+
+    {#if comparisonData?.migrationStrip}
+      <div
+        class="flex flex-col md:flex-row items-center justify-center gap-2 md:gap-3 mt-10"
+      >
+        {#each comparisonData.migrationStrip as step, idx}
+          {#if idx > 0}
+            <span
+              class="icon-[lucide--arrow-down] md:hidden text-theme-primary/65 w-4 h-4"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="icon-[lucide--arrow-right] hidden md:block self-center text-theme-primary/65 w-4 h-4"
+              aria-hidden="true"
+            ></span>
+          {/if}
+          <div
+            class="flex flex-row md:flex-col items-center gap-2 md:gap-1.5 px-5 py-3 bg-theme-surface/30 border border-theme-border/40 rounded-xl min-w-[160px] md:min-w-0"
+          >
+            <span
+              class="{step.icon} text-theme-primary w-5 h-5 shrink-0"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="text-xs font-bold uppercase tracking-wider font-header text-theme-text text-center"
+              >{step.label}</span
+            >
+          </div>
+        {/each}
+      </div>
+    {/if}
   </section>
 
   <!-- Features Grid -->
@@ -270,7 +312,7 @@
             >
               {feat.title}
             </h3>
-            <p class="text-theme-muted text-xs leading-relaxed">
+            <p class="text-theme-text/70 text-sm leading-relaxed">
               {feat.description}
             </p>
           </div>
@@ -328,22 +370,88 @@
         >
           Feature Matrix: Codex vs {comparisonData.competitorName}
         </h2>
+        <!-- Mobile: stacked cards -->
+        <div class="md:hidden space-y-3" id="comparison-table">
+          {#each comparisonData.comparisonTable as row, idx}
+            <div
+              class="border border-theme-border/60 rounded-xl bg-theme-surface/20 overflow-hidden"
+              id="feat-mobile-{idx}"
+            >
+              <div
+                class="px-4 py-2.5 bg-theme-surface/60 border-b border-theme-border/40 font-header font-bold text-xs uppercase tracking-wider"
+              >
+                {row.feature}
+              </div>
+              <div
+                class="grid grid-cols-2 divide-x divide-theme-border/30 text-xs"
+              >
+                <div class="p-3">
+                  <span
+                    class="block font-header font-bold text-[9px] uppercase tracking-wider text-theme-muted mb-1"
+                    >{comparisonData.competitorName}</span
+                  >
+                  {#if typeof row.competitorHas === "boolean"}
+                    {#if row.competitorHas}
+                      <span
+                        class="icon-[lucide--check] text-emerald-500 w-4 h-4"
+                        role="img" aria-label="Yes"
+                      ></span>
+                    {:else}
+                      <span
+                        class="icon-[lucide--x] text-rose-500 w-4 h-4"
+                        role="img" aria-label="No"
+                      ></span>
+                    {/if}
+                  {:else}
+                    <span class="text-theme-text/70 leading-snug"
+                      >{row.competitorHas}</span
+                    >
+                  {/if}
+                </div>
+                <div class="p-3">
+                  <span
+                    class="block font-header font-bold text-[9px] uppercase tracking-wider text-theme-primary mb-1"
+                    >Codex Cryptica</span
+                  >
+                  {#if typeof row.codexHas === "boolean"}
+                    {#if row.codexHas}
+                      <span
+                        class="icon-[lucide--check] text-emerald-400 w-4 h-4"
+                        role="img" aria-label="Yes"
+                      ></span>
+                    {:else}
+                      <span
+                        class="icon-[lucide--x] text-rose-500 w-4 h-4"
+                        role="img" aria-label="No"
+                      ></span>
+                    {/if}
+                  {:else}
+                    <span class="font-semibold text-theme-primary leading-snug"
+                      >{row.codexHas}</span
+                    >
+                  {/if}
+                </div>
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <!-- Desktop: table -->
         <div
-          class="overflow-x-auto border border-theme-border/60 rounded-2xl shadow-sm"
+          class="hidden md:block overflow-x-auto border border-theme-border/60 rounded-2xl shadow-sm"
         >
-          <table
-            class="w-full text-left border-collapse bg-theme-surface/20"
-            id="comparison-table"
-          >
+          <table class="w-full text-left border-collapse bg-theme-surface/20">
             <thead>
               <tr
                 class="border-b border-theme-border/60 bg-theme-surface/60 font-header text-xs uppercase tracking-wider"
               >
-                <th class="p-4 font-bold">Feature</th>
-                <th class="p-4 font-bold text-theme-muted"
+                <th class="px-4 py-4 pl-5 font-bold">Feature</th>
+                <th class="px-4 py-4 pl-5 font-bold text-theme-muted"
                   >{comparisonData.competitorName}</th
                 >
-                <th class="p-4 font-bold text-theme-primary">Codex Cryptica</th>
+                <th class="px-4 py-4 pl-5 font-bold text-theme-primary"
+                  >Codex Cryptica</th
+                >
               </tr>
             </thead>
             <tbody class="text-xs">
@@ -392,16 +500,26 @@
           </table>
         </div>
         <div
-          class="mt-8 p-6 bg-theme-surface/40 border border-theme-border/60 rounded-2xl shadow-sm text-center"
+          class="mt-8 p-8 md:p-10 bg-theme-surface/40 border border-theme-border/60 rounded-2xl shadow-sm text-center"
         >
           <h3
-            class="font-header font-bold text-sm uppercase tracking-wider text-theme-primary mb-2"
+            class="font-header font-bold text-sm uppercase tracking-wider text-theme-primary mb-4"
           >
             The Verdict
           </h3>
-          <p class="text-xs leading-relaxed text-theme-muted">
-            {comparisonData.verdict}
-          </p>
+          <div class="space-y-3">
+            {#each comparisonData.verdict.split("\n\n") as para, idx}
+              <p
+                class="leading-relaxed text-theme-text/80"
+                class:text-base={idx === 0}
+                class:font-semibold={idx === 0}
+                class:text-sm={idx > 0}
+                class:text-theme-muted={idx > 0}
+              >
+                {para}
+              </p>
+            {/each}
+          </div>
         </div>
       </div>
     </section>

--- a/apps/web/src/lib/components/timeline/TemporalPicker.svelte
+++ b/apps/web/src/lib/components/timeline/TemporalPicker.svelte
@@ -91,6 +91,10 @@
     untrack(() => toDateSelection(value, referenceValue)),
   );
 
+  $effect(() => {
+    activeSelection = toDateSelection(value, referenceValue);
+  });
+
   let directDateInput = $state("");
   let directDateError = $state("");
   let isDirectDateEditing = $state(false);

--- a/apps/web/src/lib/components/zen/ZenContent.proposals.test.ts
+++ b/apps/web/src/lib/components/zen/ZenContent.proposals.test.ts
@@ -2,13 +2,14 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("ZenContent proposals wiring", () => {
-  it("renders DetailProposals in the content area instead of a separate bonds section", () => {
+  it("renders DetailProposals and EntityProposals in the content area instead of a separate bonds section", () => {
     const source = readFileSync(
       `${process.cwd()}/src/lib/components/zen/ZenContent.svelte`,
       "utf8",
     );
 
     expect(source).toContain("DetailProposals");
+    expect(source).toContain("EntityProposals");
     expect(source).toContain("entityId={entity?.id}");
     expect(source).not.toContain("showConnections");
     expect(source).not.toContain("themeStore.jargon.connections_header");

--- a/apps/web/src/lib/components/zen/ZenContent.svelte
+++ b/apps/web/src/lib/components/zen/ZenContent.svelte
@@ -6,6 +6,7 @@
   import TemporalEditor from "$lib/components/timeline/TemporalEditor.svelte";
   import { revisionService } from "$lib/services/RevisionService.svelte";
   import DetailProposals from "$lib/components/entity-detail/proposals/DetailProposals.svelte";
+  import EntityProposals from "$lib/components/entity-detail/EntityProposals.svelte";
   import ConnectionEditor from "$lib/components/connections/ConnectionEditor.svelte";
   import { isEntityVisible, type Entity } from "schema";
   import Autocomplete from "$lib/components/ui/Autocomplete.svelte";
@@ -670,5 +671,9 @@
     {/if}
 
     <DetailProposals isEditing={editState.isEditing} entityId={entity?.id} />
+    <EntityProposals
+      content={entity?.content || ""}
+      isEditing={editState.isEditing}
+    />
   </div>
 </div>

--- a/apps/web/src/lib/components/zen/ZenSidebar.svelte
+++ b/apps/web/src/lib/components/zen/ZenSidebar.svelte
@@ -15,7 +15,6 @@
 
   import { debugStore } from "$lib/stores/debug.svelte";
   import Autocomplete from "$lib/components/ui/Autocomplete.svelte";
-  import EntityProposals from "$lib/components/entity-detail/EntityProposals.svelte";
 
   let editingConnectionTarget = $state<string | null>(null);
   let isAddingConnection = $state(false);
@@ -850,15 +849,6 @@
           <p class="text-xs text-theme-muted italic">No known connections.</p>
         {/if}
       </div>
-
-      {#if entity}
-        <div class="px-0">
-          <EntityProposals
-            content={entity.content || ""}
-            isEditing={editState.isEditing}
-          />
-        </div>
-      {/if}
     {/if}
 
     {#if editState.isEditing && !vault.isGuest}

--- a/apps/web/src/lib/config/help-content.ts
+++ b/apps/web/src/lib/config/help-content.ts
@@ -391,6 +391,13 @@ export const FEATURE_HINTS: Record<string, FeatureHint> = {
       "Organize your world hierarchically. Drag and drop entities in the explorer to nest them under parents (e.g. putting a tavern inside a city). Expand/collapse nodes using the chevron. When you delete a parent, its children are promoted to the root level. Cycle detection prevents recursive loop errors.",
     icon: "icon-[lucide--folder-tree]",
   },
+  "edit-chronology": {
+    id: "edit-chronology",
+    title: "Edit Chronology",
+    content:
+      "Timeline edit mode changes story dates. Drag an entity along the timeline, review what the placement means, then Save or Cancel before anything is written.",
+    icon: "icon-[lucide--calendar-clock]",
+  },
   "entity-auto-link": {
     id: "entity-auto-link",
     title: "Entity Links in Content",

--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -735,18 +735,18 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       },
       {
         feature: "Collaboration and subscribers",
-        competitorHas: "Strong paid features",
+        competitorHas: "Strong, built-in community features",
         codexHas: "Local-first, single-user focused",
       },
       {
-        feature: "Offline compatibility",
-        competitorHas: "No, cloud-based",
-        codexHas: "Yes",
+        feature: "Storage location",
+        competitorHas: "Remote hosted database",
+        codexHas: "Your browser / Local Markdown vault",
       },
       {
-        feature: "Local-first storage",
-        competitorHas: "No",
-        codexHas: "Yes",
+        feature: "Offline compatibility",
+        competitorHas: "No (Cloud-dependent)",
+        codexHas: "Yes (100% offline functional)",
       },
       {
         feature: "Native Markdown files",
@@ -755,18 +755,23 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       },
       {
         feature: "Full world export",
-        competitorHas: "Paid Guild feature",
-        codexHas: "Local files by default",
+        competitorHas: "Paid feature (ZIP/JSON/HTML)",
+        codexHas: "Local files by default (No lock-in)",
       },
       {
         feature: "Private worlds",
-        competitorHas: "Paid feature",
+        competitorHas: "Paid feature (Guild Tiers)",
         codexHas: "Private by default",
       },
       {
         feature: "AI assistance",
-        competitorHas: "Not core / unclear",
-        codexHas: "Optional Gemini-powered assistance",
+        competitorHas: "Third-party / Platform-dependent",
+        codexHas: "Optional Gemini-powered assistance (BYO Key)",
+      },
+      {
+        feature: "Session performance",
+        competitorHas: "Cloud-dependent performance",
+        codexHas: "Local-first performance",
       },
       {
         feature: "Graph-based lore exploration",
@@ -776,7 +781,7 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       {
         feature: "Price",
         competitorHas: "Freemium / paid tiers",
-        codexHas: "Free and open source",
+        codexHas: "Free (Source Available)",
       },
     ],
     verdict:
@@ -785,7 +790,7 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       {
         question: "Is Codex Cryptica completely free?",
         answer:
-          "Yes, Codex is free and open-source. There are no paywalls or storage restrictions on your local campaigns.",
+          "Yes, Codex is free and source-available. There are no paywalls or storage restrictions on your local campaigns.",
       },
       {
         question: "How do players access my Codex campaign?",

--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -18,6 +18,8 @@ export interface SEOPageData {
   }>;
   /** Hero badge text. Defaults to "100% Local-First Campaign Wiki". */
   eyebrow?: string;
+  /** Large emotional tagline rendered between h1 and subheading. Use \n to split lines. */
+  tagline?: string;
   /** Optional second button in the hero. */
   secondaryCtaText?: string;
   secondaryCtaHref?: string;
@@ -33,6 +35,8 @@ export interface SEOComparisonPageData extends SEOPageData {
     codexHas: boolean | string;
   }>;
   verdict: string;
+  /** Optional migration path strip shown below the hero CTAs. */
+  migrationStrip?: Array<{ icon: string; label: string }>;
 }
 
 export const solutions: Record<string, SEOPageData> = {
@@ -688,14 +692,14 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     competitorName: "World Anvil",
     title: "Codex Cryptica vs World Anvil: Private vs Cloud Worldbuilding",
     description:
-      "Compare Codex Cryptica and World Anvil. Choose between a hosted collaborative worldbuilding platform and private local-first Markdown vaults.",
-    h1: "Codex Cryptica vs World Anvil",
-    subheading:
-      "Choose hosted worldbuilding and publishing, or private local-first worldbuilding that runs in your browser.",
+      "Compare Codex Cryptica and World Anvil. Discover the differences between local-first privacy and online subscription-based worldbuilding.",
+    eyebrow: "Codex Cryptica vs World Anvil",
+    h1: "Your World Is Yours.",
+    subheading: "No subscriptions. No cloud lock-in.",
     introText:
-      "World Anvil is a powerful cloud-based worldbuilding suite for writers, GMs, and lore-heavy projects. Codex Cryptica takes a different path: your world lives in a local vault, works offline, opens fast, and can be explored as a graph with optional AI assistance.\n\nIf you want a hosted public wiki, reader-facing presentation, and collaboration features, World Anvil may be the better fit.\nIf you want privacy, portability, offline access, and direct control over your files, Codex Cryptica is built for that.",
+      "Import your World Anvil export and keep building. Your lore lives as local Markdown files — yours to keep, edit, and explore as a connected graph.",
     ctaText: "Get Free Local Vault",
-    secondaryCtaText: "Import Existing Lore",
+    secondaryCtaText: "Import World Anvil Export",
     secondaryCtaHref: "/import/world-anvil-export",
     keywords: [
       "codex cryptica vs world anvil",
@@ -704,93 +708,83 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     ],
     features: [
       {
-        title: "Local-First Storage",
+        title: "Bring Your World Anvil Export",
         description:
-          "Your campaign notes stay in your browser or local vault. Codex does not store your world in a remote hosted database.",
-        icon: "icon-[lucide--lock]",
+          "Already have years of lore in World Anvil? Import your export and pick up where you left off — no copy-pasting, no rebuilding from scratch.",
+        icon: "icon-[lucide--package-open]",
       },
       {
-        title: "Offline Session Running",
+        title: "Your Lore, Your Files",
         description:
-          "Run sessions at the table, on a plane, or in remote areas. Everything functions 100% offline-ready without latency.",
+          "Your world wiki is saved as plain Markdown files on your own device. No vendor lock-in, no export gatekeeping, no account required.",
+        icon: "icon-[lucide--file-text]",
+      },
+      {
+        title: "Core Vault Works Offline",
+        description:
+          "Write, search, and explore your campaign graph without an internet connection. No server latency at the game table.",
         icon: "icon-[lucide--wifi-off]",
       },
-      {
-        title: "Graph-Based Exploration",
-        description:
-          "Understand complex lore relationships visually. Wiki-link connections automatically build an interactive campaign graph.",
-        icon: "icon-[lucide--git-fork]",
-      },
+    ],
+    migrationStrip: [
+      { icon: "icon-[lucide--cloud-download]", label: "World Anvil Export" },
+      { icon: "icon-[lucide--file-text]", label: "Plain Markdown Vault" },
+      { icon: "icon-[lucide--network]", label: "Interactive Entity Graph" },
     ],
     comparisonTable: [
       {
-        feature: "Hosted web publishing",
-        competitorHas: "Yes",
-        codexHas: "No / limited",
-      },
-      {
-        feature: "Public world presentation",
-        competitorHas: "Strong",
-        codexHas: "Basic / not the focus",
-      },
-      {
-        feature: "Collaboration and subscribers",
-        competitorHas: "Strong, built-in community features",
-        codexHas: "Local-first, single-user focused",
-      },
-      {
         feature: "Storage location",
-        competitorHas: "Remote hosted database",
-        codexHas: "Your browser / Local Markdown vault",
+        competitorHas: "Remote hosted platform",
+        codexHas: "Browser storage / local Markdown vault",
       },
       {
-        feature: "Offline compatibility",
-        competitorHas: "No (Cloud-dependent)",
-        codexHas: "Yes (100% offline functional)",
+        feature: "Offline core workflow",
+        competitorHas: "Cloud-dependent",
+        codexHas: "Yes — core vault works offline",
       },
       {
-        feature: "Native Markdown files",
+        feature: "Native local Markdown vault",
         competitorHas: "No",
         codexHas: "Yes",
       },
       {
-        feature: "Full world export",
-        competitorHas: "Paid feature (ZIP/JSON/HTML)",
-        codexHas: "Local files by default (No lock-in)",
+        feature: "World export",
+        competitorHas: "Guild feature for full world export",
+        codexHas: "Local files by default",
       },
       {
         feature: "Private worlds",
-        competitorHas: "Paid feature (Guild Tiers)",
+        competitorHas: "Guild (paid) feature",
         codexHas: "Private by default",
       },
       {
         feature: "AI assistance",
-        competitorHas: "Third-party / Platform-dependent",
-        codexHas: "Optional Gemini-powered assistance (BYO Key)",
-      },
-      {
-        feature: "Session performance",
-        competitorHas: "Cloud-dependent performance",
-        codexHas: "Local-first performance",
+        competitorHas: "External AI tools / not local-vault focused",
+        codexHas: "Optional BYO-key vault-aware assistance",
       },
       {
         feature: "Graph-based lore exploration",
-        competitorHas: "Limited / wiki-link based",
+        competitorHas: "Wiki-link/article based",
         codexHas: "Core feature",
       },
       {
         feature: "Price",
         competitorHas: "Freemium / paid tiers",
-        codexHas: "Free (Source Available)",
+        codexHas: "Free, source-available",
       },
     ],
     verdict:
-      "Choose World Anvil if you want a hosted, collaborative worldbuilding platform with strong publishing, presentation, and community features. Choose Codex Cryptica if you want your campaign world stored locally, available offline, easy to back up, and explorable as a private AI-assisted knowledge graph.",
+      "Your world should not feel trapped.\n\nChoose Codex Cryptica if you want full ownership of your lore, offline-first access, plain Markdown files, and no subscription fees.\n\nChoose World Anvil if hosted publishing, subscriber features, public presentation, and community wikis are your priority.",
     faq: [
       {
         question: "Is Codex Cryptica completely free?",
         answer:
-          "Yes, Codex is free and source-available. There are no paywalls or storage restrictions on your local campaigns.",
+          "Yes, Codex is free and open-source. There are no paywalls or storage restrictions on your local campaigns.",
+      },
+      {
+        question: "Can I import my World Anvil content?",
+        answer:
+          "Yes. Export your world from World Anvil and import it directly into Codex Cryptica. Your articles become local Markdown files you own outright.",
       },
       {
         question: "How do players access my Codex campaign?",

--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -688,13 +688,15 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     competitorName: "World Anvil",
     title: "Codex Cryptica vs World Anvil: Private vs Cloud Worldbuilding",
     description:
-      "Compare Codex Cryptica and World Anvil. Discover the differences between local-first privacy and online subscription-based worldbuilding.",
+      "Compare Codex Cryptica and World Anvil. Choose between a hosted collaborative worldbuilding platform and private local-first Markdown vaults.",
     h1: "Codex Cryptica vs World Anvil",
     subheading:
-      "Choose between private local vaults and online cloud worldbuilding.",
+      "Choose hosted worldbuilding and publishing, or private local-first worldbuilding that runs in your browser.",
     introText:
-      "World Anvil is a cloud-based suite for worldbuilding, but it stores all your notes on remote servers and locks advanced features behind monthly paywalls. Codex Cryptica provides a modern local-first alternative that is 100% free, private, and runs entirely in your browser with offline support.",
+      "World Anvil is a powerful cloud-based worldbuilding suite for writers, GMs, and lore-heavy projects. Codex Cryptica takes a different path: your world lives in a local vault, works offline, opens fast, and can be explored as a graph with optional AI assistance.\n\nIf you want a hosted public wiki, reader-facing presentation, and collaboration features, World Anvil may be the better fit.\nIf you want privacy, portability, offline access, and direct control over your files, Codex Cryptica is built for that.",
     ctaText: "Get Free Local Vault",
+    secondaryCtaText: "Import Existing Lore",
+    secondaryCtaHref: "/import/world-anvil-export",
     keywords: [
       "codex cryptica vs world anvil",
       "world anvil alternative",
@@ -702,58 +704,83 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     ],
     features: [
       {
-        title: "100% Client-Side Privacy",
+        title: "Local-First Storage",
         description:
-          "Your campaign notes remain fully private, encrypted by the sandbox, and are never sent to remote databases.",
-        icon: "icon-[lucide--shield-alert]",
+          "Your campaign notes stay in your browser or local vault. Codex does not store your world in a remote hosted database.",
+        icon: "icon-[lucide--lock]",
       },
       {
-        title: "Offline Autonomy",
+        title: "Offline Session Running",
         description:
-          "Work on your campaign at the gaming table, on a plane, or in cabin retreats without requiring internet connection.",
+          "Run sessions at the table, on a plane, or in remote areas. Everything functions 100% offline-ready without latency.",
         icon: "icon-[lucide--wifi-off]",
       },
       {
-        title: "Standard Markdown Files",
+        title: "Graph-Based Exploration",
         description:
-          "Your world wiki is saved as readable files on your computer. No vendor lock-in or database extraction limits.",
-        icon: "icon-[lucide--file-text]",
+          "Understand complex lore relationships visually. Wiki-link connections automatically build an interactive campaign graph.",
+        icon: "icon-[lucide--git-fork]",
       },
     ],
     comparisonTable: [
       {
-        feature: "Offline Compatibility",
-        competitorHas: "No (Cloud only)",
+        feature: "Hosted web publishing",
+        competitorHas: "Yes",
+        codexHas: "No / limited",
+      },
+      {
+        feature: "Public world presentation",
+        competitorHas: "Strong",
+        codexHas: "Basic / not the focus",
+      },
+      {
+        feature: "Collaboration and subscribers",
+        competitorHas: "Strong paid features",
+        codexHas: "Local-first, single-user focused",
+      },
+      {
+        feature: "Offline compatibility",
+        competitorHas: "No, cloud-based",
         codexHas: "Yes",
       },
       {
-        feature: "Data Privacy & Local Storage",
-        competitorHas: "No (Hosted)",
-        codexHas: "Yes",
-      },
-      {
-        feature: "Price",
-        competitorHas: "Paid tier for privacy/large assets",
-        codexHas: "100% Free & Open Source",
-      },
-      {
-        feature: "Page Load Speed",
-        competitorHas: "Slow (Server dependent)",
-        codexHas: "Instant (Zero-lag local)",
-      },
-      {
-        feature: "No-Setup AI Assistance",
-        competitorHas: "No (Behind paywall)",
-        codexHas: "Yes",
-      },
-      {
-        feature: "Markdown & Folder Sync",
+        feature: "Local-first storage",
         competitorHas: "No",
         codexHas: "Yes",
       },
+      {
+        feature: "Native Markdown files",
+        competitorHas: "No",
+        codexHas: "Yes",
+      },
+      {
+        feature: "Full world export",
+        competitorHas: "Paid Guild feature",
+        codexHas: "Local files by default",
+      },
+      {
+        feature: "Private worlds",
+        competitorHas: "Paid feature",
+        codexHas: "Private by default",
+      },
+      {
+        feature: "AI assistance",
+        competitorHas: "Not core / unclear",
+        codexHas: "Optional Gemini-powered assistance",
+      },
+      {
+        feature: "Graph-based lore exploration",
+        competitorHas: "Limited / wiki-link based",
+        codexHas: "Core feature",
+      },
+      {
+        feature: "Price",
+        competitorHas: "Freemium / paid tiers",
+        codexHas: "Free and open source",
+      },
     ],
     verdict:
-      "For creators who want total control over their creative property, fast load times, and offline access, Codex Cryptica is the ideal choice. Choose World Anvil if you prefer hosting collaborative wikis directly on their web servers.",
+      "Choose World Anvil if you want a hosted, collaborative worldbuilding platform with strong publishing, presentation, and community features. Choose Codex Cryptica if you want your campaign world stored locally, available offline, easy to back up, and explorable as a private AI-assisted knowledge graph.",
     faq: [
       {
         question: "Is Codex Cryptica completely free?",

--- a/apps/web/src/lib/content/blog/lore-oracle-not-the-author.md
+++ b/apps/web/src/lib/content/blog/lore-oracle-not-the-author.md
@@ -17,89 +17,61 @@ keywords:
 publishedAt: 2026-06-06T10:00:00Z
 ---
 
-# The Lore Oracle Is Not the Author: How Codex Cryptica Uses AI Responsibly
+# The Lore Oracle Is Not the Author
 
-## RPG creators are right to be sceptical of AI
+The Lore Oracle is not here to write your world for you.
 
-There is a version of AI-assisted worldbuilding that is genuinely bad. You have probably seen it: generic fantasy slop, confident fabrications, prose that smooths every edge off your carefully built setting. NPCs who suddenly have canon you never wrote. A dragon that shows up in your city because the model thought it would be interesting.
+It is here to help your world answer back — to surface connections you forgot, flag gaps you haven't filled, and suggest ideas you can reject, rewrite, or steal wholesale. Your authorship stays intact. The Oracle just makes the archive smarter.
 
-The scepticism in RPG and worldbuilding communities toward AI tools is not irrational. It is usually a response to specific, real failures: tools that override the creator's voice, that invent facts without flagging them, that treat the setting as a prompt rather than as a living structure the GM has spent months building.
+## Why this matters
 
-Codex Cryptica does not ask you to ignore those concerns. It was built with them in mind.
+Most AI tools for worldbuilding are built around generation. Put in a prompt, get out a world. That model has a problem: it produces content that sounds plausible but isn't yours. Generic kingdoms. Familiar politics. Prose that smooths over every unusual edge in your setting.
 
-## Codex Cryptica starts with your world, not with AI
+The scepticism toward AI in RPG and worldbuilding communities is usually a response to exactly this. AI that invents canon. AI that flattens the setting. AI that generates a confidence-maxed answer when "I don't know, the GM hasn't decided yet" would have been more honest.
 
-The foundation of Codex Cryptica is your vault. Your notes, your entities, your session logs, your maps and timelines. These live as local files on your own device. No cloud account required. No vendor holds your lore.
+Codex Cryptica is built differently. The vault is the source of truth. The Oracle works from what you have already written.
 
-AI is a layer on top of that foundation, not a replacement for it.
+## What the Oracle actually does
 
-The Lore Oracle — Codex Cryptica's AI assistant — works from context you have already created. It reads your entities, your notes, your established relationships. It knows the things you have told it because they are in your vault. It does not invent a kingdom you never mentioned and silently add it to your world.
+Here is what it is useful for:
 
-## The Lore Oracle is an assistant, not an author
+**Finding what you've forgotten.** Ask which factions haven't appeared in sessions for months. Ask what was established about a location you're returning to. The Oracle reads your vault — it doesn't invent context.
 
-Think of the Lore Oracle as a scribe, an indexer, a researcher, and a brainstorming partner. It is not the GM. It is not the author of your setting. It does not own your world.
+**Spotting gaps and contradictions.** If your notes say a city was destroyed in session 4 and a character references visiting it in session 12, that's worth knowing. Pattern-finding across a large archive is exactly the kind of task that exhausts human attention and costs the Oracle nothing.
 
-When the Lore Oracle drafts something, it is making a suggestion based on what is already there. You review it. You edit it. You accept it or discard it. Until you accept a draft, it is not canon.
+**Connecting entities.** Ask what connects a minor NPC to the main antagonist, drawing only from what's already in your world. The answer surfaces lore you wrote and forgot, not lore the model fabricated.
 
-This is the core of how Codex Cryptica handles AI: the creator decides what is real in the world.
+**Drafting, not deciding.** Ask the Oracle to propose three possible motivations for an underdeveloped faction. It will. Those proposals are marked as suggestions — draft material that doesn't touch your canon until you accept it. You pick one, discard the rest, or ignore all of them and write something better.
 
-## What AI can actually help with
+**Prep support.** Recap last session. Summarise an entity's arc. Draft a player-facing handout from your private notes. These are friction-reduction tasks, not creative replacements.
 
-Used well, the Lore Oracle is genuinely useful for the kinds of tasks that take time without requiring creative judgement:
+## What it does not do
 
-- **Summarising session notes.** Paste in messy bullet points from last night's session and get a structured recap you can share with players or file in the archive.
-- **Drafting entity entries.** You have a minor NPC with three lines of notes. The Lore Oracle can expand that into a structured entry based on what you already know about the faction, region, and tone of your setting.
-- **Finding connections.** Ask the Oracle what connects two entities in your vault. It can surface links you have written but forgotten, and suggest consequences that follow from your established lore.
-- **Generating names and variants.** Give it naming conventions from your existing factions and ask for more. It stays consistent because it works from what you have.
-- **Preparing session recaps.** Turn your session log into a summary in your world's voice, suitable for a campaign journal or player handout.
-- **Creating art prompts.** Pull together descriptions from saved entities into a prompt for an image generator, drawing directly from your vault's own canon.
+The Oracle does not override canon. If you've established that resurrection is impossible in your setting, it doesn't casually suggest the party raise a dead king as a solution.
 
-The language matters here: suggest, draft, surface, summarise, organise. These are the things the Lore Oracle does well. It is not making creative decisions for you. It is reducing friction on the tasks that slow you down.
+It does not silently add facts. Generated content is marked as draft. Nothing becomes part of your world without your review.
 
-## What AI should not do
+It does not replace judgement. The Oracle doesn't know what your players find interesting, what tone you're going for this arc, or what trade-offs you've already made in your setting's design. You do.
 
-This is equally important.
-
-The Lore Oracle should not override canon. If you have established that magic is rare in your setting, the Oracle should not casually introduce a wizard school.
-
-It should not silently invent important facts. Generated material that has not been reviewed should be clearly marked as a draft.
-
-It should not replace the GM's judgement. The Oracle does not know which direction the campaign should go, what the players will find interesting, or what trade-offs you want to make in your world's design. You do.
-
-It should not flatten your setting into generic tropes. A setting built around unusual cosmology, invented languages, or unconventional power structures is exactly the kind of thing AI tends to sand down. The Oracle works from your vault to stay grounded in what you have actually built.
-
-And it should never be required. The Lore Oracle is an optional feature. If you want to ignore it entirely, Codex Cryptica should still be a complete and useful tool.
+It does not need to be used. Codex Cryptica is a campaign and worldbuilding manager without the Oracle. The knowledge graph, the entity archive, the timeline, the session log — none of that requires AI. The Oracle is an optional layer. Turning it off removes a feature, not functionality.
 
 ## Drafts are not canon
 
-It helps to think in terms of four categories:
+This is worth making explicit.
 
-| Type                 | What it means                                     |
-| -------------------- | ------------------------------------------------- |
-| **Canon**            | Saved world facts created or accepted by you      |
-| **Draft**            | AI-generated material you have not yet reviewed   |
-| **Oracle inference** | A suggested interpretation based on existing lore |
-| **Loose idea**       | Brainstorming material with no authority          |
+When the Oracle generates something, it produces a **draft** — a suggestion based on the context in your vault. Drafts live separately from your saved entities and world facts until you accept them. Accepting a draft makes it canon. Discarding it removes it. There is no ambiguity about what your world contains.
 
-Drafts are not canon until you accept them. This is not a small detail. It is the difference between an AI assistant that amplifies your work and one that contaminates it.
+The distinction matters because most AI anxiety in creative communities is about contamination: the AI-generated detail that sneaks into the setting and can't easily be removed. Codex Cryptica treats this as a design constraint, not an edge case.
 
-When you review a draft and accept it, it becomes part of your vault — your archive, your record, your world. When you discard it, it disappears. The Oracle does not argue. It does not add it back.
+## The thing the Oracle is actually good at
 
-## Codex Cryptica still matters when AI is disabled
+Your world is large. You wrote most of it months ago. The session is tomorrow.
 
-Codex Cryptica is a campaign and worldbuilding manager first. The knowledge graph, the entity archive, the timeline, the session log, the import tools, the offline-first vault — none of these require AI. They exist because organised lore is useful regardless of how it was written.
+The Oracle is good at being the part of your brain that remembers everything. It can read the whole vault, hold it in context, and answer questions about it faster than you can flip through notes. That is genuinely useful. That is the actual pitch.
 
-AI is an optional layer that can make certain parts of the workflow faster. But the tool is not built around AI. It is built around your world.
+It is not "AI writes your world." It is "AI helps your world answer back."
 
-This matters for trust. A tool that works without AI is one that respects your workflow, your privacy choices, and your relationship to technology. If you want to use the Lore Oracle, it is there. If you do not, you are not missing anything fundamental.
-
-## AI is useful when it knows its place
-
-The best AI tools in creative work are the ones that are genuinely subordinate to the creator. They suggest, not decide. They draft, not publish. They assist with the parts of the work that feel like overhead, and stay out of the parts that require judgement.
-
-Codex Cryptica uses AI because it can be useful. It limits AI because your world matters.
-
-The Lore Oracle is not the author of your campaign. You are. The Oracle is just trying to help you find your notes.
+The GM stays the author. The Oracle is a very well-read research assistant who has read every note in the archive and will never pretend to know something it doesn't.
 
 ---
 

--- a/apps/web/src/lib/content/blog/lore-oracle-not-the-author.md
+++ b/apps/web/src/lib/content/blog/lore-oracle-not-the-author.md
@@ -1,0 +1,106 @@
+---
+id: lore-oracle-not-the-author
+slug: lore-oracle-not-the-author
+title: "How Codex Cryptica Uses AI Responsibly in RPG Worldbuilding"
+description: "Codex Cryptica uses AI as an optional assistant for RPG worldbuilding, keeping the creator in control and treating AI suggestions as drafts, not canon."
+keywords:
+  [
+    "responsible AI worldbuilding",
+    "AI RPG tools",
+    "AI campaign manager",
+    "AI worldbuilding tool",
+    "RPG worldbuilding AI",
+    "GM AI assistant",
+    "Codex Cryptica AI",
+    "AI campaign prep",
+  ]
+publishedAt: 2026-06-06T10:00:00Z
+---
+
+# The Lore Oracle Is Not the Author: How Codex Cryptica Uses AI Responsibly
+
+## RPG creators are right to be sceptical of AI
+
+There is a version of AI-assisted worldbuilding that is genuinely bad. You have probably seen it: generic fantasy slop, confident fabrications, prose that smooths every edge off your carefully built setting. NPCs who suddenly have canon you never wrote. A dragon that shows up in your city because the model thought it would be interesting.
+
+The scepticism in RPG and worldbuilding communities toward AI tools is not irrational. It is usually a response to specific, real failures: tools that override the creator's voice, that invent facts without flagging them, that treat the setting as a prompt rather than as a living structure the GM has spent months building.
+
+Codex Cryptica does not ask you to ignore those concerns. It was built with them in mind.
+
+## Codex Cryptica starts with your world, not with AI
+
+The foundation of Codex Cryptica is your vault. Your notes, your entities, your session logs, your maps and timelines. These live as local files on your own device. No cloud account required. No vendor holds your lore.
+
+AI is a layer on top of that foundation, not a replacement for it.
+
+The Lore Oracle — Codex Cryptica's AI assistant — works from context you have already created. It reads your entities, your notes, your established relationships. It knows the things you have told it because they are in your vault. It does not invent a kingdom you never mentioned and silently add it to your world.
+
+## The Lore Oracle is an assistant, not an author
+
+Think of the Lore Oracle as a scribe, an indexer, a researcher, and a brainstorming partner. It is not the GM. It is not the author of your setting. It does not own your world.
+
+When the Lore Oracle drafts something, it is making a suggestion based on what is already there. You review it. You edit it. You accept it or discard it. Until you accept a draft, it is not canon.
+
+This is the core of how Codex Cryptica handles AI: the creator decides what is real in the world.
+
+## What AI can actually help with
+
+Used well, the Lore Oracle is genuinely useful for the kinds of tasks that take time without requiring creative judgement:
+
+- **Summarising session notes.** Paste in messy bullet points from last night's session and get a structured recap you can share with players or file in the archive.
+- **Drafting entity entries.** You have a minor NPC with three lines of notes. The Lore Oracle can expand that into a structured entry based on what you already know about the faction, region, and tone of your setting.
+- **Finding connections.** Ask the Oracle what connects two entities in your vault. It can surface links you have written but forgotten, and suggest consequences that follow from your established lore.
+- **Generating names and variants.** Give it naming conventions from your existing factions and ask for more. It stays consistent because it works from what you have.
+- **Preparing session recaps.** Turn your session log into a summary in your world's voice, suitable for a campaign journal or player handout.
+- **Creating art prompts.** Pull together descriptions from saved entities into a prompt for an image generator, drawing directly from your vault's own canon.
+
+The language matters here: suggest, draft, surface, summarise, organise. These are the things the Lore Oracle does well. It is not making creative decisions for you. It is reducing friction on the tasks that slow you down.
+
+## What AI should not do
+
+This is equally important.
+
+The Lore Oracle should not override canon. If you have established that magic is rare in your setting, the Oracle should not casually introduce a wizard school.
+
+It should not silently invent important facts. Generated material that has not been reviewed should be clearly marked as a draft.
+
+It should not replace the GM's judgement. The Oracle does not know which direction the campaign should go, what the players will find interesting, or what trade-offs you want to make in your world's design. You do.
+
+It should not flatten your setting into generic tropes. A setting built around unusual cosmology, invented languages, or unconventional power structures is exactly the kind of thing AI tends to sand down. The Oracle works from your vault to stay grounded in what you have actually built.
+
+And it should never be required. The Lore Oracle is an optional feature. If you want to ignore it entirely, Codex Cryptica should still be a complete and useful tool.
+
+## Drafts are not canon
+
+It helps to think in terms of four categories:
+
+| Type                 | What it means                                     |
+| -------------------- | ------------------------------------------------- |
+| **Canon**            | Saved world facts created or accepted by you      |
+| **Draft**            | AI-generated material you have not yet reviewed   |
+| **Oracle inference** | A suggested interpretation based on existing lore |
+| **Loose idea**       | Brainstorming material with no authority          |
+
+Drafts are not canon until you accept them. This is not a small detail. It is the difference between an AI assistant that amplifies your work and one that contaminates it.
+
+When you review a draft and accept it, it becomes part of your vault — your archive, your record, your world. When you discard it, it disappears. The Oracle does not argue. It does not add it back.
+
+## Codex Cryptica still matters when AI is disabled
+
+Codex Cryptica is a campaign and worldbuilding manager first. The knowledge graph, the entity archive, the timeline, the session log, the import tools, the offline-first vault — none of these require AI. They exist because organised lore is useful regardless of how it was written.
+
+AI is an optional layer that can make certain parts of the workflow faster. But the tool is not built around AI. It is built around your world.
+
+This matters for trust. A tool that works without AI is one that respects your workflow, your privacy choices, and your relationship to technology. If you want to use the Lore Oracle, it is there. If you do not, you are not missing anything fundamental.
+
+## AI is useful when it knows its place
+
+The best AI tools in creative work are the ones that are genuinely subordinate to the creator. They suggest, not decide. They draft, not publish. They assist with the parts of the work that feel like overhead, and stay out of the parts that require judgement.
+
+Codex Cryptica uses AI because it can be useful. It limits AI because your world matters.
+
+The Lore Oracle is not the author of your campaign. You are. The Oracle is just trying to help you find your notes.
+
+---
+
+_Codex Cryptica is a local-first campaign and worldbuilding manager. [Try it free](/app) — no account required._

--- a/apps/web/src/lib/content/help/edit-chronology.md
+++ b/apps/web/src/lib/content/help/edit-chronology.md
@@ -1,0 +1,14 @@
+---
+id: edit-chronology
+title: Edit Chronology
+labels:
+  - Graph
+  - Timeline
+rank: 18
+---
+
+Timeline Mode can show dated entries in chronological order. Edit Chronology turns that view into a careful editing tool.
+
+When Edit Chronology is on, dragging an entry along the timeline does not save immediately. The graph first asks what the placement means, such as setting an Event date, recording when a Character was born, or adding a custom moment. Save writes structured date information to the entry. Cancel or Escape leaves the entry unchanged.
+
+Use this mode when you want the graph to change lore. Keep it off when you only want to inspect the timeline.

--- a/apps/web/src/lib/services/ai/prompts/visual-distillation.test.ts
+++ b/apps/web/src/lib/services/ai/prompts/visual-distillation.test.ts
@@ -15,6 +15,12 @@ describe("visual-distillation prompts", () => {
       expect(result).toContain("cat");
       expect(result).toContain("dark world");
       expect(result).toContain("Visual Canon Interpreter");
+      expect(result).toContain("let the name infer an indication");
+      expect(result).toContain("Bashir al-Qadir");
+      expect(result).toContain("Michal Swanson");
+      expect(result).toContain("James Le Foy");
+      expect(result).toContain("Harald blåtann");
+      expect(result).toContain("Francesco Pancho");
     });
   });
 

--- a/apps/web/src/lib/services/ai/prompts/visual-distillation.ts
+++ b/apps/web/src/lib/services/ai/prompts/visual-distillation.ts
@@ -16,7 +16,7 @@ Search the vault context for established:
 - art direction
 - visual motifs
 - faction aesthetics
-- cultural styling
+- cultural styling, ethnicity, or heritage (if there's no clear ethnicity indication for the entity, let the name infer an indication, e.g. "Bashir al-Qadir" suggests Middle Eastern, "Michal Swanson" suggests English, "James Le Foy" suggests French, "Harald blåtann" suggests northern/vikingish, "Francesco Pancho" suggests Spanish/Latino, etc.)
 - architecture and heraldry
 - materials and symbols
 - clothing traditions
@@ -33,6 +33,7 @@ Priority order:
 
 If established visual direction exists, preserve it consistently.
 If no direct guidance exists, infer stylistically from related vault records, maintain internal consistency, and avoid generic fantasy defaults.
+If there is no clear ethnicity or cultural origin indication for the entity, let the name infer an indication (e.g. "Bashir al-Qadir" is probably a Middle Eastern guy, "Michal Swanson" is English, "James Le Foy" is French, "Harald blåtann" is northern/vikingish, "Francesco Pancho" is Spanish/Latino, etc.).
 
 Visual identity is part of canonical continuity. 
 

--- a/apps/web/src/lib/stores/chronology-edit.svelte.test.ts
+++ b/apps/web/src/lib/stores/chronology-edit.svelte.test.ts
@@ -1,0 +1,497 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  (global as any).$state = (v: any) => v;
+});
+
+vi.mock("./vault.svelte", () => ({
+  vault: {
+    entities: {},
+    updateEntity: vi.fn(),
+    createEntity: vi.fn(),
+    addConnection: vi.fn(),
+  },
+}));
+
+import { ChronologyEditService } from "./chronology-edit.svelte";
+import type { Entity } from "schema";
+
+function makeVault(entities: Record<string, Entity>) {
+  return {
+    entities,
+    updateEntity: vi.fn().mockResolvedValue(true),
+    createEntity: vi.fn().mockResolvedValue("event-new"),
+    addConnection: vi.fn().mockResolvedValue(true),
+    deleteEntity: vi.fn().mockResolvedValue(true),
+  };
+}
+
+describe("ChronologyEditService", () => {
+  it("tracks grab, drag, drop, and confirms an event date write", async () => {
+    const entity = {
+      id: "e1",
+      type: "event",
+      title: "Founding",
+      date: { year: 601 },
+    } as Entity;
+    const vault = makeVault({ e1: entity });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    expect(
+      service.beginDrag({
+        entity,
+        pressPosition: 0,
+        context: { yearPositions: { 601: 0, 605: 100 } },
+      }),
+    ).toBe(true);
+    service.updateDrag(100, { yearPositions: { 601: 0, 605: 100 } });
+    const intent = service.prepareDrop(entity);
+
+    expect(intent?.writes).toEqual({ date: { year: 605 } });
+    await service.confirm(entity);
+    expect(vault.updateEntity).toHaveBeenCalledWith("e1", {
+      date: { year: 605 },
+    });
+  });
+
+  it("persists structured event dates without graph coordinates", async () => {
+    const entity = {
+      id: "e1",
+      type: "event",
+      title: "Founding",
+      date: { year: 601 },
+      metadata: { coordinates: { x: 12, y: 18 } },
+    } as Entity;
+    const vault = makeVault({ e1: entity });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 601: 0, 605: 100 } },
+    });
+    service.updateDrag(100, { yearPositions: { 601: 0, 605: 100 } });
+    service.prepareDrop(entity);
+    await service.confirm(entity);
+
+    expect(vault.updateEntity).toHaveBeenCalledWith("e1", {
+      date: { year: 605 },
+    });
+    expect(vault.updateEntity.mock.calls[0][1]).not.toHaveProperty("metadata");
+  });
+
+  it("cancels without writing", () => {
+    const entity = {
+      id: "e1",
+      type: "event",
+      title: "Founding",
+      date: { year: 601 },
+    } as Entity;
+    const vault = makeVault({ e1: entity });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 601: 0, 605: 100 } },
+    });
+    service.prepareDrop(entity);
+    service.cancel();
+
+    expect(service.drag).toBeNull();
+    expect(vault.updateEntity).not.toHaveBeenCalled();
+  });
+
+  it("derives span gestures and rejects inverted ranges", () => {
+    const entity = { id: "n1", type: "note", title: "War" } as Entity;
+    const service = new ChronologyEditService({
+      vault: makeVault({ n1: entity }) as any,
+    });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 100,
+      context: { yearPositions: { 500: 0, 600: 100 } },
+    });
+    service.updateDrag(0, { yearPositions: { 500: 0, 600: 100 } }, 100);
+
+    expect(service.drag?.gestureKind).toBe("span");
+    expect(service.prepareDrop(entity)).toBeNull();
+    expect(service.error).toContain("End date");
+  });
+
+  it("derives span gestures into start and end date writes", () => {
+    const entity = { id: "n1", type: "note", title: "War" } as Entity;
+    const service = new ChronologyEditService({
+      vault: makeVault({ n1: entity }) as any,
+    });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 500: 0, 600: 100 } },
+    });
+    service.updateDrag(100, { yearPositions: { 500: 0, 600: 100 } }, 100);
+    const intent = service.prepareDrop(entity);
+
+    expect(service.drag?.gestureKind).toBe("span");
+    expect(intent?.writes).toEqual({
+      start_date: { year: 500 },
+      end_date: { year: 600 },
+    });
+  });
+
+  it("moves an existing range as a whole span by the dragged year delta", () => {
+    const entity = {
+      id: "n1",
+      type: "note",
+      title: "War",
+      start_date: { year: 500 },
+      end_date: { year: 510 },
+    } as Entity;
+    const service = new ChronologyEditService({
+      vault: makeVault({ n1: entity }) as any,
+    });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 500: 0, 505: 100 } },
+    });
+    service.updateDrag(100, { yearPositions: { 500: 0, 505: 100 } }, 100);
+    const intent = service.prepareDrop(entity);
+
+    expect(intent?.writes).toEqual({
+      start_date: { year: 505 },
+      end_date: { year: 515 },
+    });
+  });
+
+  it("writes only the dragged range edge handle", () => {
+    const entity = {
+      id: "n1",
+      type: "note",
+      title: "War",
+      start_date: { year: 500 },
+      end_date: { year: 510 },
+    } as Entity;
+    const service = new ChronologyEditService({
+      vault: makeVault({ n1: entity }) as any,
+    });
+
+    service.beginDrag({
+      entity,
+      anchorId: "primary-range-start",
+      pressPosition: 0,
+      context: { yearPositions: { 490: 0 } },
+    });
+    const intent = service.prepareDrop(entity);
+
+    expect(intent?.writes).toEqual({ start_date: { year: 490 } });
+  });
+
+  it("saves non-event semantic placements as anchors without changing primary fields", async () => {
+    const entity = {
+      id: "c1",
+      type: "character",
+      title: "Avel",
+      date: { year: 580 },
+    } as Entity;
+    const vault = makeVault({ c1: entity });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 621: 0 } },
+    });
+    service.buildSemanticIntent({
+      entity,
+      meaning: {
+        id: "majorAppearance",
+        label: "Major appearance",
+        kind: "point",
+        target: "anchor",
+        anchorType: "majorAppearance",
+      },
+      date: { year: 621 },
+    });
+    await service.confirm(entity);
+
+    expect(vault.updateEntity).toHaveBeenCalledWith("c1", {
+      temporalAnchors: [
+        expect.objectContaining({
+          type: "majorAppearance",
+          date: { year: 621 },
+        }),
+      ],
+    });
+    expect(vault.updateEntity.mock.calls[0][1]).not.toHaveProperty("date");
+  });
+
+  it("updates one grabbed anchor or creates a new anchor without mutating siblings", async () => {
+    const entity = {
+      id: "c1",
+      type: "character",
+      title: "Avel",
+      date: { year: 580 },
+      temporalAnchors: [
+        { id: "born-extra", type: "born", date: { year: 580 } },
+        { id: "appearance", type: "majorAppearance", date: { year: 621 } },
+      ],
+    } as Entity;
+    const vault = makeVault({ c1: entity });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    service.beginDrag({
+      entity,
+      anchorId: "appearance",
+      pressPosition: 0,
+      context: { yearPositions: { 630: 0 } },
+    });
+    service.buildSemanticIntent({
+      entity,
+      meaning: {
+        id: "majorAppearance",
+        label: "Major appearance",
+        kind: "point",
+        target: "anchor",
+        anchorType: "majorAppearance",
+      },
+      date: { year: 630 },
+      existingAnchorId: "appearance",
+    });
+    await service.confirm(entity);
+
+    expect(vault.updateEntity.mock.calls[0][1].temporalAnchors).toEqual([
+      { id: "born-extra", type: "born", date: { year: 580 } },
+      { id: "appearance", type: "majorAppearance", date: { year: 630 } },
+    ]);
+
+    const vaultForAdd = makeVault({ c1: entity });
+    const addService = new ChronologyEditService({ vault: vaultForAdd as any });
+    addService.beginDrag({
+      entity,
+      anchorId: "appearance",
+      pressPosition: 0,
+      context: { yearPositions: { 640: 0 } },
+    });
+    addService.buildSemanticIntent({
+      entity,
+      meaning: {
+        id: "majorAppearance",
+        label: "Major appearance",
+        kind: "point",
+        target: "anchor",
+        anchorType: "majorAppearance",
+      },
+      date: { year: 640 },
+      existingAnchorId: "appearance",
+      createNewAnchor: true,
+    });
+    await addService.confirm(entity);
+
+    expect(
+      vaultForAdd.updateEntity.mock.calls[0][1].temporalAnchors,
+    ).toHaveLength(3);
+    expect(
+      vaultForAdd.updateEntity.mock.calls[0][1].temporalAnchors[1],
+    ).toEqual({
+      id: "appearance",
+      type: "majorAppearance",
+      date: { year: 621 },
+    });
+  });
+
+  it("surfaces conflicts and does not overwrite newer temporal metadata", async () => {
+    const baseline = {
+      id: "e1",
+      type: "event",
+      title: "Founding",
+      date: { year: 601 },
+    } as Entity;
+    const current = { ...baseline, date: { year: 602 } } as Entity;
+    const vault = makeVault({ e1: current });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    service.beginDrag({
+      entity: baseline,
+      pressPosition: 0,
+      context: { yearPositions: { 601: 0, 605: 100 } },
+    });
+    service.updateDrag(100, { yearPositions: { 601: 0, 605: 100 } });
+    service.prepareDrop(baseline);
+
+    expect(await service.confirm(baseline)).toBe(false);
+    expect(service.conflict).toBe(true);
+    expect(vault.updateEntity).not.toHaveBeenCalled();
+  });
+
+  it("creates linked events additively", async () => {
+    const entity = {
+      id: "c1",
+      type: "character",
+      title: "Avel",
+      date: { year: 580 },
+    } as Entity;
+    const vault = makeVault({ c1: entity });
+    const service = new ChronologyEditService({
+      vault: vault as any,
+      now: () => 1,
+    });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 621: 0 } },
+    });
+    service.buildSemanticIntent({
+      entity,
+      meaning: {
+        id: "majorAppearance",
+        label: "Major appearance",
+        kind: "point",
+        target: "anchor",
+        anchorType: "majorAppearance",
+      },
+      date: { year: 621 },
+      createEvent: true,
+      eventTitle: "Avel - 621",
+    });
+
+    await service.confirm(entity);
+
+    expect(vault.createEntity).toHaveBeenCalledWith("event", "Avel - 621", {
+      date: { year: 621 },
+    });
+    expect(vault.updateEntity).toHaveBeenCalledWith("c1", {
+      temporalAnchors: [
+        {
+          id: "linked-event-1",
+          type: "majorAppearance",
+          date: { year: 621 },
+          linkedEntityId: "event-new",
+        },
+      ],
+    });
+    expect(vault.addConnection).toHaveBeenCalledWith(
+      "c1",
+      "event-new",
+      "related_to",
+    );
+  });
+
+  it("rolls back a linked event when source anchoring fails", async () => {
+    const entity = { id: "c1", type: "character", title: "Avel" } as Entity;
+    const vault = makeVault({ c1: entity });
+    vault.updateEntity.mockRejectedValueOnce(new Error("write failed"));
+    const service = new ChronologyEditService({
+      vault: vault as any,
+      now: () => 1,
+    });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 621: 0 } },
+    });
+    service.buildSemanticIntent({
+      entity,
+      meaning: {
+        id: "majorAppearance",
+        label: "Major appearance",
+        kind: "point",
+        target: "anchor",
+        anchorType: "majorAppearance",
+      },
+      date: { year: 621 },
+      createEvent: true,
+      eventTitle: "Avel - 621",
+    });
+
+    expect(await service.confirm(entity)).toBe(false);
+    expect(vault.createEntity).toHaveBeenCalled();
+    expect(vault.deleteEntity).toHaveBeenCalledWith("event-new");
+    expect(service.error).toBe("write failed");
+  });
+
+  it("removes one temporal anchor without removing sibling anchors", async () => {
+    const entity = {
+      id: "c1",
+      type: "character",
+      title: "Avel",
+      temporalAnchors: [
+        { id: "birth", type: "born", date: { year: 580 } },
+        { id: "appearance", type: "majorAppearance", date: { year: 621 } },
+      ],
+    } as Entity;
+    const vault = makeVault({ c1: entity });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    expect(await service.removeAnchor(entity, "appearance")).toBe(true);
+
+    expect(vault.updateEntity).toHaveBeenCalledWith("c1", {
+      temporalAnchors: [{ id: "birth", type: "born", date: { year: 580 } }],
+    });
+  });
+
+  it("writes a date for a previously undated entity so reload data can enter timeline mode", async () => {
+    const entity = { id: "n1", type: "note", title: "Loose note" } as Entity;
+    const vault = makeVault({ n1: entity });
+    vault.updateEntity.mockImplementation(async (id, patch) => {
+      vault.entities[id] = { ...vault.entities[id], ...patch } as Entity;
+      return true;
+    });
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 700: 0 } },
+    });
+    service.buildSemanticIntent({
+      entity,
+      meaning: {
+        id: "associatedDate",
+        label: "Associated date",
+        kind: "point",
+        target: "date",
+      },
+      date: { year: 700 },
+    });
+
+    expect(await service.confirm(entity)).toBe(true);
+    const reloadedEntity = vault.entities.n1;
+    expect(reloadedEntity.date).toEqual({ year: 700 });
+  });
+
+  it("clears stale errors when cancelling an edit", async () => {
+    const entity = { id: "e1", type: "event", title: "Founding" } as Entity;
+    const vault = makeVault({ e1: entity });
+    vault.updateEntity.mockRejectedValue(new Error("write failed"));
+    const service = new ChronologyEditService({ vault: vault as any });
+
+    service.beginDrag({
+      entity,
+      pressPosition: 0,
+      context: { yearPositions: { 700: 0 } },
+    });
+    service.buildSemanticIntent({
+      entity,
+      meaning: {
+        id: "date",
+        label: "Date",
+        kind: "point",
+        target: "date",
+      },
+      date: { year: 700 },
+    });
+
+    expect(await service.confirm(entity)).toBe(false);
+    expect(service.error).toBe("write failed");
+
+    service.cancel();
+
+    expect(service.error).toBeNull();
+  });
+});

--- a/apps/web/src/lib/stores/chronology-edit.svelte.ts
+++ b/apps/web/src/lib/stores/chronology-edit.svelte.ts
@@ -21,6 +21,7 @@ export interface ChronologyDrag {
   pressYear: number;
   targetYear: number;
   gestureKind: ChronologyGestureKind;
+  dropPosition?: { x: number; y: number };
 }
 
 export interface ChronologyEditDependencies {
@@ -69,6 +70,7 @@ export class ChronologyEditService {
     originPosition?: { x: number; y: number };
     pressPosition: number | { x: number; y: number };
     context: YearPositionContext;
+    dropPosition?: { x: number; y: number };
   }): boolean {
     const year = this.deps.resolveYear(args.pressPosition, args.context);
     if (year === null) return false;
@@ -86,6 +88,7 @@ export class ChronologyEditService {
       pressYear: year,
       targetYear: year,
       gestureKind: "point",
+      dropPosition: args.dropPosition,
     };
     return true;
   }

--- a/apps/web/src/lib/stores/chronology-edit.svelte.ts
+++ b/apps/web/src/lib/stores/chronology-edit.svelte.ts
@@ -233,6 +233,8 @@ export class ChronologyEditService {
     try {
       if (this.pendingIntent.createEvent) {
         let createdId: string | null = null;
+        const originalAnchors = entity.temporalAnchors ?? [];
+        let updatedSourceEntity = false;
         try {
           createdId = await this.deps.vault!.createEntity(
             "event",
@@ -241,7 +243,7 @@ export class ChronologyEditService {
           );
           await this.deps.vault!.updateEntity(entity.id, {
             temporalAnchors: [
-              ...(entity.temporalAnchors ?? []),
+              ...originalAnchors,
               {
                 id: `linked-event-${this.deps.now().toString(36)}`,
                 type: this.pendingIntent.createEvent.anchorType,
@@ -250,12 +252,18 @@ export class ChronologyEditService {
               },
             ],
           });
+          updatedSourceEntity = true;
           await this.deps.vault?.addConnection?.(
             entity.id,
             createdId,
             this.pendingIntent.createEvent.connectionType,
           );
         } catch (error) {
+          if (updatedSourceEntity) {
+            await this.deps.vault!.updateEntity(entity.id, {
+              temporalAnchors: originalAnchors,
+            });
+          }
           if (createdId) {
             await this.deps.vault?.deleteEntity?.(createdId);
           }

--- a/apps/web/src/lib/stores/chronology-edit.svelte.ts
+++ b/apps/web/src/lib/stores/chronology-edit.svelte.ts
@@ -73,7 +73,7 @@ export class ChronologyEditService {
     const year = this.deps.resolveYear(args.pressPosition, args.context);
     if (year === null) return false;
 
-    this.baseline = structuredClone(args.entity);
+    this.baseline = structuredClone($state.snapshot(args.entity));
     this.pendingEntity = args.entity;
     this.pendingIntent = null;
     this.conflict = false;
@@ -287,7 +287,7 @@ export class ChronologyEditService {
   }
 
   async removeAnchor(entity: Entity, anchorId: string): Promise<boolean> {
-    this.baseline ??= structuredClone(entity);
+    this.baseline ??= structuredClone($state.snapshot(entity));
     const current = this.deps.vault?.entities?.[entity.id] as
       | Entity
       | undefined;

--- a/apps/web/src/lib/stores/chronology-edit.svelte.ts
+++ b/apps/web/src/lib/stores/chronology-edit.svelte.ts
@@ -1,0 +1,324 @@
+import {
+  buildIntent,
+  detectConflict,
+  getBeginMeaning,
+  removeAnchor,
+  validateRange,
+  type PlacementIntent,
+  type TemporalMeaning,
+} from "chronology-engine";
+import { getYearForPosition, type YearPositionContext } from "graph-engine";
+import type { Entity, TemporalMetadata } from "schema";
+import { vault as defaultVault } from "./vault.svelte";
+
+export type ChronologyGestureKind = "point" | "span";
+
+export interface ChronologyDrag {
+  source: "graph" | "explorer";
+  entityId: string;
+  anchorId?: string;
+  originPosition?: { x: number; y: number };
+  pressYear: number;
+  targetYear: number;
+  gestureKind: ChronologyGestureKind;
+}
+
+export interface ChronologyEditDependencies {
+  vault?: Pick<
+    typeof defaultVault,
+    "entities" | "updateEntity" | "createEntity" | "deleteEntity"
+  > & {
+    addConnection?: (
+      source: string,
+      target: string,
+      type: string,
+    ) => Promise<unknown>;
+  };
+  resolveYear?: (
+    position: number | { x: number; y: number },
+    context: YearPositionContext,
+  ) => number | null;
+  now?: () => number;
+}
+
+export class ChronologyEditService {
+  drag = $state<ChronologyDrag | null>(null);
+  pendingIntent = $state<PlacementIntent | null>(null);
+  pendingEntity = $state<Entity | null>(null);
+  conflict = $state(false);
+  error = $state<string | null>(null);
+
+  private baseline: Entity | null = null;
+  private deps: Required<
+    Pick<ChronologyEditDependencies, "resolveYear" | "now">
+  > &
+    Omit<ChronologyEditDependencies, "resolveYear" | "now">;
+
+  constructor(deps: ChronologyEditDependencies = {}) {
+    this.deps = {
+      vault: deps.vault ?? defaultVault,
+      resolveYear: deps.resolveYear ?? getYearForPosition,
+      now: deps.now ?? Date.now,
+    };
+  }
+
+  beginDrag(args: {
+    entity: Entity;
+    source?: "graph" | "explorer";
+    anchorId?: string;
+    originPosition?: { x: number; y: number };
+    pressPosition: number | { x: number; y: number };
+    context: YearPositionContext;
+  }): boolean {
+    const year = this.deps.resolveYear(args.pressPosition, args.context);
+    if (year === null) return false;
+
+    this.baseline = structuredClone(args.entity);
+    this.pendingEntity = args.entity;
+    this.pendingIntent = null;
+    this.conflict = false;
+    this.error = null;
+    this.drag = {
+      source: args.source ?? "graph",
+      entityId: args.entity.id,
+      anchorId: args.anchorId,
+      originPosition: args.originPosition,
+      pressYear: year,
+      targetYear: year,
+      gestureKind: "point",
+    };
+    return true;
+  }
+
+  updateDrag(
+    position: number | { x: number; y: number },
+    context: YearPositionContext,
+    pixelDelta = 0,
+  ): boolean {
+    if (!this.drag) return false;
+    const year = this.deps.resolveYear(position, context);
+    if (year === null) return false;
+
+    this.drag.targetYear = year;
+    this.drag.gestureKind =
+      Math.abs(year - this.drag.pressYear) >= 1 && Math.abs(pixelDelta) >= 6
+        ? "span"
+        : "point";
+    return true;
+  }
+
+  prepareDrop(
+    entity: Entity = this.pendingEntity as Entity,
+  ): PlacementIntent | null {
+    if (!this.drag || !entity) return null;
+    if (this.drag.anchorId === "primary-range-start") {
+      const start_date = this.toDate(this.drag.targetYear);
+      const range = validateRange(start_date, entity.end_date);
+      if (!range.valid) {
+        this.error = range.reason;
+        return null;
+      }
+      this.pendingIntent = buildIntent(entity, {
+        meaning: {
+          id: "rangeStart",
+          label: "Range start",
+          kind: "point",
+          target: "start_date",
+        },
+        start_date,
+      });
+      return this.pendingIntent;
+    }
+    if (this.drag.anchorId === "primary-range-end") {
+      const end_date = this.toDate(this.drag.targetYear);
+      const range = validateRange(entity.start_date, end_date);
+      if (!range.valid) {
+        this.error = range.reason;
+        return null;
+      }
+      this.pendingIntent = buildIntent(entity, {
+        meaning: {
+          id: "rangeEnd",
+          label: "Range end",
+          kind: "point",
+          target: "end_date",
+        },
+        end_date,
+      });
+      return this.pendingIntent;
+    }
+    if (!this.drag.anchorId && entity.start_date && entity.end_date) {
+      const delta = this.drag.targetYear - this.drag.pressYear;
+      const start_date = this.toDate(entity.start_date.year + delta);
+      const end_date = this.toDate(entity.end_date.year + delta);
+      const range = validateRange(start_date, end_date);
+      if (!range.valid) {
+        this.error = range.reason;
+        return null;
+      }
+      this.pendingIntent = buildIntent(entity, {
+        meaning: {
+          id: "rangeMove",
+          label: "Range",
+          kind: "span",
+          target: "start_date",
+        },
+        start_date,
+        end_date,
+      });
+      return this.pendingIntent;
+    }
+    const meaning = getBeginMeaning(entity.type);
+    const date = this.toDate(this.drag.targetYear);
+    const selection =
+      this.drag.gestureKind === "span"
+        ? {
+            meaning: {
+              ...meaning,
+              kind: "span" as const,
+              target: "start_date" as const,
+            },
+            start_date: this.toDate(this.drag.pressYear),
+            end_date: date,
+          }
+        : { meaning, date };
+
+    if ("start_date" in selection) {
+      const range = validateRange(selection.start_date, selection.end_date);
+      if (!range.valid) {
+        this.error = range.reason;
+        return null;
+      }
+    }
+
+    this.pendingIntent = buildIntent(entity, selection);
+    return this.pendingIntent;
+  }
+
+  buildSemanticIntent(args: {
+    entity: Entity;
+    meaning: TemporalMeaning;
+    date?: TemporalMetadata;
+    start_date?: TemporalMetadata;
+    end_date?: TemporalMetadata;
+    customLabel?: string;
+    existingAnchorId?: string;
+    createNewAnchor?: boolean;
+    createEvent?: boolean;
+    eventTitle?: string;
+  }): PlacementIntent | null {
+    const range = validateRange(args.start_date, args.end_date);
+    if (!range.valid) {
+      this.error = range.reason;
+      return null;
+    }
+
+    this.pendingEntity = args.entity;
+    this.pendingIntent = buildIntent(args.entity, args);
+    return this.pendingIntent;
+  }
+
+  async confirm(
+    entity: Entity = this.pendingEntity as Entity,
+  ): Promise<boolean> {
+    if (!this.pendingIntent || !entity || !this.baseline) return false;
+    const current = this.deps.vault?.entities?.[entity.id] as
+      | Entity
+      | undefined;
+    if (current && detectConflict(this.baseline, current)) {
+      this.conflict = true;
+      return false;
+    }
+
+    try {
+      if (this.pendingIntent.createEvent) {
+        let createdId: string | null = null;
+        try {
+          createdId = await this.deps.vault!.createEntity(
+            "event",
+            this.pendingIntent.createEvent.title,
+            { date: this.pendingIntent.createEvent.date },
+          );
+          await this.deps.vault!.updateEntity(entity.id, {
+            temporalAnchors: [
+              ...(entity.temporalAnchors ?? []),
+              {
+                id: `linked-event-${this.deps.now().toString(36)}`,
+                type: this.pendingIntent.createEvent.anchorType,
+                date: this.pendingIntent.createEvent.date,
+                linkedEntityId: createdId,
+              },
+            ],
+          });
+          await this.deps.vault?.addConnection?.(
+            entity.id,
+            createdId,
+            this.pendingIntent.createEvent.connectionType,
+          );
+        } catch (error) {
+          if (createdId) {
+            await this.deps.vault?.deleteEntity?.(createdId);
+          }
+          throw error;
+        }
+      } else {
+        await this.deps.vault!.updateEntity(
+          entity.id,
+          this.pendingIntent.writes,
+        );
+      }
+      this.clear();
+      return true;
+    } catch (error) {
+      this.error =
+        error instanceof Error
+          ? error.message
+          : "Could not save chronology edit.";
+      return false;
+    }
+  }
+
+  async removeAnchor(entity: Entity, anchorId: string): Promise<boolean> {
+    this.baseline ??= structuredClone(entity);
+    const current = this.deps.vault?.entities?.[entity.id] as
+      | Entity
+      | undefined;
+    if (current && detectConflict(this.baseline, current)) {
+      this.conflict = true;
+      return false;
+    }
+
+    try {
+      await this.deps.vault!.updateEntity(entity.id, {
+        temporalAnchors: removeAnchor(entity.temporalAnchors ?? [], anchorId),
+      });
+      this.clear();
+      return true;
+    } catch (error) {
+      this.error =
+        error instanceof Error
+          ? error.message
+          : "Could not remove chronology anchor.";
+      return false;
+    }
+  }
+
+  cancel() {
+    this.clear();
+  }
+
+  private clear() {
+    this.drag = null;
+    this.pendingIntent = null;
+    this.pendingEntity = null;
+    this.baseline = null;
+    this.conflict = false;
+    this.error = null;
+  }
+
+  private toDate(year: number): TemporalMetadata {
+    return { year };
+  }
+}
+
+export const chronologyEdit = new ChronologyEditService();

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -64,6 +64,10 @@ export class GraphStore {
     const entityElements = GraphTransformer.entitiesToElements(
       visibleEntities,
       validIds,
+      {
+        includeTemporalEditHandles:
+          this.timelineMode && this.chronologyEditMode,
+      },
     );
 
     return entityElements;
@@ -80,6 +84,7 @@ export class GraphStore {
 
   // Timeline State
   timelineMode = $state(false);
+  chronologyEditMode = $state(false);
   timelineAxis = $state<"x" | "y">("x");
   timelineRange = $state<{ start: number | null; end: number | null }>({
     start: null,
@@ -112,6 +117,24 @@ export class GraphStore {
 
   requestFit() {
     this.fitRequest++;
+  }
+
+  setTimelineMode(enabled: boolean) {
+    this.timelineMode = enabled;
+    if (!enabled) {
+      this.chronologyEditMode = false;
+    }
+  }
+
+  setChronologyEditMode(enabled: boolean) {
+    this.chronologyEditMode = enabled;
+    if (enabled) {
+      this.timelineMode = true;
+    }
+  }
+
+  toggleChronologyEditMode() {
+    this.setChronologyEditMode(!this.chronologyEditMode);
   }
 
   async init() {
@@ -281,7 +304,7 @@ export class GraphStore {
   }
 
   toggleTimeline() {
-    this.timelineMode = !this.timelineMode;
+    this.setTimelineMode(!this.timelineMode);
   }
 
   setTimelineAxis(axis: "x" | "y") {

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -53,9 +53,23 @@ export class GraphStore {
     const validIds = new Set<string>();
 
     const count = allEntities.length;
+    const isTimeline = this.timelineMode;
+    const rangeStart = this.timelineRange.start;
+    const rangeEnd = this.timelineRange.end;
+
     for (let i = 0; i < count; i++) {
       const entity = allEntities[i];
       if (isEntityVisible(entity, settings)) {
+        if (isTimeline) {
+          const year =
+            entity.date?.year ??
+            entity.start_date?.year ??
+            entity.end_date?.year;
+          if (year !== undefined) {
+            if (rangeStart !== null && year < rangeStart) continue;
+            if (rangeEnd !== null && year > rangeEnd) continue;
+          }
+        }
         visibleEntities.push(entity);
         validIds.add(entity.id);
       }
@@ -119,11 +133,21 @@ export class GraphStore {
     this.fitRequest++;
   }
 
+  private async persistSetting(key: string, value: any) {
+    try {
+      const db = await getDB();
+      await db.put("settings", $state.snapshot(value), key);
+    } catch (error) {
+      console.error(`[GraphStore] Failed to persist ${key}:`, error);
+    }
+  }
+
   setTimelineMode(enabled: boolean) {
     this.timelineMode = enabled;
     if (!enabled) {
       this.chronologyEditMode = false;
     }
+    void this.persistSetting("graphTimelineMode", enabled);
   }
 
   setChronologyEditMode(enabled: boolean) {
@@ -179,6 +203,26 @@ export class GraphStore {
     );
     if (savedLabelFilterMode !== undefined) {
       this.labelFilterMode = savedLabelFilterMode;
+    }
+
+    const savedTimelineMode = await db.get("settings", "graphTimelineMode");
+    if (savedTimelineMode !== undefined) {
+      this.timelineMode = savedTimelineMode;
+    }
+
+    const savedTimelineAxis = await db.get("settings", "graphTimelineAxis");
+    if (savedTimelineAxis !== undefined) {
+      this.timelineAxis = savedTimelineAxis;
+    }
+
+    const savedTimelineScale = await db.get("settings", "graphTimelineScale");
+    if (savedTimelineScale !== undefined) {
+      this.timelineScale = savedTimelineScale;
+    }
+
+    const savedTimelineRange = await db.get("settings", "graphTimelineRange");
+    if (savedTimelineRange !== undefined) {
+      this.timelineRange = savedTimelineRange;
     }
 
     if (typeof window !== "undefined") {
@@ -309,6 +353,17 @@ export class GraphStore {
 
   setTimelineAxis(axis: "x" | "y") {
     this.timelineAxis = axis;
+    void this.persistSetting("graphTimelineAxis", axis);
+  }
+
+  setTimelineScale(scale: number) {
+    this.timelineScale = scale;
+    void this.persistSetting("graphTimelineScale", scale);
+  }
+
+  setTimelineRange(range: { start: number | null; end: number | null }) {
+    this.timelineRange = range;
+    void this.persistSetting("graphTimelineRange", range);
   }
 
   toggleOrbit() {

--- a/apps/web/src/lib/stores/graph.test.ts
+++ b/apps/web/src/lib/stores/graph.test.ts
@@ -67,6 +67,7 @@ describe("GraphStore", () => {
     graph.showImages = true;
     graph.stableLayout = true;
     graph.timelineMode = false;
+    graph.chronologyEditMode = false;
     graph.orbitMode = false;
     graph.activeLabels = new Set();
     graph.activeCategories = new Set();
@@ -88,6 +89,7 @@ describe("GraphStore", () => {
     expect(graph.showImages).toBe(true);
     expect(graph.stableLayout).toBe(true);
     expect(graph.timelineMode).toBe(false);
+    expect(graph.chronologyEditMode).toBe(false);
     expect(graph.orbitMode).toBe(false);
     expect(graph.labelFilterMode).toBe("OR");
   });
@@ -242,6 +244,18 @@ describe("GraphStore", () => {
     const initial = graph.fitRequest;
     graph.requestFit();
     expect(graph.fitRequest).toBe(initial + 1);
+  });
+
+  it("should require timeline mode for chronology editing", () => {
+    graph.setChronologyEditMode(true);
+
+    expect(graph.timelineMode).toBe(true);
+    expect(graph.chronologyEditMode).toBe(true);
+
+    graph.setTimelineMode(false);
+
+    expect(graph.timelineMode).toBe(false);
+    expect(graph.chronologyEditMode).toBe(false);
   });
 
   it("should manage eras", async () => {

--- a/apps/web/src/lib/stores/graph.test.ts
+++ b/apps/web/src/lib/stores/graph.test.ts
@@ -155,6 +155,10 @@ describe("GraphStore", () => {
       if (key === "graphStableLayout") return Promise.resolve(false);
       if (key === "graphRecentLabels") return Promise.resolve(["old"]);
       if (key === "graphLabelFilterMode") return Promise.resolve("AND");
+      if (key === "graphTimelineMode") return Promise.resolve(true);
+      if (key === "graphTimelineAxis") return Promise.resolve("y");
+      if (key === "graphTimelineScale") return Promise.resolve(150);
+      if (key === "graphTimelineRange") return Promise.resolve([100, 1000]);
       return Promise.resolve(undefined);
     });
     vi.spyOn(db, "getAll").mockResolvedValue([{ id: "era1", name: "Era 1" }]);
@@ -165,6 +169,10 @@ describe("GraphStore", () => {
     expect(graph.stableLayout).toBe(false);
     expect(graph.recentLabels).toEqual(["old"]);
     expect(graph.labelFilterMode).toBe("AND");
+    expect(graph.timelineMode).toBe(true);
+    expect(graph.timelineAxis).toBe("y");
+    expect(graph.timelineScale).toBe(150);
+    expect(graph.timelineRange).toEqual([100, 1000]);
     expect(graph.eras).toEqual([{ id: "era1", name: "Era 1" }]);
   });
 
@@ -178,7 +186,7 @@ describe("GraphStore", () => {
     await graph.init();
 
     expect(getAllSpy).toHaveBeenCalledTimes(1);
-    expect(getSpy).toHaveBeenCalledTimes(5);
+    expect(getSpy).toHaveBeenCalledTimes(9);
     expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
 
     addEventListenerSpy.mockRestore();

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -340,6 +340,10 @@ export class SyncStore {
 
       if (this.isStale(vaultIdAtStart, signal)) return;
 
+      // Reload theme from disk/cache now that config files are synced/written
+      const { themeStore } = await import("../theme.svelte");
+      await themeStore.loadForVault(vaultIdAtStart);
+
       await Promise.all([
         this.deps.loadMaps(vaultIdAtStart),
         this.deps.loadCanvases(vaultIdAtStart),

--- a/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -69,14 +69,17 @@
     </main>
 
     <footer class="pt-12 border-t border-theme-border">
-      <div class="flex flex-wrap gap-2">
-        {#each article.keywords as keyword}
-          <span
-            class="px-3 py-1 bg-theme-surface border border-theme-border rounded-full text-[10px] font-mono text-theme-muted uppercase tracking-wider"
-          >
-            #{keyword.replace(/\s+/g, "-").toLowerCase()}
-          </span>
-        {/each}
+      <div>
+        <p class="text-[10px] font-mono text-theme-muted uppercase tracking-widest mb-3">Topics</p>
+        <div class="flex flex-wrap gap-2">
+          {#each article.keywords.slice(0, 6) as keyword}
+            <span
+              class="px-3 py-1 bg-theme-surface border border-theme-border rounded-full text-[10px] font-mono text-theme-muted tracking-wider"
+            >
+              {keyword.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+            </span>
+          {/each}
+        </div>
       </div>
 
       <div
@@ -86,10 +89,10 @@
           <h3
             class="text-lg font-header font-bold uppercase tracking-widest mb-2"
           >
-            Ready to secure your lore?
+            Ready to bring your lore home?
           </h3>
           <p class="text-sm text-theme-muted">
-            The GM's most important tool is data sovereignty.
+            Local-first. Your vault stays yours.
           </p>
         </div>
         <a

--- a/docs/reddit/timeline-edit-devlog.md
+++ b/docs/reddit/timeline-edit-devlog.md
@@ -1,0 +1,42 @@
+# Reddit Devlog: Interactive Timeline Editing, Precise Drag-and-Drop, and Local Dev Fixes
+
+## Subreddit Title Options
+
+1. **[Problem-First]** My timeline layout kept shifting until I synced the global year coordinates
+2. **[I built]** I built a local-first editable campaign timeline in Svelte 5
+3. **[Devlog]** Codex Cryptica Devlog: Direct Timeline Dragging, Semantic Date Popovers, and Dev-Server SW Bypass
+
+---
+
+## Recommended Post Body
+
+For context: I’m building Codex Cryptica, a local-first campaign manager for GMs, written in Svelte 5. I've been working on turning the read-only timeline visualization into an interactive editor where you can drag and drop campaign events, place characters, and manage temporal anchors.
+
+Here is what I just shipped and what I learned resolving layout sync bugs along the way.
+
+### What’s New
+
+- **Direct Timeline Placement & Drag-and-Drop**: GMs can now drag undated entities from the sidebar explorer and drop them directly onto the campaign timeline axis to date them.
+- **Semantic Placement Popover**: When you drop an entity, a popover dynamically determines the entity's type and prompts you for the specific meaning of that date (e.g., "Born" or "Died" for characters, "Founded" or "Dissolved" for factions) or lets you create a new linked event at that location.
+- **Grid and Layout Synchronization**: Fixed a frustrating bug where dropping an explorer entity between two visually close nodes (like years 616 and 617) resolved to 610. The layout engine was generating coordinates using only the active nodes on screen, while the drop target and ruler were using the global set of campaign entities. I unified the year-coordinate mappings across the layout manager, ruler overlay, and mouse projection to ensure drops resolve to the exact visual year under the cursor.
+- **Development Service Worker Bypass**: Solved a pesky dev-server issue where dynamic component imports (like the confirmation modals) would result in a `TypeError: Failed to fetch`. If a developer had previously run a production preview on the same port, the browser's registered service worker would stay active and intercept dev-server source file requests. I added logic in the app bootstrapper to automatically detect and unregister any active service worker in development mode.
+
+### Under the Hood
+
+Under Svelte 5, local states in dynamically mounted modals can easily lose reactivity to changing props if they are untracked on mount. I resolved this in the placement popover by wrapping the target year changes in a reactive `$effect` block that updates the local binding state whenever a new drop occurs.
+
+On the layout side, our timeline utilizes sequential gap compression (`getSequentialYearPositions`). It places years close in sequence at standard scale distances (100px) and compresses large gaps so that centuries of empty space don't force infinite scrolling. Reusing the same gap-compressed year positioning registry across the Cytoscape preset layout, the SVG ruler overlay, and the coordinate resolver was key to aligning the mouse drop projection.
+
+### What's to Come
+
+Next up, I'm working on:
+
+- **Multiple Temporal Anchors**: Allowing entities to have multiple appearances or events on the timeline, with each anchor rendering as a grabbable handle.
+- **Timeline Controls**: Fine-tuning zoom and range filters to dynamically hide/reveal eras without resetting the layout.
+- **Vague Dates**: Supporting temporal uncertainty (like "mid-reign" or "circa 600 P.C.").
+
+---
+
+## Closing Discussion Question
+
+**How do you prefer to represent temporal uncertainty or vague dates (e.g., "late spring, 616" or "around 590") on a visual campaign timeline?** Do you prefer keeping them as simple approximate years or having a visual "fuzziness" range indicator?

--- a/docs/reddit/timeline-edit-devlog.md
+++ b/docs/reddit/timeline-edit-devlog.md
@@ -1,42 +1,27 @@
-# Reddit Devlog: Interactive Timeline Editing, Precise Drag-and-Drop, and Local Dev Fixes
+# Reddit Devlog Teaser: Interactive Campaign Timeline Editing
 
 ## Subreddit Title Options
 
-1. **[Problem-First]** My timeline layout kept shifting until I synced the global year coordinates
-2. **[I built]** I built a local-first editable campaign timeline in Svelte 5
-3. **[Devlog]** Codex Cryptica Devlog: Direct Timeline Dragging, Semantic Date Popovers, and Dev-Server SW Bypass
+1. **[I built]** I added interactive drag-and-drop timeline editing to my local-first campaign manager
+2. **[Showcase]** Teaser: Drag-and-drop timeline planning and semantic date placement
+3. **[Devlog]** A teaser of the new interactive timeline editor functionality
 
 ---
 
 ## Recommended Post Body
 
-For context: I’m building Codex Cryptica, a local-first campaign manager for GMs, written in Svelte 5. I've been working on turning the read-only timeline visualization into an interactive editor where you can drag and drop campaign events, place characters, and manage temporal anchors.
+For context: I’m building Codex Cryptica, a local-first campaign manager for GMs. I’ve been working on turning the read-only timeline view into a direct-manipulation editor.
 
-Here is what I just shipped and what I learned resolving layout sync bugs along the way.
+Here is a quick tease of the new timeline functionality:
 
-### What’s New
+- **Direct Drag-and-Drop**: You can grab characters, factions, or notes directly from your explorer sidebar and drop them anywhere onto the campaign timeline ruler to place them in time.
+- **Semantic Date Popovers**: When you drop a character or faction, the interface automatically detects the entity type and prompts you to define what the date represents (e.g., "Born" or "Died" for characters, "Founded" or "Dissolved" for factions), writing the changes back to their markdown files.
+- **Interactive Timeline Handles**: Existing events and lifelines render with grabbable timeline handles, letting you shift dates interactively by sliding them horizontally.
 
-- **Direct Timeline Placement & Drag-and-Drop**: GMs can now drag undated entities from the sidebar explorer and drop them directly onto the campaign timeline axis to date them.
-- **Semantic Placement Popover**: When you drop an entity, a popover dynamically determines the entity's type and prompts you for the specific meaning of that date (e.g., "Born" or "Died" for characters, "Founded" or "Dissolved" for factions) or lets you create a new linked event at that location.
-- **Grid and Layout Synchronization**: Fixed a frustrating bug where dropping an explorer entity between two visually close nodes (like years 616 and 617) resolved to 610. The layout engine was generating coordinates using only the active nodes on screen, while the drop target and ruler were using the global set of campaign entities. I unified the year-coordinate mappings across the layout manager, ruler overlay, and mouse projection to ensure drops resolve to the exact visual year under the cursor.
-- **Development Service Worker Bypass**: Solved a pesky dev-server issue where dynamic component imports (like the confirmation modals) would result in a `TypeError: Failed to fetch`. If a developer had previously run a production preview on the same port, the browser's registered service worker would stay active and intercept dev-server source file requests. I added logic in the app bootstrapper to automatically detect and unregister any active service worker in development mode.
-
-### Under the Hood
-
-Under Svelte 5, local states in dynamically mounted modals can easily lose reactivity to changing props if they are untracked on mount. I resolved this in the placement popover by wrapping the target year changes in a reactive `$effect` block that updates the local binding state whenever a new drop occurs.
-
-On the layout side, our timeline utilizes sequential gap compression (`getSequentialYearPositions`). It places years close in sequence at standard scale distances (100px) and compresses large gaps so that centuries of empty space don't force infinite scrolling. Reusing the same gap-compressed year positioning registry across the Cytoscape preset layout, the SVG ruler overlay, and the coordinate resolver was key to aligning the mouse drop projection.
-
-### What's to Come
-
-Next up, I'm working on:
-
-- **Multiple Temporal Anchors**: Allowing entities to have multiple appearances or events on the timeline, with each anchor rendering as a grabbable handle.
-- **Timeline Controls**: Fine-tuning zoom and range filters to dynamically hide/reveal eras without resetting the layout.
-- **Vague Dates**: Supporting temporal uncertainty (like "mid-reign" or "circa 600 P.C.").
+Everything runs entirely client-side, offline, and private in the browser.
 
 ---
 
 ## Closing Discussion Question
 
-**How do you prefer to represent temporal uncertainty or vague dates (e.g., "late spring, 616" or "around 590") on a visual campaign timeline?** Do you prefer keeping them as simple approximate years or having a visual "fuzziness" range indicator?
+When preparing or running campaigns, do you find yourself relying more on spatial relationship maps (node graphs) or sequential timelines to keep track of your lore?

--- a/packages/chronology-engine/src/anchors.ts
+++ b/packages/chronology-engine/src/anchors.ts
@@ -1,0 +1,98 @@
+import type { TemporalMetadata } from "./types";
+
+export interface TemporalAnchor {
+  id: string;
+  type: string;
+  label?: string;
+  date?: TemporalMetadata;
+  start_date?: TemporalMetadata;
+  end_date?: TemporalMetadata;
+  linkedEntityId?: string;
+  note?: string;
+}
+
+export interface TemporalEntity {
+  id: string;
+  type: string;
+  title?: string;
+  date?: TemporalMetadata;
+  start_date?: TemporalMetadata;
+  end_date?: TemporalMetadata;
+  temporalAnchors?: TemporalAnchor[];
+}
+
+export interface ProjectedAnchor extends TemporalAnchor {
+  entityId: string;
+  anchorId: string;
+  primary: boolean;
+}
+
+export function validateRange(
+  start?: TemporalMetadata,
+  end?: TemporalMetadata,
+): { valid: true } | { valid: false; reason: string } {
+  if (start && end && end.year < start.year) {
+    return { valid: false, reason: "End date cannot be before start date." };
+  }
+  return { valid: true };
+}
+
+export function deriveProjectedAnchors(
+  entity: TemporalEntity,
+): ProjectedAnchor[] {
+  const projected: ProjectedAnchor[] = [];
+
+  if (entity.date) {
+    projected.push({
+      id: "primary",
+      anchorId: "primary",
+      entityId: entity.id,
+      type: "primary",
+      date: entity.date,
+      primary: true,
+    });
+  }
+
+  if (entity.start_date || entity.end_date) {
+    projected.push({
+      id: "primary-range",
+      anchorId: "primary-range",
+      entityId: entity.id,
+      type: "primaryRange",
+      start_date: entity.start_date,
+      end_date: entity.end_date,
+      primary: true,
+    });
+  }
+
+  for (const anchor of entity.temporalAnchors ?? []) {
+    projected.push({
+      ...anchor,
+      anchorId: anchor.id,
+      entityId: entity.id,
+      primary: false,
+    });
+  }
+
+  return projected;
+}
+
+export function upsertAnchor(
+  anchors: TemporalAnchor[] | undefined,
+  anchor: TemporalAnchor,
+): TemporalAnchor[] {
+  const existing = anchors ?? [];
+  const index = existing.findIndex((candidate) => candidate.id === anchor.id);
+  if (index === -1) return [...existing, anchor];
+
+  return existing.map((candidate, candidateIndex) =>
+    candidateIndex === index ? anchor : candidate,
+  );
+}
+
+export function removeAnchor(
+  anchors: TemporalAnchor[] | undefined,
+  anchorId: string,
+): TemporalAnchor[] {
+  return (anchors ?? []).filter((anchor) => anchor.id !== anchorId);
+}

--- a/packages/chronology-engine/src/anchors.ts
+++ b/packages/chronology-engine/src/anchors.ts
@@ -31,8 +31,30 @@ export function validateRange(
   start?: TemporalMetadata,
   end?: TemporalMetadata,
 ): { valid: true } | { valid: false; reason: string } {
-  if (start && end && end.year < start.year) {
-    return { valid: false, reason: "End date cannot be before start date." };
+  if (start && end) {
+    if (end.year < start.year) {
+      return { valid: false, reason: "End date cannot be before start date." };
+    }
+    if (end.year === start.year) {
+      const startMonth = start.month ?? 0;
+      const endMonth = end.month ?? 0;
+      if (endMonth < startMonth) {
+        return {
+          valid: false,
+          reason: "End date cannot be before start date.",
+        };
+      }
+      if (endMonth === startMonth) {
+        const startDay = start.day ?? 0;
+        const endDay = end.day ?? 0;
+        if (endDay < startDay) {
+          return {
+            valid: false,
+            reason: "End date cannot be before start date.",
+          };
+        }
+      }
+    }
   }
   return { valid: true };
 }

--- a/packages/chronology-engine/src/index.ts
+++ b/packages/chronology-engine/src/index.ts
@@ -1,2 +1,5 @@
 export * from "./types";
 export * from "./engine";
+export * from "./meaning-sets";
+export * from "./anchors";
+export * from "./placement";

--- a/packages/chronology-engine/src/meaning-sets.ts
+++ b/packages/chronology-engine/src/meaning-sets.ts
@@ -1,0 +1,280 @@
+export type TemporalMeaningRole = "primary" | "begin" | "end" | "custom";
+export type TemporalMeaningKind = "point" | "span";
+export type TemporalMeaningTarget =
+  | "date"
+  | "start_date"
+  | "end_date"
+  | "anchor";
+
+export interface TemporalMeaning {
+  id: string;
+  label: string;
+  kind: TemporalMeaningKind;
+  target: TemporalMeaningTarget;
+  anchorType?: string;
+  role?: TemporalMeaningRole;
+  endMeaningId?: string;
+}
+
+const customMeaning: TemporalMeaning = {
+  id: "custom",
+  label: "Custom anchor",
+  kind: "point",
+  target: "anchor",
+  anchorType: "custom",
+  role: "custom",
+};
+
+export const MEANING_SETS: Record<string, TemporalMeaning[]> = {
+  event: [
+    {
+      id: "date",
+      label: "Date",
+      kind: "point",
+      target: "date",
+      role: "primary",
+      endMeaningId: "end_date",
+    },
+    {
+      id: "start_date",
+      label: "Start date",
+      kind: "span",
+      target: "start_date",
+      role: "begin",
+      endMeaningId: "end_date",
+    },
+    {
+      id: "end_date",
+      label: "End date",
+      kind: "point",
+      target: "end_date",
+      role: "end",
+    },
+    customMeaning,
+  ],
+  character: [
+    {
+      id: "born",
+      label: "Born",
+      kind: "point",
+      target: "date",
+      role: "primary",
+      endMeaningId: "died",
+    },
+    {
+      id: "died",
+      label: "Died",
+      kind: "point",
+      target: "anchor",
+      anchorType: "died",
+      role: "end",
+    },
+    {
+      id: "activePeriod",
+      label: "Active period",
+      kind: "span",
+      target: "anchor",
+      anchorType: "activePeriod",
+    },
+    {
+      id: "reign",
+      label: "Reign",
+      kind: "span",
+      target: "anchor",
+      anchorType: "reign",
+    },
+    {
+      id: "majorAppearance",
+      label: "Major appearance",
+      kind: "point",
+      target: "anchor",
+      anchorType: "majorAppearance",
+    },
+    customMeaning,
+  ],
+  faction: [
+    {
+      id: "founded",
+      label: "Founded",
+      kind: "point",
+      target: "date",
+      role: "primary",
+      endMeaningId: "dissolved",
+    },
+    {
+      id: "dissolved",
+      label: "Dissolved",
+      kind: "point",
+      target: "anchor",
+      anchorType: "dissolved",
+      role: "end",
+    },
+    {
+      id: "activePeriod",
+      label: "Active period",
+      kind: "span",
+      target: "anchor",
+      anchorType: "activePeriod",
+    },
+    {
+      id: "schism",
+      label: "Schism",
+      kind: "point",
+      target: "anchor",
+      anchorType: "schism",
+    },
+    {
+      id: "merger",
+      label: "Merger",
+      kind: "point",
+      target: "anchor",
+      anchorType: "merger",
+    },
+    customMeaning,
+  ],
+  location: [
+    {
+      id: "founded",
+      label: "Founded",
+      kind: "point",
+      target: "date",
+      role: "primary",
+      endMeaningId: "destroyed",
+    },
+    {
+      id: "destroyed",
+      label: "Destroyed",
+      kind: "point",
+      target: "anchor",
+      anchorType: "destroyed",
+      role: "end",
+    },
+    {
+      id: "occupied",
+      label: "Occupied",
+      kind: "span",
+      target: "anchor",
+      anchorType: "occupied",
+    },
+    {
+      id: "goldenAge",
+      label: "Golden age",
+      kind: "span",
+      target: "anchor",
+      anchorType: "goldenAge",
+    },
+    {
+      id: "relevantPeriod",
+      label: "Relevant period",
+      kind: "span",
+      target: "anchor",
+      anchorType: "relevantPeriod",
+    },
+    customMeaning,
+  ],
+  item: [
+    {
+      id: "created",
+      label: "Created",
+      kind: "point",
+      target: "date",
+      role: "primary",
+      endMeaningId: "lost",
+    },
+    {
+      id: "discovered",
+      label: "Discovered",
+      kind: "point",
+      target: "anchor",
+      anchorType: "discovered",
+    },
+    {
+      id: "lost",
+      label: "Lost",
+      kind: "point",
+      target: "anchor",
+      anchorType: "lost",
+      role: "end",
+    },
+    {
+      id: "ownershipPeriod",
+      label: "Ownership period",
+      kind: "span",
+      target: "anchor",
+      anchorType: "ownershipPeriod",
+    },
+    {
+      id: "recovered",
+      label: "Recovered",
+      kind: "point",
+      target: "anchor",
+      anchorType: "recovered",
+    },
+    customMeaning,
+  ],
+  note: [
+    {
+      id: "associatedDate",
+      label: "Associated date",
+      kind: "point",
+      target: "date",
+      role: "primary",
+    },
+    {
+      id: "associatedPeriod",
+      label: "Associated period",
+      kind: "span",
+      target: "anchor",
+      anchorType: "associatedPeriod",
+    },
+    customMeaning,
+  ],
+};
+
+export const GENERIC_MEANINGS: TemporalMeaning[] = [
+  {
+    id: "date",
+    label: "Date",
+    kind: "point",
+    target: "date",
+    role: "primary",
+    endMeaningId: "end_date",
+  },
+  {
+    id: "range",
+    label: "Relevant period",
+    kind: "span",
+    target: "start_date",
+    role: "begin",
+    endMeaningId: "end_date",
+  },
+  {
+    id: "end_date",
+    label: "End date",
+    kind: "point",
+    target: "end_date",
+    role: "end",
+  },
+  customMeaning,
+];
+
+export function getMeanings(entityType: string): TemporalMeaning[] {
+  return MEANING_SETS[entityType] ?? GENERIC_MEANINGS;
+}
+
+export function getBeginMeaning(entityType: string): TemporalMeaning {
+  return (
+    getMeanings(entityType).find(
+      (meaning) => meaning.role === "primary" || meaning.role === "begin",
+    ) ?? GENERIC_MEANINGS[0]
+  );
+}
+
+export function getEndMeaning(entityType: string): TemporalMeaning | undefined {
+  const meanings = getMeanings(entityType);
+  const begin = getBeginMeaning(entityType);
+  return (
+    meanings.find((meaning) => meaning.id === begin.endMeaningId) ??
+    meanings.find((meaning) => meaning.role === "end")
+  );
+}

--- a/packages/chronology-engine/src/placement.ts
+++ b/packages/chronology-engine/src/placement.ts
@@ -1,0 +1,118 @@
+import type { TemporalMetadata } from "./types";
+import type { TemporalAnchor, TemporalEntity } from "./anchors";
+import { upsertAnchor } from "./anchors";
+import type { TemporalMeaning } from "./meaning-sets";
+
+export interface PlacementSelection {
+  meaning: TemporalMeaning;
+  date?: TemporalMetadata;
+  start_date?: TemporalMetadata;
+  end_date?: TemporalMetadata;
+  customLabel?: string;
+  existingAnchorId?: string;
+  createNewAnchor?: boolean;
+  createEvent?: boolean;
+  eventTitle?: string;
+}
+
+export interface PlacementIntent {
+  summary: string;
+  writes: Partial<TemporalEntity>;
+  anchor?: TemporalAnchor;
+  target: "primary" | "anchor" | "event";
+  createEvent?: {
+    title: string;
+    date: TemporalMetadata;
+    anchorType: string;
+    connectionType: "related_to";
+  };
+}
+
+function anchorId(type: string): string {
+  return `${type}-${Date.now().toString(36)}`;
+}
+
+export function buildIntent(
+  entity: TemporalEntity,
+  selection: PlacementSelection,
+): PlacementIntent {
+  const { meaning } = selection;
+  const date = selection.date ?? selection.start_date;
+
+  if (selection.createEvent) {
+    if (!date) throw new Error("A linked event requires a date.");
+    return {
+      summary: `Create an event for ${date.year}.`,
+      writes: {},
+      target: "event",
+      createEvent: {
+        title:
+          selection.eventTitle || `${entity.title ?? entity.id} - ${date.year}`,
+        date,
+        anchorType: meaning.anchorType ?? meaning.id,
+        connectionType: "related_to",
+      },
+    };
+  }
+
+  if (meaning.target === "date") {
+    if (!date) throw new Error("A date placement requires a date.");
+    return {
+      summary: `Set date to ${date.label ?? date.year}.`,
+      writes: { date },
+      target: "primary",
+    };
+  }
+
+  if (meaning.target === "start_date" || meaning.target === "end_date") {
+    return {
+      summary: "Update date range.",
+      writes: {
+        ...(selection.start_date ? { start_date: selection.start_date } : {}),
+        ...(selection.end_date ? { end_date: selection.end_date } : {}),
+      },
+      target: "primary",
+    };
+  }
+
+  const anchor: TemporalAnchor = {
+    id:
+      !selection.createNewAnchor && selection.existingAnchorId
+        ? selection.existingAnchorId
+        : anchorId(meaning.anchorType ?? meaning.id),
+    type: meaning.anchorType ?? meaning.id,
+    label: meaning.id === "custom" ? selection.customLabel : undefined,
+    ...(selection.date ? { date: selection.date } : {}),
+    ...(selection.start_date ? { start_date: selection.start_date } : {}),
+    ...(selection.end_date ? { end_date: selection.end_date } : {}),
+  };
+
+  return {
+    summary: `Save ${meaning.label.toLowerCase()}.`,
+    writes: {
+      temporalAnchors: upsertAnchor(entity.temporalAnchors, anchor),
+    },
+    anchor,
+    target: "anchor",
+  };
+}
+
+export function detectConflict(
+  baseline: TemporalEntity,
+  current: TemporalEntity,
+): boolean {
+  return (
+    JSON.stringify({
+      date: baseline.date,
+      start_date: baseline.start_date,
+      end_date: baseline.end_date,
+      temporalAnchors: baseline.temporalAnchors,
+    }) !==
+    JSON.stringify({
+      date: current.date,
+      start_date: current.start_date,
+      end_date: current.end_date,
+      temporalAnchors: current.temporalAnchors,
+    })
+  );
+}

--- a/packages/chronology-engine/tests/anchors.test.ts
+++ b/packages/chronology-engine/tests/anchors.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveProjectedAnchors,
+  removeAnchor,
+  upsertAnchor,
+  validateRange,
+} from "../src";
+
+describe("anchor helpers", () => {
+  it("projects primary fields and additional anchors independently", () => {
+    const projected = deriveProjectedAnchors({
+      id: "char-1",
+      type: "character",
+      date: { year: 580 },
+      temporalAnchors: [
+        { id: "a1", type: "majorAppearance", date: { year: 621 } },
+      ],
+    });
+
+    expect(projected.map((anchor) => anchor.anchorId)).toEqual([
+      "primary",
+      "a1",
+    ]);
+    expect(projected[0].primary).toBe(true);
+    expect(projected[1].primary).toBe(false);
+  });
+
+  it("validates non-inverted ranges", () => {
+    expect(validateRange({ year: 600 }, { year: 500 }).valid).toBe(false);
+    expect(validateRange({ year: 500 }, { year: 600 }).valid).toBe(true);
+  });
+
+  it("upserts and removes a single anchor without mutating siblings", () => {
+    const anchors = [
+      { id: "a1", type: "born", date: { year: 580 } },
+      { id: "a2", type: "appearance", date: { year: 621 } },
+    ];
+
+    const updated = upsertAnchor(anchors, {
+      id: "a2",
+      type: "appearance",
+      date: { year: 622 },
+    });
+
+    expect(updated).toHaveLength(2);
+    expect(updated[0].date?.year).toBe(580);
+    expect(updated[1].date?.year).toBe(622);
+    expect(removeAnchor(updated, "a1").map((anchor) => anchor.id)).toEqual([
+      "a2",
+    ]);
+  });
+});

--- a/packages/chronology-engine/tests/meaning-sets.test.ts
+++ b/packages/chronology-engine/tests/meaning-sets.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBeginMeaning,
+  getEndMeaning,
+  getMeanings,
+  MEANING_SETS,
+} from "../src";
+
+describe("meaning sets", () => {
+  it("provides type-specific meanings and universal custom anchors", () => {
+    expect(getMeanings("character").map((meaning) => meaning.id)).toEqual(
+      expect.arrayContaining([
+        "born",
+        "died",
+        "activePeriod",
+        "reign",
+        "majorAppearance",
+        "custom",
+      ]),
+    );
+    expect(getMeanings("faction").map((meaning) => meaning.id)).toEqual(
+      expect.arrayContaining([
+        "founded",
+        "dissolved",
+        "schism",
+        "merger",
+        "custom",
+      ]),
+    );
+  });
+
+  it("defines one primary meaning per explicit entity type", () => {
+    for (const meanings of Object.values(MEANING_SETS)) {
+      expect(
+        meanings.filter((meaning) => meaning.role === "primary"),
+      ).toHaveLength(1);
+    }
+  });
+
+  it("resolves begin and end meanings with a generic fallback", () => {
+    expect(getBeginMeaning("character").id).toBe("born");
+    expect(getEndMeaning("character")?.id).toBe("died");
+    expect(getBeginMeaning("creature").id).toBe("date");
+    expect(getEndMeaning("creature")?.id).toBe("end_date");
+  });
+});

--- a/packages/chronology-engine/tests/placement.test.ts
+++ b/packages/chronology-engine/tests/placement.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildIntent, detectConflict, getBeginMeaning } from "../src";
+
+describe("placement intent", () => {
+  it("maps event primary placement to date writes without coordinates", () => {
+    const intent = buildIntent(
+      { id: "event-1", type: "event", title: "Founding" },
+      { meaning: getBeginMeaning("event"), date: { year: 605 } },
+    );
+
+    expect(intent.target).toBe("primary");
+    expect(intent.writes).toEqual({ date: { year: 605 } });
+    expect(JSON.stringify(intent.writes)).not.toContain("coordinates");
+  });
+
+  it("maps non-primary placement to an anchor write", () => {
+    const meaning = {
+      id: "majorAppearance",
+      label: "Major appearance",
+      kind: "point" as const,
+      target: "anchor" as const,
+      anchorType: "majorAppearance",
+    };
+    const intent = buildIntent(
+      {
+        id: "char-1",
+        type: "character",
+        temporalAnchors: [{ id: "a1", type: "born", date: { year: 580 } }],
+      },
+      { meaning, date: { year: 621 } },
+    );
+
+    expect(intent.target).toBe("anchor");
+    expect(intent.writes.temporalAnchors).toHaveLength(2);
+    expect(intent.writes.temporalAnchors?.[0].date?.year).toBe(580);
+  });
+
+  it("supports span writes and detects calendar-equality conflicts", () => {
+    const meaning = {
+      id: "range",
+      label: "Relevant period",
+      kind: "span" as const,
+      target: "start_date" as const,
+    };
+    const intent = buildIntent(
+      { id: "note-1", type: "note" },
+      { meaning, start_date: { year: 500 }, end_date: { year: 550 } },
+    );
+
+    expect(intent.writes).toEqual({
+      start_date: { year: 500 },
+      end_date: { year: 550 },
+    });
+    expect(
+      detectConflict(
+        { id: "e", type: "event", date: { year: 1 } },
+        { id: "e", type: "event", date: { year: 2 } },
+      ),
+    ).toBe(true);
+    expect(
+      detectConflict(
+        { id: "e", type: "event", date: { year: 1 } },
+        { id: "e", type: "event", date: { year: 1 } },
+      ),
+    ).toBe(false);
+  });
+
+  it("builds create-event intents without moving the source entity", () => {
+    const intent = buildIntent(
+      { id: "char-1", type: "character", title: "Avel", date: { year: 580 } },
+      {
+        meaning: {
+          id: "majorAppearance",
+          label: "Major appearance",
+          kind: "point",
+          target: "anchor",
+          anchorType: "majorAppearance",
+        },
+        date: { year: 621 },
+        createEvent: true,
+        eventTitle: "Avel - 621",
+      },
+    );
+
+    expect(intent.writes).toEqual({});
+    expect(intent.createEvent).toEqual({
+      title: "Avel - 621",
+      date: { year: 621 },
+      anchorType: "majorAppearance",
+      connectionType: "related_to",
+    });
+  });
+});

--- a/packages/chronology-engine/tests/placement.test.ts
+++ b/packages/chronology-engine/tests/placement.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { buildIntent, detectConflict, getBeginMeaning } from "../src";
+import {
+  buildIntent,
+  detectConflict,
+  getBeginMeaning,
+  validateRange,
+} from "../src";
 
 describe("placement intent", () => {
   it("maps event primary placement to date writes without coordinates", () => {
@@ -89,5 +93,36 @@ describe("placement intent", () => {
       anchorType: "majorAppearance",
       connectionType: "related_to",
     });
+  });
+});
+
+describe("validateRange", () => {
+  it("passes valid ranges and flags basic inverted year ranges", () => {
+    expect(validateRange({ year: 500 }, { year: 600 }).valid).toBe(true);
+    expect(validateRange({ year: 600 }, { year: 500 }).valid).toBe(false);
+  });
+
+  it("flags inverted month ranges within the same year", () => {
+    expect(
+      validateRange({ year: 600, month: 2 }, { year: 600, month: 5 }).valid,
+    ).toBe(true);
+    expect(
+      validateRange({ year: 600, month: 5 }, { year: 600, month: 2 }).valid,
+    ).toBe(false);
+  });
+
+  it("flags inverted day ranges within the same year and month", () => {
+    expect(
+      validateRange(
+        { year: 600, month: 5, day: 10 },
+        { year: 600, month: 5, day: 20 },
+      ).valid,
+    ).toBe(true);
+    expect(
+      validateRange(
+        { year: 600, month: 5, day: 20 },
+        { year: 600, month: 5, day: 10 },
+      ).valid,
+    ).toBe(false);
   });
 });

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -375,6 +375,13 @@ export class LayoutManager {
         .nodes()
         .filter((n) => positions[n.id()] !== undefined);
 
+      this.cy.batch(() => {
+        nodesToLayout.forEach((node) => {
+          node.removeData("isPendingLayout");
+          node.removeClass("pending-layout");
+        });
+      });
+
       nodesToLayout
         .layout({
           name: "preset",

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -17,6 +17,7 @@ export interface LayoutOptions {
   centralNodeId: string | null;
   stableLayout: boolean;
   isGuest: boolean;
+  fit?: boolean;
   onLayoutStart?: () => void;
   onLayoutStop?: () => void;
   onLayoutComputed?: (durationMs: number) => void;
@@ -369,6 +370,7 @@ export class LayoutManager {
         scale: options.timelineScale,
         jitter: 150,
         yearPositions: options.yearPositions,
+        zoom: this.cy.zoom(),
       });
 
       const nodesToLayout = this.cy
@@ -389,7 +391,7 @@ export class LayoutManager {
           animate: true,
           animationDuration: 500,
           animationEasing: "ease-out-cubic",
-          fit: true,
+          fit: options.fit !== false,
           padding: 20,
           stop: () => options.onLayoutStop?.(),
         } as any)

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -12,6 +12,7 @@ export interface LayoutOptions {
   timelineMode: boolean;
   timelineAxis: "x" | "y";
   timelineScale: number;
+  yearPositions?: Record<number, number>;
   orbitMode: boolean;
   centralNodeId: string | null;
   stableLayout: boolean;
@@ -367,6 +368,7 @@ export class LayoutManager {
         axis: options.timelineAxis,
         scale: options.timelineScale,
         jitter: 150,
+        yearPositions: options.yearPositions,
       });
 
       const nodesToLayout = this.cy

--- a/packages/graph-engine/src/events/useGraphEvents.test.ts
+++ b/packages/graph-engine/src/events/useGraphEvents.test.ts
@@ -127,10 +127,14 @@ describe("setupGraphEvents", () => {
 
     mockCy.zoom = vi.fn().mockReturnValue(0.2);
     zoomHandler();
-    expect(mockCy.options).toHaveBeenCalledWith({ wheelSensitivity: 3.0 });
+    expect(mockCy.options).toHaveBeenCalledWith({
+      wheelSensitivity: expect.closeTo(0.8),
+    });
 
-    mockCy.zoom = vi.fn().mockReturnValue(2.0);
+    mockCy.zoom = vi.fn().mockReturnValue(9.0);
     zoomHandler();
-    expect(mockCy.options).toHaveBeenCalledWith({ wheelSensitivity: 0.5 });
+    expect(mockCy.options).toHaveBeenCalledWith({
+      wheelSensitivity: expect.closeTo(0.15),
+    });
   });
 });

--- a/packages/graph-engine/src/events/useGraphEvents.ts
+++ b/packages/graph-engine/src/events/useGraphEvents.ts
@@ -47,10 +47,12 @@ export function setupGraphEvents(cy: Core, handlers: GraphEventHandlers) {
     // ⚡ LOD (Level of Detail) & Wheel Sensitivity Optimization
     const zoom = cy.zoom();
 
-    // Dynamic wheel sensitivity scaling:
-    // Zoomed out (e.g. 0.2) -> Higher sensitivity (up to 3.0) to stay responsive.
-    // Zoomed in (e.g. 5.0) -> Lower sensitivity (down to 0.15) for precision.
-    const dynamicSensitivity = Math.max(0.15, Math.min(3.0, 1.0 / zoom));
+    // Keep wheel zoom gentle, especially in high-zoom temporal views where
+    // small changes can jump from year to month/day detail too quickly.
+    const dynamicSensitivity = Math.max(
+      0.12,
+      Math.min(0.8, 0.45 / Math.sqrt(zoom)),
+    );
     if (typeof (cy as any).options === "function") {
       (cy as any).options({ wheelSensitivity: dynamicSensitivity });
     }

--- a/packages/graph-engine/src/index.test.ts
+++ b/packages/graph-engine/src/index.test.ts
@@ -47,12 +47,12 @@ describe("initGraph adaptive zoom", () => {
     expect(cy.maxZoom()).toBe(9.0);
   });
 
-  it("should configure wheelSensitivity to 1.0 for smoother scrolling", async () => {
+  it("should configure a restrained wheelSensitivity for smoother scrolling", async () => {
     const cy = await initGraph({
       headless: true,
       elements: [],
     });
 
-    expect((cy as any)._private?.options?.wheelSensitivity).toBe(1.0);
+    expect((cy as any)._private?.options?.wheelSensitivity).toBe(0.45);
   });
 });

--- a/packages/graph-engine/src/index.ts
+++ b/packages/graph-engine/src/index.ts
@@ -87,6 +87,6 @@ export const initGraph = async (options: GraphOptions) => {
         : 1,
     minZoom: Math.max(0.01, 0.3 - nodeCount * 0.0005),
     maxZoom: 9.0,
-    wheelSensitivity: 1.0,
+    wheelSensitivity: 0.45,
   });
 };

--- a/packages/graph-engine/src/layouts/timeline.ts
+++ b/packages/graph-engine/src/layouts/timeline.ts
@@ -10,6 +10,7 @@ export interface TimelineLayoutOptions {
 export interface YearPositionContext {
   yearPositions: Record<number, number>;
   axis?: "x" | "y";
+  sortedEntries?: Array<{ year: number; coord: number }>;
 }
 
 export interface TimelineAnchorProjection {
@@ -73,9 +74,12 @@ export function getYearForPosition(
   position: number | { x: number; y: number },
   context: YearPositionContext,
 ): number | null {
-  const entries = Object.entries(context.yearPositions)
-    .map(([year, coord]) => ({ year: Number(year), coord }))
-    .sort((a, b) => a.coord - b.coord);
+  if (!context.sortedEntries) {
+    context.sortedEntries = Object.entries(context.yearPositions)
+      .map(([year, coord]) => ({ year: Number(year), coord }))
+      .sort((a, b) => a.coord - b.coord);
+  }
+  const entries = context.sortedEntries;
 
   if (entries.length === 0) return null;
 

--- a/packages/graph-engine/src/layouts/timeline.ts
+++ b/packages/graph-engine/src/layouts/timeline.ts
@@ -148,7 +148,7 @@ export function getAnchorTimelineLayout(
  */
 export function getTimelineLayout(
   nodes: GraphNode[],
-  options: TimelineLayoutOptions,
+  options: TimelineLayoutOptions & { yearPositions?: Record<number, number> },
 ): Record<string, { x: number; y: number }> {
   const positions: Record<string, { x: number; y: number }> = {};
 
@@ -174,7 +174,8 @@ export function getTimelineLayout(
   }
 
   // 3. Calculate coordinates (Sequential with Gap Compression)
-  const yearPositions = getSequentialYearPositions(years, options.scale);
+  const yearPositions =
+    options.yearPositions || getSequentialYearPositions(years, options.scale);
   const secondaryAxisOffset = 100; // Shift nodes away from ruler area
 
   for (const [yearStr, yearNodes] of Object.entries(groupedByYear)) {

--- a/packages/graph-engine/src/layouts/timeline.ts
+++ b/packages/graph-engine/src/layouts/timeline.ts
@@ -5,6 +5,7 @@ export interface TimelineLayoutOptions {
   scale: number; // base pixels between sequential time steps
   jitter: number; // separation on secondary axis
   minYear?: number;
+  zoom?: number;
 }
 
 export interface YearPositionContext {
@@ -13,10 +14,78 @@ export interface YearPositionContext {
   sortedEntries?: Array<{ year: number; coord: number }>;
 }
 
+export const TIMELINE_MONTH_ZOOM_THRESHOLD = 3.0;
+export const TIMELINE_DAY_ZOOM_THRESHOLD = 8.0;
+
 export interface TimelineAnchorProjection {
   entityId: string;
   anchorId: string;
   year: number;
+}
+
+function parseMonthFromUnitId(unitId?: string): number | undefined {
+  if (!unitId) return undefined;
+  if (!isNaN(Number(unitId))) return Number(unitId);
+  const match = unitId.match(/\d+/);
+  if (match) return Number(match[0]);
+  const lower = unitId.toLowerCase();
+  const months = [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
+  ];
+  for (let i = 0; i < months.length; i++) {
+    if (lower.startsWith(months[i])) {
+      return i + 1;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Calculates a fractional year value from a date with optional month and day.
+ */
+export function getFractionalYear(date?: {
+  year: number;
+  month?: number;
+  day?: number;
+  unitId?: string;
+}): number | undefined {
+  if (!date) return undefined;
+  let val = date.year;
+  let month = date.month;
+  if (month === undefined && date.unitId !== undefined) {
+    month = parseMonthFromUnitId(date.unitId);
+  }
+  if (month !== undefined) {
+    val += (month - 1) / 12;
+    if (date.day !== undefined) {
+      val += (date.day - 1) / 365;
+    }
+  }
+  return val;
+}
+
+/**
+ * Quantizes a fractional year based on the current zoom level.
+ */
+export function getQuantizedYear(val: number, zoom: number = 1.0): number {
+  if (zoom < TIMELINE_MONTH_ZOOM_THRESHOLD) {
+    return Math.floor(val);
+  } else if (zoom < TIMELINE_DAY_ZOOM_THRESHOLD) {
+    return Math.floor(val * 12) / 12;
+  } else {
+    return Math.floor(val * 365) / 365;
+  }
 }
 
 /**
@@ -106,6 +175,34 @@ export function getYearForPosition(
   return last.year;
 }
 
+export function getPositionForYear(
+  year: number,
+  context: YearPositionContext,
+): number | null {
+  if (!context.sortedEntries) {
+    context.sortedEntries = Object.entries(context.yearPositions)
+      .map(([y, coord]) => ({ year: Number(y), coord }))
+      .sort((a, b) => a.year - b.year);
+  }
+  const entries = context.sortedEntries;
+  if (entries.length === 0) return null;
+
+  if (year <= entries[0].year) return entries[0].coord;
+  const last = entries[entries.length - 1];
+  if (year >= last.year) return last.coord;
+
+  for (let index = 1; index < entries.length; index += 1) {
+    const previous = entries[index - 1];
+    const next = entries[index];
+    if (year <= next.year) {
+      const ratio = (year - previous.year) / (next.year - previous.year);
+      return previous.coord + (next.coord - previous.coord) * ratio;
+    }
+  }
+
+  return last.coord;
+}
+
 export function getAnchorTimelineLayout(
   anchors: TimelineAnchorProjection[],
   options: TimelineLayoutOptions,
@@ -113,23 +210,30 @@ export function getAnchorTimelineLayout(
   const positions: Record<string, { x: number; y: number }> = {};
   if (anchors.length === 0) return positions;
 
-  const groupedByYear: Record<number, TimelineAnchorProjection[]> = {};
+  const zoom = options.zoom ?? 1.0;
   const years: number[] = [];
+  const groupedByFracYear: Record<number, TimelineAnchorProjection[]> = {};
+
   for (const anchor of anchors) {
-    years.push(anchor.year);
-    groupedByYear[anchor.year] ??= [];
-    groupedByYear[anchor.year].push(anchor);
+    const quantizedYear = getQuantizedYear(anchor.year, zoom);
+    years.push(quantizedYear);
+    groupedByFracYear[anchor.year] ??= [];
+    groupedByFracYear[anchor.year].push(anchor);
   }
 
   const yearPositions = getSequentialYearPositions(years, options.scale);
   const secondaryAxisOffset = 100;
 
-  for (const [yearValue, yearAnchors] of Object.entries(groupedByYear)) {
-    const year = Number(yearValue);
-    const primaryCoord = yearPositions[year] ?? 0;
-    yearAnchors.forEach((anchor, index) => {
+  for (const [fracYearStr, groupAnchors] of Object.entries(groupedByFracYear)) {
+    const fracYear = Number(fracYearStr);
+    const quantizedYear = getQuantizedYear(fracYear, zoom);
+    const baseCoord = yearPositions[quantizedYear] ?? 0;
+    const fraction = fracYear - quantizedYear;
+    const primaryCoord = baseCoord + fraction * options.scale;
+
+    groupAnchors.forEach((anchor, index) => {
       const jitterCoord =
-        (index - (yearAnchors.length - 1) / 2) * options.jitter;
+        (index - (groupAnchors.length - 1) / 2) * options.jitter;
       const secondaryCoord = jitterCoord + secondaryAxisOffset;
       const key = `${anchor.entityId}::${anchor.anchorId}`;
       positions[key] =
@@ -144,7 +248,8 @@ export function getAnchorTimelineLayout(
 
 /**
  * Calculates positions for a chronological layout.
- * Nodes with identical years are spread along the secondary axis to prevent occlusion.
+ * Nodes with identical exact dates are stacked on top of each other,
+ * while nodes with different dates are spread out.
  */
 export function getTimelineLayout(
   nodes: GraphNode[],
@@ -158,33 +263,45 @@ export function getTimelineLayout(
   if (datedNodes.length === 0) return {};
 
   const getYear = (n: GraphNode) => {
-    return (
-      n.data.date?.year ?? n.data.start_date?.year ?? n.data.end_date?.year ?? 0
-    );
+    const d = n.data.date ?? n.data.start_date ?? n.data.end_date;
+    return getFractionalYear(d) ?? 0;
   };
 
-  // 2. Group by year to handle concurrent events (jitter)
-  const groupedByYear: Record<number, GraphNode[]> = {};
-  const years: number[] = [];
-  for (const node of datedNodes) {
-    const year = getYear(node);
-    years.push(year);
-    if (!groupedByYear[year]) groupedByYear[year] = [];
-    groupedByYear[year].push(node);
-  }
+  const zoom = options.zoom ?? 1.0;
+
+  // 2. Extract quantized years for the sequential mapping
+  const quantizedYears = datedNodes.map((n) =>
+    getQuantizedYear(getYear(n), zoom),
+  );
 
   // 3. Calculate coordinates (Sequential with Gap Compression)
   const yearPositions =
-    options.yearPositions || getSequentialYearPositions(years, options.scale);
-  const secondaryAxisOffset = 100; // Shift nodes away from ruler area
+    options.yearPositions ||
+    getSequentialYearPositions(quantizedYears, options.scale);
 
-  for (const [yearStr, yearNodes] of Object.entries(groupedByYear)) {
-    const year = Number(yearStr);
-    const primaryCoord = yearPositions[year] ?? 0;
+  // Group by exact fractional year to apply jitter (stacking) only to events with the exact same date
+  const groupedByFracYear: Record<number, GraphNode[]> = {};
+  for (const node of datedNodes) {
+    const fracYear = getYear(node);
+    if (!groupedByFracYear[fracYear]) {
+      groupedByFracYear[fracYear] = [];
+    }
+    groupedByFracYear[fracYear].push(node);
+  }
 
-    yearNodes.forEach((node, index) => {
-      // Offset from center for jitter
-      const jitterCoord = (index - (yearNodes.length - 1) / 2) * options.jitter;
+  const secondaryAxisOffset = 100;
+
+  for (const [fracYearStr, groupNodes] of Object.entries(groupedByFracYear)) {
+    const fracYear = Number(fracYearStr);
+    const quantizedYear = getQuantizedYear(fracYear, zoom);
+    const baseCoord = yearPositions[quantizedYear] ?? 0;
+    const fraction = fracYear - quantizedYear;
+    const primaryCoord = baseCoord + fraction * options.scale;
+
+    groupNodes.forEach((node, index) => {
+      // Offset from center for jitter (stacking concurrent events)
+      const jitterCoord =
+        (index - (groupNodes.length - 1) / 2) * options.jitter;
       const secondaryCoord = jitterCoord + secondaryAxisOffset;
 
       if (options.axis === "x") {

--- a/packages/graph-engine/src/layouts/timeline.ts
+++ b/packages/graph-engine/src/layouts/timeline.ts
@@ -7,6 +7,17 @@ export interface TimelineLayoutOptions {
   minYear?: number;
 }
 
+export interface YearPositionContext {
+  yearPositions: Record<number, number>;
+  axis?: "x" | "y";
+}
+
+export interface TimelineAnchorProjection {
+  entityId: string;
+  anchorId: string;
+  year: number;
+}
+
 /**
  * Checks whether a node has any timeline-related date metadata.
  *
@@ -56,6 +67,75 @@ export function getSequentialYearPositions(
   }
 
   return yearPositions;
+}
+
+export function getYearForPosition(
+  position: number | { x: number; y: number },
+  context: YearPositionContext,
+): number | null {
+  const entries = Object.entries(context.yearPositions)
+    .map(([year, coord]) => ({ year: Number(year), coord }))
+    .sort((a, b) => a.coord - b.coord);
+
+  if (entries.length === 0) return null;
+
+  const coord =
+    typeof position === "number"
+      ? position
+      : context.axis === "y"
+        ? position.y
+        : position.x;
+
+  if (coord <= entries[0].coord) return entries[0].year;
+  const last = entries[entries.length - 1];
+  if (coord >= last.coord) return last.year;
+
+  for (let index = 1; index < entries.length; index += 1) {
+    const previous = entries[index - 1];
+    const next = entries[index];
+    if (coord <= next.coord) {
+      const ratio = (coord - previous.coord) / (next.coord - previous.coord);
+      return Math.round(previous.year + (next.year - previous.year) * ratio);
+    }
+  }
+
+  return last.year;
+}
+
+export function getAnchorTimelineLayout(
+  anchors: TimelineAnchorProjection[],
+  options: TimelineLayoutOptions,
+): Record<string, { x: number; y: number }> {
+  const positions: Record<string, { x: number; y: number }> = {};
+  if (anchors.length === 0) return positions;
+
+  const groupedByYear: Record<number, TimelineAnchorProjection[]> = {};
+  const years: number[] = [];
+  for (const anchor of anchors) {
+    years.push(anchor.year);
+    groupedByYear[anchor.year] ??= [];
+    groupedByYear[anchor.year].push(anchor);
+  }
+
+  const yearPositions = getSequentialYearPositions(years, options.scale);
+  const secondaryAxisOffset = 100;
+
+  for (const [yearValue, yearAnchors] of Object.entries(groupedByYear)) {
+    const year = Number(yearValue);
+    const primaryCoord = yearPositions[year] ?? 0;
+    yearAnchors.forEach((anchor, index) => {
+      const jitterCoord =
+        (index - (yearAnchors.length - 1) / 2) * options.jitter;
+      const secondaryCoord = jitterCoord + secondaryAxisOffset;
+      const key = `${anchor.entityId}::${anchor.anchorId}`;
+      positions[key] =
+        options.axis === "x"
+          ? { x: primaryCoord, y: secondaryCoord }
+          : { x: secondaryCoord, y: primaryCoord };
+    });
+  }
+
+  return positions;
 }
 
 /**

--- a/packages/graph-engine/src/renderer/overlays.ts
+++ b/packages/graph-engine/src/renderer/overlays.ts
@@ -1,9 +1,16 @@
 import type { Era } from "schema";
+import {
+  getPositionForYear,
+  TIMELINE_DAY_ZOOM_THRESHOLD,
+  TIMELINE_MONTH_ZOOM_THRESHOLD,
+} from "../layouts/timeline";
 
 export interface RulerTick {
   year: number;
   pos: number;
   isMajor: boolean;
+  label: string;
+  type: "year" | "month" | "day";
 }
 
 export interface EraRegion {
@@ -14,31 +21,137 @@ export interface EraRegion {
   color?: string;
 }
 
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
 /**
- * Calculates tick marks for a timeline ruler based on actual data positions.
+ * Calculates tick marks for a timeline ruler based on actual data positions and current zoom level.
  */
 export function getRulerTicks(
   yearPositions: Record<number, number>,
+  zoom: number = 1.0,
 ): RulerTick[] {
   const ticks: RulerTick[] = [];
-  const years = Object.keys(yearPositions)
+  const rawYears = Object.keys(yearPositions)
     .map(Number)
     .sort((a, b) => a - b);
+  if (rawYears.length === 0) return [];
 
-  if (years.length === 0) return [];
+  const context = { yearPositions };
+  const getPos = (yr: number) => getPositionForYear(yr, context);
 
-  // Determine which years to show as ticks to avoid clutter
-  // For now, let's show all years if there aren't too many, or filter them
-  const maxTicks = 50;
-  const step = Math.ceil(years.length / maxTicks);
+  // If zoom is standard, only show year ticks
+  if (zoom < TIMELINE_MONTH_ZOOM_THRESHOLD) {
+    const entries = Object.entries(yearPositions)
+      .map(([yearStr, pos]) => ({
+        rawYear: Number(yearStr),
+        year: Math.floor(Number(yearStr)),
+        pos,
+      }))
+      .sort((a, b) => a.rawYear - b.rawYear);
 
-  for (let i = 0; i < years.length; i += step) {
-    const year = years[i];
-    ticks.push({
-      year,
-      pos: yearPositions[year],
-      isMajor: i % 5 === 0,
-    });
+    const seenYears = new Set<number>();
+    const uniqueEntries: typeof entries = [];
+    for (const entry of entries) {
+      if (!seenYears.has(entry.year)) {
+        seenYears.add(entry.year);
+        uniqueEntries.push(entry);
+      }
+    }
+
+    const maxTicks = 50;
+    const step = Math.ceil(uniqueEntries.length / maxTicks);
+
+    for (let i = 0; i < uniqueEntries.length; i += step) {
+      const entry = uniqueEntries[i];
+      ticks.push({
+        year: entry.year,
+        pos: entry.pos,
+        isMajor: i % 5 === 0,
+        label: String(entry.year),
+        type: "year",
+      });
+    }
+    return ticks;
+  }
+
+  const seenYearTicks = new Set<number>();
+  const seenMonthTicks = new Set<string>();
+  const seenDayTicks = new Set<string>();
+
+  for (const rawYear of rawYears) {
+    const integerYear = Math.floor(rawYear);
+
+    if (!seenYearTicks.has(integerYear)) {
+      const yearPos = getPos(integerYear);
+      if (yearPos !== null) {
+        ticks.push({
+          year: integerYear,
+          pos: yearPos,
+          isMajor: true,
+          label: String(integerYear),
+          type: "year",
+        });
+      }
+      seenYearTicks.add(integerYear);
+    }
+
+    if (Number.isInteger(rawYear)) continue;
+
+    const monthIndex = Math.floor((rawYear - integerYear) * 12);
+    const normalizedMonthIndex = Math.max(0, Math.min(11, monthIndex));
+    const fractionalMonth = integerYear + normalizedMonthIndex / 12;
+    const monthKey = `${integerYear}-${normalizedMonthIndex}`;
+
+    if (!seenMonthTicks.has(monthKey)) {
+      const monthPos = getPos(fractionalMonth);
+      if (monthPos !== null) {
+        const isDayZoom = zoom >= TIMELINE_DAY_ZOOM_THRESHOLD;
+        ticks.push({
+          year: integerYear,
+          pos: monthPos,
+          isMajor: isDayZoom,
+          label: isDayZoom
+            ? `${MONTH_NAMES[normalizedMonthIndex]} ${integerYear}`
+            : MONTH_NAMES[normalizedMonthIndex],
+          type: "month",
+        });
+      }
+      seenMonthTicks.add(monthKey);
+    }
+
+    if (zoom >= TIMELINE_DAY_ZOOM_THRESHOLD) {
+      const dayOfYear = Math.floor((rawYear - integerYear) * 365) + 1;
+      const dayKey = `${integerYear}-${normalizedMonthIndex}-${dayOfYear}`;
+      if (seenDayTicks.has(dayKey)) continue;
+
+      const dayPos = getPos(rawYear);
+      if (dayPos !== null) {
+        const approximateDayInMonth =
+          Math.floor((rawYear - fractionalMonth) * 365) + 1;
+        const label = String(Math.max(1, approximateDayInMonth));
+        ticks.push({
+          year: integerYear,
+          pos: dayPos,
+          isMajor: false,
+          label,
+          type: "day",
+        });
+      }
+      seenDayTicks.add(dayKey);
+    }
   }
 
   return ticks;

--- a/packages/graph-engine/src/transformer.test.ts
+++ b/packages/graph-engine/src/transformer.test.ts
@@ -102,6 +102,121 @@ describe("GraphTransformer", () => {
     expect(node?.data.image).toBe("http://example.com/img.png");
   });
 
+  it("should not emit temporal edit handle nodes by default", () => {
+    const entities: Entity[] = [
+      {
+        id: "char-1",
+        type: "character",
+        title: "Avel",
+        tags: [],
+        labels: [],
+        connections: [],
+        content: "",
+        start_date: { year: 580 },
+        end_date: { year: 640 },
+        temporalAnchors: [
+          {
+            id: "appearance-1",
+            type: "majorAppearance",
+            date: { year: 621 },
+          },
+        ],
+      },
+    ];
+
+    const elements = GraphTransformer.entitiesToElements(entities);
+
+    expect(
+      elements.filter((element) => element.group === "nodes"),
+    ).toHaveLength(1);
+    expect(
+      elements.some(
+        (element) => element.group === "nodes" && element.data.isTemporalAnchor,
+      ),
+    ).toBe(false);
+  });
+
+  it("should emit independently addressable nodes for temporal anchors when requested", () => {
+    const entities: Entity[] = [
+      {
+        id: "char-1",
+        type: "character",
+        title: "Avel",
+        tags: [],
+        labels: [],
+        connections: [],
+        content: "",
+        date: { year: 580 },
+        temporalAnchors: [
+          {
+            id: "appearance-1",
+            type: "majorAppearance",
+            date: { year: 621 },
+          },
+        ],
+      },
+    ];
+
+    const elements = GraphTransformer.entitiesToElements(entities, undefined, {
+      includeTemporalEditHandles: true,
+    });
+    const anchorNode = elements.find(
+      (element): element is GraphNode =>
+        element.group === "nodes" && element.data.id === "char-1::appearance-1",
+    );
+
+    expect(anchorNode).toBeDefined();
+    expect(anchorNode?.data.entityId).toBe("char-1");
+    expect(anchorNode?.data.anchorId).toBe("appearance-1");
+    expect(anchorNode?.data.isTemporalAnchor).toBe(true);
+    expect(anchorNode?.data.date?.year).toBe(621);
+  });
+
+  it("should emit independently addressable primary range edge handles when requested", () => {
+    const entities: Entity[] = [
+      {
+        id: "war-1",
+        type: "note",
+        title: "The Long War",
+        tags: [],
+        labels: [],
+        connections: [],
+        content: "",
+        start_date: { year: 500 },
+        end_date: { year: 510 },
+      },
+    ];
+
+    const elements = GraphTransformer.entitiesToElements(entities, undefined, {
+      includeTemporalEditHandles: true,
+    });
+    const startHandle = elements.find(
+      (element): element is GraphNode =>
+        element.group === "nodes" &&
+        element.data.id === "war-1::primary-range-start",
+    );
+    const endHandle = elements.find(
+      (element): element is GraphNode =>
+        element.group === "nodes" &&
+        element.data.id === "war-1::primary-range-end",
+    );
+
+    expect(startHandle?.data).toMatchObject({
+      entityId: "war-1",
+      anchorId: "primary-range-start",
+      anchorType: "rangeStart",
+      isTemporalAnchor: true,
+      date: { year: 500 },
+    });
+    expect(endHandle?.data).toMatchObject({
+      entityId: "war-1",
+      anchorId: "primary-range-end",
+      anchorType: "rangeEnd",
+      isTemporalAnchor: true,
+      date: { year: 510 },
+    });
+  });
+
   it("should use custom label on edges when provided", () => {
     const entities: Entity[] = [
       {

--- a/packages/graph-engine/src/transformer.ts
+++ b/packages/graph-engine/src/transformer.ts
@@ -24,6 +24,10 @@ export interface GraphNode {
     start_date?: TemporalMetadata;
     end_date?: TemporalMetadata;
     dateLabel?: string;
+    entityId?: string;
+    anchorId?: string;
+    anchorType?: string;
+    isTemporalAnchor?: boolean;
     textureVariant?: number;
   };
   position?: { x: number; y: number };
@@ -42,6 +46,10 @@ export interface GraphEdge {
 }
 
 export type GraphElement = GraphNode | GraphEdge;
+
+export interface GraphTransformOptions {
+  includeTemporalEditHandles?: boolean;
+}
 
 const incrementWeight = (weights: Map<string, number>, id: string) => {
   weights.set(id, (weights.get(id) ?? 0) + 1);
@@ -84,7 +92,10 @@ export class GraphTransformer {
   static entitiesToElements(
     entities: Entity[],
     validIds?: Set<string>,
+    options: GraphTransformOptions = {},
   ): GraphElement[] {
+    const includeTemporalEditHandles =
+      options.includeTemporalEditHandles === true;
     // Create a Set of valid entity IDs for O(1) lookups
     if (!validIds) {
       // OPTIMIZATION: Use a loop instead of map to avoid array allocation
@@ -191,6 +202,8 @@ export class GraphTransformer {
 
       // Assign a stable-ish random position based on ID if no coords exist.
       // Performance: Compute a simple hash in a single pass to avoid multiple split/reduce cycles.
+      const angle = i * GOLDEN_ANGLE;
+      const distance = spiralRadius * Math.sqrt((i + 0.5) / count);
       if (hasValidCoords) {
         elements.push({
           group: "nodes",
@@ -198,8 +211,6 @@ export class GraphTransformer {
           position: coords,
         });
       } else {
-        const angle = i * GOLDEN_ANGLE;
-        const distance = spiralRadius * Math.sqrt((i + 0.5) / count);
         // Mark as pending layout so it stays invisible until placed
         (nodeData as any).isPendingLayout = true;
         elements.push({
@@ -210,6 +221,76 @@ export class GraphTransformer {
             y: Math.sin(angle) * distance,
           },
         });
+      }
+
+      const basePosition = hasValidCoords
+        ? { x: coords.x, y: coords.y }
+        : {
+            x: Math.cos(angle) * distance,
+            y: Math.sin(angle) * distance,
+          };
+      if (includeTemporalEditHandles && entity.start_date) {
+        elements.push({
+          group: "nodes",
+          data: {
+            ...nodeData,
+            id: `${entity.id}::primary-range-start`,
+            entityId: entity.id,
+            anchorId: "primary-range-start",
+            anchorType: "rangeStart",
+            isTemporalAnchor: true,
+            label: `${entity.title} - start`,
+            date: entity.start_date,
+            start_date: undefined,
+            end_date: undefined,
+            dateLabel: formatDate(entity.start_date),
+          },
+          position: basePosition,
+        });
+      }
+      if (includeTemporalEditHandles && entity.end_date) {
+        elements.push({
+          group: "nodes",
+          data: {
+            ...nodeData,
+            id: `${entity.id}::primary-range-end`,
+            entityId: entity.id,
+            anchorId: "primary-range-end",
+            anchorType: "rangeEnd",
+            isTemporalAnchor: true,
+            label: `${entity.title} - end`,
+            date: entity.end_date,
+            start_date: undefined,
+            end_date: undefined,
+            dateLabel: formatDate(entity.end_date),
+          },
+          position: basePosition,
+        });
+      }
+
+      if (includeTemporalEditHandles) {
+        for (const anchor of entity.temporalAnchors ?? []) {
+          const anchorDateLabel = formatDate(
+            anchor.date || anchor.start_date || anchor.end_date,
+          );
+          elements.push({
+            group: "nodes",
+            data: {
+              ...nodeData,
+              id: `${entity.id}::${anchor.id}`,
+              entityId: entity.id,
+              anchorId: anchor.id,
+              anchorType: anchor.type,
+              isTemporalAnchor: true,
+              label: anchor.label || `${entity.title} - ${anchor.type}`,
+              date: anchor.date,
+              start_date: anchor.start_date,
+              end_date: anchor.end_date,
+              dateLabel: anchorDateLabel,
+            },
+            position: basePosition,
+          });
+        }
       }
 
       // Create Edges

--- a/packages/graph-engine/tests/timeline-anchor.test.ts
+++ b/packages/graph-engine/tests/timeline-anchor.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAnchorTimelineLayout,
+  getSequentialYearPositions,
+  getYearForPosition,
+} from "../src/layouts/timeline";
+
+describe("timeline anchor layout", () => {
+  it("resolves exact year positions and interpolates between compressed gaps", () => {
+    const yearPositions = getSequentialYearPositions([500, 510, 620], 100);
+
+    expect(getYearForPosition(yearPositions[510], { yearPositions })).toBe(510);
+    expect(getYearForPosition(-999, { yearPositions })).toBe(500);
+    expect(getYearForPosition(9999, { yearPositions })).toBe(620);
+    expect(
+      getYearForPosition({ x: 50, y: 0 }, { yearPositions, axis: "x" }),
+    ).toBe(505);
+  });
+
+  it("keys projected anchors by entity and anchor id", () => {
+    const layout = getAnchorTimelineLayout(
+      [
+        { entityId: "char-1", anchorId: "born", year: 580 },
+        { entityId: "char-1", anchorId: "appearance", year: 621 },
+      ],
+      { axis: "x", scale: 100, jitter: 24 },
+    );
+
+    expect(Object.keys(layout)).toEqual(["char-1::born", "char-1::appearance"]);
+    expect(layout["char-1::born"].x).not.toBe(layout["char-1::appearance"].x);
+  });
+});

--- a/packages/graph-engine/tests/timeline.test.ts
+++ b/packages/graph-engine/tests/timeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getTimelineLayout, hasTimelineDate } from "../src/layouts/timeline";
+import { getRulerTicks } from "../src/renderer/overlays";
 import type { GraphNode } from "../src/transformer";
 
 describe("Timeline Layout", () => {
@@ -79,6 +80,58 @@ describe("Timeline Layout", () => {
     expect(positions["n1"].x).toBe(75);
   });
 
+  it("should space out events horizontally within the same year if they have different months/days and stack if they have the same date", () => {
+    const nodes: GraphNode[] = [
+      {
+        group: "nodes",
+        data: {
+          id: "event-sep",
+          label: "September Event",
+          type: "event",
+          weight: 0,
+          date: { year: 1005, month: 9, day: 15 },
+        },
+      },
+      {
+        group: "nodes",
+        data: {
+          id: "event-oct",
+          label: "October Event",
+          type: "event",
+          weight: 0,
+          date: { year: 1005, month: 10, day: 1 },
+        },
+      },
+      {
+        group: "nodes",
+        data: {
+          id: "event-sep-dup",
+          label: "September Event 2",
+          type: "event",
+          weight: 0,
+          date: { year: 1005, month: 9, day: 15 },
+        },
+      },
+    ];
+
+    const positions = getTimelineLayout(nodes, {
+      axis: "x",
+      scale: 100,
+      jitter: 50,
+      zoom: 1.0,
+    });
+
+    // September Event and October Event have different dates, so they spread out horizontally
+    expect(positions["event-sep"].x).not.toBe(positions["event-oct"].x);
+    // October Event is unique, so it sits on the baseline Y = 100
+    expect(positions["event-oct"].y).toBe(100);
+
+    // September Event and September Event 2 have the exact same date, so they stack vertically (different Y, same X)
+    expect(positions["event-sep"].x).toBe(positions["event-sep-dup"].x);
+    expect(positions["event-sep"].y).toBe(75);
+    expect(positions["event-sep-dup"].y).toBe(125);
+  });
+
   it("should detect nodes without timeline metadata", () => {
     const undatedNode: GraphNode = {
       group: "nodes",
@@ -111,5 +164,57 @@ describe("Timeline Layout", () => {
     expect(hasTimelineDate(undatedNode)).toBe(false);
     expect(hasTimelineDate(nodeWithStartDate)).toBe(true);
     expect(hasTimelineDate(nodeWithEndDate)).toBe(true);
+  });
+
+  it("should floor and deduplicate fractional years in getRulerTicks", () => {
+    const yearPositions = {
+      1005: 100,
+      1005.67: 200,
+      1005.75: 300,
+      1006: 400,
+    };
+    const ticks = getRulerTicks(yearPositions);
+
+    // Should only have 1005 (at coordinate 100) and 1006 (at coordinate 400)
+    expect(ticks).toHaveLength(2);
+    expect(ticks[0]).toEqual({
+      year: 1005,
+      pos: 100,
+      isMajor: true,
+      label: "1005",
+      type: "year",
+    });
+    expect(ticks[1]).toEqual({
+      year: 1006,
+      pos: 400,
+      isMajor: false,
+      label: "1006",
+      type: "year",
+    });
+  });
+
+  it("should generate months and days ticks at deeper zoom levels in getRulerTicks", () => {
+    const yearPositions = {
+      1005: 100,
+      1005.67: 200,
+      1006: 300,
+    };
+
+    // Zoom 3.0: should show year + month ticks
+    const monthTicks = getRulerTicks(yearPositions, 3.0);
+    const monthsFor1005 = monthTicks.filter(
+      (t) => t.year === 1005 && t.type === "month",
+    );
+    expect(monthsFor1005.length).toBeGreaterThan(0);
+    expect(monthsFor1005.length).toBe(1);
+    expect(monthsFor1005[0].label).toBeDefined();
+
+    // Zoom 8.0: should show days ticks
+    const dayTicks = getRulerTicks(yearPositions, 8.0);
+    const daysFor1005 = dayTicks.filter(
+      (t) => t.year === 1005 && t.type === "day",
+    );
+    expect(daysFor1005.length).toBeGreaterThan(0);
+    expect(daysFor1005.length).toBe(1);
   });
 });

--- a/packages/schema/src/entity.test.ts
+++ b/packages/schema/src/entity.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { EntitySchema, TemporalAnchorSchema } from "./entity";
+
+const date = { year: 605, label: "605 P.C." };
+
+describe("TemporalAnchorSchema", () => {
+  it("requires at least one temporal value", () => {
+    expect(() =>
+      TemporalAnchorSchema.parse({ id: "a1", type: "majorAppearance" }),
+    ).toThrow();
+  });
+
+  it("requires a label for custom anchors", () => {
+    expect(() =>
+      TemporalAnchorSchema.parse({ id: "a1", type: "custom", date }),
+    ).toThrow();
+
+    expect(
+      TemporalAnchorSchema.parse({
+        id: "a1",
+        type: "custom",
+        label: "Prophecy",
+        date,
+      }).label,
+    ).toBe("Prophecy");
+  });
+
+  it("rejects inverted ranges", () => {
+    expect(() =>
+      TemporalAnchorSchema.parse({
+        id: "a1",
+        type: "activePeriod",
+        start_date: { year: 620 },
+        end_date: { year: 610 },
+      }),
+    ).toThrow();
+  });
+
+  it("validates date-selection shapes", () => {
+    expect(() =>
+      TemporalAnchorSchema.parse({
+        id: "a1",
+        type: "born",
+        date: { precision: "day", year: 605, calendarRevision: 1 },
+      }),
+    ).toThrow();
+
+    expect(
+      TemporalAnchorSchema.parse({
+        id: "a1",
+        type: "born",
+        date: {
+          precision: "day",
+          year: 605,
+          unitId: "firstmoon",
+          day: 12,
+          calendarRevision: 1,
+        },
+      }).date?.year,
+    ).toBe(605);
+  });
+});
+
+describe("EntitySchema temporal anchors", () => {
+  it("preserves backwards compatibility when temporalAnchors is absent", () => {
+    const entity = EntitySchema.parse({
+      id: "event-1",
+      type: "event",
+      title: "Founding",
+    });
+
+    expect(entity.temporalAnchors).toBeUndefined();
+    expect(entity.tags).toEqual([]);
+    expect(entity.labels).toEqual([]);
+  });
+
+  it("accepts additional temporal anchors without requiring primary dates", () => {
+    const entity = EntitySchema.parse({
+      id: "char-1",
+      type: "character",
+      title: "Avel",
+      temporalAnchors: [{ id: "born", type: "born", date }],
+    });
+
+    expect(entity.temporalAnchors).toHaveLength(1);
+  });
+});

--- a/packages/schema/src/entity.ts
+++ b/packages/schema/src/entity.ts
@@ -57,12 +57,25 @@ export const DateSelectionSchema = z
     }
   });
 
-export const LegacyTemporalMetadataSchema = z.object({
+const LegacyTemporalMetadataBaseSchema = z.object({
   year: z.number(),
   month: z.number().min(1).max(12).optional(),
   day: z.number().min(1).max(31).optional(),
   label: z.string().optional(),
 });
+
+export const LegacyTemporalMetadataSchema =
+  LegacyTemporalMetadataBaseSchema.passthrough()
+    .superRefine((data, ctx) => {
+      if ("precision" in data) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Legacy temporal metadata cannot include precision",
+          path: ["precision"],
+        });
+      }
+    })
+    .transform((data) => LegacyTemporalMetadataBaseSchema.parse(data));
 
 export const TemporalMetadataSchema = z.union([
   DateSelectionSchema,
@@ -70,6 +83,51 @@ export const TemporalMetadataSchema = z.union([
 ]);
 
 export type TemporalMetadata = z.infer<typeof TemporalMetadataSchema>;
+
+export const TemporalAnchorSchema = z
+  .object({
+    id: z.string().min(1),
+    type: z.string().min(1),
+    label: z.string().trim().min(1).optional(),
+    date: TemporalMetadataSchema.optional(),
+    start_date: TemporalMetadataSchema.optional(),
+    end_date: TemporalMetadataSchema.optional(),
+    linkedEntityId: z.string().min(1).optional(),
+    note: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.date && !data.start_date && !data.end_date) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Temporal anchor requires date, start_date, or end_date",
+        path: ["date"],
+      });
+    }
+
+    if (data.type === "custom" && !data.label) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Custom temporal anchors require a label",
+        path: ["label"],
+      });
+    }
+
+    const startYear = data.start_date?.year;
+    const endYear = data.end_date?.year;
+    if (
+      typeof startYear === "number" &&
+      typeof endYear === "number" &&
+      endYear < startYear
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Temporal anchor range cannot end before it starts",
+        path: ["end_date"],
+      });
+    }
+  });
+
+export type TemporalAnchor = z.infer<typeof TemporalAnchorSchema>;
 
 export const EraSchema = z.object({
   id: z.string().min(1),
@@ -153,6 +211,7 @@ export const EntitySchema = z.object({
   date: TemporalMetadataSchema.optional(),
   start_date: TemporalMetadataSchema.optional(),
   end_date: TemporalMetadataSchema.optional(),
+  temporalAnchors: z.array(TemporalAnchorSchema).optional(),
   metadata: z
     .object({
       coordinates: z.object({ x: z.number(), y: z.number() }).optional(),

--- a/specs/130-editable-time-graph/checklists/requirements.md
+++ b/specs/130-editable-time-graph/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Editable Time Graph with Semantic Temporal Placement
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Validation passed on first iteration. No [NEEDS CLARIFICATION] markers were required: the issue (#1159) is unusually detailed, so gaps were resolved with documented assumptions (in-world calendar handling reuses `026-world-timeline`; the anchor model supplements existing date fields via mapping rather than migration; pointer-first interaction with touch/keyboard deferred to planning).
+- One area a reviewer may wish to revisit during `/speckit-clarify`: whether undo (FR-008 / SC-007) is in-scope for the first iteration (currently SHOULD, not MUST) and whether non-temporal layout movement (FR-007) coexists with chronology editing in this graph at all.

--- a/specs/130-editable-time-graph/contracts/chronology-engine.placement.md
+++ b/specs/130-editable-time-graph/contracts/chronology-engine.placement.md
@@ -1,0 +1,100 @@
+# Contract: `chronology-engine` — meaning-sets, anchors, placement
+
+Package: `packages/chronology-engine`. New modules `meaning-sets.ts`, `anchors.ts`, `placement.ts`; reuse `engine.ts` (`calendarEngine`, `parseDirectDateInput`).
+
+## meaning-sets.ts
+
+```ts
+export interface Meaning {
+  id: string; // e.g. "born", "founded", "custom"
+  label: string; // plain natural-language label (Constitution IX)
+  kind: "point" | "span";
+  target: "date" | "start_date" | "end_date" | "anchor";
+  anchorType?: string; // when target === "anchor"
+  primary?: boolean; // the meaning that writes the legacy date field
+  role?: "begin" | "end"; // category-correct begin/end concept (FR-016a)
+}
+
+export const MEANING_SETS: Record<string, Meaning[]>;
+export function getMeanings(entityType: string): Meaning[]; // falls back to generic set
+export function getBeginMeaning(entityType: string): Meaning; // the role:"begin" meaning
+export function getEndMeaning(entityType: string): Meaning | undefined; // role:"end", if any
+```
+
+**Guarantees**:
+
+1. Every supported type (`event`, `period`, `character`, `faction`, `location`, `item`, `note`) returns a non-empty, type-appropriate set (FR-016, SC-003).
+2. Returned meanings differ across types (e.g. `character` ≠ `faction`) (US2 scenario 2).
+3. Every set includes a universal `custom` meaning (FR-017).
+4. Exactly one `primary: true` meaning per type, and it is the `role: "begin"` meaning (FR-016a).
+5. `getBeginMeaning` returns the category-correct begin word (Character→`born`, Faction→`founded`, Item→`created`, Event→`date`); `getEndMeaning` returns the counterpart where applicable (Character→`died`, Faction→`dissolved`, Location→`destroyed`, Item→`lost`) or `undefined` (e.g. Note).
+6. Unknown type → generic fallback set (no throw).
+
+## anchors.ts
+
+```ts
+export function deriveProjectedAnchors(entity: Entity): ProjectedAnchor[];
+export function validateRange(
+  start: TemporalMetadata | undefined,
+  end: TemporalMetadata | undefined,
+): { ok: true } | { ok: false; reason: string };
+export function upsertAnchor(
+  anchors: TemporalAnchor[] | undefined,
+  anchor: TemporalAnchor,
+): TemporalAnchor[];
+export function removeAnchor(
+  anchors: TemporalAnchor[] | undefined,
+  anchorId: string,
+): TemporalAnchor[];
+```
+
+**Guarantees**:
+
+1. `deriveProjectedAnchors` emits a `"primary"` projection from `date`/`start_date`+`end_date` **plus** one per `temporalAnchors[]` (FR-025, FR-028).
+2. An entity with only `date` → exactly one projection (`kind: "point"`); with `start_date`+`end_date` → one `kind: "span"` (FR-026/FR-027).
+3. `validateRange` rejects `end < start` with a reason; accepts equal or ascending (FR-031).
+4. `upsertAnchor`/`removeAnchor` are pure, never mutate input, and never touch sibling anchors or primary fields (FR-023/FR-024).
+
+## placement.ts
+
+```ts
+export interface PlacementIntent {
+  entityId: string;
+  meaning: Meaning;
+  value: TemporalMetadata; // resolved point or span start
+  endValue?: TemporalMetadata; // for spans
+  writes: {
+    field?: "date" | "start_date" | "end_date";
+    anchor?: TemporalAnchor;
+  };
+  describesAs: string; // human summary for the popover ("Set event date to 605 P.C.")
+  createEvent?: {
+    // US7 — present only for the "create a linked event" option
+    title: string; // pre-filled, editable ("{Entity} — {year}")
+    date: TemporalMetadata; // = value (resolved year)
+    anchorType: string; // anchor added to the source, e.g. "majorAppearance"
+    connectionType: string; // e.g. "related_to"
+  };
+}
+
+export function buildIntent(args: {
+  entity: Entity;
+  meaning: Meaning;
+  targetYear: number;
+  endYear?: number;
+  anchorId?: string; // when updating an existing anchor
+}): PlacementIntent;
+
+export function detectConflict(
+  originalValue: TemporalMetadata | undefined,
+  currentValue: TemporalMetadata | undefined,
+): boolean; // true ⇒ entity changed underneath (FR-032)
+```
+
+**Guarantees**:
+
+1. `buildIntent` for an Event primary meaning targets the legacy `date` field and produces a direct `describesAs` (FR-013); for a non-primary meaning it produces an `anchor` write (FR-015/FR-022).
+2. `buildIntent` never emits raw graph coordinates — only structured date/range/anchor writes (SC-008).
+3. `detectConflict` returns false when values are calendar-equal, true otherwise (FR-032).
+4. Span meanings yield both `value` and `endValue`; point meanings only `value` (FR-018).
+5. When asked for the "create a linked event" option, `buildIntent` populates `createEvent` (title, date, anchorType, connectionType) and leaves the source entity's primary date/anchors untouched in `writes` (additive only, FR-038). The actual create/link is executed by the `ChronologyEditService` (engine stays pure — no vault access).

--- a/specs/130-editable-time-graph/contracts/graph-engine.anchor-projection.md
+++ b/specs/130-editable-time-graph/contracts/graph-engine.anchor-projection.md
@@ -1,0 +1,32 @@
+# Contract: `graph-engine` — position↔year + anchor projection
+
+Package: `packages/graph-engine`. Additions to `src/layouts/timeline.ts`.
+
+## Exports
+
+```ts
+// Inverse of the forward sequential/gap-compressed layout.
+export function getYearForPosition(
+  position: number, // pixel on the primary axis
+  ctx: {
+    yearPositions: Record<number, number>; // from getSequentialYearPositions
+    scale: number;
+    minYear?: number;
+  },
+): number | null; // null ⇒ outside resolvable range (FR-012)
+
+// Layout that places each projected anchor as its own point/span.
+export function getAnchorTimelineLayout(
+  anchors: ProjectedAnchor[],
+  options: TimelineLayoutOptions,
+): Record<string /* "entityId::anchorId" */, { x: number; y: number }>;
+```
+
+## Guarantees (test these)
+
+1. **Round-trip stability**: for any year `Y` present in `yearPositions`, `getYearForPosition(yearPositions[Y], ctx) === Y` (R1, SC-008).
+2. **Interpolation**: a position between two year stops resolves to the nearer year (boundary rounding deterministic).
+3. **Out-of-range**: a position before the first / after the last stop beyond a tolerance returns `null` (FR-012).
+4. **Per-anchor keys**: `getAnchorTimelineLayout` returns one entry per projected anchor, keyed `"<entityId>::<anchorId>"`, so the controller can recover `(entityId, anchorId)` on drag (R2, FR-009a).
+5. **Determinism**: identical input → identical output; concurrent anchors at the same year are jitter-offset on the secondary axis (FR-029/FR-030), reusing existing jitter logic.
+6. **No regression**: existing `getTimelineLayout`/`getSequentialYearPositions`/`hasTimelineDate` signatures and behaviour are unchanged (additive only).

--- a/specs/130-editable-time-graph/contracts/schema.temporal-anchor.md
+++ b/specs/130-editable-time-graph/contracts/schema.temporal-anchor.md
@@ -1,0 +1,32 @@
+# Contract: `schema` — TemporalAnchor
+
+Package: `packages/schema`. Public exports added to `src/entity.ts` (and re-exported via `src/index.ts`).
+
+## Exports
+
+```ts
+export const TemporalAnchorSchema: z.ZodType<TemporalAnchor>;
+export type TemporalAnchor = {
+  id: string;
+  type: string;
+  label?: string;
+  date?: TemporalMetadata;
+  start_date?: TemporalMetadata;
+  end_date?: TemporalMetadata;
+  linkedEntityId?: string;
+  note?: string;
+};
+
+// EntitySchema gains:
+//   temporalAnchors: z.array(TemporalAnchorSchema).optional()
+// Entity type gains: temporalAnchors?: TemporalAnchor[]
+```
+
+## Guarantees (test these)
+
+1. **Back-compat**: an existing entity object **without** `temporalAnchors` parses successfully and is unchanged (SC-005).
+2. **Validation**: an anchor with no `date`/`start_date`/`end_date` fails parse.
+3. **Custom requires label**: `{ type: "custom" }` without `label` fails; with `label` passes.
+4. **Range**: `{ start_date: {year: 600}, end_date: {year: 500} }` fails parse (inverted) (FR-031).
+5. **Date shape**: anchor dates accept the same `TemporalMetadata` union as `entity.date` (year-precision and `DateSelection`), and reject free-form strings (FR-021, R5).
+6. **Round-trip**: `TemporalAnchorSchema.parse(x)` is idempotent for valid `x`.

--- a/specs/130-editable-time-graph/data-model.md
+++ b/specs/130-editable-time-graph/data-model.md
@@ -1,0 +1,151 @@
+# Phase 1 Data Model: Editable Time Graph
+
+Source: spec FR-020..FR-025, Key Entities, and Clarifications (hybrid storage). All new types live in `packages/schema`; resolution/derivation logic lives in `chronology-engine`.
+
+## 1. TemporalAnchor (NEW — `packages/schema/src/entity.ts`)
+
+A structured record of **one additional chronological meaning** for an entity.
+
+| Field            | Type               | Required | Notes                                                                                                                                                                                      |
+| ---------------- | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`             | `string` (min 1)   | yes      | Stable per-anchor id, unique within the entity (e.g. `anchor-major-621`).                                                                                                                  |
+| `type`           | `string` (min 1)   | yes      | Semantic meaning id from the meaning catalogue (`born`, `died`, `founded`, `dissolved`, `majorAppearance`, `schism`, `merger`, `created`, `discovered`, `lost`, `recovered`, `custom`, …). |
+| `label`          | `string`           | no       | User-facing override, required when `type === "custom"`.                                                                                                                                   |
+| `date`           | `TemporalMetadata` | no       | Point-in-time anchor. Mutually exclusive in practice with `start_date`/`end_date`.                                                                                                         |
+| `start_date`     | `TemporalMetadata` | no       | Span start.                                                                                                                                                                                |
+| `end_date`       | `TemporalMetadata` | no       | Span end. Must be ≥ `start_date` (see `validateRange`).                                                                                                                                    |
+| `linkedEntityId` | `string`           | no       | Soft reference to another entity (e.g. event of a major appearance). Dangling = render broken link (FR-033).                                                                               |
+| `note`           | `string`           | no       | Free-text annotation.                                                                                                                                                                      |
+
+**Validation rules**:
+
+- Exactly one of {`date`} or {`start_date` and/or `end_date`} should be meaningful; an anchor with neither is invalid (must carry at least one date).
+- `type === "custom"` ⇒ `label` required (non-empty).
+- If both `start_date` and `end_date` present ⇒ `end_date.year >= start_date.year` (and month/day tiebreak) — enforced by `validateRange` (FR-031).
+- `date`/`start_date`/`end_date` reuse the existing `TemporalMetadataSchema` (year-precision minimum); no free-form strings (R5).
+
+**Zod sketch**:
+
+```ts
+export const TemporalAnchorSchema = z
+  .object({
+    id: z.string().min(1),
+    type: z.string().min(1),
+    label: z.string().optional(),
+    date: TemporalMetadataSchema.optional(),
+    start_date: TemporalMetadataSchema.optional(),
+    end_date: TemporalMetadataSchema.optional(),
+    linkedEntityId: z.string().optional(),
+    note: z.string().optional(),
+  })
+  .superRefine(/* at least one date; custom ⇒ label; range non-inverted */);
+export type TemporalAnchor = z.infer<typeof TemporalAnchorSchema>;
+```
+
+## 2. Entity (MODIFIED — `packages/schema/src/entity.ts`)
+
+Add one optional field; **do not** touch the existing temporal fields.
+
+| Field             | Type                | Change    | Notes                                                                                                                                             |
+| ----------------- | ------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `date`            | `TemporalMetadata?` | unchanged | **Authoritative** for the primary point (FR-020a).                                                                                                |
+| `start_date`      | `TemporalMetadata?` | unchanged | Authoritative for primary span start.                                                                                                             |
+| `end_date`        | `TemporalMetadata?` | unchanged | Authoritative for primary span end.                                                                                                               |
+| `temporalAnchors` | `TemporalAnchor[]?` | **NEW**   | Additional meanings only (FR-020b). Absent/empty when the entity has only a primary value. Default: omitted (not `[]`) to keep frontmatter clean. |
+
+Back-compat: the field is optional; all existing vaults parse unchanged (SC-005). Existing readers (`timeline.svelte.ts`, `getTimelineLayout`) keep working on the flat fields.
+
+## 3. Derived: ProjectedAnchor (NEW — `chronology-engine` / `graph-engine`)
+
+A non-persisted view used for rendering and drag (R2). One per displayable anchor of an entity.
+
+| Field         | Type                                               | Notes                                                             |
+| ------------- | -------------------------------------------------- | ----------------------------------------------------------------- |
+| `entityId`    | `string`                                           | Host entity.                                                      |
+| `anchorId`    | `string`                                           | `"primary"` for the legacy-field value, else `TemporalAnchor.id`. |
+| `source`      | `'date' \| 'start_date' \| 'end_date' \| 'anchor'` | Where it came from (drives the save target).                      |
+| `kind`        | `'point' \| 'span'`                                | Determines node vs span rendering (FR-026/FR-027).                |
+| `year`        | `number`                                           | Resolved positioning year (point) or span start.                  |
+| `endYear`     | `number?`                                          | For spans.                                                        |
+| `meaningType` | `string`                                           | For label/popover context.                                        |
+| `linkBroken`  | `boolean?`                                         | True if `linkedEntityId` missing (FR-033).                        |
+
+`deriveProjectedAnchors(entity): ProjectedAnchor[]` = the primary value (from `date`/`start_date`+`end_date`) as `anchorId: "primary"` **plus** one per `temporalAnchors[]` entry. This is the single source for both the renderer and FR-028.
+
+## 4. Meaning catalogue (NEW — `chronology-engine/src/meaning-sets.ts`)
+
+`Meaning = { id, label, kind: 'point'|'span', target: 'date'|'start_date'|'end_date'|'anchor', anchorType?, primary?: boolean, role?: 'begin'|'end' }`
+
+The `role` field encodes FR-016a: per type, exactly one meaning is `role: 'begin'` (the category-correct "when it started" word — `date`/`born`/`founded`/`created`/`associatedDate`) and at most one is `role: 'end'` (`end_date`/`died`/`dissolved`/`destroyed`/`lost`). A point drop defaults to the `begin` meaning; a span gesture defaults to the `begin`+`end` pair. The `begin` meaning is also the `primary: true` meaning that writes the legacy `date` (or `start_date` for span-primary types). Helper: `getBeginMeaning(type)` / `getEndMeaning(type)`.
+
+`MEANING_SETS: Record<string, Meaning[]>` keyed by category id (R4). Minimum coverage (FR-016):
+
+| Type                                            | Meanings (id → target)                                                                                                                                                      |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `event`                                         | date→`date` (primary, point); start→`start_date`; end→`end_date` (span via start+end)                                                                                       |
+| `character`                                     | born→`date`/anchor `born` (primary point); died→anchor `died`; active→anchor `active` (span); reign→anchor `reign` (span); majorAppearance→anchor `majorAppearance` (point) |
+| `faction`                                       | founded→`date`/anchor `founded` (primary); dissolved→anchor `dissolved`; active→anchor `active` (span); schism→anchor `schism`; merger→anchor `merger`                      |
+| `location`                                      | founded→`date` (primary); destroyed→anchor `destroyed`; occupied→anchor `occupied` (span); goldenAge→anchor `goldenAge` (span); relevant→anchor `relevant` (span)           |
+| `item`                                          | created→`date` (primary); discovered→anchor `discovered`; lost→anchor `lost`; ownership→anchor `ownership` (span); recovered→anchor `recovered`                             |
+| `note`                                          | associatedDate→`date` (primary); associatedPeriod→anchor `associatedPeriod` (span); custom→anchor `custom`                                                                  |
+| _(fallback — `creature` + any custom category)_ | date→`date` (primary begin, point); range→`start_date`+`end_date` (span); custom→anchor                                                                                     |
+
+There is **no `period` type** — date ranges are expressed via `start_date`/`end_date` on any type (US3), not a dedicated category. Every set implicitly includes the universal **`custom`** meaning (FR-017). The `primary` meaning is the one that writes the legacy `date` (or `start_date`/`end_date` for span-primary types) instead of an anchor entry — encoding the hybrid decision.
+
+## 5. Transient: ChronologyDrag (NEW — `apps/web` store, non-persisted)
+
+Exists only between `grab` and save/cancel (spec "Placement interaction").
+
+| Field            | Type                            | Notes                                                                                                                                                                                                     |
+| ---------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`         | `'canvas' \| 'explorer'`        | `'canvas'` = in-graph anchor drag (US1–US4); `'explorer'` = external drag from the Entity Explorer (US6).                                                                                                 |
+| `entityId`       | `string`                        | Dragged entity.                                                                                                                                                                                           |
+| `anchorId`       | `string`                        | Grabbed projected anchor (`"primary"` or an anchor id). For `'explorer'` placements the target anchor is chosen at confirm time.                                                                          |
+| `originPosition` | `{x,y} \| null`                 | For restore-on-cancel (FR-006). `null` for `'explorer'` (no pre-existing node to restore).                                                                                                                |
+| `originalValue`  | `TemporalMetadata \| undefined` | Captured at drag-start for conflict detection (FR-032).                                                                                                                                                   |
+| `pressYear`      | `number \| null`                | Year at gesture start (in-canvas press). Equals `targetYear` until a width is swept.                                                                                                                      |
+| `targetYear`     | `number \| null`                | Live-resolved current year (R1); `null` ⇒ invalid drop (FR-012).                                                                                                                                          |
+| `gestureKind`    | `'point' \| 'span'`             | Derived live: `'span'` once the swept width resolves to a difference of **≥ 1 year** (and ≥ ~6px to avoid jitter), else `'point'` (FR-011a). For `source: 'explorer'` always `'point'` at drop (FR-011b). |
+| `pending`        | `PlacementIntent \| null`       | Resolved on drop, awaiting confirm. For a span gesture, carries both `value` (from `pressYear`) and `endValue` (from `targetYear`).                                                                       |
+
+## 6. Mode state (MODIFIED — `apps/web/src/lib/stores/graph.svelte.ts`)
+
+| Field                | Type      | Notes                                                                                                                                 |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `timelineMode`       | `boolean` | existing — view positioning.                                                                                                          |
+| `chronologyEditMode` | `boolean` | **NEW** — gates temporal mutation (FR-001/FR-003). Requires `timelineMode`. Toggling off clears any pending drag (treated as cancel). |
+
+## 7. State transitions (drag lifecycle)
+
+```
+view (chronologyEditMode=false)
+  └─ toggle edit ─▶ edit-idle
+edit-idle
+  └─ grab anchor point ─▶ dragging (capture origin + originalValue)
+dragging
+  ├─ move ─▶ dragging (update targetYear via getYearForPosition)
+  ├─ drop on valid year ─▶ confirming (build PlacementIntent)
+  └─ drop on invalid / Escape ─▶ edit-idle (restore origin, no write)
+confirming
+  ├─ save (valid range, no conflict) ─▶ vault.updateEntity ─▶ edit-idle
+  ├─ range invalid ─▶ confirming (blocked, show reason — FR-031)
+  ├─ conflict detected ─▶ confirming (surface conflict — FR-032)
+  └─ cancel / Escape / exit edit mode ─▶ edit-idle (restore origin, no write)
+```
+
+## 7a. Linked-event creation (US7)
+
+A placement may, instead of (or in addition to) writing the dragged entity's own date/anchor, **create a new Event entity** linked back to it. This produces three coordinated writes via the existing vault APIs:
+
+1. `vault.createEntity("event", title, { date: <resolved> })` → new Event (auto-Labels, unique id).
+2. `upsertAnchor` on the dragged entity → a `TemporalAnchor` (e.g. `type: "majorAppearance"`) with `linkedEntityId` = new event id.
+3. A `Connection` (`{ target: eventId, type: "related_to" }`) added to the dragged entity's `connections[]`.
+
+It is additive (never touches the source's primary date/existing anchors) and transactional (rollback on partial failure). The transient drag's `pending` `PlacementIntent` carries an optional `createEvent` payload (see contract) when this option is chosen.
+
+## 8. Relationships & integrity
+
+- An entity owns 0..N `temporalAnchors`; deleting/editing one never affects siblings or the primary fields (FR-023/FR-024).
+- `temporalAnchors[*].linkedEntityId` → soft FK to another entity; dangling tolerated (FR-033).
+- Primary fields ↔ `ProjectedAnchor("primary")` is a pure derivation, never duplicated into `temporalAnchors` (FR-025).
+- Status Labels (e.g. `past`) remain derived by `applyAutoLabels` on save (Constitution XII), not stored on anchors.

--- a/specs/130-editable-time-graph/plan.md
+++ b/specs/130-editable-time-graph/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Editable Time Graph with Semantic Temporal Placement
+
+**Branch**: `130-editable-time-graph` | **Date**: 2026-06-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/130-editable-time-graph/spec.md`
+
+## Summary
+
+Turn the existing read-only Timeline Mode (`026-world-timeline`) into a chronology **editing** tool. In an explicit _edit-chronology mode_, the user drags an entity (or one of its anchor points) horizontally along the time axis; a live indicator shows the resolved target year; on drop a canon-safe confirmation appears (direct for Events, a semantic meaning-selection popover for other types) and saving writes structured temporal metadata.
+
+Per the clarifications: the existing flat `date`/`start_date`/`end_date` fields stay **authoritative for the primary** point/range (zero migration), and a new `temporalAnchors[]` collection on the entity holds **additional** meanings (multiple appearances, custom anchors). Each anchor renders as its own grabbable point; dragging one proposes updating it, with an "add new anchor instead" option. Undo is deferred this iteration; cancel-before-save is the safety net.
+
+Entities not yet on the timeline (new/undated) are placed for the first time by **dragging them from the Entity Explorer onto the axis** (US6) — reusing the Explorer's existing `application/codex-entity` HTML5 drag source and routing the drop into the same confirmation flow. The confirmation can also **create a new linked Event** at the dropped time (US7), reusing `vault.createEntity` plus an anchor `linkedEntityId` and a connection — an explicit, additive, opt-in action.
+
+Technical approach: keep all semantics and resolution logic in `packages/` (Library-First). `schema` gains the `TemporalAnchor` type and `temporalAnchors` field; `chronology-engine` gains entity-type → meaning-set mapping, anchor helpers, range validation, and **position↔year** resolution; `graph-engine` gains the inverse position→year mapping and per-anchor point projection. The Svelte layer in `apps/web` stays thin: an edit-mode toggle, in-graph drag handlers wired into the existing graph controller, a **canvas drop target** for Explorer drags, a live axis indicator, and a semantic placement popover that reuses the existing `TemporalPicker`. Saving routes through the existing `vault.updateEntity()` path (which already applies auto-Labels).
+
+## Technical Context
+
+**Language/Version**: TypeScript (strict), Svelte 5 (runes mode)
+**Primary Dependencies**: Cytoscape.js (graph rendering/drag), `@floating-ui/dom` (popover positioning), Zod (schema validation); internal workspace packages `schema`, `chronology-engine`, `graph-engine`, `vault-engine`
+**Storage**: Client-side only — entities persisted as Markdown + YAML frontmatter in OPFS; calendar/era config in IndexedDB. All writes via the existing vault store (`vault.updateEntity`)
+**Testing**: Vitest (unit + property tests already exist in `chronology-engine`); `pnpm run lint` + `pnpm test` per Constitution VI
+**Target Platform**: Browser (SvelteKit SPA, static deploy to GitHub Pages), offline-capable
+**Project Type**: Web monorepo (`packages/*` libraries + `apps/web` thin UI)
+**Performance Goals**: Drag interaction at 60 fps; timeline layout of 500+ dated nodes under 200 ms (inherited from `026`); position→year resolution O(1) per drag frame
+**Constraints**: No AI dependency (explicit non-goal); no silent metadata mutation; client-side/private; no migration of existing vaults
+**Scale/Scope**: Vaults up to several thousand entities; 7 entity types with distinct meaning sets; 0..N anchors per entity
+
+No unresolved `NEEDS CLARIFICATION` — the three highest-impact ambiguities (storage model, drag target, undo scope) were resolved in `/speckit-clarify`. Remaining open design details (per-anchor cytoscape representation, position→year precision, touch/keyboard) are addressed in Phase 0 research, not blocking.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle                  | Status  | Notes                                                                                                                                                                                                                              |
+| -------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| I. Library-First           | ✅ Pass | Anchor model (`schema`), meaning-sets + range validation + position↔year resolution (`chronology-engine`), per-anchor projection + inverse mapping (`graph-engine`). `apps/web` is a thin UI layer (toggle, drag wiring, popover). |
+| II. TDD                    | ✅ Pass | Each package change starts with a failing Vitest spec (meaning-set mapping, anchor schema, range validation, position↔year round-trip). Red-Green-Refactor.                                                                        |
+| III. Simplicity & YAGNI    | ✅ Pass | Reuse Cytoscape, existing `getTimelineLayout`, `TemporalPicker`, `@floating-ui/dom`. No new libraries. Undo + touch/keyboard deferred.                                                                                             |
+| IV. AI-First Extraction    | ✅ N/A  | This is a manual, deterministic editing tool; AI-First governs the extraction pipeline, not direct-manipulation editing. Feature explicitly must work without AI (non-goal). Not a violation.                                      |
+| V. Privacy & Client-Side   | ✅ Pass | All resolution and persistence are local (OPFS/IndexedDB); no network.                                                                                                                                                             |
+| VI. Clean Implementation   | ✅ Pass | Svelte 5 runes, Tailwind 4 tokens, `@docs/STYLE_GUIDE.md`. Lint + tests gate completion.                                                                                                                                           |
+| VII. User Documentation    | ✅ Pass | Add an `apps/web/src/lib/config/help-content.ts` article for "Edit Chronology"; add a `FeatureHint` for first-time edit-mode entry.                                                                                                |
+| VIII. Dependency Injection | ✅ Pass | New `ChronologyEditService` (placement resolution + save) uses constructor DI with a production singleton default and injectable vault/calendar deps.                                                                              |
+| IX. Natural Language       | ✅ Pass | Popover copy is plain ("Set temporal meaning", "Born", "Founded", "Set event date to 605 P.C.?").                                                                                                                                  |
+| X. Quality & Coverage      | ✅ Pass | New package logic targets ≥70%; pure resolution/validation functions are highly testable.                                                                                                                                          |
+| XII. Labels Over Tags      | ✅ Pass | Status implied by anchors (e.g. an end/`died` anchor → "past"/historical) flows through the existing `applyAutoLabels` on `vault.updateEntity`; rendered as **Labels**, never Tags.                                                |
+
+**Result**: PASS. No violations → Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/130-editable-time-graph/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (package contracts)
+│   ├── schema.temporal-anchor.md
+│   ├── chronology-engine.placement.md
+│   └── graph-engine.anchor-projection.md
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+packages/
+├── schema/src/
+│   └── entity.ts                     # ADD TemporalAnchorSchema + EntitySchema.temporalAnchors
+├── chronology-engine/src/
+│   ├── meaning-sets.ts               # NEW: entity-type → temporal-meaning catalogue + span/point classification
+│   ├── anchors.ts                    # NEW: anchor CRUD helpers, primary↔anchor derivation, range validation
+│   ├── placement.ts                  # NEW: resolve drag → {field|anchor} intent; conflict detection
+│   └── engine.ts                     # REUSE: calendar/date validation; parseDirectDateInput
+└── graph-engine/src/
+    └── layouts/timeline.ts           # ADD getYearForPosition (inverse) + per-anchor point projection
+
+apps/web/src/lib/
+├── stores/
+│   ├── graph.svelte.ts               # ADD chronologyEditMode state + actions
+│   └── chronology-edit.svelte.ts     # NEW: ChronologyEditService (DI) — transient drag state, save routing
+├── components/
+│   ├── graph/
+│   │   ├── graph-view-controller.svelte.ts  # WIRE: anchor-point drag handlers (grab/drag/dragfree) in edit mode
+│   │   ├── ChronologyEditToggle.svelte      # NEW: mode toggle (lives near TimelineControls)
+│   │   ├── ChronologyDragIndicator.svelte   # NEW: live target-year axis indicator
+│   │   └── SemanticPlacementPopover.svelte  # NEW: meaning-selection confirmation (reuses TemporalPicker)
+│   ├── GraphView.svelte              # WIRE: canvas dragover/drop target for Explorer entities (US6)
+│   ├── graph/GraphHUD.svelte         # WIRE: view vs edit-chronology mode indicator (US5)
+│   ├── graph/GraphToolbar.svelte     # WIRE: edit-mode affordance near timeline controls (US5)
+│   ├── explorer/
+│   │   └── EntityExplorer.svelte     # REUSE existing `application/codex-entity` drag source (US6)
+│   └── timeline/
+│       └── TemporalPicker.svelte     # REUSE for date/range field inside the popover
+└── config/
+    └── help-content.ts               # ADD "Edit Chronology" help article + FeatureHint
+```
+
+**Structure Decision**: Web monorepo. Library-First mandates that all temporal semantics, validation, and geometry live in `packages/` (`schema`, `chronology-engine`, `graph-engine`) with full unit/property coverage. `apps/web` only orchestrates: mode state, Cytoscape drag wiring, the popover UI, and routing saves through the existing `vault.updateEntity()`. This mirrors how `026-world-timeline` already split pure layout (`graph-engine/layouts/timeline.ts`) from UI (`TimelineControls.svelte`).
+
+## Complexity Tracking
+
+> No Constitution violations — section intentionally empty.

--- a/specs/130-editable-time-graph/plan.md
+++ b/specs/130-editable-time-graph/plan.md
@@ -101,6 +101,23 @@ apps/web/src/lib/
 
 **Structure Decision**: Web monorepo. Library-First mandates that all temporal semantics, validation, and geometry live in `packages/` (`schema`, `chronology-engine`, `graph-engine`) with full unit/property coverage. `apps/web` only orchestrates: mode state, Cytoscape drag wiring, the popover UI, and routing saves through the existing `vault.updateEntity()`. This mirrors how `026-world-timeline` already split pure layout (`graph-engine/layouts/timeline.ts`) from UI (`TimelineControls.svelte`).
 
+## Future Extensions (Phase 3): Visual Lifespans and Story Chains
+
+Conceptual design modifications to support advanced temporal visualization layout (deferred, not for active implementation):
+
+### Packages
+
+#### `graph-engine`
+
+- **Span Connector Layout**: Extend `getTimelineLayout` and LayoutManager to compute visual connecting span paths/lines between start and end node handles.
+- **Narrative Sequence Filter**: Filter out standard non-chronological edges (e.g. `allied_with`) in timeline mode, leaving only sequential narrative edges (e.g. `precedes`, `leads_to`).
+- **Storyline Swimlanes**: Organize parallel or concurrent sequence chains into layered horizontal swimlanes to keep visual pathways clean.
+
+### Svelte Layer (apps/web)
+
+- **Unified Span Gestures**: Update the graph-view-controller to recognize drags on the connecting span lines (translates the entire range) vs boundary nodes (resizes range).
+- **Theme-specific Spans**: Style connecting span paths according to active vault theme parameters (fantasy calligraphies vs. scifi digital lines).
+
 ## Complexity Tracking
 
 > No Constitution violations — section intentionally empty.

--- a/specs/130-editable-time-graph/quickstart.md
+++ b/specs/130-editable-time-graph/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart: Editable Time Graph
+
+How to exercise the feature end-to-end once implemented. Assumes a dev vault with a few dated entities.
+
+## Run
+
+```bash
+pnpm install
+pnpm dev            # SvelteKit dev server (apps/web)
+# package tests:
+pnpm test           # vitest across workspace
+pnpm run lint
+```
+
+## Happy path — drag an Event (US1, MVP)
+
+1. Open the graph, enable **Timeline Mode** (existing control).
+2. Toggle **Edit Chronology** (new). The graph shows a clear edit-mode indicator (FR-001/FR-007).
+3. Grab an Event node and drag it horizontally; a live indicator shows the target year (e.g. "605 P.C.") (FR-010).
+4. Release. A direct confirmation appears: **"Set event date to 605 P.C.?"** (FR-013).
+5. Confirm → the Event's `date` updates and the node settles at the derived position.
+6. Reload the vault → the new date persists (FR-022, SC-001).
+7. Repeat but **cancel** at the confirmation → date unchanged, node returns to origin (FR-006).
+
+## Semantic placement — drag a Character (US2)
+
+1. In edit mode, drag a Character to ~580 P.C. and drop.
+2. The **semantic placement popover** opens showing the name, target year, and Character meanings: Born / Died / Became active / Reign / Major appearance / Custom (FR-015/FR-016).
+3. Pick **Born**, confirm. The popover states it will set the primary date (or a `born` anchor) before saving (FR-005). Verify the value persisted.
+4. Drag a Faction → confirm the popover offers Founded / Dissolved / Active / Schism / Merger (different set) (US2 scenario 2).
+
+## Period range (US3)
+
+1. Drag a Period's span 50 years later → confirmation shows the shifted range; save updates `start_date` **and** `end_date`.
+2. Drag only the end edge → only `end_date` updates.
+3. Try to drag the end before the start → save is blocked with a reason; metadata unchanged (FR-031).
+
+## Multiple anchors (US4)
+
+1. Take the Character from US2 (has a `born` primary). Grab its born point, drag, and in the confirmation choose **"create a new anchor instead"**, set type **Major appearance** at 621 P.C. (FR-009a).
+2. The entity now renders at two points; neither overwrote the other (FR-023, FR-028, SC-004).
+3. Add a third (`disappeared`, 634 P.C.). Remove one anchor → the others are unaffected (FR-024).
+
+## Canon-safety checks
+
+- In **view mode** (edit toggle off), dragging never changes temporal metadata (FR-002).
+- Dropping on empty canvas / outside the axis cancels with no write (FR-012).
+- If the entity's date changes via sync while the popover is open, saving surfaces a conflict instead of clobbering (FR-032).
+
+## Automated test entry points
+
+| Layer               | What to assert                                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `schema`            | `TemporalAnchorSchema` validation + `Entity` back-compat (contract: schema.temporal-anchor)             |
+| `chronology-engine` | meaning-sets per type, `validateRange`, `deriveProjectedAnchors`, `buildIntent`, `detectConflict`       |
+| `graph-engine`      | `getYearForPosition` round-trip + `getAnchorTimelineLayout` keys                                        |
+| `apps/web` store    | `ChronologyEditService` lifecycle: grab→drag→drop→confirm/cancel, restore-on-cancel, no-write-on-cancel |
+| component           | `SemanticPlacementPopover` renders type-specific meanings; blocks save on invalid range                 |
+
+## Done when
+
+- All FR acceptance scenarios in `spec.md` pass.
+- `pnpm test` + `pnpm run lint` green; new package logic ≥70% coverage (Constitution X).
+- Help article + `FeatureHint` for Edit Chronology present (Constitution VII).

--- a/specs/130-editable-time-graph/quickstart.md
+++ b/specs/130-editable-time-graph/quickstart.md
@@ -29,9 +29,9 @@ pnpm run lint
 3. Pick **Born**, confirm. The popover states it will set the primary date (or a `born` anchor) before saving (FR-005). Verify the value persisted.
 4. Drag a Faction → confirm the popover offers Founded / Dissolved / Active / Schism / Merger (different set) (US2 scenario 2).
 
-## Period range (US3)
+## Range span (US3)
 
-1. Drag a Period's span 50 years later → confirmation shows the shifted range; save updates `start_date` **and** `end_date`.
+1. Drag an entity's range span 50 years later → confirmation shows the shifted range; save updates `start_date` **and** `end_date`.
 2. Drag only the end edge → only `end_date` updates.
 3. Try to drag the end before the start → save is blocked with a reason; metadata unchanged (FR-031).
 

--- a/specs/130-editable-time-graph/research.md
+++ b/specs/130-editable-time-graph/research.md
@@ -1,0 +1,132 @@
+# Phase 0 Research: Editable Time Graph
+
+This phase resolves the open design details left after `/speckit-clarify` (the three big ambiguities — storage model, drag target, undo scope — are already decided in the spec's Clarifications). Each item records Decision / Rationale / Alternatives.
+
+## R1. Position → year resolution (inverse of the timeline layout)
+
+**Decision**: Add a pure `getYearForPosition(position, context)` to `graph-engine/src/layouts/timeline.ts`, where `context` carries the same `{ yearPositions, scale, axis, minYear }` already computed by `getSequentialYearPositions`. Resolve a dropped pixel coordinate to the nearest year by inverting the sequential/gap-compressed mapping: find the bracketing year stops and linearly interpolate, then round to a whole year (the axis is year-granular by default).
+
+**Rationale**: The existing forward layout is deterministic and already groups by year with gap compression. Reusing the same `yearPositions` map guarantees that a node dropped where year _Y_ sits resolves back to _Y_ (round-trip stable — required by SC-008 and FR-011). Keeping it pure keeps it testable (round-trip property test) and avoids coupling to Cytoscape.
+
+**Alternatives considered**:
+
+- _Uniform pixels-per-year inversion_ (ignore gap compression): rejected — would mis-resolve in compressed gaps, breaking round-trip stability.
+- _Read the year off the nearest existing node_: rejected — fails when dropping into empty regions or creating a brand-new date.
+
+## R2. Per-anchor rendering of multi-anchor entities in Cytoscape
+
+**Decision**: In timeline/edit mode, project each anchor to a **synthetic anchor node** keyed `"<entityId>::<anchorId>"`, parented/visually linked to the source entity, positioned by its own resolved year. The primary (legacy-field) value is projected as the anchor with a reserved id (`"<entityId>::primary"`). Organic (non-timeline) mode is unchanged — entities remain single nodes. Projection lives in `graph-engine`; the controller materialises/removes synthetic nodes only while in timeline edit/view.
+
+**Rationale**: FR-009a needs each anchor individually grabbable, and FR-028 needs each anchor at its own position. Synthetic nodes give Cytoscape real drag targets per anchor without polluting the persisted graph or organic layout. Namespacing the id lets drag handlers recover `(entityId, anchorId)` trivially. Building it in `graph-engine` keeps the projection unit-testable.
+
+**Alternatives considered**:
+
+- _Single node + custom canvas glyphs for extra anchors_: rejected — extra points wouldn't be native drag targets; we'd reimplement hit-testing (violates YAGNI/Simplicity).
+- _Persisting anchor nodes as real entities_: rejected — anchors are metadata of one entity, not separate nodes; would corrupt the graph and connection model.
+
+## R3. Drag interaction states & canon safety wiring
+
+**Decision**: Drive everything off a new `graph.chronologyEditMode` boolean (separate from `timelineMode`). Edit mode requires timeline mode to be on. Cytoscape node `grabify`/dragging stays **disabled for temporal mutation** unless `chronologyEditMode` is true. Handlers: `grab` records the source `(entityId, anchorId)` + origin position into the transient `ChronologyEditService` state; `drag` updates the live target year (R1) for `ChronologyDragIndicator`; `dragfree` (drop) resolves the intent and opens the confirmation — it does **not** write. The write happens only on explicit confirm. Any of {cancel, Escape, drop on invalid target (R1 returns null), leaving edit mode} restores the node to origin and clears transient state with no write (FR-006, FR-012, edge cases).
+
+**Rationale**: A single explicit mode flag makes "are we editing lore?" unambiguous for both the guard logic and the UI affordance (FR-001/FR-007). Resolving on `dragfree` but writing only on confirm enforces FR-004 (no silent mutation) structurally.
+
+**Alternatives considered**:
+
+- _Write on drop, offer undo_: rejected — undo is deferred and this violates the no-silent-mutation rule.
+- _Reuse `timelineMode` as the edit flag_: rejected — view mode must stay safe/deterministic (FR-002); they are distinct states.
+
+## R4. Mapping entity types to semantic meanings
+
+**Decision**: A static, data-driven catalogue in `chronology-engine/src/meaning-sets.ts`: `Record<entityType, Meaning[]>`, each `Meaning` = `{ id, label, kind: 'point'|'span', target: 'date'|'start_date'|'end_date'|'anchor', anchorType? }`. Events map their meanings to **legacy fields** (`date`; `start_date`/`end_date`); Character/Faction/Location/Item/Note map most meanings to **anchors** (with a designated "primary"/`begin` meaning that writes the legacy `date`). Every type also gets a universal **Custom anchor** meaning. Entity _type_ is matched against the vault's category ids (`character`, `faction`, `location`, `item`, `event`, `note`). **There is no `period` category** — date ranges are `start_date`/`end_date` on any type (US3). Unmatched types — the default `creature` and any user-defined category — fall back to a generic set (`date` begin point, `start_date`/`end_date` range, custom).
+
+**Rationale**: Centralises FR-016/FR-017 in one tested table, keeps the popover dumb, and encodes the hybrid storage decision (which meanings hit legacy fields vs anchors) declaratively. Matching category ids reuses the existing `DEFAULT_CATEGORIES` taxonomy (`schema`) so user-renamed labels still resolve.
+
+**Alternatives considered**:
+
+- _Hard-code meanings inside the popover component_: rejected — violates Library-First and isn't unit-testable.
+- _Free-form meanings only_: rejected — loses the entity-type-specific suggestions the spec requires (FR-016, SC-003).
+
+## R5. Temporal value shape for anchors
+
+**Decision**: Anchor dates use the schema's existing `TemporalMetadata`/`DateSelection` union (year-precision minimum), **not** free-form strings (the issue's `"580 PC"` examples are display forms). The popover's date field reuses `TemporalPicker`, which already converts between legacy `TemporalMetadata` and `DateSelection` and honours the active calendar (`calendarStore`).
+
+**Rationale**: Consistency with `entity.date` (FR-021) means anchors sort, position, and validate using the same `calendarEngine` logic with zero new date-parsing. Reusing `TemporalPicker` satisfies the "show target year, confirm value" UX with no new component.
+
+**Alternatives considered**:
+
+- _Store raw strings ("604 P.C.")_: rejected — unsortable, unvalidatable, and inconsistent with existing fields; would need a parallel parser.
+
+## R6. Range validation & conflict detection
+
+**Decision**: `chronology-engine/src/anchors.ts` exposes `validateRange(start, end)` (rejects end < start, returning a typed reason) and `placement.ts` exposes `detectConflict(originalValue, currentEntityValue)` comparing the value captured at drag-start against the entity's value at save time (using `calendarEngine` equality). The popover blocks save on invalid range (FR-031) and surfaces a conflict prompt instead of overwriting when the entity changed underneath (FR-032).
+
+**Rationale**: Pure functions for both keep FR-031/FR-032 testable and UI-agnostic. Capturing the original at drag-start is cheap (already in transient state) and gives a deterministic conflict check without a new locking mechanism.
+
+**Alternatives considered**:
+
+- _Last-write-wins_: rejected — violates FR-032 (silent clobber on concurrent sync edit).
+- _Optimistic version numbers on every field_: rejected as over-engineering for this iteration (YAGNI); value-equality is sufficient.
+
+## R7. Linked-entity anchors & graceful degradation
+
+**Decision**: An anchor's optional `linkedEntityId` is a soft reference. Projection (R2) and the detail view check existence at render time; a dangling link renders the anchor as a plain dated point with a "broken link" affordance (FR-033) and never throws.
+
+**Rationale**: Matches the existing connection model's tolerance for missing targets and satisfies the deletion edge case without cascade bookkeeping.
+
+**Alternatives considered**:
+
+- _Cascade-delete anchors when the linked entity is removed_: rejected — anchors belong to their host entity; the date is still meaningful without the link.
+
+## R8. Persistence & auto-Labels
+
+**Decision**: All writes go through `vault.updateEntity(id, { date | start_date | end_date | temporalAnchors })`. No new persistence path. The existing `applyAutoLabels` (in `vault/entities.ts`) continues to derive status Labels (e.g. `past`) from `end_date`; anchor-implied status reuses the same hook (extend `applyAutoLabels` only if an anchor type must influence a Label — kept minimal, Constitution XII).
+
+**Rationale**: Reuses the canonical, already-tested save + frontmatter + sync pipeline (Simplicity/Privacy), and keeps Label derivation in one place.
+
+**Alternatives considered**:
+
+- _Direct OPFS writes from the edit service_: rejected — bypasses validation, sync, and auto-Labels.
+
+## R11. Gesture shape → point vs span
+
+**Decision**: For in-canvas drags, derive point-vs-span from the gesture: track `pressYear` at grab/press and `targetYear` live; once the swept horizontal distance exceeds a small threshold (a few pixels / ≥1 resolved year), mark the gesture `'span'` (start = `pressYear`, end = `targetYear`), otherwise `'point'`. The confirmation defaults to the entity type's span vs point meanings accordingly but the user can still change the meaning. Explorer→timeline drops always resolve to a `'point'` (the external HTML5 drag ends on release), with span ends set in the popover (R10, FR-011b).
+
+**Refinement (begin/end roles)**: A point drop is not a _different kind_ of thing from a span start — it is the entity's **begin** moment, expressed with the category-correct word (Event `date`, Character `born`, Faction `founded`, Location `founded`, Item `created`, Note `associated date`). Dragging out a width adds the **end** counterpart (`end date` / `died` / `dissolved` / `destroyed` / `lost`). So each meaning set marks one `role: 'begin'` and (where applicable) one `role: 'end'` meaning (FR-016a); a point gesture defaults to `begin`, a span gesture to `begin→end`. This makes "drop = when it started, drag = when it ended" literally true while keeping the right vocabulary per type. The popover still lets the user pick any other meaning (appearance, reign, schism, discovered).
+
+**Rationale**: Lets the user "draw the duration" in one natural motion where the surface allows it (in-canvas), with plain drops setting the begin moment (not a wrongly open-ended range). The meaning popover still owns semantics, so the gesture is a hint, not a silent decision (FR-011a, FR-004). Unifies US3 (Period range) with the general drag model.
+
+**Alternatives considered**:
+
+- _Drop always = start of a range_: rejected — most primary meanings are points (Event date, born, founded, created); forcing "start" contradicts the meaning sets and the user's own refinement discussion.
+- _Spans only via popover fields (no gesture)_: viable but loses the direct-manipulation feel for durations; kept as the fallback for Explorer drops only.
+
+## R10. Explorer → timeline external drag-and-drop (US6)
+
+**Decision**: Reuse the Explorer's existing HTML5 drag source — `EntityExplorer.svelte` already calls `dataTransfer.setData("application/codex-entity", entityId)` with `effectAllowed = "copyMove"`. Add a `dragover`/`drop` handler on the graph canvas (`GraphView.svelte`) that, **only in `chronologyEditMode`**, reads that entity id, converts the drop's `clientX/Y` to a Cytoscape model position (`cy.pan()`/`cy.zoom()` inverse), resolves it to a year via `getYearForPosition` (R1), and routes into the same `ChronologyEditService` placement flow used by in-graph drops. The transient drag state gains a `source: 'canvas' | 'explorer'` discriminator; for `'explorer'` there is no origin node to restore on cancel.
+
+**Rationale**: The drag source already exists and is used elsewhere (e.g. dropping onto the graph/map), so this is additive and consistent (Simplicity). Gating on edit mode and reusing the placement flow keeps canon-safety identical to in-graph drags (FR-009c). This is the only entry path for placing entities that are absent from Timeline Mode because they have no date yet (FR-009b).
+
+**Alternatives considered**:
+
+- _A dedicated "add to timeline" button in the detail panel_: rejected as the primary path — it doesn't deliver the direct-manipulation value the issue asks for (though it remains a reasonable secondary affordance, out of scope here).
+- _A new drag MIME type_: rejected — reusing `application/codex-entity` keeps one cross-surface contract.
+
+## R12. Create a linked event from a placement (US7)
+
+**Decision**: Add an explicit **"create a linked event"** option to the confirmation popover. On save the `ChronologyEditService` calls the existing `vault.createEntity("event", title, { date })` to make a new Event dated at the resolved year, then `upsertAnchor` on the dragged entity with `linkedEntityId` = the new event id, then adds a `Connection` (`{ target: eventId, type: "related_to" }`) on the dragged entity — all via `vault.updateEntity`/`vault.createEntity`. The title field is pre-filled (`"{Entity} — {year}"`) and editable. It is offered for any dragged entity and is purely additive (never moves the existing placement).
+
+**Rationale**: Realises the `linkedEntityId` already in the anchor schema and the issue's `majorAppearance → event-id` example. Reusing `vault.createEntity` (which runs `applyAutoLabels` and id-uniquing) and the standard connection model keeps it consistent and avoids a bespoke creation path (Simplicity/Privacy). Making it explicit and additive preserves canon safety (FR-035/FR-038) — creating an entity is the most consequential action and must never be a silent drag side effect.
+
+**Atomicity**: Sequence is create-event → add-anchor → add-connection. On any step failure, surface an error and roll back already-applied steps (delete the just-created event / revert the anchor) so no orphaned event, dangling anchor, or stray connection remains (FR-039). The vault's mutation methods are async; the service awaits each and guards with try/catch.
+
+**Alternatives considered**:
+
+- _Auto-create an event whenever an already-placed entity is dragged_: rejected — surprising, litters the vault, violates the no-silent-mutation spirit.
+- _Link only via a connection (no anchor)_ or _only an anchor (no connection)_: rejected — the anchor gives the temporal link (so the event shows at that point relative to the entity) and the connection gives the relational link (so it appears in the graph/explorer); both are wanted.
+
+## R9. Deferred (explicitly out of scope this iteration)
+
+- **Undo** of committed changes (clarified: deferred). Cancel-before-save is the safety net.
+- **Touch & keyboard-accessible** drag alternatives — desirable; design deferred to a follow-up (pointer-first this iteration, per Assumptions).
+- **Bulk/multi-select** temporal edits (spec Out of Scope).
+- **New calendar/era configuration** beyond what `026` provides.

--- a/specs/130-editable-time-graph/spec.md
+++ b/specs/130-editable-time-graph/spec.md
@@ -150,6 +150,36 @@ As a World Builder, in edit-chronology mode I want the option — when I drag an
 4. **Given** the dragged entity already has a placement, **When** I grab one of its points and choose "Create an event here", **Then** a new event is created **without moving or altering** the existing primary date or existing anchors (the action is purely additive).
 5. **Given** the confirmation is open, **When** I cancel, **Then** no event, anchor, or connection is created and the dragged entity is unchanged.
 
+### User Story 8 - Visual Lifespans (Priority: P2)
+
+As a World Builder, when I view entities with start and end dates on the timeline, I want to see their duration represented as a continuous visual span rather than two disconnected points, and I want to shift the entire span or resize its boundaries by dragging.
+
+**Why this priority**: Connects separate start/end anchors into a single conceptual lifespan, which is key for visual chronology layout of lifespans, reigns, and eras.
+
+**Independent Test**: Create a character with a birth and death year. Verify they render with a connecting horizontal span line in the timeline. Drag the center of the span to shift the entire lifespan, and drag the start or end handles to contract/stretch it, verifying metadata updates correctly on save.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Character with a `start_date` of 580 P.C. and an `end_date` of 630 P.C., **When** Timeline Mode is active, **Then** a horizontal span line is rendered connecting the start and end nodes.
+2. **Given** edit-chronology mode is active, **When** I drag the connecting span line, **Then** both the start and end years shift by the same amount (preserving the 50-year duration), and confirming updates both fields.
+3. **Given** edit-chronology mode is active, **When** I drag only the end node/handle of the lifespan, **Then** only the end date is proposed for update, stretching or shrinking the duration.
+
+---
+
+### User Story 9 - Story Chains (Priority: P2)
+
+As a World Builder, I want to define causal sequences between events (e.g. event A leads to event B) and see them rendered as clean, directional paths in timeline mode, while hiding unrelated relationship lines, so I can trace questlines or historical flows without clutter.
+
+**Why this priority**: Causal sequencing is the logical flow of time in worldbuilding; normal relationships clutter the timeline, but sequence chains organize it.
+
+**Independent Test**: Connect event A to event B with a `precedes` or `leads_to` connection. Toggle timeline mode and verify that only the sequence arrow is drawn running forward along the axis, while standard edges (e.g. `allied_with`) are hidden.
+
+**Acceptance Scenarios**:
+
+1. **Given** two events linked by a sequence connection (`precedes` or `leads_to`), **When** I view them on the timeline, **Then** a directed edge is drawn from the earlier event to the later event.
+2. **Given** two events linked by a non-sequential connection (`allied_with`), **When** I view them on the timeline, **Then** no edge is rendered between them (preventing timeline spaghetti).
+3. **Given** multiple sequence chains, **When** they run concurrently in time, **Then** the timeline layout organizes them into separate vertical swimlanes to prevent overlapping paths.
+
 ---
 
 ### Edge Cases
@@ -166,6 +196,8 @@ As a World Builder, in edit-chronology mode I want the option — when I drag an
 - **Explorer drop with no node to restore**: An entity dragged from the Explorer has no pre-existing timeline node, so a cancelled external placement simply creates nothing (there is no node position to restore); the entity stays off the timeline.
 - **Explorer drop of an entity already on the timeline**: Treated as an update-or-add-anchor placement on the existing entity, never as a new/duplicate node.
 - **Linked-event creation cancelled or failed**: If the user cancels, or entity creation/linking fails partway, the vault MUST be left with no orphaned event, dangling anchor, or stray connection (FR-039).
+- **Lifespan span drag boundary bounds**: If a span translation would shift dates out of allowed calendar limits, the proposed change MUST be validated and rejected.
+- **Story sequence chronological inconsistency**: If a sequence connection is created where event B precedes event A chronologically, the system SHOULD display a chronological mismatch warning.
 
 ## Requirements _(mandatory)_
 
@@ -258,6 +290,13 @@ As a World Builder, in edit-chronology mode I want the option — when I drag an
 - **FR-038**: Creating a linked event MUST be purely **additive** — it MUST NOT move or alter the dragged entity's existing primary date or existing anchors.
 - **FR-039**: Cancelling MUST create no event, anchor, or connection (canon safety); a failure during creation MUST surface an error rather than leave a half-created/half-linked state.
 
+#### Conceptual Lifespans & Story Chains
+
+- **FR-040**: In timeline mode, the system MUST render a styled horizontal connecting span line between the start and end nodes of any entity with a start and end date (lifespan duration).
+- **FR-041**: Dragging the connecting span line in edit-chronology mode MUST translate both the start and end years by the same offset, proposing an update to both dates on drop.
+- **FR-042**: The system MUST hide standard non-temporal edges (e.g. `allied_with`) in timeline mode, and MUST render only sequential narrative edges (e.g. `precedes`, `leads_to`, `then`) as forward-pointing directed edges.
+- **FR-043**: The timeline layout MUST support arranging concurrent sequence chains into distinct vertical swimlanes.
+
 ### Key Entities
 
 - **Temporal Anchor**: A structured record of one chronological meaning for an entity. Attributes: identifier; type/meaning (e.g. born, died, founded, dissolved, majorAppearance, custom); optional point date; optional start date and end date (for spans); optional linked-entity reference; optional note. Dates reuse the schema's existing `TemporalMetadata`/`DateSelection` shape. An entity's _primary_ meaning lives in the legacy `date`/`start_date`/`end_date` fields and is presented as a derived anchor; _additional_ meanings are stored in the entity's `temporalAnchors[]` collection.
@@ -280,6 +319,9 @@ As a World Builder, in edit-chronology mode I want the option — when I drag an
 - **SC-008**: No drag interaction leaves a raw graph coordinate stored as the entity's temporal value (100% of saved placements resolve to structured date/range/anchor metadata).
 - **SC-009**: A user can place a previously-undated entity onto the timeline by dragging it from the Entity Explorer and confirming, in under 15 seconds, with the placement persisting across reload and the entity now appearing in Timeline Mode.
 - **SC-010**: A user can create a linked event by dragging an entity and confirming, producing a dated Event, a linking anchor (`linkedEntityId`), and a connection between the two — in under 20 seconds, all persisting across reload, with the dragged entity's existing placement unchanged.
+- **SC-011**: A user can drag a lifespan span to shift both start and end dates synchronously in under 10 seconds.
+- **SC-012**: 100% of standard relationship edges are hidden in timeline mode, leaving only sequence-flow edges visible.
+- **SC-013**: The timeline layout successfully groups parallel story chains into separate vertical swimlanes to maintain legibility.
 
 ## Assumptions
 
@@ -299,22 +341,11 @@ As a World Builder, in edit-chronology mode I want the option — when I drag an
 - Bulk/multi-select temporal editing of many entities in one drag (single-entity placement only in this iteration).
 - Dragging **Era** background-region boundaries on the timeline. Eras are calendar _configuration_ (not entity lore); editing their `start_year`/`end_year` by dragging is a possible follow-up, separate from entity chronology editing.
 
-## Future Extensions: Lifespans and Story Chains
+## Out of Scope
 
-These conceptual design outlines govern the next iteration of the time graph, transforming it from a point-based timeline into a view of overlapping durations and causal sequences.
-
-### 1. Lifespans (Entity Durations)
-
-Rather than rendering start and end dates (e.g. birth and death, founding and collapse) as unrelated, disjointed points in space:
-
-- **Visual Span Connectors**: The time graph will render a styled horizontal connector/span edge linking the start handle/node to the end handle/node for any entity with a resolved start and end date. This edge will represent the entity's duration (lifespan, reign, or operation period).
-- **Unified Drag Gestures**: Grabbing and dragging the connecting span line translates the entire entity's timeline footprint (shifting both start and end years synchronously, preserving duration). Dragging individual boundary handles (start/end) stretches or contracts the span.
-- **Theme Integration**: Spans will be styled using Svelte component parameters matching the vault's active theme (e.g., solid calligraphic paths in `fantasy` mode, pulsing digital tracks in `scifi` mode).
-
-### 2. Story Chains (Sequential Event Flow)
-
-To show narrative progression without the clutter of non-temporal connections:
-
-- **Filtered Sequence Edges**: Normal relational connections (e.g. `allied_with`, `member_of`) remain hidden in timeline mode to prevent visual clutter. Only sequential narrative connections (e.g. `precedes`, `leads_to`, `then`) are rendered.
-- **Directional Timeline Flow**: Sequence edges are rendered as clean, directed paths running forward along the temporal axis.
-- **Storyline swimlanes**: Concurrent storylines or questlines can be layered vertically into separate visual lanes (swimlanes), allowing GMs to trace parallel narrative tracks (e.g. different party tracks or concurrent plots) across time.
+- AI-assisted date inference or suggestion (explicit non-goal — the feature must work without AI).
+- Storing chronology purely as graph x/y layout coordinates (explicit non-goal).
+- Requiring every entity to have exactly one date (explicit non-goal — entities may have zero or many anchors).
+- A new calendar/era configuration system beyond what `026-world-timeline` already provides.
+- Bulk/multi-select temporal editing of many entities in one drag (single-entity placement only in this iteration).
+- Dragging **Era** background-region boundaries on the timeline. Eras are calendar _configuration_ (not entity lore); editing their `start_year`/`end_year` by dragging is a possible follow-up, separate from entity chronology editing.

--- a/specs/130-editable-time-graph/spec.md
+++ b/specs/130-editable-time-graph/spec.md
@@ -1,0 +1,299 @@
+# Feature Specification: Editable Time Graph with Semantic Temporal Placement
+
+**Feature Branch**: `130-editable-time-graph`
+**Created**: 2026-06-04
+**Status**: Draft
+**Source**: GitHub issue #1159
+**Input**: User description: "Add an edit mode to the time graph where users can drag entities along the timeline to define or adjust their chronological meaning. Dragging an entity should not only change visual layout — it should create or update structured temporal metadata. The goal is to make the time graph both a visualisation and a chronology editing tool."
+
+## Overview
+
+The vault already has a read-only **Timeline Mode** (spec `026-world-timeline`) that positions dated nodes along a chronological axis based on existing temporal metadata (`date`, `start_date`, `end_date`, `era`). This feature extends the time graph from a passive visualisation into an **interactive chronology editing tool**: in an explicit edit mode, a World Builder drags an entity horizontally along the time axis, and on drop confirms what that placement _means_ (born, founded, became active, etc.). Confirming writes structured temporal metadata — modelled as one or more **temporal anchors** per entity — rather than storing a raw graph coordinate.
+
+The defining constraint is **canon safety**: moving a node must never silently mutate lore. View mode remains the deterministic default; mutation happens only inside an explicit edit-chronology mode, only after a semantic confirmation, and only to the metadata field/anchor the user confirms.
+
+> **Terminology note**: This spec's **temporal anchor** (a per-entity chronological meaning such as born/founded/disappeared) is distinct from the existing calendar `DateSelection.precision: "anchor"` / `anchorId` in `packages/schema` (a _calendar reference point_). The two concepts must not be conflated in naming during implementation.
+
+## Clarifications
+
+### Session 2026-06-04
+
+- Q: When a placement is saved, where does the temporal value live — a new `temporalAnchors` array or the existing flat fields? → A: **Hybrid, legacy authoritative for the primary.** The existing `date`/`start_date`/`end_date` fields remain the source of truth for an entity's primary point/range (existing Timeline Mode reads and current vaults untouched, zero migration). A new `temporalAnchors[]` stores _additional/multiple/custom_ meanings. The primary legacy field is also surfaced as a derived anchor in the editable view.
+- Q: When dragging an entity that already has temporal anchors, what does the drag affect? → A: **The specific anchor point grabbed.** Each anchor renders as its own draggable point; grabbing one proposes updating _that_ anchor, and the confirmation popover also offers "create a new anchor instead." Both adjusting an existing anchor and adding a new one are reachable directly from the graph.
+- Q: Is undo of a committed chronology change required this iteration? → A: **Deferred.** No general entity-edit undo exists in the codebase (only oracle/canvas/dice have bespoke undo), so undo is treated as a fast-follow. Cancel-before-save plus normal re-editing is the safety net for this iteration. FR-008 stays a non-blocking SHOULD; SC-007 is moved to a later iteration.
+- Q: The issue lists a "Period" entity type — does it exist? → A: **No.** The default categories are character, creature, location, item, event, faction, note; there is no "Period" type. Date ranges live in the existing `start_date`/`end_date` fields on **any** entity (US3 is reframed around that). The named **Era** is background-region _config_ (`graph.eras`, start_year/end_year), not entity lore — dragging Era boundaries is out of scope this iteration.
+- Q: How are non-enumerated/custom categories (e.g. the default Creature) handled in the popover? → A: They use a **generic fallback** meaning set — a begin point (`date`), an optional range (`start_date`/`end_date`), and the universal custom anchor (FR-016).
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Drag an Event to set its date (Priority: P1) 🎯 MVP
+
+As a World Builder, when I am in chronology edit mode, I want to drag an Event node horizontally along the time axis and have the graph show me the target year as I drag, so that on drop I can confirm "Set event date to 605 P.C.?" and have the event's date metadata updated directly from the graph.
+
+**Why this priority**: This is the smallest end-to-end slice that proves the core value — direct manipulation of time becomes a structured metadata edit. Events have a single, unambiguous primary date, so they require the simplest confirmation (a direct yes/no) and exercise the whole pipeline: mode toggle → drag → live axis indicator → drop → confirm → metadata write → re-render. Delivered alone, it is already a usable chronology editor for the most common dated entity.
+
+**Independent Test**: Enter edit-chronology mode, drag an Event node to a new horizontal position, observe the live target-year indicator, drop, confirm the direct prompt, and verify the Event's date metadata changed and persisted (survives reload).
+
+**Acceptance Scenarios**:
+
+1. **Given** an Event with date "601 P.C." and the graph in edit-chronology mode, **When** I drag the node to the position corresponding to 605 P.C., **Then** the axis shows a live "605 P.C." indicator while dragging.
+2. **Given** I have dragged the Event and released it, **When** the confirmation prompt "Set event date to 605 P.C.?" appears and I confirm, **Then** the Event's date metadata is updated to "605 P.C." and the node settles at the position derived from that new date.
+3. **Given** the same drag, **When** I cancel the confirmation instead, **Then** the Event's date metadata is unchanged and the node returns to its original position.
+4. **Given** I confirmed a date change, **When** I reload the vault, **Then** the Event still shows the new date (the change was a metadata write, not a transient layout offset).
+
+---
+
+### User Story 2 - Semantic placement popover for non-trivial entities (Priority: P1)
+
+As a World Builder, when I drag a Character, Faction, Location, Item, or Note in edit-chronology mode, I want a popover that asks what the placement represents and offers meanings appropriate to that entity type, so that I can record, for example, that a Character was _born_ in 580 P.C. rather than guessing which hidden field to edit.
+
+**Why this priority**: Most entity types do not have one obvious "the date" field — a Character has birth, death, active period, reign, and appearances. Without the semantic popover, dragging these entities is meaningless. This story is what makes the feature general across the entity model rather than an event-only tool, and together with US1 it forms the complete drag-to-place experience.
+
+**Independent Test**: In edit-chronology mode, drag a Character to 580 P.C.; verify the popover offers Character-appropriate meanings (Born, Died, Became active, Reign, Major appearance, Custom anchor), select "Born", save, and confirm a `born` temporal anchor with date 580 P.C. is recorded on that Character.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Character dragged to 580 P.C., **When** the popover opens, **Then** it shows the entity name, the target year, and a list of meanings appropriate to a Character (e.g. Born, Died, Became active, Reign period, Major appearance, Custom anchor).
+2. **Given** a Faction dragged in edit mode, **When** the popover opens, **Then** the offered meanings are Faction-appropriate (e.g. Founded, Dissolved, Active period, Schism, Merger) and differ from those offered for a Character.
+3. **Given** the popover open with a meaning selected, **When** I save, **Then** the popover states which metadata field or anchor will be created/updated before the write occurs, and after saving that anchor exists on the entity.
+4. **Given** a meaning that represents a span (e.g. "Active period", "Reign"), **When** I select it, **Then** I can specify both a start and end value rather than a single point.
+5. **Given** any open popover, **When** I cancel, **Then** no temporal metadata is created or modified.
+
+---
+
+### User Story 3 - Set a date range (start/end) by dragging (Priority: P2)
+
+As a World Builder, I want to give **any entity** a date _range_ — a start and an end — by dragging on the time axis (sweeping a span, or adjusting a start/end edge), so that I can reshape spans such as an Event's duration, a Character's active period, or a Faction's lifetime directly on the graph.
+
+> **Note on "Period" vs "Era"**: The codebase has no "Period" entity type; date ranges live in the existing `start_date`/`end_date` fields on **any** entity. The in-world calendar's named **Eras** are background-region _configuration_ (not entity lore); dragging Era boundaries is a separate concern and is **out of scope** this iteration (see Out of Scope).
+
+**Why this priority**: Ranges use the existing `start_date`/`end_date` fields and render as spans rather than points, so they need range-aware handling (sweep a width, or drag a start/end edge) that the point-based stories do not cover. Valuable but builds on the interaction model established by US1/US2.
+
+**Independent Test**: In edit-chronology mode, give an entity a start/end range by sweeping a span (or dragging an edge of an existing range), confirm, and verify its `start_date`/`end_date` metadata updated accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** an entity with a range 500–600 P.C., **When** I drag the whole span 50 years later, **Then** the confirmation reflects a new range of 550–650 P.C. and on save both start and end update.
+2. **Given** the same entity, **When** I drag only its end edge to 650 P.C., **Then** the confirmation reflects 500–650 P.C. and only the end date updates on save.
+3. **Given** a drag that would invert the range (end before start), **When** I attempt to drop, **Then** the system prevents the invalid range and explains why, leaving metadata unchanged.
+4. **Given** any span-capable entity in edit-chronology mode, **When** I press at one year and drag out a horizontal width before releasing, **Then** the placement is resolved as a span (press = start, release = end) and the confirmation defaults to span meanings with both ends pre-filled (FR-011a).
+
+---
+
+### User Story 4 - Multiple temporal anchors per entity (Priority: P2)
+
+As a World Builder, I want a single entity to hold several temporal anchors — for example a Character who was born in 580 P.C., had a major appearance in 621 P.C., and disappeared in 634 P.C. — so that figures who recur across history are represented faithfully instead of being flattened to one date.
+
+**Why this priority**: The temporal-anchor model is the structural heart of the feature; supporting more than one anchor per entity is what distinguishes it from the existing single-date timeline. It depends on US2 (anchor creation) being in place, hence P2.
+
+**Independent Test**: Add three anchors of different types to one Character via successive drags/confirmations, and verify all three persist and that the entity renders at the corresponding positions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Character that already has a `born` anchor, **When** I grab its born point and drag, **Then** the confirmation proposes updating the born anchor _and_ offers "create a new anchor instead"; choosing the latter at 621 P.C. as `majorAppearance` yields two distinct anchors and neither overwrites the other.
+2. **Given** an entity with multiple anchors, **When** I view it in the time graph, **Then** it renders at each anchored position (e.g. as repeated points, a track, or a grouped node with expandable anchors) rather than at a single point.
+3. **Given** an entity with multiple anchors, **When** I edit or remove one anchor, **Then** the other anchors are unaffected.
+4. **Given** an anchor optionally linked to another entity (e.g. a major appearance tied to an event), **When** I record it, **Then** the link is preserved on the anchor.
+
+---
+
+### User Story 5 - Clear distinction between editing lore and editing layout (Priority: P3)
+
+As a World Builder, I want it to be visually unmistakable when a drag changes canon (temporal metadata) versus when it merely rearranges the visual layout, so that I never alter history by accident.
+
+**Why this priority**: A safety and confidence layer over the core editing flows. It does not add new placement capability but materially reduces the risk of accidental canon changes and increases trust, which the issue calls out explicitly. Sequenced last because it polishes flows defined in US1–US4.
+
+**Independent Test**: Toggle between view, layout-only movement (if present), and edit-chronology mode and confirm each is visually distinct, and that only edit-chronology drags can write temporal metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** the time graph, **When** I am in view mode, **Then** entities cannot have their temporal metadata changed by dragging, and the mode is clearly indicated.
+2. **Given** edit-chronology mode is active, **When** I look at the graph, **Then** it is visually obvious (mode indicator and/or drag affordance) that drags will change lore.
+3. **Given** non-temporal layout movement is supported, **When** I move a node for layout only, **Then** it is visually distinct from a chronology-editing drag and does not write temporal metadata.
+
+> _Undo of a committed chronology change is deferred to a later iteration (see Clarifications); cancel-before-save is the safety net for this iteration._
+
+---
+
+### User Story 6 - Place an entity from the Explorer by dragging it onto the timeline (Priority: P3)
+
+As a World Builder, I want to drag an entity out of the Entity Explorer and drop it onto the time axis, so that I can give a chronological placement to an entity that is **not yet on the timeline at all** — including brand-new or undated entities — without first opening its detail panel to type a date.
+
+**Why this priority**: The in-graph stories (US1–US4) can only reposition entities that already appear on the timeline; an entity with no temporal metadata is hidden from Timeline Mode and cannot be grabbed there. This story is the entry path for _first-time_ placement: it lets a World Builder pull any entity from the full Explorer list straight into time. It reuses the semantic-placement flow from US1/US2, so it is sequenced after them but adds a distinct, high-value interaction surface (external drag-and-drop onto the canvas).
+
+**Independent Test**: In edit-chronology mode, drag an undated entity from the Explorer, drop it at a target year on the axis, complete the resulting confirmation/popover, and verify the entity gains temporal metadata, now appears on the timeline at that year, and persists across reload.
+
+**Acceptance Scenarios**:
+
+1. **Given** edit-chronology mode is active and an entity with no temporal metadata listed in the Explorer, **When** I drag it from the Explorer and drop it on the axis at ~610 P.C., **Then** the live indicator shows the target year during the drag and, on drop, the same confirmation flow opens (direct for an Event, semantic popover otherwise) for that entity as a **point** at 610 P.C.; if I then choose a span meaning, I set the end via the popover's start/end fields (FR-011b).
+2. **Given** that drop, **When** I confirm the placement, **Then** the entity gains the corresponding temporal metadata, immediately appears on the timeline at the resolved year, and the placement persists across reload.
+3. **Given** I drag an entity from the Explorer but drop it outside the axis / on empty canvas, **When** I release, **Then** no placement is created and no metadata changes (consistent with the invalid-drop rule).
+4. **Given** the graph is in view mode (edit-chronology off), **When** I drag an entity from the Explorer onto the timeline, **Then** it does not change any temporal metadata (external placement is gated by edit-chronology mode, like in-graph drags).
+5. **Given** an entity that is already on the timeline, **When** I drag it from the Explorer and drop it at a year, **Then** the same update-or-add-anchor flow applies and the entity is not duplicated.
+
+---
+
+### User Story 7 - Create a linked event by dragging an entity onto the timeline (Priority: P3)
+
+As a World Builder, in edit-chronology mode I want the option — when I drag an entity to a year — to **create a new Event at that time, linked back to the entity**, so that I can capture "something happened to this entity then" as a real, relational event node (with its own lore and participants) rather than only an abstract anchor.
+
+**Why this priority**: This turns the timeline into a lightweight event-authoring surface and realises the `linkedEntityId` already present in the temporal-anchor model (e.g. a major appearance tied to an event). It is sequenced last among placement stories because it builds on the semantic popover (US2), the anchor model (US4), and the vault's entity-creation path, and because creating entities is the most consequential action — it must be an explicit, opt-in choice, never automatic.
+
+**Independent Test**: In edit-chronology mode, drag a Character to ~621 P.C., choose "Create an event here", accept/edit the pre-filled title, and save; verify a new Event entity exists dated 621 P.C., the Character has an anchor whose `linkedEntityId` references that event, and a connection joins the two — all persisting across reload.
+
+**Acceptance Scenarios**:
+
+1. **Given** edit-chronology mode and an entity dragged to a year, **When** the confirmation opens, **Then** one of the offered options is **"Create an event here"**, alongside setting a date / adding an anchor (it is offered for any dragged entity, not only those already on the timeline).
+2. **Given** I choose "Create an event here", **When** the option expands, **Then** it shows an **editable, pre-filled title** (e.g. "Avel Darvold — 621 P.C.") and states that it will create a new Event and link it to the dragged entity before saving (FR-005).
+3. **Given** I confirm, **When** the save completes, **Then** a new **Event** entity is created dated at the resolved year (via the normal entity-creation path, gaining auto-Labels and a unique id), an anchor is added to the dragged entity with `linkedEntityId` referencing the new event, and a connection is created between the two entities.
+4. **Given** the dragged entity already has a placement, **When** I grab one of its points and choose "Create an event here", **Then** a new event is created **without moving or altering** the existing primary date or existing anchors (the action is purely additive).
+5. **Given** the confirmation is open, **When** I cancel, **Then** no event, anchor, or connection is created and the dragged entity is unchanged.
+
+---
+
+### Edge Cases
+
+- **Undated entity dragged in edit mode**: An entity with no existing temporal metadata, when dragged and confirmed, gains its first anchor; the system must not require it to have had a date beforehand.
+- **Non-numeric / fictional calendar values**: Dates use in-world notation (e.g. "604 P.C."). Placement requires a value the axis can position numerically; the system maps recognised in-world dates to axis positions and rejects or flags values it cannot place, without corrupting the stored label.
+- **Drop outside the axis / on empty canvas**: A drop that does not correspond to a meaningful time position cancels the placement rather than writing a garbage date.
+- **Overlapping anchors at the same position**: Multiple entities (or multiple anchors) sharing a year must be offset along the non-temporal axis so none is occluded (consistent with existing Timeline Mode behaviour).
+- **Cancel mid-drag**: Pressing escape or releasing on an invalid target during a drag aborts with no metadata change and returns the node to origin.
+- **Concurrent edit / sync conflict**: If the same entity's temporal metadata changes elsewhere (e.g. via vault sync) while a popover is open, saving must not silently clobber the newer value; surface the conflict.
+- **Span inversion**: Any edit that would make an end precede its start is rejected with an explanation.
+- **Linked-entity anchor whose target is deleted**: An anchor referencing a now-missing linked entity must degrade gracefully (anchor remains as a plain dated anchor; link is shown as broken rather than crashing the view).
+- **Mode exit with an open popover**: Leaving edit-chronology mode while a confirmation is pending is treated as a cancel (no write).
+- **Explorer drop with no node to restore**: An entity dragged from the Explorer has no pre-existing timeline node, so a cancelled external placement simply creates nothing (there is no node position to restore); the entity stays off the timeline.
+- **Explorer drop of an entity already on the timeline**: Treated as an update-or-add-anchor placement on the existing entity, never as a new/duplicate node.
+- **Linked-event creation cancelled or failed**: If the user cancels, or entity creation/linking fails partway, the vault MUST be left with no orphaned event, dangling anchor, or stray connection (FR-039).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+#### Modes & safety
+
+- **FR-001**: The time graph MUST provide two explicit modes — a **view mode** (default) and an **edit-chronology mode** — with a clear, visible indication of which is active.
+- **FR-002**: In view mode, entity positions MUST be derived solely from existing temporal metadata, and dragging MUST NOT create or modify any temporal metadata.
+- **FR-003**: Temporal metadata mutation MUST be possible only while edit-chronology mode is active.
+- **FR-004**: The system MUST NOT silently mutate temporal metadata as a side effect of a drag; every mutation MUST be preceded by an explicit user confirmation.
+- **FR-005**: Before a save commits, the confirmation UI MUST state which metadata field or temporal anchor will be created or updated.
+- **FR-006**: Cancelling a placement (via cancel control, escape, drop on an invalid target, or exiting edit mode) MUST leave all entity temporal metadata unchanged and return the dragged node to its pre-drag position.
+- **FR-007**: The UI MUST make it unmistakable when a drag changes lore (temporal metadata) versus when it only changes visual layout; if non-temporal layout movement is supported, the two MUST be visually distinct.
+- **FR-008**: The system SHOULD support undo of a committed chronology change, reverting the affected temporal metadata to its prior value. **(Deferred to a later iteration** — see Clarifications; no general entity-edit undo exists today, so cancel-before-save is the safety net for this iteration.)
+
+#### Drag interaction
+
+- **FR-009**: In edit-chronology mode, users MUST be able to drag entities horizontally along the time axis.
+- **FR-009a**: For an entity rendered at multiple anchored positions, each anchor MUST be an individually grabbable point. Dragging a specific anchor point MUST propose updating _that_ anchor, and the resulting confirmation MUST also offer the option to create a new anchor instead of updating the grabbed one.
+- **FR-009b**: In edit-chronology mode, users MUST be able to drag an entity from the Entity Explorer and drop it onto the time axis. This MUST work for entities that are **not yet on the timeline**, including new or undated entities, giving them a chronological placement for the first time. The drop year MUST be resolved as in FR-011 and the same confirmation flow MUST apply (direct for Events per FR-013, semantic popover otherwise per FR-015).
+- **FR-009c**: External (Explorer→timeline) placement MUST be gated by edit-chronology mode and MUST obey the same canon-safety rules as in-graph drags: no write without explicit confirmation (FR-004), an invalid/out-of-axis drop cancels without a write (FR-012), and dropping an entity already on the timeline MUST follow the update-or-add-anchor flow without duplicating the entity.
+- **FR-010**: While dragging, the graph MUST display a live indicator of the target year/date/period at the current drag position.
+- **FR-011**: On drop, the system MUST resolve the drag position to a concrete temporal value (point or range) before presenting the confirmation.
+- **FR-011a**: For in-canvas drags, the **gesture shape** MUST determine point-vs-span: a quick drop (press and release at effectively one position) resolves to a **point** at that year; a press-hold-drag that sweeps a horizontal width resolves to a **span**, where the press position is the begin year and the release position is the end year. The confirmation MUST default to the entity type's **begin** meaning for a point gesture and its **begin→end** pair for a span gesture (see FR-016a), while still letting the user change the meaning. A span gesture MUST pre-fill both begin and end in the confirmation (FR-018).
+- **FR-011b**: For Explorer→timeline drops (FR-009b), because the external drag ends on release, the drop MUST resolve to a **point** (a start candidate); if the chosen meaning is a span, the end MUST be set via the confirmation popover's start/end fields rather than a continued drag.
+- **FR-012**: A drop that cannot be resolved to a meaningful temporal position MUST cancel the placement without writing metadata.
+
+#### Semantic placement
+
+- **FR-013**: Dragging an **Event** MUST allow setting or updating its date through a direct confirmation (no full meaning-selection popover required for the primary date).
+- **FR-014**: Dragging a **span** (an entity's `start_date`/`end_date` range) MUST allow setting or updating its start and/or end, including dragging the whole span or an individual start/end edge. This applies to any entity given a range (e.g. an Event with a duration, a Character's active period), not to a dedicated "Period" entity type (which does not exist in the model).
+- **FR-015**: Dragging any other entity type MUST open a semantic placement popover that asks what the placement represents.
+- **FR-016**: The meanings offered in the popover MUST depend on the entity type, at minimum:
+  - **Character**: birth, death, active period, reign, major appearance
+  - **Faction**: founded, dissolved, active period, schism, merger
+  - **Location**: founded, destroyed, occupied, golden age, relevant period
+  - **Item**: created, discovered, lost, ownership period, recovered
+  - **Note**: associated date, associated period, custom anchor
+  - Any other category (the default **Creature** type, or any user-defined/custom category) MUST fall back to a **generic** set — a begin point (`date`), an optional range (`start_date`/`end_date`), and the universal custom anchor.
+- **FR-016a**: Each entity type's meaning set MUST designate a **begin** meaning — the category-correct word for when the entity starts existing/being relevant — and, where applicable, a corresponding **end** meaning. These are the same underlying concept ("when it started" / "when it ended") expressed with the right word per type:
+
+  | Entity type                      | Begin meaning        | End meaning        |
+  | -------------------------------- | -------------------- | ------------------ |
+  | Event                            | date (or start date) | end date           |
+  | Character                        | born                 | died               |
+  | Faction                          | founded              | dissolved          |
+  | Location                         | founded              | destroyed          |
+  | Item                             | created              | lost / destroyed   |
+  | Note                             | associated date      | — (optional)       |
+  | _Other / custom (e.g. Creature)_ | date (generic begin) | end date (generic) |
+
+  A point drop defaults to the **begin** meaning; a span gesture defaults to the **begin→end** pair for that type. Users MAY still select any other meaning from the type's set (e.g. major appearance, reign, schism, discovered).
+
+- **FR-017**: The popover MUST offer a **custom anchor** option allowing a user-named temporal meaning when no preset fits.
+- **FR-018**: Meanings that represent a span MUST let the user provide both start and end values; meanings that represent a point MUST capture a single value.
+- **FR-019**: The popover MUST display the entity name and the resolved target time to confirm context before saving.
+
+#### Temporal anchor data model
+
+- **FR-020**: An entity MUST be able to hold one or more temporal anchors, stored in a new `temporalAnchors[]` collection that supplements (does not replace) the existing flat `date`/`start_date`/`end_date` fields.
+- **FR-020a**: The existing flat `date`/`start_date`/`end_date` fields MUST remain the source of truth for an entity's **primary** point/range. Saving a placement whose meaning maps to the primary point/range MUST update the corresponding legacy field (so existing Timeline Mode reads and current vaults keep working with zero migration), and that primary value MUST also be surfaced as a derived anchor in the editable view.
+- **FR-020b**: `temporalAnchors[]` MUST store only _additional_ meanings beyond the primary — secondary appearances, custom anchors, and any meaning not represented by a legacy field. Entities with no additional meanings MUST NOT require a `temporalAnchors[]` entry.
+- **FR-021**: Each temporal anchor MUST carry an identifier and a type (the semantic meaning), and MUST be able to carry a point date, a start/end range, an optional link to another entity, and an optional note. Anchor dates MUST use the same temporal value shape the schema already uses for `date` (a `TemporalMetadata`/`DateSelection`), not a free-form string.
+- **FR-022**: Saving a placement MUST write structured temporal metadata (a legacy date/range field per FR-020a, or a `temporalAnchors[]` entry), NOT a raw graph coordinate.
+- **FR-023**: Adding a new anchor to an entity MUST NOT overwrite or remove its existing anchors or its primary legacy date field.
+- **FR-024**: Users MUST be able to edit or remove an individual anchor without affecting the entity's other anchors or its primary legacy date field.
+- **FR-025**: Pre-existing date metadata (`date`, `start_date`, `end_date`, and any `Era` membership for background regions) MUST position entities correctly in the editable view without manual migration; the primary fields are read in place and presented as derived anchors rather than being copied into `temporalAnchors[]`.
+
+#### Rendering
+
+- **FR-026**: An entity with a single temporal anchor MUST render as a point/node on the time axis.
+- **FR-027**: An entity with a start/end anchor MUST render as a span.
+- **FR-028**: An entity with multiple anchors MUST render at each anchored position (e.g. repeated points, a track, or a grouped/expandable representation) rather than collapsing to one position.
+- **FR-029**: Entities or anchors sharing the same temporal position MUST be offset on the non-temporal axis so none is visually occluded.
+- **FR-030**: View-mode positioning MUST remain deterministic — the same temporal metadata always yields the same arrangement.
+
+#### Integrity & conflicts
+
+- **FR-031**: Edits that would invert a range (end before start) MUST be rejected with an explanation, leaving metadata unchanged.
+- **FR-032**: If an entity's temporal metadata is changed by another source while a placement confirmation is open, saving MUST NOT silently overwrite the newer value; the conflict MUST be surfaced to the user.
+- **FR-033**: An anchor whose linked entity no longer exists MUST degrade gracefully (retained as a dated anchor with the link shown as broken) without breaking the time-graph view.
+- **FR-034**: The feature MUST function without any AI service; temporal editing MUST NOT depend on AI.
+
+#### Event creation from placement
+
+- **FR-035**: In edit-chronology mode, the placement confirmation MUST offer a **"create a linked event"** option for any dragged entity (not only entities already on the timeline), as an explicit, opt-in choice — never an automatic side effect of a drag.
+- **FR-036**: Choosing "create a linked event" MUST create a new **Event** entity dated at the resolved target year via the standard entity-creation path (so it gains auto-Labels and a unique id), and MUST present an **editable, pre-filled title** before saving.
+- **FR-037**: On save, the system MUST link the new event to the dragged entity by both (a) adding a temporal anchor on the dragged entity whose `linkedEntityId` references the new event, and (b) creating a connection between the two entities.
+- **FR-038**: Creating a linked event MUST be purely **additive** — it MUST NOT move or alter the dragged entity's existing primary date or existing anchors.
+- **FR-039**: Cancelling MUST create no event, anchor, or connection (canon safety); a failure during creation MUST surface an error rather than leave a half-created/half-linked state.
+
+### Key Entities
+
+- **Temporal Anchor**: A structured record of one chronological meaning for an entity. Attributes: identifier; type/meaning (e.g. born, died, founded, dissolved, majorAppearance, custom); optional point date; optional start date and end date (for spans); optional linked-entity reference; optional note. Dates reuse the schema's existing `TemporalMetadata`/`DateSelection` shape. An entity's _primary_ meaning lives in the legacy `date`/`start_date`/`end_date` fields and is presented as a derived anchor; _additional_ meanings are stored in the entity's `temporalAnchors[]` collection.
+- **Entity (time-graph participant)**: Any vault node that can be placed in time (default categories: Event, Character, Creature, Location, Item, Faction, Note — plus any user-defined category). Retains its existing flat `date`/`start_date`/`end_date` fields (authoritative for the primary point/range) and gains a `temporalAnchors[]` collection for additional meanings.
+- **Entity-type meaning set**: The mapping from an entity type to the list of suggested temporal meanings shown in the placement popover (Character → birth/death/active/reign/appearance, etc.), plus the universal custom-anchor option.
+- **Placement interaction (transient)**: The in-progress drag state — source entity, live resolved target time, and pending confirmation — that exists only between drag-start and save/cancel and never persists as layout coordinates.
+- **Mode state**: Whether the time graph is in view mode or edit-chronology mode, governing whether drags can mutate temporal metadata.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A user can change an Event's date by dragging it on the graph and confirming, in under 10 seconds, with the change persisting across reload.
+- **SC-002**: 100% of temporal-metadata changes originate from an explicit confirmation; zero metadata changes occur from a drag that the user cancelled.
+- **SC-003**: For every entity type with a dedicated meaning set (Event, Character, Faction, Location, Item, Note), the placement popover offers type-appropriate meanings (no Character meanings shown for a Faction, etc.); any other category (default Creature, or a custom category) shows the documented generic fallback set.
+- **SC-004**: A single entity can carry at least three distinct temporal anchors simultaneously, all of which persist and render at their respective positions.
+- **SC-005**: 100% of entities already dated under the existing Timeline Mode position identically after the anchor model is introduced (no regression, no manual migration required).
+- **SC-006**: In a usability check, users correctly identify whether the graph is in view mode or edit-chronology mode on first glance at least 90% of the time.
+- **SC-007**: _(Deferred to a later iteration.)_ A committed chronology change can be reverted via undo with the metadata returning exactly to its prior value in 100% of attempts.
+- **SC-008**: No drag interaction leaves a raw graph coordinate stored as the entity's temporal value (100% of saved placements resolve to structured date/range/anchor metadata).
+- **SC-009**: A user can place a previously-undated entity onto the timeline by dragging it from the Entity Explorer and confirming, in under 15 seconds, with the placement persisting across reload and the entity now appearing in Timeline Mode.
+- **SC-010**: A user can create a linked event by dragging an entity and confirming, producing a dated Event, a linking anchor (`linkedEntityId`), and a connection between the two — in under 20 seconds, all persisting across reload, with the dragged entity's existing placement unchanged.
+
+## Assumptions
+
+- This feature builds directly on the existing World Timeline (`026-world-timeline`): the read-only chronological graph, numeric axis positioning, era backgrounds, and date metadata already exist and are reused. This spec adds the _editable_ layer and the multi-anchor model on top.
+- Dates are expressed in the campaign's in-world calendar notation (e.g. "604 P.C."); positioning relies on resolving these to a numeric year as Timeline Mode already does. Calendar-format handling beyond what Timeline Mode supports is out of scope here.
+- "View mode" is the existing Timeline Mode behaviour; "edit-chronology mode" is a new explicit toggle layered on it.
+- The temporal-anchor model supplements rather than replaces existing single-field dates; existing fields are surfaced as anchors via mapping (FR-025) so older vaults need no migration step.
+- Persistence and sync reuse the vault's existing entity-metadata storage and sync mechanisms; this feature defines _what_ is written, not a new storage backend. (Undo is out of scope this iteration — see Clarifications — and there is no general entity-edit undo facility to reuse today.)
+- Drag-to-place targets pointer/mouse interaction; touch and keyboard-accessible alternatives are desirable but their detailed design is deferred to planning.
+
+## Out of Scope
+
+- AI-assisted date inference or suggestion (explicit non-goal — the feature must work without AI).
+- Storing chronology purely as graph x/y layout coordinates (explicit non-goal).
+- Requiring every entity to have exactly one date (explicit non-goal — entities may have zero or many anchors).
+- A new calendar/era configuration system beyond what `026-world-timeline` already provides.
+- Bulk/multi-select temporal editing of many entities in one drag (single-entity placement only in this iteration).
+- Dragging **Era** background-region boundaries on the timeline. Eras are calendar _configuration_ (not entity lore); editing their `start_year`/`end_year` by dragging is a possible follow-up, separate from entity chronology editing.

--- a/specs/130-editable-time-graph/spec.md
+++ b/specs/130-editable-time-graph/spec.md
@@ -2,7 +2,8 @@
 
 **Feature Branch**: `130-editable-time-graph`
 **Created**: 2026-06-04
-**Status**: Draft
+**Status**: Implemented
+**Implementation Plan**: [plan.md](./plan.md)
 **Source**: GitHub issue #1159
 **Input**: User description: "Add an edit mode to the time graph where users can drag entities along the timeline to define or adjust their chronological meaning. Dragging an entity should not only change visual layout — it should create or update structured temporal metadata. The goal is to make the time graph both a visualisation and a chronology editing tool."
 

--- a/specs/130-editable-time-graph/spec.md
+++ b/specs/130-editable-time-graph/spec.md
@@ -298,3 +298,23 @@ As a World Builder, in edit-chronology mode I want the option — when I drag an
 - A new calendar/era configuration system beyond what `026-world-timeline` already provides.
 - Bulk/multi-select temporal editing of many entities in one drag (single-entity placement only in this iteration).
 - Dragging **Era** background-region boundaries on the timeline. Eras are calendar _configuration_ (not entity lore); editing their `start_year`/`end_year` by dragging is a possible follow-up, separate from entity chronology editing.
+
+## Future Extensions: Lifespans and Story Chains
+
+These conceptual design outlines govern the next iteration of the time graph, transforming it from a point-based timeline into a view of overlapping durations and causal sequences.
+
+### 1. Lifespans (Entity Durations)
+
+Rather than rendering start and end dates (e.g. birth and death, founding and collapse) as unrelated, disjointed points in space:
+
+- **Visual Span Connectors**: The time graph will render a styled horizontal connector/span edge linking the start handle/node to the end handle/node for any entity with a resolved start and end date. This edge will represent the entity's duration (lifespan, reign, or operation period).
+- **Unified Drag Gestures**: Grabbing and dragging the connecting span line translates the entire entity's timeline footprint (shifting both start and end years synchronously, preserving duration). Dragging individual boundary handles (start/end) stretches or contracts the span.
+- **Theme Integration**: Spans will be styled using Svelte component parameters matching the vault's active theme (e.g., solid calligraphic paths in `fantasy` mode, pulsing digital tracks in `scifi` mode).
+
+### 2. Story Chains (Sequential Event Flow)
+
+To show narrative progression without the clutter of non-temporal connections:
+
+- **Filtered Sequence Edges**: Normal relational connections (e.g. `allied_with`, `member_of`) remain hidden in timeline mode to prevent visual clutter. Only sequential narrative connections (e.g. `precedes`, `leads_to`, `then`) are rendered.
+- **Directional Timeline Flow**: Sequence edges are rendered as clean, directed paths running forward along the temporal axis.
+- **Storyline swimlanes**: Concurrent storylines or questlines can be layered vertically into separate visual lanes (swimlanes), allowing GMs to trace parallel narrative tracks (e.g. different party tracks or concurrent plots) across time.

--- a/specs/130-editable-time-graph/tasks.md
+++ b/specs/130-editable-time-graph/tasks.md
@@ -185,6 +185,19 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 ---
 
+## Phase 11: Conceptual Lifespans & Story Chains (Deferred / Post-MVP)
+
+**Goal**: Support rendering visual lifespan connections and sequential story chains forward on the timeline.
+
+- [ ] T053 [P] [US8] Write failing tests for connecting span coordinates and layout in packages/graph-engine/tests/timeline.test.ts
+- [ ] T054 [US8] Implement span connector calculations in packages/graph-engine/src/layouts/timeline.ts
+- [ ] T055 [US8] Render connecting span decorators and support span translation vs boundary resize in apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+- [ ] T056 [P] [US9] Write failing tests for sequence edge filtering and swimlane layout in packages/graph-engine/tests/timeline.test.ts
+- [ ] T057 [US9] Implement sequence edge filtering and swimlane grouping in packages/graph-engine/src/layouts/timeline.ts
+- [ ] T058 [US9] Style narrative sequence edges with arrowheads in apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase dependencies

--- a/specs/130-editable-time-graph/tasks.md
+++ b/specs/130-editable-time-graph/tasks.md
@@ -1,0 +1,255 @@
+---
+description: "Task list for Editable Time Graph with Semantic Temporal Placement"
+---
+
+# Tasks: Editable Time Graph with Semantic Temporal Placement
+
+**Input**: Design documents from `/specs/130-editable-time-graph/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included — Constitution II (TDD) mandates Red-Green-Refactor; test tasks precede implementation within each phase.
+
+**Organization**: Tasks are grouped by user story (spec.md priorities) so each story is an independently testable increment. All temporal logic lives in `packages/` (Library-First); `apps/web` is the thin UI layer.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US6 (user-story phases only)
+
+## Path Conventions
+
+Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs), UI in `apps/web/src/lib/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create stub modules/files so packages compile and parallel TDD can begin.
+
+- [ ] T001 [P] Create `chronology-engine` module stubs `meaning-sets.ts`, `anchors.ts`, `placement.ts` in `packages/chronology-engine/src/` and re-export them from `packages/chronology-engine/src/index.ts`
+- [ ] T002 [P] Create edit-mode UI stubs `ChronologyEditToggle.svelte`, `ChronologyDragIndicator.svelte`, `SemanticPlacementPopover.svelte` in `apps/web/src/lib/components/graph/`
+- [ ] T003 [P] Create `ChronologyEditService` stub with constructor DI (injectable vault/calendar/resolver deps) + default singleton export in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The anchor model, pure resolution/semantics engines, edit-mode state, the placement service, and the drag plumbing shared by every user story.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+### Schema (contract: `contracts/schema.temporal-anchor.md`)
+
+- [ ] T004 [P] Write failing tests for `TemporalAnchorSchema` (at-least-one-date, custom⇒label, range non-inverted, date-shape) and `Entity` back-compat in `packages/schema/src/entity.test.ts`
+- [ ] T005 Implement `TemporalAnchorSchema` + add optional `temporalAnchors` to `EntitySchema` and `TemporalAnchor` type export in `packages/schema/src/entity.ts` (green for T004)
+
+### graph-engine — position↔year + projection (contract: `contracts/graph-engine.anchor-projection.md`)
+
+- [ ] T006 [P] Write failing tests for `getYearForPosition` round-trip/out-of-range and `getAnchorTimelineLayout` per-anchor keys in `packages/graph-engine/tests/timeline-anchor.test.ts`
+- [ ] T007 Implement `getYearForPosition` (inverse of sequential/gap-compressed layout) and `getAnchorTimelineLayout` (keyed `"entityId::anchorId"`) additively in `packages/graph-engine/src/layouts/timeline.ts`
+
+### chronology-engine — meanings, anchors, placement (contract: `contracts/chronology-engine.placement.md`)
+
+- [ ] T008 [P] Write failing tests for `MEANING_SETS`/`getMeanings`/`getBeginMeaning`/`getEndMeaning` (per-type sets, begin/end roles per FR-016a, universal custom, fallback) in `packages/chronology-engine/tests/meaning-sets.test.ts`
+- [ ] T009 Implement `MEANING_SETS` + `getMeanings`/`getBeginMeaning`/`getEndMeaning` (begin/end `role`, one `primary` per type) in `packages/chronology-engine/src/meaning-sets.ts`
+- [ ] T010 [P] Write failing tests for `deriveProjectedAnchors`, `validateRange`, `upsertAnchor`, `removeAnchor` (primary projection + per-anchor, no sibling/primary mutation) in `packages/chronology-engine/tests/anchors.test.ts`
+- [ ] T011 Implement `anchors.ts` helpers in `packages/chronology-engine/src/anchors.ts` (depends on T005, T009)
+- [ ] T012 [P] Write failing tests for `buildIntent` (Event primary→`date`; non-primary→anchor; span yields begin+end; never coordinates) and `detectConflict` (calendar-equality) in `packages/chronology-engine/tests/placement.test.ts`
+- [ ] T013 Implement `placement.ts` (`buildIntent`, `PlacementIntent`, `detectConflict`) in `packages/chronology-engine/src/placement.ts` (depends on T009, T011)
+
+### Edit-mode state, service & drag plumbing (apps/web)
+
+- [ ] T014 Add `chronologyEditMode` state (requires `timelineMode`; toggling off clears pending drag) + toggle/guard actions to `apps/web/src/lib/stores/graph.svelte.ts`
+- [ ] T015 [P] Write failing tests for `ChronologyEditService` lifecycle — grab→drag→drop→confirm/cancel, gesture point/span derivation, restore-on-cancel, no-write-on-cancel, save via injected vault, conflict surfacing — in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [ ] T016 Implement `ChronologyEditService` (transient `ChronologyDrag` state, `pressYear`/`targetYear`/`gestureKind`, routes saves through injected `vault.updateEntity`; uses `buildIntent`/`detectConflict`/`getYearForPosition`) in `apps/web/src/lib/stores/chronology-edit.svelte.ts` (depends on T013, T007, T014)
+- [ ] T017 Implement `ChronologyEditToggle.svelte` mode toggle (placed near `TimelineControls`, clear "editing lore" affordance) in `apps/web/src/lib/components/graph/ChronologyEditToggle.svelte`
+- [ ] T018 Implement `ChronologyDragIndicator.svelte` live target-year axis indicator bound to service state, formatting the label via `calendarStore`/`chronology-engine` so it reads in-world notation (e.g. "605 P.C.") not a bare number (FR-010, U2), in `apps/web/src/lib/components/graph/ChronologyDragIndicator.svelte`
+- [ ] T019 Wire Cytoscape `grab`/`drag`/`dragfree` handlers (gated on `chronologyEditMode`) into `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts` to drive `ChronologyEditService`
+
+**Checkpoint**: Foundation ready — pure engines green, edit mode toggles, a gated drag updates the live indicator and resolves an intent (without writing yet).
+
+---
+
+## Phase 3: User Story 1 - Drag an Event to set its date (Priority: P1) 🎯 MVP
+
+**Goal**: In edit-chronology mode, dragging an Event resolves a target year, shows a direct "Set event date to X?" confirmation, and on confirm updates the Event's `date` (persisted), with cancel a no-op.
+
+**Independent Test**: Drag an Event in edit mode, observe the live year, confirm the direct prompt, verify `entity.date` changed and survives reload; repeat and cancel to verify no change.
+
+- [ ] T020 [P] [US1] Write failing test: an Event drop yields a primary-`date` intent with a "Set event date to {year}?" summary, and confirm→`vault.updateEntity({date})`, cancel→no write, in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [ ] T021 [US1] Implement the direct-confirmation path (primary `date` write) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte` — a compact "Set event date to {year}? Save/Cancel" mode (no full meaning list)
+- [ ] T022 [US1] Wire Event `dragfree` → `buildIntent` (begin/primary `date`) → direct confirm → `vault.updateEntity`; settle node at derived position on save and restore origin on cancel, in `ChronologyEditService` + `graph-view-controller.svelte.ts`
+- [ ] T023 [US1] Add persistence assertion test: saved Event has updated structured `date` and no raw graph coordinate stored (SC-008), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+
+**Checkpoint**: MVP — Events can be re-dated by direct manipulation, canon-safe.
+
+---
+
+## Phase 4: User Story 2 - Semantic placement popover (Priority: P1)
+
+**Goal**: Dragging a Character/Faction/Location/Item/Note opens a popover offering type-appropriate meanings; saving writes the primary field or a `temporalAnchors[]` entry and discloses which field/anchor changes.
+
+**Independent Test**: Drag a Character → popover shows Born/Died/Active/Reign/Major appearance/Custom; pick Born, save, verify the value persisted; drag a Faction → different (Founded/Dissolved/…) set.
+
+- [ ] T024 [P] [US2] Write failing tests for `SemanticPlacementPopover` rendering type-specific meanings (via `getMeanings`), begin-default selection, and the "field/anchor to be changed" disclosure (FR-005) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts`
+- [ ] T025 [US2] Implement `SemanticPlacementPopover.svelte`: `@floating-ui/dom`-anchored popover showing entity name + target year, meaning list from `getMeanings(type)` (generic fallback for creature/custom categories), value field reusing `TemporalPicker`, write-target disclosure, a **conflict prompt** when `detectConflict` is true (FR-032), Save/Cancel (depends on T024)
+- [ ] T026 [US2] Route non-Event drops to the popover; on save apply `buildIntent` → `vault.updateEntity` writing the primary field or `upsertAnchor`-produced `temporalAnchors[]`, in `apps/web/src/lib/stores/chronology-edit.svelte.ts` + `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`
+- [ ] T027 [US2] Natural-language copy + keyboard/escape accessibility for the popover (Constitution IX); confirm cancel/escape writes nothing, in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
+
+**Checkpoint**: All entity types can be placed in time with the right vocabulary, canon-safe.
+
+---
+
+## Phase 5: User Story 3 - Drag a Period to set its range (Priority: P2)
+
+**Goal**: Reshape Periods (and any span meaning) on the graph — move the whole span, drag a start/end edge, or draw a span in one gesture; reject inverted ranges.
+
+**Independent Test**: Drag a Period span 50 years later → range shifts and both ends update; drag only the end edge → only end updates; attempt an inverted range → blocked with reason.
+
+- [ ] T028 [P] [US3] Write failing tests for span-gesture resolution (press=begin, release=end → begin+end pre-fill) and `validateRange` block in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [ ] T029 [US3] Implement gesture point/span derivation (threshold = swept width resolving to **≥ 1 year** and ≥ ~6px → `gestureKind`, `pressYear`/`targetYear`, begin→end pair via `getBeginMeaning`/`getEndMeaning`) and span pre-fill into the popover, in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
+- [ ] T030 [US3] Implement whole-span move + individual start/end edge-drag handles for **any entity's `start_date`/`end_date` range** (not a "Period" type, which does not exist) in `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`, mapping to `start_date`/`end_date` writes
+- [ ] T031 [US3] Enforce range-inversion rejection in `SemanticPlacementPopover.svelte` using `validateRange` (block save + explain, FR-031)
+
+**Checkpoint**: Spans are first-class — drawable, edge-adjustable, integrity-checked.
+
+---
+
+## Phase 6: User Story 4 - Multiple temporal anchors per entity (Priority: P2)
+
+**Goal**: An entity renders at each of its anchor positions; grabbing one proposes updating it with an "add a new anchor instead" option; anchors are independently editable/removable; linked anchors degrade gracefully.
+
+**Independent Test**: Add born/majorAppearance/disappeared to one Character; verify three persistent points; remove one → others unaffected.
+
+- [ ] T032 [P] [US4] Write failing tests for the update-or-add-new flow and per-anchor independence (`upsertAnchor`/`removeAnchor` via service, no sibling/primary mutation) in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [ ] T033 [US4] Wire `getAnchorTimelineLayout` projected synthetic nodes (`"entityId::anchorId"`) into `LayoutManager`/`graph-view-controller.svelte.ts` for timeline edit mode so each anchor is a grabbable point (FR-009a/FR-028)
+- [ ] T034 [US4] Implement "update this anchor / create new anchor instead" choice in `SemanticPlacementPopover.svelte`; persist via `vault.updateEntity` with `upsertAnchor` (depends on T026)
+- [ ] T035 [US4] Implement per-anchor edit/remove affordance + linked-entity soft reference with broken-link degradation (FR-033) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
+
+**Checkpoint**: Recurring figures are represented faithfully across history.
+
+---
+
+## Phase 7: User Story 5 - Clear lore-vs-layout distinction (Priority: P3)
+
+**Goal**: It is unmistakable which mode is active; only edit-chronology drags mutate metadata; layout-only movement (if any) is visually distinct.
+
+**Independent Test**: Toggle view/edit; verify view-mode drags never change temporal metadata and the active mode is obvious at a glance.
+
+- [ ] T036 [P] [US5] Write failing tests asserting view-mode drags never mutate temporal metadata and the edit-mode guard blocks writes when off, in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [ ] T037 [US5] Implement clear mode indicators (view vs edit-chronology, plus layout-only if supported) and edit-drag affordance styling per `@docs/STYLE_GUIDE.md` in the graph HUD/toolbar (`GraphHUD.svelte`/`GraphToolbar.svelte`)
+- [ ] T038 [US5] Ensure layout-only node movement is visually distinct from chronology drags and writes no temporal metadata (guard + styling), in `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`
+
+**Checkpoint**: Accidental canon changes are structurally and visually guarded.
+
+---
+
+## Phase 8: User Story 6 - Place an entity from the Explorer onto the timeline (Priority: P3)
+
+**Goal**: Drag an entity from the Entity Explorer onto the axis to place it in time for the first time (incl. undated entities), gated on edit mode, routed through the same confirmation flow.
+
+**Independent Test**: Drag an undated entity from the Explorer, drop at a year, confirm, verify it now appears in Timeline Mode and persists.
+
+- [ ] T039 [P] [US6] Write failing tests for the canvas drop handler: `clientX/Y`→model position→year resolution, edit-mode gating, invalid-drop cancel, in `apps/web/src/lib/components/graph/graph-view-controller.svelte.test.ts`
+- [ ] T040 [US6] Add `dragover`/`drop` handler on `apps/web/src/lib/components/GraphView.svelte` reading `application/codex-entity` (reusing the existing Explorer drag source), gated on `chronologyEditMode`, converting the drop point to a year via `getYearForPosition`
+- [ ] T041 [US6] Route the Explorer drop into the placement flow as a point/start candidate (FR-011b); support first-time placement of undated entities; for entities already on the timeline use the update-or-add-anchor flow (no duplicate), in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
+- [ ] T042 [US6] Add test that a previously-undated entity appears in Timeline Mode after placement and persists across reload (SC-009), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+
+**Checkpoint**: Any entity, dated or not, can be pulled into time by direct manipulation.
+
+---
+
+## Phase 9: User Story 7 - Create a linked event by dragging (Priority: P3)
+
+**Goal**: From the placement confirmation, optionally create a new Event dated at the target year, linked to the dragged entity via an anchor `linkedEntityId` and a connection — explicit, additive, transactional.
+
+**Independent Test**: Drag a Character to 621, choose "Create an event here", edit the title, save; verify a new dated Event exists, the Character has an anchor with `linkedEntityId` to it and a connection, and the Character's existing placement is unchanged.
+
+- [ ] T043 [P] [US7] Write failing tests for the `createEvent` intent (`buildIntent` populates `createEvent` payload, leaves source primary/anchors untouched) in `packages/chronology-engine/tests/placement.test.ts`, and for the service create-link-connect-and-rollback flow in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [ ] T044 [US7] Extend `buildIntent`/`PlacementIntent` with the optional `createEvent` payload (title, date, anchorType, connectionType) in `packages/chronology-engine/src/placement.ts`
+- [ ] T045 [US7] Add the "Create an event here" option + editable pre-filled title field (`"{Entity} — {year}"`) and write-disclosure to `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
+- [ ] T046 [US7] Implement the event-creation save path in `apps/web/src/lib/stores/chronology-edit.svelte.ts`: `vault.createEntity("event", title, { date })` → `upsertAnchor` with `linkedEntityId` on the source → add `related_to` connection; additive, with rollback on partial failure (FR-039)
+- [ ] T047 [US7] Add test asserting the linked event + anchor `linkedEntityId` + connection all persist and the source entity's existing placement is unchanged (SC-010), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+
+**Checkpoint**: The timeline doubles as a lightweight event-authoring surface.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+- [ ] T048 [P] Add an "Edit Chronology" help article to `apps/web/src/lib/config/help-content.ts` and a `FeatureHint` for first edit-mode entry (Constitution VII)
+- [ ] T049 [P] STYLE_GUIDE / Tailwind-4 token + Svelte 5 runes compliance pass on all new components (Constitution VI)
+- [ ] T050 Run `quickstart.md` end-to-end and fix any gaps against the acceptance scenarios
+- [ ] T051 Verify ≥70% coverage on new package logic and run `pnpm run lint && pnpm test` green (Constitution VI, X)
+- [ ] T052 [P] Update `spec.md` status and cross-link the plan; confirm auto-Label (`past`) behaviour unchanged for anchor-driven status (Constitution XII)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (P1)**: no dependencies.
+- **Foundational (P2)**: depends on Setup; **blocks all user stories**. Within it: schema (T004→T005) and graph-engine (T006→T007) are independent of each other; chronology-engine `anchors`/`placement` (T011/T013) depend on schema (T005) and meaning-sets (T009); the service (T016) depends on placement (T013), graph-engine (T007) and the store flag (T014).
+- **User stories (P3–P8)**: all depend on Foundational. US1 is the MVP. US2 builds the popover that US3/US4 extend. US5/US6 depend only on the foundation + (US6 reuses the popover/placement of US1/US2).
+- **Polish (P9)**: after the desired stories.
+
+### User story dependencies
+
+- **US1 (P1)**: foundation only.
+- **US2 (P1)**: foundation; introduces `SemanticPlacementPopover` (T025) reused later.
+- **US3 (P2)**: foundation + popover (T025/T026).
+- **US4 (P2)**: foundation + popover save path (T026).
+- **US5 (P3)**: foundation; mostly UI/guard, independent.
+- **US6 (P3)**: foundation + placement/popover flow (T022/T026).
+- **US7 (P3)**: foundation + popover (T025) + anchor save path (T026/T034); adds entity creation. Independently testable.
+
+### Within each story
+
+Tests (Red) → implementation (Green) → integration. Models/engine before services; services before UI wiring.
+
+### Parallel opportunities
+
+- Setup T001–T003 all `[P]`.
+- Foundational test-writing T004, T006, T008, T010, T012, T015 are `[P]` (distinct files); each paired implementation follows its test.
+- Across packages, schema (T004/T005) ∥ graph-engine (T006/T007) ∥ meaning-sets (T008/T009).
+- Once Foundational completes, US5 (UI/guard) can proceed in parallel with US3/US4 by a second developer.
+
+---
+
+## Parallel Example: Foundational test-first
+
+```bash
+# Write these failing tests together (different files):
+Task: "T004 schema TemporalAnchor tests in packages/schema/src/entity.test.ts"
+Task: "T006 graph-engine position↔year tests in packages/graph-engine/tests/timeline-anchor.test.ts"
+Task: "T008 meaning-sets tests in packages/chronology-engine/tests/meaning-sets.test.ts"
+Task: "T010 anchors tests in packages/chronology-engine/tests/anchors.test.ts"
+Task: "T012 placement tests in packages/chronology-engine/tests/placement.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational (CRITICAL) → 3. Phase 3 US1 → **STOP & validate**: Events can be re-dated by dragging, canon-safe, persisted. Demo-able MVP.
+
+### Incremental delivery
+
+Foundation → US1 (MVP) → US2 (all types) → US3 (spans) → US4 (multi-anchor) → US5 (mode clarity) → US6 (Explorer placement) → US7 (linked-event creation). Each story is an independently testable, shippable increment.
+
+### Deferred (per spec/clarifications)
+
+- Undo of committed changes; touch/keyboard drag alternatives; bulk multi-select temporal edits — out of scope this iteration.
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete dependency.
+- All saves go through `vault.updateEntity` (auto-Labels via `applyAutoLabels`); never write raw graph coordinates as temporal values.
+- Verify each test fails before implementing (Constitution II).
+- Commit after each task or logical group.
+- FR-034 (must function without AI) is a standing constraint, not a buildable task — satisfied by keeping all logic in `chronology-engine`/`graph-engine`/`vault` with no AI calls; verify during T050/T051.

--- a/specs/130-editable-time-graph/tasks.md
+++ b/specs/130-editable-time-graph/tasks.md
@@ -26,9 +26,9 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Purpose**: Create stub modules/files so packages compile and parallel TDD can begin.
 
-- [ ] T001 [P] Create `chronology-engine` module stubs `meaning-sets.ts`, `anchors.ts`, `placement.ts` in `packages/chronology-engine/src/` and re-export them from `packages/chronology-engine/src/index.ts`
-- [ ] T002 [P] Create edit-mode UI stubs `ChronologyEditToggle.svelte`, `ChronologyDragIndicator.svelte`, `SemanticPlacementPopover.svelte` in `apps/web/src/lib/components/graph/`
-- [ ] T003 [P] Create `ChronologyEditService` stub with constructor DI (injectable vault/calendar/resolver deps) + default singleton export in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
+- [x] T001 [P] Create `chronology-engine` module stubs `meaning-sets.ts`, `anchors.ts`, `placement.ts` in `packages/chronology-engine/src/` and re-export them from `packages/chronology-engine/src/index.ts`
+- [x] T002 [P] Create edit-mode UI stubs `ChronologyEditToggle.svelte`, `ChronologyDragIndicator.svelte`, `SemanticPlacementPopover.svelte` in `apps/web/src/lib/components/graph/`
+- [x] T003 [P] Create `ChronologyEditService` stub with constructor DI (injectable vault/calendar/resolver deps) + default singleton export in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
 
 ---
 
@@ -40,31 +40,31 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 ### Schema (contract: `contracts/schema.temporal-anchor.md`)
 
-- [ ] T004 [P] Write failing tests for `TemporalAnchorSchema` (at-least-one-date, custom⇒label, range non-inverted, date-shape) and `Entity` back-compat in `packages/schema/src/entity.test.ts`
-- [ ] T005 Implement `TemporalAnchorSchema` + add optional `temporalAnchors` to `EntitySchema` and `TemporalAnchor` type export in `packages/schema/src/entity.ts` (green for T004)
+- [x] T004 [P] Write failing tests for `TemporalAnchorSchema` (at-least-one-date, custom⇒label, range non-inverted, date-shape) and `Entity` back-compat in `packages/schema/src/entity.test.ts`
+- [x] T005 Implement `TemporalAnchorSchema` + add optional `temporalAnchors` to `EntitySchema` and `TemporalAnchor` type export in `packages/schema/src/entity.ts` (green for T004)
 
 ### graph-engine — position↔year + projection (contract: `contracts/graph-engine.anchor-projection.md`)
 
-- [ ] T006 [P] Write failing tests for `getYearForPosition` round-trip/out-of-range and `getAnchorTimelineLayout` per-anchor keys in `packages/graph-engine/tests/timeline-anchor.test.ts`
-- [ ] T007 Implement `getYearForPosition` (inverse of sequential/gap-compressed layout) and `getAnchorTimelineLayout` (keyed `"entityId::anchorId"`) additively in `packages/graph-engine/src/layouts/timeline.ts`
+- [x] T006 [P] Write failing tests for `getYearForPosition` round-trip/out-of-range and `getAnchorTimelineLayout` per-anchor keys in `packages/graph-engine/tests/timeline-anchor.test.ts`
+- [x] T007 Implement `getYearForPosition` (inverse of sequential/gap-compressed layout) and `getAnchorTimelineLayout` (keyed `"entityId::anchorId"`) additively in `packages/graph-engine/src/layouts/timeline.ts`
 
 ### chronology-engine — meanings, anchors, placement (contract: `contracts/chronology-engine.placement.md`)
 
-- [ ] T008 [P] Write failing tests for `MEANING_SETS`/`getMeanings`/`getBeginMeaning`/`getEndMeaning` (per-type sets, begin/end roles per FR-016a, universal custom, fallback) in `packages/chronology-engine/tests/meaning-sets.test.ts`
-- [ ] T009 Implement `MEANING_SETS` + `getMeanings`/`getBeginMeaning`/`getEndMeaning` (begin/end `role`, one `primary` per type) in `packages/chronology-engine/src/meaning-sets.ts`
-- [ ] T010 [P] Write failing tests for `deriveProjectedAnchors`, `validateRange`, `upsertAnchor`, `removeAnchor` (primary projection + per-anchor, no sibling/primary mutation) in `packages/chronology-engine/tests/anchors.test.ts`
-- [ ] T011 Implement `anchors.ts` helpers in `packages/chronology-engine/src/anchors.ts` (depends on T005, T009)
-- [ ] T012 [P] Write failing tests for `buildIntent` (Event primary→`date`; non-primary→anchor; span yields begin+end; never coordinates) and `detectConflict` (calendar-equality) in `packages/chronology-engine/tests/placement.test.ts`
-- [ ] T013 Implement `placement.ts` (`buildIntent`, `PlacementIntent`, `detectConflict`) in `packages/chronology-engine/src/placement.ts` (depends on T009, T011)
+- [x] T008 [P] Write failing tests for `MEANING_SETS`/`getMeanings`/`getBeginMeaning`/`getEndMeaning` (per-type sets, begin/end roles per FR-016a, universal custom, fallback) in `packages/chronology-engine/tests/meaning-sets.test.ts`
+- [x] T009 Implement `MEANING_SETS` + `getMeanings`/`getBeginMeaning`/`getEndMeaning` (begin/end `role`, one `primary` per type) in `packages/chronology-engine/src/meaning-sets.ts`
+- [x] T010 [P] Write failing tests for `deriveProjectedAnchors`, `validateRange`, `upsertAnchor`, `removeAnchor` (primary projection + per-anchor, no sibling/primary mutation) in `packages/chronology-engine/tests/anchors.test.ts`
+- [x] T011 Implement `anchors.ts` helpers in `packages/chronology-engine/src/anchors.ts` (depends on T005, T009)
+- [x] T012 [P] Write failing tests for `buildIntent` (Event primary→`date`; non-primary→anchor; span yields begin+end; never coordinates) and `detectConflict` (calendar-equality) in `packages/chronology-engine/tests/placement.test.ts`
+- [x] T013 Implement `placement.ts` (`buildIntent`, `PlacementIntent`, `detectConflict`) in `packages/chronology-engine/src/placement.ts` (depends on T009, T011)
 
 ### Edit-mode state, service & drag plumbing (apps/web)
 
-- [ ] T014 Add `chronologyEditMode` state (requires `timelineMode`; toggling off clears pending drag) + toggle/guard actions to `apps/web/src/lib/stores/graph.svelte.ts`
-- [ ] T015 [P] Write failing tests for `ChronologyEditService` lifecycle — grab→drag→drop→confirm/cancel, gesture point/span derivation, restore-on-cancel, no-write-on-cancel, save via injected vault, conflict surfacing — in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
-- [ ] T016 Implement `ChronologyEditService` (transient `ChronologyDrag` state, `pressYear`/`targetYear`/`gestureKind`, routes saves through injected `vault.updateEntity`; uses `buildIntent`/`detectConflict`/`getYearForPosition`) in `apps/web/src/lib/stores/chronology-edit.svelte.ts` (depends on T013, T007, T014)
-- [ ] T017 Implement `ChronologyEditToggle.svelte` mode toggle (placed near `TimelineControls`, clear "editing lore" affordance) in `apps/web/src/lib/components/graph/ChronologyEditToggle.svelte`
-- [ ] T018 Implement `ChronologyDragIndicator.svelte` live target-year axis indicator bound to service state, formatting the label via `calendarStore`/`chronology-engine` so it reads in-world notation (e.g. "605 P.C.") not a bare number (FR-010, U2), in `apps/web/src/lib/components/graph/ChronologyDragIndicator.svelte`
-- [ ] T019 Wire Cytoscape `grab`/`drag`/`dragfree` handlers (gated on `chronologyEditMode`) into `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts` to drive `ChronologyEditService`
+- [x] T014 Add `chronologyEditMode` state (requires `timelineMode`; toggling off clears pending drag) + toggle/guard actions to `apps/web/src/lib/stores/graph.svelte.ts`
+- [x] T015 [P] Write failing tests for `ChronologyEditService` lifecycle — grab→drag→drop→confirm/cancel, gesture point/span derivation, restore-on-cancel, no-write-on-cancel, save via injected vault, conflict surfacing — in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T016 Implement `ChronologyEditService` (transient `ChronologyDrag` state, `pressYear`/`targetYear`/`gestureKind`, routes saves through injected `vault.updateEntity`; uses `buildIntent`/`detectConflict`/`getYearForPosition`) in `apps/web/src/lib/stores/chronology-edit.svelte.ts` (depends on T013, T007, T014)
+- [x] T017 Implement `ChronologyEditToggle.svelte` mode toggle (placed near `TimelineControls`, clear "editing lore" affordance) in `apps/web/src/lib/components/graph/ChronologyEditToggle.svelte`
+- [x] T018 Implement `ChronologyDragIndicator.svelte` live target-year axis indicator bound to service state, formatting the label via `calendarStore`/`chronology-engine` so it reads in-world notation (e.g. "605 P.C.") not a bare number (FR-010, U2), in `apps/web/src/lib/components/graph/ChronologyDragIndicator.svelte`
+- [x] T019 Wire Cytoscape `grab`/`drag`/`dragfree` handlers (gated on `chronologyEditMode`) into `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts` to drive `ChronologyEditService`
 
 **Checkpoint**: Foundation ready — pure engines green, edit mode toggles, a gated drag updates the live indicator and resolves an intent (without writing yet).
 
@@ -76,10 +76,10 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Independent Test**: Drag an Event in edit mode, observe the live year, confirm the direct prompt, verify `entity.date` changed and survives reload; repeat and cancel to verify no change.
 
-- [ ] T020 [P] [US1] Write failing test: an Event drop yields a primary-`date` intent with a "Set event date to {year}?" summary, and confirm→`vault.updateEntity({date})`, cancel→no write, in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
-- [ ] T021 [US1] Implement the direct-confirmation path (primary `date` write) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte` — a compact "Set event date to {year}? Save/Cancel" mode (no full meaning list)
-- [ ] T022 [US1] Wire Event `dragfree` → `buildIntent` (begin/primary `date`) → direct confirm → `vault.updateEntity`; settle node at derived position on save and restore origin on cancel, in `ChronologyEditService` + `graph-view-controller.svelte.ts`
-- [ ] T023 [US1] Add persistence assertion test: saved Event has updated structured `date` and no raw graph coordinate stored (SC-008), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T020 [P] [US1] Write failing test: an Event drop yields a primary-`date` intent with a "Set event date to {year}?" summary, and confirm→`vault.updateEntity({date})`, cancel→no write, in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T021 [US1] Implement the direct-confirmation path (primary `date` write) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte` — a compact "Set event date to {year}? Save/Cancel" mode (no full meaning list)
+- [x] T022 [US1] Wire Event `dragfree` → `buildIntent` (begin/primary `date`) → direct confirm → `vault.updateEntity`; settle node at derived position on save and restore origin on cancel, in `ChronologyEditService` + `graph-view-controller.svelte.ts`
+- [x] T023 [US1] Add persistence assertion test: saved Event has updated structured `date` and no raw graph coordinate stored (SC-008), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
 
 **Checkpoint**: MVP — Events can be re-dated by direct manipulation, canon-safe.
 
@@ -91,10 +91,10 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Independent Test**: Drag a Character → popover shows Born/Died/Active/Reign/Major appearance/Custom; pick Born, save, verify the value persisted; drag a Faction → different (Founded/Dissolved/…) set.
 
-- [ ] T024 [P] [US2] Write failing tests for `SemanticPlacementPopover` rendering type-specific meanings (via `getMeanings`), begin-default selection, and the "field/anchor to be changed" disclosure (FR-005) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts`
-- [ ] T025 [US2] Implement `SemanticPlacementPopover.svelte`: `@floating-ui/dom`-anchored popover showing entity name + target year, meaning list from `getMeanings(type)` (generic fallback for creature/custom categories), value field reusing `TemporalPicker`, write-target disclosure, a **conflict prompt** when `detectConflict` is true (FR-032), Save/Cancel (depends on T024)
-- [ ] T026 [US2] Route non-Event drops to the popover; on save apply `buildIntent` → `vault.updateEntity` writing the primary field or `upsertAnchor`-produced `temporalAnchors[]`, in `apps/web/src/lib/stores/chronology-edit.svelte.ts` + `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`
-- [ ] T027 [US2] Natural-language copy + keyboard/escape accessibility for the popover (Constitution IX); confirm cancel/escape writes nothing, in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
+- [x] T024 [P] [US2] Write failing tests for `SemanticPlacementPopover` rendering type-specific meanings (via `getMeanings`), begin-default selection, and the "field/anchor to be changed" disclosure (FR-005) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.test.ts`
+- [x] T025 [US2] Implement `SemanticPlacementPopover.svelte`: `@floating-ui/dom`-anchored popover showing entity name + target year, meaning list from `getMeanings(type)` (generic fallback for creature/custom categories), value field reusing `TemporalPicker`, write-target disclosure, a **conflict prompt** when `detectConflict` is true (FR-032), Save/Cancel (depends on T024)
+- [x] T026 [US2] Route non-Event drops to the popover; on save apply `buildIntent` → `vault.updateEntity` writing the primary field or `upsertAnchor`-produced `temporalAnchors[]`, in `apps/web/src/lib/stores/chronology-edit.svelte.ts` + `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`
+- [x] T027 [US2] Natural-language copy + keyboard/escape accessibility for the popover (Constitution IX); confirm cancel/escape writes nothing, in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
 
 **Checkpoint**: All entity types can be placed in time with the right vocabulary, canon-safe.
 
@@ -106,10 +106,10 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Independent Test**: Drag a Period span 50 years later → range shifts and both ends update; drag only the end edge → only end updates; attempt an inverted range → blocked with reason.
 
-- [ ] T028 [P] [US3] Write failing tests for span-gesture resolution (press=begin, release=end → begin+end pre-fill) and `validateRange` block in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
-- [ ] T029 [US3] Implement gesture point/span derivation (threshold = swept width resolving to **≥ 1 year** and ≥ ~6px → `gestureKind`, `pressYear`/`targetYear`, begin→end pair via `getBeginMeaning`/`getEndMeaning`) and span pre-fill into the popover, in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
-- [ ] T030 [US3] Implement whole-span move + individual start/end edge-drag handles for **any entity's `start_date`/`end_date` range** (not a "Period" type, which does not exist) in `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`, mapping to `start_date`/`end_date` writes
-- [ ] T031 [US3] Enforce range-inversion rejection in `SemanticPlacementPopover.svelte` using `validateRange` (block save + explain, FR-031)
+- [x] T028 [P] [US3] Write failing tests for span-gesture resolution (press=begin, release=end → begin+end pre-fill) and `validateRange` block in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T029 [US3] Implement gesture point/span derivation (threshold = swept width resolving to **≥ 1 year** and ≥ ~6px → `gestureKind`, `pressYear`/`targetYear`, begin→end pair via `getBeginMeaning`/`getEndMeaning`) and span pre-fill into the popover, in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
+- [x] T030 [US3] Implement whole-span move + individual start/end edge-drag handles for **any entity's `start_date`/`end_date` range** (not a "Period" type, which does not exist) in `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`, mapping to `start_date`/`end_date` writes
+- [x] T031 [US3] Enforce range-inversion rejection in `SemanticPlacementPopover.svelte` using `validateRange` (block save + explain, FR-031)
 
 **Checkpoint**: Spans are first-class — drawable, edge-adjustable, integrity-checked.
 
@@ -121,10 +121,10 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Independent Test**: Add born/majorAppearance/disappeared to one Character; verify three persistent points; remove one → others unaffected.
 
-- [ ] T032 [P] [US4] Write failing tests for the update-or-add-new flow and per-anchor independence (`upsertAnchor`/`removeAnchor` via service, no sibling/primary mutation) in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
-- [ ] T033 [US4] Wire `getAnchorTimelineLayout` projected synthetic nodes (`"entityId::anchorId"`) into `LayoutManager`/`graph-view-controller.svelte.ts` for timeline edit mode so each anchor is a grabbable point (FR-009a/FR-028)
-- [ ] T034 [US4] Implement "update this anchor / create new anchor instead" choice in `SemanticPlacementPopover.svelte`; persist via `vault.updateEntity` with `upsertAnchor` (depends on T026)
-- [ ] T035 [US4] Implement per-anchor edit/remove affordance + linked-entity soft reference with broken-link degradation (FR-033) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
+- [x] T032 [P] [US4] Write failing tests for the update-or-add-new flow and per-anchor independence (`upsertAnchor`/`removeAnchor` via service, no sibling/primary mutation) in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T033 [US4] Wire `getAnchorTimelineLayout` projected synthetic nodes (`"entityId::anchorId"`) into `LayoutManager`/`graph-view-controller.svelte.ts` for timeline edit mode so each anchor is a grabbable point (FR-009a/FR-028)
+- [x] T034 [US4] Implement "update this anchor / create new anchor instead" choice in `SemanticPlacementPopover.svelte`; persist via `vault.updateEntity` with `upsertAnchor` (depends on T026)
+- [x] T035 [US4] Implement per-anchor edit/remove affordance + linked-entity soft reference with broken-link degradation (FR-033) in `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
 
 **Checkpoint**: Recurring figures are represented faithfully across history.
 
@@ -136,9 +136,9 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Independent Test**: Toggle view/edit; verify view-mode drags never change temporal metadata and the active mode is obvious at a glance.
 
-- [ ] T036 [P] [US5] Write failing tests asserting view-mode drags never mutate temporal metadata and the edit-mode guard blocks writes when off, in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
-- [ ] T037 [US5] Implement clear mode indicators (view vs edit-chronology, plus layout-only if supported) and edit-drag affordance styling per `@docs/STYLE_GUIDE.md` in the graph HUD/toolbar (`GraphHUD.svelte`/`GraphToolbar.svelte`)
-- [ ] T038 [US5] Ensure layout-only node movement is visually distinct from chronology drags and writes no temporal metadata (guard + styling), in `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`
+- [x] T036 [P] [US5] Write failing tests asserting view-mode drags never mutate temporal metadata and the edit-mode guard blocks writes when off, in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T037 [US5] Implement clear mode indicators (view vs edit-chronology, plus layout-only if supported) and edit-drag affordance styling per `@docs/STYLE_GUIDE.md` in the graph HUD/toolbar (`GraphHUD.svelte`/`GraphToolbar.svelte`)
+- [x] T038 [US5] Ensure layout-only node movement is visually distinct from chronology drags and writes no temporal metadata (guard + styling), in `apps/web/src/lib/components/graph/graph-view-controller.svelte.ts`
 
 **Checkpoint**: Accidental canon changes are structurally and visually guarded.
 
@@ -150,10 +150,10 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Independent Test**: Drag an undated entity from the Explorer, drop at a year, confirm, verify it now appears in Timeline Mode and persists.
 
-- [ ] T039 [P] [US6] Write failing tests for the canvas drop handler: `clientX/Y`→model position→year resolution, edit-mode gating, invalid-drop cancel, in `apps/web/src/lib/components/graph/graph-view-controller.svelte.test.ts`
-- [ ] T040 [US6] Add `dragover`/`drop` handler on `apps/web/src/lib/components/GraphView.svelte` reading `application/codex-entity` (reusing the existing Explorer drag source), gated on `chronologyEditMode`, converting the drop point to a year via `getYearForPosition`
-- [ ] T041 [US6] Route the Explorer drop into the placement flow as a point/start candidate (FR-011b); support first-time placement of undated entities; for entities already on the timeline use the update-or-add-anchor flow (no duplicate), in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
-- [ ] T042 [US6] Add test that a previously-undated entity appears in Timeline Mode after placement and persists across reload (SC-009), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T039 [P] [US6] Write failing tests for the canvas drop handler: `clientX/Y`→model position→year resolution, edit-mode gating, invalid-drop cancel, in `apps/web/src/lib/components/graph/graph-view-controller.svelte.test.ts`
+- [x] T040 [US6] Add `dragover`/`drop` handler on `apps/web/src/lib/components/GraphView.svelte` reading `application/codex-entity` (reusing the existing Explorer drag source), gated on `chronologyEditMode`, converting the drop point to a year via `getYearForPosition`
+- [x] T041 [US6] Route the Explorer drop into the placement flow as a point/start candidate (FR-011b); support first-time placement of undated entities; for entities already on the timeline use the update-or-add-anchor flow (no duplicate), in `apps/web/src/lib/stores/chronology-edit.svelte.ts`
+- [x] T042 [US6] Add test that a previously-undated entity appears in Timeline Mode after placement and persists across reload (SC-009), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
 
 **Checkpoint**: Any entity, dated or not, can be pulled into time by direct manipulation.
 
@@ -165,11 +165,11 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 **Independent Test**: Drag a Character to 621, choose "Create an event here", edit the title, save; verify a new dated Event exists, the Character has an anchor with `linkedEntityId` to it and a connection, and the Character's existing placement is unchanged.
 
-- [ ] T043 [P] [US7] Write failing tests for the `createEvent` intent (`buildIntent` populates `createEvent` payload, leaves source primary/anchors untouched) in `packages/chronology-engine/tests/placement.test.ts`, and for the service create-link-connect-and-rollback flow in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
-- [ ] T044 [US7] Extend `buildIntent`/`PlacementIntent` with the optional `createEvent` payload (title, date, anchorType, connectionType) in `packages/chronology-engine/src/placement.ts`
-- [ ] T045 [US7] Add the "Create an event here" option + editable pre-filled title field (`"{Entity} — {year}"`) and write-disclosure to `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
-- [ ] T046 [US7] Implement the event-creation save path in `apps/web/src/lib/stores/chronology-edit.svelte.ts`: `vault.createEntity("event", title, { date })` → `upsertAnchor` with `linkedEntityId` on the source → add `related_to` connection; additive, with rollback on partial failure (FR-039)
-- [ ] T047 [US7] Add test asserting the linked event + anchor `linkedEntityId` + connection all persist and the source entity's existing placement is unchanged (SC-010), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T043 [P] [US7] Write failing tests for the `createEvent` intent (`buildIntent` populates `createEvent` payload, leaves source primary/anchors untouched) in `packages/chronology-engine/tests/placement.test.ts`, and for the service create-link-connect-and-rollback flow in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
+- [x] T044 [US7] Extend `buildIntent`/`PlacementIntent` with the optional `createEvent` payload (title, date, anchorType, connectionType) in `packages/chronology-engine/src/placement.ts`
+- [x] T045 [US7] Add the "Create an event here" option + editable pre-filled title field (`"{Entity} — {year}"`) and write-disclosure to `apps/web/src/lib/components/graph/SemanticPlacementPopover.svelte`
+- [x] T046 [US7] Implement the event-creation save path in `apps/web/src/lib/stores/chronology-edit.svelte.ts`: `vault.createEntity("event", title, { date })` → `upsertAnchor` with `linkedEntityId` on the source → add `related_to` connection; additive, with rollback on partial failure (FR-039)
+- [x] T047 [US7] Add test asserting the linked event + anchor `linkedEntityId` + connection all persist and the source entity's existing placement is unchanged (SC-010), in `apps/web/src/lib/stores/chronology-edit.svelte.test.ts`
 
 **Checkpoint**: The timeline doubles as a lightweight event-authoring surface.
 
@@ -177,11 +177,11 @@ Web monorepo: libraries in `packages/<pkg>/src/` (+ co-located or `tests/` specs
 
 ## Phase 10: Polish & Cross-Cutting Concerns
 
-- [ ] T048 [P] Add an "Edit Chronology" help article to `apps/web/src/lib/config/help-content.ts` and a `FeatureHint` for first edit-mode entry (Constitution VII)
-- [ ] T049 [P] STYLE_GUIDE / Tailwind-4 token + Svelte 5 runes compliance pass on all new components (Constitution VI)
-- [ ] T050 Run `quickstart.md` end-to-end and fix any gaps against the acceptance scenarios
-- [ ] T051 Verify ≥70% coverage on new package logic and run `pnpm run lint && pnpm test` green (Constitution VI, X)
-- [ ] T052 [P] Update `spec.md` status and cross-link the plan; confirm auto-Label (`past`) behaviour unchanged for anchor-driven status (Constitution XII)
+- [x] T048 [P] Add an "Edit Chronology" help article to `apps/web/src/lib/config/help-content.ts` and a `FeatureHint` for first edit-mode entry (Constitution VII)
+- [x] T049 [P] STYLE_GUIDE / Tailwind-4 token + Svelte 5 runes compliance pass on all new components (Constitution VI)
+- [x] T050 Run `quickstart.md` end-to-end and fix any gaps against the acceptance scenarios
+- [x] T051 Verify ≥70% coverage on new package logic and run `pnpm run lint && pnpm test` green (Constitution VI, X)
+- [x] T052 [P] Update `spec.md` status and cross-link the plan; confirm auto-Label (`past`) behaviour unchanged for anchor-driven status (Constitution XII)
 
 ---
 


### PR DESCRIPTION
## Summary
- Render article keywords as title-case chips (no `#` prefix)
- Add muted "Topics" heading above chips
- Limit to 6 chips max
- Fix hardcoded CTA: "Ready to secure your lore?" → "Ready to bring your lore home?", "data sovereignty" tagline → "Local-first. Your vault stays yours."

## Test plan
- [ ] Visit any blog article and verify keywords render as readable title-case chips
- [ ] Verify no `#` prefix visible
- [ ] Verify CTA heading and subtext updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)