### PR TITLE
Fix prerender 404 on /app link from blog articles

### DIFF
--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -48,6 +48,8 @@ const config = {
       handleHttpError: ({ path, message }) => {
         // Ignore static assets/metadata files that return 404 during local crawling
         if (
+          path === "/app" ||
+          path.startsWith("/app/") ||
           path.endsWith("/llms.txt") ||
           path.endsWith("/favicon.png") ||
           path.endsWith("/logo.png") ||


### PR DESCRIPTION
## Summary
Blog articles link to `/app` as a CTA. The prerenderer follows this link and fails with 404 since `/app` is a client-only route, not a prerendered page.

- Add `/app` and `/app/*` to the `handleHttpError` ignore list in `svelte.config.js`

The blog article links themselves have also been fixed on the `blog` branch (`[Try it free](/)` instead of `/app`), but this guard prevents the same failure if any future content links there.

## Test plan
- [ ] Staging build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)