### PR TITLE
Scope blog CDN publish to push events; decouple prod deploy job

### DIFF
--- a/.github/workflows/deploy-blog-content.yml
+++ b/.github/workflows/deploy-blog-content.yml
@@ -36,6 +36,9 @@ permissions:
 jobs:
   publish-cdn:
     name: Publish to CDN branch
+    # Only republish the blog-content branch on real pushes to `blog` — never on a
+    # manual workflow_dispatch (which may run from an arbitrary ref / preview test).
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -81,7 +84,9 @@ jobs:
 
   deploy-production:
     name: Prerender and deploy
-    needs: publish-cdn
+    # No dependency on publish-cdn: this job prerenders from the local overlay, not the
+    # CDN, so the two are independent. On push they run in parallel; on workflow_dispatch
+    # (preview) publish-cdn is skipped and this still runs.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:


### PR DESCRIPTION
Follow-up addressing Copilot review on #1190.

- **`publish-cdn` is now push-only** (`if: github.event_name == 'push'`) — a manual `workflow_dispatch` (e.g. a preview test from an arbitrary ref) no longer force-pushes the `blog-content` branch.
- **`deploy-production` drops `needs: publish-cdn`** — the prod/preview build prerenders from the local overlay, not the CDN, so the jobs are independent. On push they now run in parallel; on dispatch (preview) `publish-cdn` is skipped and `deploy-production` still runs.

Not changed (deliberate):
- **dispatch → `target_branch=main`** kept as the manual production-refresh escape hatch (default is preview; prod requires explicitly typing `main`).
- **type-check before build** skipped — the overlay is markdown-only and can't introduce type errors, and `main` is already type-checked as prod-of-record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)