### PR TITLE
Blog series polish: article 2, series-nav consistency, single CTA

### DIFF
--- a/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
+++ b/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
@@ -92,6 +92,3 @@ _This article is part of the Codex Cryptica responsible AI series._
 - [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
 - [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)
 
----
-
-_Codex Cryptica is a local-first campaign and worldbuilding manager. [Try it free](/) — no account required._

--- a/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
+++ b/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
@@ -89,7 +89,7 @@ _This article is part of the Codex Cryptica responsible AI series._
 - [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore)
 - [Drafts Are Not Canon](/blog/drafts-are-not-canon)
 - **Six Ways to Use AI in Campaign Prep Without Losing Your Voice** _(this article)_
-- AI Slop Happens When the Tool Has No Memory _(coming soon)_
+- [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
 - [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)
 
 ---

--- a/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
+++ b/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
@@ -82,6 +82,3 @@ _This article is part of the Codex Cryptica responsible AI series._
 - **AI Slop Happens When the Tool Has No Memory** _(this article)_
 - [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)
 
----
-
-_Codex Cryptica is a local-first campaign and worldbuilding manager. [Try it free](/) — no account required._

--- a/apps/web/src/lib/content/blog/drafts-are-not-canon.md
+++ b/apps/web/src/lib/content/blog/drafts-are-not-canon.md
@@ -88,6 +88,3 @@ _This article is part of the Codex Cryptica responsible AI series._
 - [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
 - [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)
 
----
-
-_Codex Cryptica is a local-first campaign and worldbuilding manager. [Try it free](/) — no account required._

--- a/apps/web/src/lib/content/blog/drafts-are-not-canon.md
+++ b/apps/web/src/lib/content/blog/drafts-are-not-canon.md
@@ -84,8 +84,8 @@ _This article is part of the Codex Cryptica responsible AI series._
 - [A Worldbuilding Tool Should Still Work Without AI](/blog/worldbuilding-tool-without-ai)
 - [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore)
 - **Drafts Are Not Canon** _(this article)_
-- Six Ways to Use AI in Campaign Prep Without Losing Your Voice _(coming soon)_
-- AI Slop Happens When the Tool Has No Memory _(coming soon)_
+- [Six Ways to Use AI in Campaign Prep Without Losing Your Voice](/blog/ai-campaign-prep-without-losing-your-voice)
+- [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
 - [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)
 
 ---

--- a/apps/web/src/lib/content/blog/lore-oracle-not-the-author.md
+++ b/apps/web/src/lib/content/blog/lore-oracle-not-the-author.md
@@ -68,7 +68,3 @@ The Oracle is designed to distinguish between vault canon and its own suggestion
 Codex Cryptica is a local-first campaign and worldbuilding manager. Your vault stays on your machine by default. When you use the Oracle, only the context needed for your request is sent to the configured AI provider — Codex Cryptica does not host your vault or index it publicly.
 
 Your lore stays yours. Your canon stays yours. The Oracle is there to help you navigate what you have already built.
-
-[Try it free](/) — no account required.
-
-_Ready to bring your lore home?_

--- a/apps/web/src/lib/content/blog/revising-your-lore-with-the-oracle.md
+++ b/apps/web/src/lib/content/blog/revising-your-lore-with-the-oracle.md
@@ -92,6 +92,3 @@ _This article is part of the Codex Cryptica responsible AI series._
 - [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
 - **Revising Your Lore with the Oracle** _(this article)_
 
----
-
-_Codex Cryptica is a local-first campaign and worldbuilding manager. [Try it free](/) — no account required._

--- a/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
+++ b/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
@@ -94,6 +94,3 @@ _This article is part of the Codex Cryptica responsible AI series._
 - [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
 - [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)
 
----
-
-_Codex Cryptica is a local-first campaign and worldbuilding manager. [Try it free](/) — no account required._

--- a/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
+++ b/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
@@ -89,9 +89,9 @@ _This article is part of the Codex Cryptica responsible AI series._
 - [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)
 - [A Worldbuilding Tool Should Still Work Without AI](/blog/worldbuilding-tool-without-ai)
 - **Why Worldbuilding AI Should Know Your Lore Before It Speaks** _(this article)_
-- Drafts Are Not Canon _(coming soon)_
-- Six Ways to Use AI in Campaign Prep Without Losing Your Voice _(coming soon)_
-- AI Slop Happens When the Tool Has No Memory _(coming soon)_
+- [Drafts Are Not Canon](/blog/drafts-are-not-canon)
+- [Six Ways to Use AI in Campaign Prep Without Losing Your Voice](/blog/ai-campaign-prep-without-losing-your-voice)
+- [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
 - [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)
 
 ---

--- a/apps/web/src/lib/content/blog/worldbuilding-tool-without-ai.md
+++ b/apps/web/src/lib/content/blog/worldbuilding-tool-without-ai.md
@@ -36,13 +36,19 @@ None of that requires the Lore Oracle. None of it calls out to a model provider.
 
 ## What disabling the Oracle removes — and what it doesn't
 
-| With AI off, you lose | You keep |
-|---|---|
-| AI-assisted entity drafting | The archive |
-| Vault-aware Q&A | The knowledge graph |
-| Context-aware prep suggestions | The timeline and session log |
-| | Search and imports |
-| | Local storage and offline access |
+With AI off, you lose:
+
+- AI-assisted entity drafting
+- Vault-aware Q&A
+- Context-aware prep suggestions
+
+You keep:
+
+- The archive
+- The knowledge graph
+- The timeline and session log
+- Search and imports
+- Local storage and offline access
 
 **The product is smaller with AI off. It is not broken.**
 
@@ -66,9 +72,11 @@ Codex Cryptica was built starting from step one. The Lore Oracle came later, and
 
 ---
 
-Ready for a worldbuilding tool that still works without AI? Build your vault. Use the Oracle when it helps. Turn it off when it doesn't.
+Ready for a worldbuilding tool that still works without AI?
 
-[Try it free](/) — no account required.
+Build your vault. Use the Oracle when it helps. Turn it off when it doesn't.
+
+[Enter the Codex](/) — no account required.
 
 ---
 

--- a/apps/web/src/lib/content/blog/worldbuilding-tool-without-ai.md
+++ b/apps/web/src/lib/content/blog/worldbuilding-tool-without-ai.md
@@ -72,14 +72,6 @@ Codex Cryptica was built starting from step one. The Lore Oracle came later, and
 
 ---
 
-Ready for a worldbuilding tool that still works without AI?
-
-Build your vault. Use the Oracle when it helps. Turn it off when it doesn't.
-
-[Enter the Codex](/) — no account required.
-
----
-
 _Part of the [Codex Cryptica responsible AI series](/blog/lore-oracle-not-the-author):_
 
 1. [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)


### PR DESCRIPTION
Applies reviewer feedback on article 2, plus two series-wide consistency fixes.

**Article 2 (`worldbuilding-tool-without-ai`)**
- Replaced the awkward comparison table (empty cells in the "lose" column) with two clean bullet lists — reads better on mobile.

**Series nav (articles 3–5)**
- Converted stale `_(coming soon)_` entries to live links. All 7 articles are published, so the markers were wrong.

**Single CTA (decision: keep the styled card, drop markdown CTAs)**
- Each blog page already renders a styled "Enter the Codex" card via the template (`blog/[slug]/+page.svelte`). The per-article markdown CTAs duplicated it.
- Removed the redundant trailing markdown CTAs from all 7 series articles, leaving the card as the single CTA. Article 1 keeps its substantive privacy/ownership closing; only the redundant `Try it free` link + `Ready to bring your lore home?` line (which exactly duplicated the card heading) were removed.
- No app/template change needed — the card stays as-is.

**Scope note:** older non-series marketing articles (e.g. spatial-intelligence, supercharged-discovery) have their own content-integral CTAs and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)