### PR TITLE
Article 3 trust fixes: CTA, keyword chips, vault-aware reassurance

### DIFF
--- a/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
+++ b/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
@@ -14,9 +14,10 @@ keywords:
     "AI grounded in lore",
   ]
 publishedAt: 2026-06-06T14:00:00Z
+cta:
+  heading: "Ready for AI that actually knows your lore?"
+  subheading: "Build your vault. Let the Oracle work from your world, not a blank prompt."
 ---
-
-# Why Worldbuilding AI Should Know Your Lore Before It Speaks
 
 Ask most AI tools to generate a tavern and you get the same tavern. Creaking floorboards. A grizzled barkeep. Suspicious strangers in the corner. It is competent and forgettable.
 
@@ -46,7 +47,7 @@ versus:
 
 The second version does not need the AI to be smarter. It just needs the AI to work from what already exists. The output stays consistent with your world because your world is in the prompt.
 
-The Lore Oracle in Codex Cryptica works this way. When you ask it a question or request a draft, it pulls from your vault — your entities, your factions, your session log, your established relationships. The context is not something you have to manually assemble every time. It is already there because you built it — including every entry about Velundra, the Ashward district, and the Iron Covenant.
+The Lore Oracle in Codex Cryptica works this way. When you ask it a question or request a draft, it pulls from your vault — your entities, your factions, your session log, your established relationships. The context is not something you have to manually assemble every time. It is already there because you built it — including relevant entries about Velundra, the Ashward district, and the Iron Covenant.
 
 ## What the vault provides
 
@@ -56,7 +57,9 @@ Every piece of structured lore you add to Codex Cryptica becomes context the Ora
 - **Relationships.** Explicit links between entities — allies, rivals, locations, histories.
 - **Session log.** What actually happened, in the order it happened.
 - **Timeline.** When events occurred relative to each other and to the current moment.
-- **Custom notes.** Unstructured text, hidden scratchpads, and scratch notes that map out your raw thoughts.
+- **Custom notes.** Unstructured notes, GM-only scratchpads, and rough ideas can provide context when you choose to include them.
+
+Vault-aware does not mean the whole vault is blindly dumped into every request. The Oracle retrieves relevant context for the task, then treats the result as a draft for you to review.
 
 Ask the Oracle to suggest what a minor faction might want from the players, and it can read who that faction is, who leads it, what it has done in past sessions, and what its rivals are doing. The suggestion comes from your world, not from a generic template.
 

--- a/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -70,11 +70,13 @@
 
     <footer class="pt-12 border-t border-theme-border">
       <div class="flex flex-wrap gap-2">
-        {#each article.keywords as keyword}
+        {#each article.keywords.slice(0, 6) as keyword}
           <span
             class="px-3 py-1 bg-theme-surface border border-theme-border rounded-full text-[10px] font-mono text-theme-muted uppercase tracking-wider"
           >
-            #{keyword.replace(/\s+/g, "-").toLowerCase()}
+            {keyword
+              .replace(/-/g, " ")
+              .replace(/\b\w/g, (c) => c.toUpperCase())}
           </span>
         {/each}
       </div>
@@ -86,10 +88,10 @@
           <h3
             class="text-lg font-header font-bold uppercase tracking-widest mb-2"
           >
-            Ready to secure your lore?
+            {article.cta?.heading ?? "Ready to bring your lore home?"}
           </h3>
           <p class="text-sm text-theme-muted">
-            The GM's most important tool is data sovereignty.
+            {article.cta?.subheading ?? "Local-first. Your vault stays yours."}
           </p>
         </div>
         <a

--- a/packages/editor-core/src/blog/parser.ts
+++ b/packages/editor-core/src/blog/parser.ts
@@ -78,6 +78,13 @@ export function parseBlogArticle(
     const finalPublishedAt =
       publishedAt instanceof Date ? publishedAt.toISOString() : publishedAt;
 
+    const cta =
+      metadata.cta &&
+      typeof metadata.cta.heading === "string" &&
+      typeof metadata.cta.subheading === "string"
+        ? { heading: metadata.cta.heading, subheading: metadata.cta.subheading }
+        : undefined;
+
     return {
       id: String(metadata.id),
       slug: String(metadata.slug),
@@ -86,6 +93,7 @@ export function parseBlogArticle(
       keywords,
       publishedAt: finalPublishedAt,
       content,
+      ...(cta ? { cta } : {}),
     };
   } catch (e) {
     console.error(`Failed to parse frontmatter for ${path}:`, e);

--- a/packages/editor-core/src/blog/types.ts
+++ b/packages/editor-core/src/blog/types.ts
@@ -6,6 +6,7 @@ export interface BlogArticle {
   keywords: string[];
   publishedAt: string;
   content: string; // Raw Markdown
+  cta?: { heading: string; subheading: string };
 }
 
 export interface BlogIndexItem {


### PR DESCRIPTION
## Summary
- **Duplicate H1 fix**: Removed `# Title` H1 from article 3 markdown — template already renders `article.title` as an `<h1>`
- **Keyword chips**: Fixed rendering — removed `#` prefix, switched to title-case (was `#ai-worldbuilding-context`, now `AI Worldbuilding Context`)
- **Per-article CTA**: Added optional `cta: { heading, subheading }` to `BlogArticle` type + parser; template uses it with fallback to defaults. Article 3 CTA: "Ready for AI that actually knows your lore?" / "Build your vault. Let the Oracle work from your world, not a blank prompt."
- **"every" → "relevant"**: Softens retrieval claim on Velundra example
- **Custom notes copy**: Reframed as "GM-only scratchpads, and rough ideas can provide context when you choose to include them" (user control framing)
- **Vault-aware reassurance**: Added "Vault-aware does not mean the whole vault is blindly dumped into every request..." paragraph after vault list

## Files changed
- `packages/editor-core/src/blog/types.ts` — optional `cta` field
- `packages/editor-core/src/blog/parser.ts` — parse `cta` from frontmatter
- `apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte` — keyword chips + dynamic CTA
- `apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md` — all content fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)