### PR TITLE
Article 6 content: memory/context split, continuity rot, slot machine expansion

### DIFF
--- a/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
+++ b/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
@@ -16,55 +16,77 @@ keywords:
 publishedAt: 2026-06-06T20:00:00Z
 ---
 
-You have seen it. The AI-generated tavern with the grizzled barkeep and the suspicious strangers. The faction with the ancient grudge and the shadowy leader. The NPC with a tragic past and a mysterious scar.
+You have seen it. The ancient cult with the shadowy leader who has no history. The MacGuffin hidden in a generic ruin with no name. The merchant with a mysterious scar who exists in isolation, connected to nothing you have established. The villain who forgets what they wanted three sessions ago because the model never knew. The NPC your players killed in session 4, reappearing in a generated rumour table as if nothing happened.
 
-It is technically competent. It is completely forgettable. And after a few sessions of it accumulating in your notes, it actively makes your world worse — a pile of plausible-sounding text that belongs to no particular place or time, connected to nothing, accountable to nothing.
+Bad prose is the symptom. Lack of memory is the disease.
 
-That is AI slop. And it is almost never a prose problem.
+AI slop is not just adjective-heavy, over-polished, bloodless writing — though it is often that too, because generic prose is what you get when a model has no campaign-specific continuity to anchor itself to. The deeper problem is that every generated detail arrives with no relationship to what already happened. The cult has no connection to your factions. The ruin has no place in your geography. The rumour contradicts established canon. The model produced text that is technically fine and contextually useless.
 
-## It is a context problem
+That is AI slop. And it accumulates.
 
-A language model with no information about your world will produce output shaped by everything it was trained on. Every tavern in every fantasy novel. Every faction in every RPG supplement. Every tragic NPC backstory from every video game.
+## Context and memory are not the same thing
 
-The output is statistically average across a massive body of genre fiction. That is why it feels generic. It is not reflecting your world. It is reflecting the genre.
+These two terms often get conflated. They describe different problems.
 
-Give the same model structured context — the specific city, the controlling faction, the events of the last three sessions, the tone you are going for — and the output changes. Not because the model got smarter, but because it has something to be accountable to. The average gets pulled toward your world instead of toward the genre baseline.
+Context is what you include in a specific request — the lore, the faction details, the session notes you pass alongside the prompt. A well-structured context prompt produces better output. This is covered in the previous article in this series.
 
-Context is not a workaround for AI limitations. It is the mechanism that makes AI useful for worldbuilding at all.
+Memory is something larger. It is campaign continuity over time. It is the accumulated fact that session 1 introduced a particular faction, session 12 changed their allegiance, session 30 saw their leader killed, and session 50 is still dealing with the consequences. A tool with no memory treats every request like a fresh start. It has no knowledge of what happened before, no record of what has changed, and no way to avoid contradicting the last fifty sessions of play.
 
-## Why disconnected AI text is worse than no text
+A context-aware prompt is something a GM can assemble manually. Campaign memory is not. That is why it requires a vault.
 
-A blank page is neutral. AI-generated text without context is actively misleading.
+## What a long campaign actually contains
 
-When you generate an NPC with no vault grounding, you get a character who may use naming conventions from the wrong culture, belong to a faction that does not exist, reference history your world does not have, or speak in a tone that does not fit the setting.
+By session 30, a campaign has accumulated facts that a blank-prompt AI cannot know:
 
-If you use that text uncritically, you have just introduced inconsistency. If you spend time correcting it, you have spent more effort than writing from scratch. If you discard it, you have wasted a round-trip through a model for nothing.
+- Characters who died and must not reappear
+- Allegiances that shifted after a specific event
+- Locations that were destroyed or renamed
+- Promises made to the players that were never kept
+- Faction consequences still unresolved
+- Player-facing history that shaped the current political situation
 
-The slop problem is not just aesthetic. It has a practical cost in a long-running campaign where consistency is everything.
+A model generating from nothing ignores all of this. It reaches for genre defaults instead. The cult leader is sinister and mysterious. The ruin is ancient and cursed. The faction is ambitious and secretive. These descriptions are not wrong. They are just not yours.
+
+The further into a campaign you are, the more likely any given AI output is to contradict something established. The model is not malicious. It simply has no idea what already happened.
+
+## The editing cost is not small
+
+This is where the practical argument sharpens. AI without memory does not save prep time if the GM has to audit every generated detail against forty sessions of established canon.
+
+The editing overhead is real:
+
+- Catching the dead NPC before the rumour goes into your session prep
+- Correcting faction motivations that conflict with established history
+- Rewriting location descriptions that contradict your geography
+- Removing references to events that happened differently, or not at all
+
+Call it what it is: continuity rot, cleanup tax, lore debt. A model generating from nothing creates contradiction cleanup as a side effect. The more established your world, the worse the ratio of useful output to correction work.
+
+A vault-aware tool changes this. If the model knows your world, it can avoid the contradictions it would otherwise produce. The cleanup tax drops. The output is usable more often.
 
 ## What memory actually means for a worldbuilding tool
 
-Memory, in this context, does not mean the model remembers your world between sessions. It means the tool maintains a structured vault that is passed as context when the model is asked to generate anything.
+Memory, in this context, does not mean the model retains anything between sessions on its own. It means the tool maintains a structured vault that is passed as context whenever the model is asked to generate anything.
 
-The Lore Oracle in Codex Cryptica works from your vault. When you ask it to suggest a motivation for a faction, it reads that faction's existing entry, its relationships, its history in the session log. When you ask it to draft a location, it has access to the region, the controlling power, the events that shaped the area.
+The Lore Oracle in Codex Cryptica works from your vault. When you ask it to suggest a faction motivation, it reads that faction's existing entry, its relationships, its history in the session log. When you ask it to draft a rumour, it knows which NPCs are alive, which locations exist, which events are in the public record. The model cannot accidentally resurrect a dead character if the vault records their death.
 
-The suggestions are grounded because the context is structured. Your world has entities, relationships, timelines, and notes — not just a pile of freeform text. That structure gives the model something specific to work from.
+The suggestions are grounded because the context is structured. Not freeform notes, but entities, relationships, timelines — information the model can work from specifically rather than inferring from genre convention.
 
-## The floor is higher when the context is real
+## The slot machine, and what changes it
 
-This is the practical benefit of vault-grounded AI: the floor on output quality is much higher.
+AI worldbuilding without a vault is a slot machine. Sometimes something interesting comes out. Usually it is noise — plausible-sounding text that belongs to no particular world, accountable to nothing.
 
-A contextless model might produce something usable one time in five. You spend most of your time filtering. A model working from your structured lore is more likely to produce something in the right ballpark on the first pass — not because it is inspired, but because it is constrained by real information.
+A local vault turns the AI from a random generation engine into an analytical filter. Instead of pulling tropes from a training distribution shaped by every fantasy property ever written, it works through saved lore, detects the patterns specific to your campaign, and suggests material shaped by what actually happened. The output is not always right. But it is wrong in ways that are easy to catch — because the vault makes the contradiction visible — rather than wrong in ways that quietly poison your notes.
 
-You still review everything. You still discard what does not fit. But you are starting from a draft that knows what district it is in, what faction it belongs to, and what happened last session. That is a much better starting point than average genre fiction.
+The difference is whether the tool remembers the world it is helping with.
 
-## Slop is what you get when AI has nothing to lose
+## AI without memory produces slop. AI with a vault can become useful.
 
-A model generating from nothing has no accountability. It cannot be wrong because it has no facts to contradict. It cannot produce inconsistency because it has no established canon to violate.
+The article title is the thesis: AI slop happens when the tool has no memory.
 
-The fix is not better prose prompts. The fix is structure, memory, and a tool that treats your world as the source of truth rather than as an optional input.
+Not when the model is bad. Not when the prose is weak. When the tool generates without continuity, without respect for established canon, without any record of what this particular campaign has built over dozens of sessions.
 
-AI worldbuilding without a vault is a slot machine. Sometimes something interesting comes out. Usually it is noise. A structured vault changes the bet — the model is working with your world, not against it.
+The fix is not a better prompt. It is a tool that treats your world as the source of truth rather than as an optional input. Structure, memory, and accountability to what has already happened.
 
 ---
 


### PR DESCRIPTION
Rewrites article 6 body per reviewer feedback:

- New opening hook: plot/history examples (dead NPC in rumour table, forgotten villain motivation, generic ruin) replacing tavern overlap with article 3
- Frames bad prose as symptom; lack of memory as disease
- Separates context (per-request lore) from memory (campaign continuity over time)
- Long-campaign accumulated facts section: dead characters, changed allegiances, destroyed locations, unresolved promises
- Sharpened editing-cost argument: continuity rot, cleanup tax, lore debt, contradiction cleanup
- Slot machine metaphor expanded: vault turns AI from random engine into analytical filter
- Closes with clear thesis: AI without memory = slop; AI with vault = useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)