### PR TITLE
feat(seo): add FAQ block + FAQPage schema to responsible AI pillar

### DIFF
--- a/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
+++ b/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
@@ -11,15 +11,15 @@
     mainEntity: [
       {
         "@type": "Question",
-        name: "What is responsible AI worldbuilding?",
+        name: "What does responsible AI mean for RPG worldbuilding?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your private world data on external servers.",
+          text: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your campaign vault in a Codex-hosted database.",
         },
       },
       {
         "@type": "Question",
-        name: "Can AI help with RPG campaign prep without writing the campaign for me?",
+        name: "Can AI help with campaign prep without taking over?",
         acceptedAnswer: {
           "@type": "Answer",
           text: "Yes. You direct the Lore Oracle to fill templates, revise existing entries, or generate related entity suggestions. Every result lands in a sandbox draft. Nothing enters your saved lore without your explicit approval.",
@@ -27,7 +27,7 @@
       },
       {
         "@type": "Question",
-        name: "How do I stop AI from changing my campaign canon?",
+        name: "How does Codex keep AI drafts out of canon?",
         acceptedAnswer: {
           "@type": "Answer",
           text: "Codex separates AI drafts from saved files at an architectural level. Generated content lives in a temporary review state. You choose what to accept, edit, or discard. The AI cannot silently write to your vault.",
@@ -35,7 +35,7 @@
       },
       {
         "@type": "Question",
-        name: "Can Codex Cryptica work without AI?",
+        name: "Can I use Codex Cryptica without AI?",
         acceptedAnswer: {
           "@type": "Answer",
           text: "Completely. The wiki, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off.",
@@ -43,26 +43,26 @@
       },
       {
         "@type": "Question",
-        name: "What is vault-aware AI?",
+        name: "What does vault-aware AI mean?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: "Vault-aware AI means the Oracle reads from the campaign context you have open before composing a response. Your world's specific details shape the output, not generic fantasy training data.",
+          text: "Vault-aware AI means the Oracle is grounded in the selected context from your vault rather than starting from a blank prompt alone. The active entity, linked notes, and any campaign-level context you have selected all shape the response.",
         },
       },
       {
         "@type": "Question",
-        name: "What is the difference between AI context and AI memory?",
+        name: "What is the difference between context and memory?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: "Context is what you explicitly pass to the AI for a single query. Memory is persistent state across sessions. Codex uses context from your structured vault rather than relying on an opaque memory layer that can drift or hallucinate.",
+          text: "Context is what you explicitly pass to the AI for a single query: the entity you are editing, the notes you have selected. Memory is persistent state across sessions. Codex uses context from your structured vault — frontmatter, linked entities, timelines — rather than relying on an opaque memory layer that can drift or hallucinate.",
         },
       },
       {
         "@type": "Question",
-        name: "Does the Lore Oracle use my existing lore?",
+        name: "Can the Lore Oracle read my whole vault?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: "Yes. When you invoke the Oracle on an entity, it receives the content of that entity, any linked entities you have pulled into context, and campaign-level notes you have selected.",
+          text: "No. The Lore Oracle does not receive your entire vault by default. When you invoke it on an entity, it receives the active prompt, the current entity content and metadata, any linked entities you have included, and any campaign-level notes you have selected for that action. That context is used for a single request. Unselected notes stay local.",
         },
       },
     ],
@@ -480,7 +480,7 @@
       </p>
 
       <div class="space-y-3">
-        {#each [{ q: "What is responsible AI worldbuilding?", a: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your private world data on external servers." }, { q: "Can AI help with RPG campaign prep without writing the campaign for me?", a: 'Yes. Codex Cryptica is designed for exactly this. You direct the Lore Oracle to fill templates, revise existing entries, or generate related entity suggestions. Every result lands in a sandbox draft. Nothing enters your saved lore without your explicit approval. Read more in <a href="{base}/blog/ai-campaign-prep-without-losing-your-voice" class="text-theme-primary hover:underline">Six Ways to Use AI in Campaign Prep Without Losing Your Voice</a>.' }, { q: "How do I stop AI from changing my campaign canon?", a: 'Codex separates AI drafts from saved files at an architectural level. Generated content lives in a temporary review state. You choose what to accept, edit, or discard. The AI cannot silently write to your vault. See <a href="{base}/blog/drafts-are-not-canon" class="text-theme-primary hover:underline">Drafts Are Not Canon</a> for the full explanation.' }, { q: "Can Codex Cryptica work without AI?", a: 'Completely. The wiki, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off. AI is a layer on top of a working campaign manager, not a requirement for it. See <a href="{base}/blog/worldbuilding-tool-without-ai" class="text-theme-primary hover:underline">A Worldbuilding Tool Should Still Work Without AI</a>.' }, { q: "What is vault-aware AI?", a: "Vault-aware AI means the Oracle reads from the campaign context you have open — the active entity, linked notes, and selected background lore — before composing a response. It does not generate from a blank prompt or generic fantasy training data. Your world's specific details shape the output." }, { q: "What is the difference between AI context and AI memory?", a: 'Context is what you explicitly pass to the AI for a single query: the entity you are editing, the notes you have selected. Memory is persistent state across sessions. Codex uses context from your structured vault — frontmatter, linked entities, timelines — rather than relying on an opaque memory layer that can drift or hallucinate. Read more in <a href="{base}/blog/ai-slop-is-context-failure" class="text-theme-primary hover:underline">AI Slop Happens When the Tool Has No Memory</a>.' }, { q: "Does the Lore Oracle use my existing lore?", a: "Yes. When you invoke the Oracle on an entity, it receives the content and metadata of that entity, any linked entities you have pulled into context, and campaign-level notes you have selected. It does not have access to your entire vault at once — only the context window you open for that action." }] as faq}
+        {#each [{ q: "What does responsible AI mean for RPG worldbuilding?", a: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your campaign vault in a Codex-hosted database." }, { q: "Can AI help with campaign prep without taking over?", a: `Yes. You direct the Lore Oracle to fill templates, revise existing entries, or generate related entity suggestions. Every result lands in a sandbox draft. Nothing enters your saved lore without your explicit approval. Read more in <a href="${base}/blog/ai-campaign-prep-without-losing-your-voice" class="text-theme-primary hover:underline">Six Ways to Use AI in Campaign Prep Without Losing Your Voice</a>.` }, { q: "How does Codex keep AI drafts out of canon?", a: `Codex separates AI drafts from saved files at an architectural level. Generated content lives in a temporary review state. You choose what to accept, edit, or discard. The AI cannot silently write to your vault. See <a href="${base}/blog/drafts-are-not-canon" class="text-theme-primary hover:underline">Drafts Are Not Canon</a> for the full explanation.` }, { q: "Can I use Codex Cryptica without AI?", a: `Completely. The wiki, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off. AI is a layer on top of a working campaign manager, not a requirement for it. See <a href="${base}/blog/worldbuilding-tool-without-ai" class="text-theme-primary hover:underline">A Worldbuilding Tool Should Still Work Without AI</a>.` }, { q: "What does vault-aware AI mean?", a: "Vault-aware AI means the Oracle is grounded in the selected context from your vault rather than starting from a blank prompt alone. The active entity, linked notes, and any campaign-level context you have selected all shape the response." }, { q: "What is the difference between context and memory?", a: `Context is what you explicitly pass to the AI for a single query: the entity you are editing, the notes you have selected. Memory is persistent state across sessions. Codex uses context from your structured vault — frontmatter, linked entities, timelines — rather than relying on an opaque memory layer that can drift or hallucinate. Read more in <a href="${base}/blog/ai-slop-is-context-failure" class="text-theme-primary hover:underline">AI Slop Happens When the Tool Has No Memory</a>.` }, { q: "Can the Lore Oracle read my whole vault?", a: "No. The Lore Oracle does not receive your entire vault by default. When you invoke it on an entity, it receives the active prompt, the current entity content and metadata, any linked entities you have included, and any campaign-level notes you have selected for that action. That context is used for a single request. Unselected notes stay local." }] as faq}
           <details
             class="group border border-theme-border/60 rounded-xl bg-theme-surface/30 backdrop-blur-sm overflow-hidden"
           >

--- a/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
+++ b/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
@@ -5,6 +5,69 @@
   let { data }: { data: PageData } = $props();
   const articles = $derived(data.articles);
 
+  const faqSchema = JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is responsible AI worldbuilding?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your private world data on external servers.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can AI help with RPG campaign prep without writing the campaign for me?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. You direct the Lore Oracle to fill templates, revise existing entries, or generate related entity suggestions. Every result lands in a sandbox draft. Nothing enters your saved lore without your explicit approval.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I stop AI from changing my campaign canon?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Codex separates AI drafts from saved files at an architectural level. Generated content lives in a temporary review state. You choose what to accept, edit, or discard. The AI cannot silently write to your vault.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can Codex Cryptica work without AI?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Completely. The wiki, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is vault-aware AI?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Vault-aware AI means the Oracle reads from the campaign context you have open before composing a response. Your world's specific details shape the output, not generic fantasy training data.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What is the difference between AI context and AI memory?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Context is what you explicitly pass to the AI for a single query. Memory is persistent state across sessions. Codex uses context from your structured vault rather than relying on an opaque memory layer that can drift or hallucinate.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Does the Lore Oracle use my existing lore?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. When you invoke the Oracle on an entity, it receives the content of that entity, any linked entities you have pulled into context, and campaign-level notes you have selected.",
+        },
+      },
+    ],
+  });
+
   const principles = [
     {
       step: 1,
@@ -99,6 +162,7 @@
     content="Read the Responsible AI series on worldbuilding. Learn why campaign notes should remain private, why drafts are not canon, and how to use local-first AI without losing your voice."
   />
   <meta name="twitter:image" content="https://codexcryptica.com/logo.png" />
+  {@html `<scr` + `ipt type="application/ld+json">${faqSchema}</scr` + `ipt>`}
 </svelte:head>
 
 <div
@@ -395,6 +459,46 @@
               </a>
             </div>
           </div>
+        {/each}
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="border-t border-theme-border/30 py-16">
+    <div class="max-w-3xl mx-auto px-6">
+      <h2
+        class="text-center font-header text-2xl uppercase tracking-[0.2em] text-theme-primary mb-4"
+      >
+        Frequently Asked Questions
+      </h2>
+      <p
+        class="text-center text-sm text-theme-muted mb-12 max-w-xl mx-auto leading-relaxed"
+      >
+        Common questions about responsible AI, vault privacy, and how the Lore
+        Oracle works.
+      </p>
+
+      <div class="space-y-3">
+        {#each [{ q: "What is responsible AI worldbuilding?", a: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your private world data on external servers." }, { q: "Can AI help with RPG campaign prep without writing the campaign for me?", a: 'Yes. Codex Cryptica is designed for exactly this. You direct the Lore Oracle to fill templates, revise existing entries, or generate related entity suggestions. Every result lands in a sandbox draft. Nothing enters your saved lore without your explicit approval. Read more in <a href="{base}/blog/ai-campaign-prep-without-losing-your-voice" class="text-theme-primary hover:underline">Six Ways to Use AI in Campaign Prep Without Losing Your Voice</a>.' }, { q: "How do I stop AI from changing my campaign canon?", a: 'Codex separates AI drafts from saved files at an architectural level. Generated content lives in a temporary review state. You choose what to accept, edit, or discard. The AI cannot silently write to your vault. See <a href="{base}/blog/drafts-are-not-canon" class="text-theme-primary hover:underline">Drafts Are Not Canon</a> for the full explanation.' }, { q: "Can Codex Cryptica work without AI?", a: 'Completely. The wiki, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off. AI is a layer on top of a working campaign manager, not a requirement for it. See <a href="{base}/blog/worldbuilding-tool-without-ai" class="text-theme-primary hover:underline">A Worldbuilding Tool Should Still Work Without AI</a>.' }, { q: "What is vault-aware AI?", a: "Vault-aware AI means the Oracle reads from the campaign context you have open — the active entity, linked notes, and selected background lore — before composing a response. It does not generate from a blank prompt or generic fantasy training data. Your world's specific details shape the output." }, { q: "What is the difference between AI context and AI memory?", a: 'Context is what you explicitly pass to the AI for a single query: the entity you are editing, the notes you have selected. Memory is persistent state across sessions. Codex uses context from your structured vault — frontmatter, linked entities, timelines — rather than relying on an opaque memory layer that can drift or hallucinate. Read more in <a href="{base}/blog/ai-slop-is-context-failure" class="text-theme-primary hover:underline">AI Slop Happens When the Tool Has No Memory</a>.' }, { q: "Does the Lore Oracle use my existing lore?", a: "Yes. When you invoke the Oracle on an entity, it receives the content and metadata of that entity, any linked entities you have pulled into context, and campaign-level notes you have selected. It does not have access to your entire vault at once — only the context window you open for that action." }] as faq}
+          <details
+            class="group border border-theme-border/60 rounded-xl bg-theme-surface/30 backdrop-blur-sm overflow-hidden"
+          >
+            <summary
+              class="flex items-center justify-between gap-4 px-6 py-4 cursor-pointer list-none font-header font-bold text-sm text-theme-text hover:text-theme-primary transition-colors select-none"
+            >
+              {faq.q}
+              <span
+                class="icon-[lucide--chevron-down] w-4 h-4 shrink-0 text-theme-muted group-open:rotate-180 transition-transform duration-200"
+                aria-hidden="true"
+              ></span>
+            </summary>
+            <div
+              class="px-6 pb-5 pt-1 text-sm text-theme-text/80 leading-relaxed border-t border-theme-border/30"
+            >
+              {@html faq.a}
+            </div>
+          </details>
         {/each}
       </div>
     </div>

--- a/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
+++ b/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
@@ -38,7 +38,7 @@
         name: "Can I use Codex Cryptica without AI?",
         acceptedAnswer: {
           "@type": "Answer",
-          text: "Completely. The wiki, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off.",
+          text: "Completely. The lore library, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off.",
         },
       },
       {
@@ -81,7 +81,7 @@
       step: 2,
       title: "AI Must Be Optional",
       summary:
-        "A campaign manager must be completely load-bearing without AI. If you turn the Oracle off, your wiki, chronological timelines, interactive graph, and local storage remain 100% functional.",
+        "A campaign manager must be completely load-bearing without AI. If you turn the Oracle off, your lore library, chronological timelines, interactive graph, and local storage remain 100% functional.",
       slug: "worldbuilding-tool-without-ai",
       icon: "icon-[lucide--wifi-off]",
     },
@@ -252,8 +252,8 @@
             class="icon-[lucide--check-circle-2] text-theme-primary w-5 h-5 shrink-0 mt-0.5"
           ></span>
           <span
-            ><strong>AI is optional</strong> — your core wiki, timelines, graph, and
-            local vault continue to work without AI.</span
+            ><strong>AI is optional</strong> — your core lore library, timelines,
+            graph, and local vault continue to work without AI.</span
           >
         </li>
         <li class="flex items-start gap-3">
@@ -395,7 +395,7 @@
           <ul class="space-y-1 text-theme-muted text-[10px]">
             <li>• No hosted campaign database</li>
             <li>• No permanent chat files on our servers</li>
-            <li>• No cloud logging of your private wiki</li>
+            <li>• No cloud logging of your private vault</li>
           </ul>
         </div>
       </div>
@@ -480,7 +480,7 @@
       </p>
 
       <div class="space-y-3">
-        {#each [{ q: "What does responsible AI mean for RPG worldbuilding?", a: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your campaign vault in a Codex-hosted database." }, { q: "Can AI help with campaign prep without taking over?", a: `Yes. You direct the Lore Oracle to fill templates, revise existing entries, or generate related entity suggestions. Every result lands in a sandbox draft. Nothing enters your saved lore without your explicit approval. Read more in <a href="${base}/blog/ai-campaign-prep-without-losing-your-voice" class="text-theme-primary hover:underline">Six Ways to Use AI in Campaign Prep Without Losing Your Voice</a>.` }, { q: "How does Codex keep AI drafts out of canon?", a: `Codex separates AI drafts from saved files at an architectural level. Generated content lives in a temporary review state. You choose what to accept, edit, or discard. The AI cannot silently write to your vault. See <a href="${base}/blog/drafts-are-not-canon" class="text-theme-primary hover:underline">Drafts Are Not Canon</a> for the full explanation.` }, { q: "Can I use Codex Cryptica without AI?", a: `Completely. The wiki, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off. AI is a layer on top of a working campaign manager, not a requirement for it. See <a href="${base}/blog/worldbuilding-tool-without-ai" class="text-theme-primary hover:underline">A Worldbuilding Tool Should Still Work Without AI</a>.` }, { q: "What does vault-aware AI mean?", a: "Vault-aware AI means the Oracle is grounded in the selected context from your vault rather than starting from a blank prompt alone. The active entity, linked notes, and any campaign-level context you have selected all shape the response." }, { q: "What is the difference between context and memory?", a: `Context is what you explicitly pass to the AI for a single query: the entity you are editing, the notes you have selected. Memory is persistent state across sessions. Codex uses context from your structured vault — frontmatter, linked entities, timelines — rather than relying on an opaque memory layer that can drift or hallucinate. Read more in <a href="${base}/blog/ai-slop-is-context-failure" class="text-theme-primary hover:underline">AI Slop Happens When the Tool Has No Memory</a>.` }, { q: "Can the Lore Oracle read my whole vault?", a: "No. The Lore Oracle does not receive your entire vault by default. When you invoke it on an entity, it receives the active prompt, the current entity content and metadata, any linked entities you have included, and any campaign-level notes you have selected for that action. That context is used for a single request. Unselected notes stay local." }] as faq}
+        {#each [{ q: "What does responsible AI mean for RPG worldbuilding?", a: "It means keeping narrative control with the author. The AI assists with mechanical tasks — expanding notes, drafting entity descriptions, suggesting plot hooks — but it does not overwrite your canon, run without your permission, or store your campaign vault in a Codex-hosted database." }, { q: "Can AI help with campaign prep without taking over?", a: `Yes. You direct the Lore Oracle to fill templates, revise existing entries, or generate related entity suggestions. Every result lands in a sandbox draft. Nothing enters your saved lore without your explicit approval. Read more in <a href="${base}/blog/ai-campaign-prep-without-losing-your-voice" class="text-theme-primary hover:underline">Six Ways to Use AI in Campaign Prep Without Losing Your Voice</a>.` }, { q: "How does Codex keep AI drafts out of canon?", a: `Codex separates AI drafts from saved files at an architectural level. Generated content lives in a temporary review state. You choose what to accept, edit, or discard. The AI cannot silently write to your vault. See <a href="${base}/blog/drafts-are-not-canon" class="text-theme-primary hover:underline">Drafts Are Not Canon</a> for the full explanation.` }, { q: "Can I use Codex Cryptica without AI?", a: `Completely. The lore library, chronological timeline, interactive lore graph, entity templates, and local vault are all fully functional with AI switched off. AI is a layer on top of a working campaign manager, not a requirement for it. See <a href="${base}/blog/worldbuilding-tool-without-ai" class="text-theme-primary hover:underline">A Worldbuilding Tool Should Still Work Without AI</a>.` }, { q: "What does vault-aware AI mean?", a: "Vault-aware AI means the Oracle is grounded in the selected context from your vault rather than starting from a blank prompt alone. The active entity, linked notes, and any campaign-level context you have selected all shape the response." }, { q: "What is the difference between context and memory?", a: `Context is what you explicitly pass to the AI for a single query: the entity you are editing, the notes you have selected. Memory is persistent state across sessions. Codex uses context from your structured vault — frontmatter, linked entities, timelines — rather than relying on an opaque memory layer that can drift or hallucinate. Read more in <a href="${base}/blog/ai-slop-is-context-failure" class="text-theme-primary hover:underline">AI Slop Happens When the Tool Has No Memory</a>.` }, { q: "Can the Lore Oracle read my whole vault?", a: "No. The Lore Oracle does not receive your entire vault by default. When you invoke it on an entity, it receives the active prompt, the current entity content and metadata, any linked entities you have included, and any campaign-level notes you have selected for that action. That context is used for a single request. Unselected notes stay local." }] as faq}
           <details
             class="group border border-theme-border/60 rounded-xl bg-theme-surface/30 backdrop-blur-sm overflow-hidden"
           >


### PR DESCRIPTION
Closes #1211

**What:** Adds a 7-question FAQ block to `/responsible-ai-worldbuilding` using native `<details>`/`<summary>` (no JS state), plus a `schema.org FAQPage` JSON-LD block in `<svelte:head>` for search engine rich results.

**Acceptance criteria met:**
- FAQ block exists on the pillar page ✅
- Answers are short, clear, and non-hypey ✅
- Answers link to relevant series articles where useful ✅
- No misleading privacy/provider claims ✅