### PR TITLE
seo(blog): add contextual inline links across responsible AI series

### DIFF
--- a/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
+++ b/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
@@ -25,7 +25,7 @@ Here are six uses that consistently deliver without getting in the way.
 
 You know the notes. Half-sentences. Abbreviations only you understand. A name scrawled in the margin with no context. After a long session the last thing you want to do is rewrite them into something readable.
 
-Ask the Lore Oracle to turn your raw notes into a structured recap. It can produce a clean summary organised by event, NPC interaction, or location — whatever format you use. The result is a draft. You trim it, correct anything the Oracle misread, and file it in the session log.
+Ask the Lore Oracle to turn your raw notes into a structured recap. It can produce a clean summary organised by event, NPC interaction, or location — whatever format you use. The result is a [draft](/blog/drafts-are-not-canon). You trim it, correct anything the Oracle misread, and file it in the session log.
 
 **What you save:** thirty minutes of post-session admin.
 **What you keep:** the judgement call about which details matter.

--- a/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
+++ b/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
@@ -25,7 +25,7 @@ Here are six uses that consistently deliver without getting in the way.
 
 You know the notes. Half-sentences. Abbreviations only you understand. A name scrawled in the margin with no context. After a long session the last thing you want to do is rewrite them into something readable.
 
-Ask the Lore Oracle to turn your raw notes into a structured recap. It can produce a clean summary organised by event, NPC interaction, or location — whatever format you use. The result is a [draft](/blog/drafts-are-not-canon). You trim it, correct anything the Oracle misread, and file it in the session log.
+Ask the Lore Oracle to turn your raw notes into a structured recap. It can produce a clean summary organised by event, NPC interaction, or location — whatever format you use. The result is a draft ([Drafts Are Not Canon](/blog/drafts-are-not-canon)). You trim it, correct anything the Oracle misread, and file it in the session log.
 
 **What you save:** thirty minutes of post-session admin.
 **What you keep:** the judgement call about which details matter.

--- a/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
+++ b/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
@@ -28,7 +28,7 @@ That is AI slop. And it accumulates.
 
 These two terms often get conflated. They describe different problems.
 
-Context is what you include in a specific request — the lore, the faction details, the session notes you pass alongside the prompt. A well-structured context prompt produces better output. This is covered in the previous article in this series.
+Context is what you include in a specific request — the lore, the faction details, the session notes you pass alongside the prompt. A well-structured context prompt produces better output. This is covered in [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore).
 
 Memory is something larger. It is campaign continuity over time. It is the accumulated fact that session 1 introduced a particular faction, session 12 changed their allegiance, session 30 saw their leader killed, and session 50 is still dealing with the consequences. A tool with no memory treats every request like a fresh start. It has no knowledge of what happened before, no record of what has changed, and no way to avoid contradicting the last fifty sessions of play.
 

--- a/apps/web/src/lib/content/blog/drafts-are-not-canon.md
+++ b/apps/web/src/lib/content/blog/drafts-are-not-canon.md
@@ -68,7 +68,7 @@ AI is most trustworthy when it cannot act without your permission.
 
 Suggestions that require acceptance before they become fact are suggestions you remain in control of. Suggestions that silently enter the archive are a slow erosion of authorship.
 
-Codex Cryptica is built around the first model. The Oracle suggests. You decide.
+Codex Cryptica is built around the first model. [The Oracle suggests](/blog/lore-oracle-not-the-author). You decide.
 
 ---
 

--- a/apps/web/src/lib/content/blog/revising-your-lore-with-the-oracle.md
+++ b/apps/web/src/lib/content/blog/revising-your-lore-with-the-oracle.md
@@ -54,7 +54,7 @@ Good revision prompts usually include three things:
 
 > The players exposed Mira as a resistance informant in session 22. Update her entry to reflect that her cover is blown, her motivation has shifted from survival to active defiance, and she is now operating openly. Keep her voice and her established relationships with the dockworkers' guild.
 
-The Oracle reads the existing entry alongside your instruction and produces a revision as a draft. The original stays intact. You compare, accept the parts that work, edit what does not, and discard anything that missed.
+The Oracle reads the existing entry alongside your instruction and produces a revision as a draft. The original stays intact. You compare, accept the parts that work, edit what does not, and discard anything that missed. The principle that [drafts are not canon](/blog/drafts-are-not-canon) applies here too — nothing replaces the existing entry until you decide it should.
 
 **Quick revision commands:**
 


### PR DESCRIPTION
## Summary

- Adds one inline body cross-link to each of the four Responsible AI articles that needed them (per issue #1209)
- `drafts-are-not-canon`: "The Oracle suggests" → `/blog/lore-oracle-not-the-author`
- `ai-slop-is-context-failure`: replaces vague "previous article in this series" with named link to `/blog/worldbuilding-ai-needs-your-lore`
- `ai-campaign-prep-without-losing-your-voice`: "The result is a draft" → `/blog/drafts-are-not-canon`
- `revising-your-lore-with-the-oracle`: explicit sentence linking concept to `/blog/drafts-are-not-canon`
- Pillar page already links all 7 articles via article cards — no change needed there

Closes #1209

## Test plan
- [ ] Visit each of the 4 changed articles and confirm the inline links render and navigate correctly
- [ ] Series footer navigation still present on all articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)