### PR TITLE
feat(seo): add responsible AI trust banner to World Anvil pages

### DIFF
--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -354,12 +354,14 @@
                     {#if row.competitorHas}
                       <span
                         class="icon-[lucide--check] text-emerald-500 w-4 h-4"
-                        role="img" aria-label="Yes"
+                        role="img"
+                        aria-label="Yes"
                       ></span>
                     {:else}
                       <span
                         class="icon-[lucide--x] text-rose-500 w-4 h-4"
-                        role="img" aria-label="No"
+                        role="img"
+                        aria-label="No"
                       ></span>
                     {/if}
                   {:else}
@@ -377,12 +379,14 @@
                     {#if row.codexHas}
                       <span
                         class="icon-[lucide--check] text-emerald-400 w-4 h-4"
-                        role="img" aria-label="Yes"
+                        role="img"
+                        aria-label="Yes"
                       ></span>
                     {:else}
                       <span
                         class="icon-[lucide--x] text-rose-500 w-4 h-4"
-                        role="img" aria-label="No"
+                        role="img"
+                        aria-label="No"
                       ></span>
                     {/if}
                   {:else}
@@ -508,6 +512,29 @@
             </a>
           {/each}
         </div>
+      </div>
+    </section>
+  {/if}
+
+  <!-- Responsible AI Trust Banner -->
+  {#if data.aiTrustSection}
+    <section class="border-t border-theme-border/30 py-10">
+      <div class="max-w-3xl mx-auto px-6 text-center">
+        <p class="text-xs text-theme-muted leading-relaxed mb-3">
+          Responsible AI, not replacement authorship. The Lore Oracle is
+          optional, vault-aware, and draft-based. Your vault remains the source
+          of truth.
+        </p>
+        <a
+          href="{base}/responsible-ai-worldbuilding"
+          class="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-theme-primary hover:underline"
+        >
+          <span
+            class="icon-[lucide--shield-check] w-3.5 h-3.5"
+            aria-hidden="true"
+          ></span>
+          Read our responsible AI principles
+        </a>
       </div>
     </section>
   {/if}

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -520,7 +520,7 @@
   {#if data.aiTrustSection}
     <section class="border-t border-theme-border/30 py-10">
       <div class="max-w-3xl mx-auto px-6 text-center">
-        <p class="text-xs text-theme-muted leading-relaxed mb-3">
+        <p class="text-sm text-theme-muted leading-relaxed mb-3">
           Responsible AI, not replacement authorship. The Lore Oracle is
           optional, vault-aware, and draft-based. Your vault remains the source
           of truth.

--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -25,6 +25,8 @@ export interface SEOPageData {
   secondaryCtaHref?: string;
   /** Links shown in a "Related pages" section above the FAQ. */
   relatedLinks?: Array<{ href: string; label: string }>;
+  /** Show the Responsible AI trust banner before the final CTA. */
+  aiTrustSection?: boolean;
 }
 
 export interface SEOComparisonPageData extends SEOPageData {
@@ -800,6 +802,7 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
         label: "Local-first worldbuilding",
       },
     ],
+    aiTrustSection: true,
   },
   legendkeeper: {
     slug: "legendkeeper",
@@ -1241,6 +1244,7 @@ export const importsConfig: Record<string, SEOImportPageData> = {
           "Yes. Since the JSON backup contains all articles, your private lore is fully imported and kept secure on your local drive.",
       },
     ],
+    aiTrustSection: true,
   },
   "kanka-json": {
     slug: "kanka-json",

--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -25,7 +25,7 @@ export interface SEOPageData {
   secondaryCtaHref?: string;
   /** Links shown in a "Related pages" section above the FAQ. */
   relatedLinks?: Array<{ href: string; label: string }>;
-  /** Show the Responsible AI trust banner before the final CTA. */
+  /** Show the Responsible AI trust banner before the FAQ section. */
   aiTrustSection?: boolean;
 }
 

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -690,6 +690,27 @@
       </section>
     {/if}
 
+    <!-- Responsible AI Trust Banner -->
+    {#if pageData.aiTrustSection}
+      <section class="border-t border-theme-border/60 mt-16 pt-10 text-center">
+        <p class="text-sm text-theme-muted leading-relaxed mb-3">
+          Responsible AI, not replacement authorship. The Lore Oracle is
+          optional, vault-aware, and draft-based. Your vault remains the source
+          of truth.
+        </p>
+        <a
+          href="{base}/responsible-ai-worldbuilding"
+          class="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-theme-primary hover:underline"
+        >
+          <span
+            class="icon-[lucide--shield-check] w-3.5 h-3.5"
+            aria-hidden="true"
+          ></span>
+          Read our responsible AI principles
+        </a>
+      </section>
+    {/if}
+
     <!-- FAQ Section -->
     <section class="border-t border-theme-border/60 mt-16 pt-16">
       <h2

--- a/apps/web/src/routes/(marketing)/import/[slug]/import.test.ts
+++ b/apps/web/src/routes/(marketing)/import/[slug]/import.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render } from "@testing-library/svelte";
+import { render, screen } from "@testing-library/svelte";
 import { load, entries } from "./+page";
 import Page from "./+page.svelte";
 
@@ -111,6 +111,68 @@ describe("Imports SvelteKit Route", () => {
 
       expect(softwareAppFound).toBe(true);
       expect(breadcrumbFound).toBe(true);
+    });
+  });
+
+  describe("Responsible AI trust banner", () => {
+    afterEach(() => {
+      document.head.innerHTML = "";
+    });
+
+    it("renders the trust banner when aiTrustSection is true", () => {
+      const mockPageData = {
+        slug: "world-anvil-export",
+        competitorName: "World Anvil",
+        title: "T",
+        description: "D",
+        h1: "H",
+        subheading: "S",
+        introText: "I",
+        ctaText: "C",
+        keywords: [],
+        features: [],
+        faq: [],
+        aiTrustSection: true,
+      };
+
+      render(Page, { props: { data: { importPage: mockPageData } } });
+
+      expect(
+        screen.getByText(/Responsible AI, not replacement authorship/i),
+      ).toBeTruthy();
+      const link = screen.getByRole("link", {
+        name: /responsible ai principles/i,
+      });
+      expect(link.getAttribute("href")).toBe("/responsible-ai-worldbuilding");
+    });
+
+    it("does not render the trust banner when aiTrustSection is absent", () => {
+      const mockPageData = {
+        slug: "obsidian-vault",
+        competitorName: "Obsidian",
+        title: "T",
+        description: "D",
+        h1: "H",
+        subheading: "S",
+        introText: "I",
+        ctaText: "C",
+        keywords: [],
+        features: [],
+        faq: [],
+      };
+
+      render(Page, { props: { data: { importPage: mockPageData } } });
+
+      expect(
+        screen.queryByText(/Responsible AI, not replacement authorship/i),
+      ).toBeNull();
+    });
+
+    it("world-anvil-export config has aiTrustSection enabled", async () => {
+      const { importsConfig } = (await vi.importActual(
+        "$lib/config/seo-pages",
+      )) as typeof import("$lib/config/seo-pages");
+      expect(importsConfig["world-anvil-export"].aiTrustSection).toBe(true);
     });
   });
 });

--- a/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
+++ b/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
@@ -224,8 +224,7 @@
       class="text-4xl md:text-6xl font-extrabold font-header leading-tight mb-6 tracking-wide uppercase"
       id="hero-h1"
     >
-      Responsible AI for <span
-        class="text-theme-primary bg-gradient-to-r from-theme-primary to-theme-accent bg-clip-text text-transparent"
+      Responsible AI for <span class="text-theme-primary"
         >RPG Worldbuilding</span
       >
     </h1>

--- a/apps/web/src/routes/(marketing)/vs/[slug]/vs.test.ts
+++ b/apps/web/src/routes/(marketing)/vs/[slug]/vs.test.ts
@@ -34,3 +34,24 @@ describe("Comparisons SvelteKit Route", () => {
     });
   });
 });
+
+describe("Responsible AI trust banner config", () => {
+  it("world-anvil comparison has aiTrustSection enabled", async () => {
+    const { comparisons: realComparisons } = (await vi.importActual(
+      "$lib/config/seo-pages",
+    )) as typeof import("$lib/config/seo-pages");
+    expect(realComparisons["world-anvil"].aiTrustSection).toBe(true);
+  });
+
+  it("non-World-Anvil comparisons do not have aiTrustSection", async () => {
+    const { comparisons: realComparisons } = (await vi.importActual(
+      "$lib/config/seo-pages",
+    )) as typeof import("$lib/config/seo-pages");
+    const others = Object.entries(realComparisons).filter(
+      ([slug]) => slug !== "world-anvil",
+    );
+    for (const [, page] of others) {
+      expect(page.aiTrustSection).toBeFalsy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an optional `aiTrustSection` flag to `SEOPageData` interface
- Adds a small trust banner in `SEOPageLayout` (between related links and FAQ) when the flag is set
- Enables it on `/vs/world-anvil` and `/import/world-anvil-export` — the two highest-intent pages for the AI authorship concern
- Banner copy: "Responsible AI, not replacement authorship. The Lore Oracle is optional, vault-aware, and draft-based. Your vault remains the source of truth." with a crawlable link to `/responsible-ai-worldbuilding`
- Flag-driven so other pages are unaffected; easy to enable on more pages later

Closes #1212

## Test plan
- [ ] Visit `/vs/world-anvil` — trust banner appears before FAQ
- [ ] Visit `/import/world-anvil-export` — trust banner appears before FAQ
- [ ] Visit any other vs/solutions page — no trust banner shown
- [ ] Link to `/responsible-ai-worldbuilding` is crawlable (plain `<a>` tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)