### PR TITLE
feat(blog): add ResponsibleAISeriesNav component, strip markdown footers

### DIFF
--- a/apps/web/src/lib/components/blog/ResponsibleAISeriesNav.svelte
+++ b/apps/web/src/lib/components/blog/ResponsibleAISeriesNav.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  let { currentSlug }: { currentSlug: string } = $props();
+
+  const series = [
+    {
+      slug: "lore-oracle-not-the-author",
+      title: "The Lore Oracle Is Not the Author",
+    },
+    {
+      slug: "worldbuilding-tool-without-ai",
+      title: "A Worldbuilding Tool Should Still Work Without AI",
+    },
+    {
+      slug: "worldbuilding-ai-needs-your-lore",
+      title: "Why Worldbuilding AI Should Know Your Lore Before It Speaks",
+    },
+    { slug: "drafts-are-not-canon", title: "Drafts Are Not Canon" },
+    {
+      slug: "ai-campaign-prep-without-losing-your-voice",
+      title: "Six Ways to Use AI in Campaign Prep Without Losing Your Voice",
+    },
+    {
+      slug: "ai-slop-is-context-failure",
+      title: "AI Slop Happens When the Tool Has No Memory",
+    },
+    {
+      slug: "revising-your-lore-with-the-oracle",
+      title: "Revising Your Lore with the Oracle",
+    },
+  ];
+</script>
+
+<aside
+  class="mt-16 p-6 rounded-xl border border-theme-border/60 bg-theme-surface/20"
+  aria-label="Responsible AI series navigation"
+>
+  <p
+    class="text-[10px] font-mono text-theme-muted uppercase tracking-widest mb-4"
+  >
+    Part of the Codex Cryptica Responsible AI Series
+  </p>
+  <ol class="space-y-2">
+    {#each series as article, i}
+      <li class="flex items-start gap-3">
+        <span
+          class="text-[10px] font-mono text-theme-muted mt-0.5 w-4 shrink-0 text-right"
+          >{i + 1}.</span
+        >
+        {#if article.slug === currentSlug}
+          <span
+            class="text-sm font-bold text-theme-primary leading-snug"
+            aria-current="page"
+          >
+            {article.title}
+            <span
+              class="ml-1.5 text-[10px] font-mono text-theme-muted normal-case tracking-normal"
+              >(this article)</span
+            >
+          </span>
+        {:else}
+          <a
+            href="{base}/blog/{article.slug}"
+            class="text-sm text-theme-text/70 hover:text-theme-primary transition-colors leading-snug"
+          >
+            {article.title}
+          </a>
+        {/if}
+      </li>
+    {/each}
+  </ol>
+</aside>

--- a/apps/web/src/lib/components/blog/ResponsibleAISeriesNav.svelte
+++ b/apps/web/src/lib/components/blog/ResponsibleAISeriesNav.svelte
@@ -62,7 +62,7 @@
         {:else}
           <a
             href="{base}/blog/{article.slug}"
-            class="text-sm text-theme-text/70 hover:text-theme-primary transition-colors leading-snug"
+            class="text-sm text-theme-text hover:text-theme-primary transition-colors leading-snug"
           >
             {article.title}
           </a>

--- a/apps/web/src/lib/components/blog/ResponsibleAISeriesNav.svelte
+++ b/apps/web/src/lib/components/blog/ResponsibleAISeriesNav.svelte
@@ -1,35 +1,8 @@
 <script lang="ts">
   import { base } from "$app/paths";
+  import { RA_SERIES } from "$lib/content/responsible-ai-series";
 
   let { currentSlug }: { currentSlug: string } = $props();
-
-  const series = [
-    {
-      slug: "lore-oracle-not-the-author",
-      title: "The Lore Oracle Is Not the Author",
-    },
-    {
-      slug: "worldbuilding-tool-without-ai",
-      title: "A Worldbuilding Tool Should Still Work Without AI",
-    },
-    {
-      slug: "worldbuilding-ai-needs-your-lore",
-      title: "Why Worldbuilding AI Should Know Your Lore Before It Speaks",
-    },
-    { slug: "drafts-are-not-canon", title: "Drafts Are Not Canon" },
-    {
-      slug: "ai-campaign-prep-without-losing-your-voice",
-      title: "Six Ways to Use AI in Campaign Prep Without Losing Your Voice",
-    },
-    {
-      slug: "ai-slop-is-context-failure",
-      title: "AI Slop Happens When the Tool Has No Memory",
-    },
-    {
-      slug: "revising-your-lore-with-the-oracle",
-      title: "Revising Your Lore with the Oracle",
-    },
-  ];
 </script>
 
 <aside
@@ -42,7 +15,7 @@
     Part of the Codex Cryptica Responsible AI Series
   </p>
   <ol class="space-y-2">
-    {#each series as article, i}
+    {#each RA_SERIES as article, i}
       <li class="flex items-start gap-3">
         <span
           class="text-[10px] font-mono text-theme-muted mt-0.5 w-4 shrink-0 text-right"

--- a/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
+++ b/apps/web/src/lib/content/blog/ai-campaign-prep-without-losing-your-voice.md
@@ -86,15 +86,3 @@ This is particularly useful when a campaign event changes something established 
 ---
 
 None of these replace the creative decisions. They reduce the friction around them. The session still needs a plot. The NPC still needs a reason to matter. The names still need to feel right to you. The Oracle handles the overhead. The authorship stays where it belongs.
-
----
-
-_Part of the [Codex Cryptica responsible AI series](/blog/lore-oracle-not-the-author):_
-
-1. [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)
-2. [A Worldbuilding Tool Should Still Work Without AI](/blog/worldbuilding-tool-without-ai)
-3. [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore)
-4. [Drafts Are Not Canon](/blog/drafts-are-not-canon)
-5. **Six Ways to Use AI in Campaign Prep Without Losing Your Voice** _(this article)_
-6. [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
-7. [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)

--- a/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
+++ b/apps/web/src/lib/content/blog/ai-slop-is-context-failure.md
@@ -87,15 +87,3 @@ The article title is the thesis: AI slop happens when the tool has no memory.
 Not when the model is bad. Not when the prose is weak. When the tool generates without continuity, without respect for established canon, without any record of what this particular campaign has built over dozens of sessions.
 
 The fix is not a better prompt. It is a tool that treats your world as the source of truth rather than as an optional input. Structure, memory, and accountability to what has already happened.
-
----
-
-_Part of the [Codex Cryptica responsible AI series](/blog/lore-oracle-not-the-author):_
-
-1. [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)
-2. [A Worldbuilding Tool Should Still Work Without AI](/blog/worldbuilding-tool-without-ai)
-3. [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore)
-4. [Drafts Are Not Canon](/blog/drafts-are-not-canon)
-5. [Six Ways to Use AI in Campaign Prep Without Losing Your Voice](/blog/ai-campaign-prep-without-losing-your-voice)
-6. **AI Slop Happens When the Tool Has No Memory** _(this article)_
-7. [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)

--- a/apps/web/src/lib/content/blog/drafts-are-not-canon.md
+++ b/apps/web/src/lib/content/blog/drafts-are-not-canon.md
@@ -69,15 +69,3 @@ AI is most trustworthy when it cannot act without your permission.
 Suggestions that require acceptance before they become fact are suggestions you remain in control of. Suggestions that silently enter the archive are a slow erosion of authorship.
 
 Codex Cryptica is built around the first model. [The Oracle suggests](/blog/lore-oracle-not-the-author). You decide.
-
----
-
-_Part of the [Codex Cryptica responsible AI series](/blog/lore-oracle-not-the-author):_
-
-1. [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)
-2. [A Worldbuilding Tool Should Still Work Without AI](/blog/worldbuilding-tool-without-ai)
-3. [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore)
-4. **Drafts Are Not Canon** _(this article)_
-5. [Six Ways to Use AI in Campaign Prep Without Losing Your Voice](/blog/ai-campaign-prep-without-losing-your-voice)
-6. [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
-7. [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)

--- a/apps/web/src/lib/content/blog/revising-your-lore-with-the-oracle.md
+++ b/apps/web/src/lib/content/blog/revising-your-lore-with-the-oracle.md
@@ -83,15 +83,3 @@ Using revision as a regular habit — after major arcs, after session events tha
 Because the vault is local-first, you can experiment freely: radical structural rewrites, tonal shifts, speculative changes to see how they feel — without server latency, data tracking, or cloud storage limits. Nothing leaves your machine until you decide it should.
 
 The Oracle handles the mechanical rewrite. You handle the judgement. The vault stays honest.
-
----
-
-_Part of the [Codex Cryptica responsible AI series](/blog/lore-oracle-not-the-author):_
-
-1. [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)
-2. [A Worldbuilding Tool Should Still Work Without AI](/blog/worldbuilding-tool-without-ai)
-3. [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore)
-4. [Drafts Are Not Canon](/blog/drafts-are-not-canon)
-5. [Six Ways to Use AI in Campaign Prep Without Losing Your Voice](/blog/ai-campaign-prep-without-losing-your-voice)
-6. [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
-7. **Revising Your Lore with the Oracle** _(this article)_

--- a/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
+++ b/apps/web/src/lib/content/blog/worldbuilding-ai-needs-your-lore.md
@@ -77,15 +77,3 @@ The difference is not intelligence. It is memory.
 Context-aware AI is still AI. It still suggests rather than decides. The Oracle can surface a connection you forgot, but it can also surface a connection that does not hold up on closer inspection — because it mapped a thematic link but missed a spatial constraint. Every output is a draft until you review it.
 
 Grounding AI in your lore reduces the noise — fewer suggestions that are obviously wrong, fewer details that contradict established canon. It does not eliminate the need for your judgement. That part stays yours.
-
----
-
-_Part of the [Codex Cryptica responsible AI series](/blog/lore-oracle-not-the-author):_
-
-1. [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)
-2. [A Worldbuilding Tool Should Still Work Without AI](/blog/worldbuilding-tool-without-ai)
-3. **Why Worldbuilding AI Should Know Your Lore Before It Speaks** _(this article)_
-4. [Drafts Are Not Canon](/blog/drafts-are-not-canon)
-5. [Six Ways to Use AI in Campaign Prep Without Losing Your Voice](/blog/ai-campaign-prep-without-losing-your-voice)
-6. [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
-7. [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)

--- a/apps/web/src/lib/content/blog/worldbuilding-tool-without-ai.md
+++ b/apps/web/src/lib/content/blog/worldbuilding-tool-without-ai.md
@@ -69,15 +69,3 @@ AI earns its place by being useful, not by being mandatory. If the Lore Oracle h
 If AI comes first — if the pitch is "AI generates your campaign" and the structured archive is an afterthought — you get a product that is impressive in demos and unreliable in long-running campaigns where consistency, memory, and canon control matter most.
 
 Codex Cryptica was built starting from step one. The Lore Oracle came later, and it works from the archive you already built. That order matters.
-
----
-
-_Part of the [Codex Cryptica responsible AI series](/blog/lore-oracle-not-the-author):_
-
-1. [The Lore Oracle Is Not the Author](/blog/lore-oracle-not-the-author)
-2. **A Worldbuilding Tool Should Still Work Without AI** _(this article)_
-3. [Why Worldbuilding AI Should Know Your Lore Before It Speaks](/blog/worldbuilding-ai-needs-your-lore)
-4. [Drafts Are Not Canon](/blog/drafts-are-not-canon)
-5. [Six Ways to Use AI in Campaign Prep Without Losing Your Voice](/blog/ai-campaign-prep-without-losing-your-voice)
-6. [AI Slop Happens When the Tool Has No Memory](/blog/ai-slop-is-context-failure)
-7. [Revising Your Lore with the Oracle](/blog/revising-your-lore-with-the-oracle)

--- a/apps/web/src/lib/content/responsible-ai-series.ts
+++ b/apps/web/src/lib/content/responsible-ai-series.ts
@@ -1,0 +1,34 @@
+export interface RASeriesArticle {
+  slug: string;
+  title: string;
+}
+
+export const RA_SERIES: RASeriesArticle[] = [
+  {
+    slug: "lore-oracle-not-the-author",
+    title: "The Lore Oracle Is Not the Author",
+  },
+  {
+    slug: "worldbuilding-tool-without-ai",
+    title: "A Worldbuilding Tool Should Still Work Without AI",
+  },
+  {
+    slug: "worldbuilding-ai-needs-your-lore",
+    title: "Why Worldbuilding AI Should Know Your Lore Before It Speaks",
+  },
+  { slug: "drafts-are-not-canon", title: "Drafts Are Not Canon" },
+  {
+    slug: "ai-campaign-prep-without-losing-your-voice",
+    title: "Six Ways to Use AI in Campaign Prep Without Losing Your Voice",
+  },
+  {
+    slug: "ai-slop-is-context-failure",
+    title: "AI Slop Happens When the Tool Has No Memory",
+  },
+  {
+    slug: "revising-your-lore-with-the-oracle",
+    title: "Revising Your Lore with the Oracle",
+  },
+];
+
+export const RA_SERIES_SLUGS = new Set(RA_SERIES.map((a) => a.slug));

--- a/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -3,20 +3,14 @@
   import { themeStore } from "$lib/stores/theme.svelte";
   import ArticleRenderer from "$lib/components/blog/ArticleRenderer.svelte";
   import ResponsibleAISeriesNav from "$lib/components/blog/ResponsibleAISeriesNav.svelte";
-
-  const RA_SERIES_SLUGS = new Set([
-    "lore-oracle-not-the-author",
-    "worldbuilding-tool-without-ai",
-    "worldbuilding-ai-needs-your-lore",
-    "drafts-are-not-canon",
-    "ai-campaign-prep-without-losing-your-voice",
-    "ai-slop-is-context-failure",
-    "revising-your-lore-with-the-oracle",
-  ]);
+  import { RA_SERIES_SLUGS } from "$lib/content/responsible-ai-series";
 
   let { data } = $props();
   const article = $derived(data.article);
   const isRASeries = $derived(RA_SERIES_SLUGS.has(article.slug));
+  const articleContent = $derived(
+    article.content.replace(/^#[^\n]+\n/, "").trimStart(),
+  );
 </script>
 
 <svelte:head>
@@ -60,7 +54,11 @@
             timeZone: "UTC",
           })}
         </time>
-        <span aria-hidden="true" class="w-8 h-px bg-theme-border"></span>
+        <span aria-hidden="true" class="w-8 h-px bg-theme-border"></span><span
+          class="sr-only"
+        >
+          ·
+        </span>
         <span>{themeStore.resolveJargon("blog_entry")}</span>
       </div>
 
@@ -78,7 +76,7 @@
     </header>
 
     <main class="mb-20">
-      <ArticleRenderer content={article.content} />
+      <ArticleRenderer content={articleContent} />
     </main>
 
     {#if isRASeries}

--- a/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -2,8 +2,21 @@
   import { base } from "$app/paths";
   import { themeStore } from "$lib/stores/theme.svelte";
   import ArticleRenderer from "$lib/components/blog/ArticleRenderer.svelte";
+  import ResponsibleAISeriesNav from "$lib/components/blog/ResponsibleAISeriesNav.svelte";
+
+  const RA_SERIES_SLUGS = new Set([
+    "lore-oracle-not-the-author",
+    "worldbuilding-tool-without-ai",
+    "worldbuilding-ai-needs-your-lore",
+    "drafts-are-not-canon",
+    "ai-campaign-prep-without-losing-your-voice",
+    "ai-slop-is-context-failure",
+    "revising-your-lore-with-the-oracle",
+  ]);
+
   let { data } = $props();
   const article = $derived(data.article);
+  const isRASeries = $derived(RA_SERIES_SLUGS.has(article.slug));
 </script>
 
 <svelte:head>
@@ -47,7 +60,7 @@
             timeZone: "UTC",
           })}
         </time>
-        <span class="w-8 h-px bg-theme-border"></span>
+        <span aria-hidden="true" class="w-8 h-px bg-theme-border"></span>
         <span>{themeStore.resolveJargon("blog_entry")}</span>
       </div>
 
@@ -68,15 +81,25 @@
       <ArticleRenderer content={article.content} />
     </main>
 
+    {#if isRASeries}
+      <ResponsibleAISeriesNav currentSlug={article.slug} />
+    {/if}
+
     <footer class="pt-12 border-t border-theme-border">
       <div>
-        <p class="text-[10px] font-mono text-theme-muted uppercase tracking-widest mb-3">Topics</p>
+        <p
+          class="text-[10px] font-mono text-theme-muted uppercase tracking-widest mb-3"
+        >
+          Topics
+        </p>
         <div class="flex flex-wrap gap-2">
           {#each article.keywords.slice(0, 6) as keyword}
             <span
               class="px-3 py-1 bg-theme-surface border border-theme-border rounded-full text-[10px] font-mono text-theme-muted tracking-wider"
             >
-              {keyword.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+              {keyword
+                .replace(/-/g, " ")
+                .replace(/\b\w/g, (c) => c.toUpperCase())}
             </span>
           {/each}
         </div>


### PR DESCRIPTION
## Summary

- Creates `ResponsibleAISeriesNav.svelte` — a dedicated series nav component that replaces the plain markdown numbered footer on all 7 Responsible AI articles
- Component marks the current article with bold + `aria-current="page"` and links all others with hover transitions
- Detects RA series membership by slug in `+page.svelte` and conditionally renders the component after `<main>`
- Strips the old `_Part of the...` markdown footer blocks from all 6 articles that had them (lore-oracle-not-the-author never had one)
- Adds `aria-hidden="true"` to the visual date separator span so screen readers don't concatenate date and jargon label

Closes #1213

## Test plan
- [ ] Visit any RA series article — series nav appears below the article body
- [ ] Current article is bold + `(this article)` label, no link
- [ ] All other 6 articles are crawlable `<a>` links
- [ ] Visit a non-RA article — no series nav shown
- [ ] Series nav renders on mobile without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)