### PR TITLE
test(sitemap): assert RA pillar page and all 7 series articles covered

### DIFF
--- a/apps/web/src/routes/sitemap.xml/sitemap.test.ts
+++ b/apps/web/src/routes/sitemap.xml/sitemap.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi } from "vitest";
 import { GET } from "./+server";
 
+const { RA_SLUGS } = vi.hoisted(() => ({
+  RA_SLUGS: [
+    "lore-oracle-not-the-author",
+    "worldbuilding-tool-without-ai",
+    "worldbuilding-ai-needs-your-lore",
+    "drafts-are-not-canon",
+    "ai-campaign-prep-without-losing-your-voice",
+    "ai-slop-is-context-failure",
+    "revising-your-lore-with-the-oracle",
+  ],
+}));
+
 vi.mock("$lib/config/seo-pages", () => ({
   solutions: {
     "test-sol": { slug: "test-sol" },
@@ -21,27 +33,12 @@ vi.mock("$lib/content/blog-content", () => ({
     .fn()
     .mockReturnValue([
       { slug: "test-blog-post", publishedAt: "2026-06-01T12:00:00.000Z" },
-      ...[
-        "lore-oracle-not-the-author",
-        "worldbuilding-tool-without-ai",
-        "worldbuilding-ai-needs-your-lore",
-        "drafts-are-not-canon",
-        "ai-campaign-prep-without-losing-your-voice",
-        "ai-slop-is-context-failure",
-        "revising-your-lore-with-the-oracle",
-      ].map((slug) => ({ slug, publishedAt: "2026-06-06T16:00:00.000Z" })),
+      ...RA_SLUGS.map((slug) => ({
+        slug,
+        publishedAt: "2026-06-06T16:00:00.000Z",
+      })),
     ]),
 }));
-
-const RA_SLUGS = [
-  "lore-oracle-not-the-author",
-  "worldbuilding-tool-without-ai",
-  "worldbuilding-ai-needs-your-lore",
-  "drafts-are-not-canon",
-  "ai-campaign-prep-without-losing-your-voice",
-  "ai-slop-is-context-failure",
-  "revising-your-lore-with-the-oracle",
-];
 
 describe("Sitemap.xml API Endpoint", () => {
   it("should return a valid XML response with all routes", async () => {

--- a/apps/web/src/routes/sitemap.xml/sitemap.test.ts
+++ b/apps/web/src/routes/sitemap.xml/sitemap.test.ts
@@ -21,8 +21,27 @@ vi.mock("$lib/content/blog-content", () => ({
     .fn()
     .mockReturnValue([
       { slug: "test-blog-post", publishedAt: "2026-06-01T12:00:00.000Z" },
+      ...[
+        "lore-oracle-not-the-author",
+        "worldbuilding-tool-without-ai",
+        "worldbuilding-ai-needs-your-lore",
+        "drafts-are-not-canon",
+        "ai-campaign-prep-without-losing-your-voice",
+        "ai-slop-is-context-failure",
+        "revising-your-lore-with-the-oracle",
+      ].map((slug) => ({ slug, publishedAt: "2026-06-06T16:00:00.000Z" })),
     ]),
 }));
+
+const RA_SLUGS = [
+  "lore-oracle-not-the-author",
+  "worldbuilding-tool-without-ai",
+  "worldbuilding-ai-needs-your-lore",
+  "drafts-are-not-canon",
+  "ai-campaign-prep-without-losing-your-voice",
+  "ai-slop-is-context-failure",
+  "revising-your-lore-with-the-oracle",
+];
 
 describe("Sitemap.xml API Endpoint", () => {
   it("should return a valid XML response with all routes", async () => {
@@ -45,5 +64,13 @@ describe("Sitemap.xml API Endpoint", () => {
     expect(xml).toContain("https://codexcryptica.com/import/test-import");
     expect(xml).toContain("https://codexcryptica.com/generators/npc");
     expect(xml).toContain("https://codexcryptica.com/blog/test-blog-post");
+    // Responsible AI pillar page
+    expect(xml).toContain(
+      "https://codexcryptica.com/responsible-ai-worldbuilding",
+    );
+    // All seven RA series articles
+    for (const slug of RA_SLUGS) {
+      expect(xml).toContain(`https://codexcryptica.com/blog/${slug}`);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds explicit sitemap test assertions for the `/responsible-ai-worldbuilding` pillar page
- Asserts all 7 Responsible AI series article slugs appear in the generated sitemap XML
- Fixes a hoisting issue where `RA_SLUGS` was referenced inside `vi.mock` before declaration

## Test plan
- [ ] `pnpm test run src/routes/sitemap.xml/sitemap.test.ts` passes

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)