### PR TITLE
feat(analytics): add ?ref= funnel params to CTAs, strip on app entry

### DIFF
--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -191,7 +191,7 @@
       </nav>
       <div>
         <a
-          href="{base}/"
+          href="{base}/?ref={type === 'comparison' ? 'vs-nav' : 'solution-nav'}"
           class="px-5 py-2.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
           id="nav-cta-btn"
         >
@@ -241,7 +241,7 @@
     {/each}
     <div class="flex flex-col sm:flex-row flex-wrap justify-center gap-4">
       <a
-        href="{base}/"
+        href="{base}/?ref={type === 'comparison' ? 'vs-hero' : 'solution-hero'}"
         class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 hover:-translate-y-0.5 transition-all duration-200"
         id="hero-primary-cta"
       >
@@ -598,7 +598,9 @@
           : "No account. No server database leaks. Just quick, private, local-first worldbuilding."}
       </p>
       <a
-        href="{base}/"
+        href="{base}/?ref={type === 'comparison'
+          ? 'vs-footer'
+          : 'solution-footer'}"
         class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 transition-all"
         id="footer-cta-btn"
       >

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -88,6 +88,14 @@
     if (requestedTheme && requestedTheme in THEMES) {
       themeStore.currentThemeId = requestedTheme;
     }
+
+    // Strip funnel tracking params after CF has logged them
+    const trackingParams = ["ref", "utm_source", "utm_medium", "utm_campaign"];
+    if (trackingParams.some((p) => page.url.searchParams.has(p))) {
+      const clean = new URL(page.url);
+      trackingParams.forEach((p) => clean.searchParams.delete(p));
+      history.replaceState(history.state, "", clean.toString());
+    }
   }
 
   onDestroy(() => {

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -89,12 +89,15 @@
       themeStore.currentThemeId = requestedTheme;
     }
 
-    // Strip funnel tracking params after CF has logged them
+    // Strip funnel tracking params — defer so the CF beacon fires first
     const trackingParams = ["ref", "utm_source", "utm_medium", "utm_campaign"];
     if (trackingParams.some((p) => page.url.searchParams.has(p))) {
       const clean = new URL(page.url);
       trackingParams.forEach((p) => clean.searchParams.delete(p));
-      history.replaceState(history.state, "", clean.toString());
+      requestIdleCallback(
+        () => history.replaceState(history.state, "", clean.toString()),
+        { timeout: 3000 },
+      );
     }
   }
 

--- a/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -117,7 +117,7 @@
           </p>
         </div>
         <a
-          href="{base}/"
+          href="{base}/{isRASeries ? '?ref=ra-blog' : ''}"
           class="px-8 py-4 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded hover:bg-theme-primary/90 transition-all active:scale-95 shadow-[0_0_30px_rgba(var(--color-primary-rgb),0.3)]"
         >
           Enter the Codex

--- a/apps/web/src/routes/(marketing)/changelog/+page.svelte
+++ b/apps/web/src/routes/(marketing)/changelog/+page.svelte
@@ -22,7 +22,7 @@
     <!-- Header -->
     <header class="mb-16 md:mb-24">
       <a
-        href="{base}/"
+        href="{base}/?ref=changelog"
         class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] mb-8 transition-colors"
       >
         <span class="icon-[lucide--arrow-left] w-3 h-3"></span>
@@ -130,7 +130,7 @@
         Cryptica today.
       </p>
       <a
-        href="{base}/"
+        href="{base}/?ref=changelog"
         class="inline-block px-12 py-5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/90 hover:shadow-[0_0_30px_rgba(var(--color-theme-primary-rgb),0.3)] transition-all active:scale-95"
       >
         Enter Workspace

--- a/apps/web/src/routes/(marketing)/features/+page.svelte
+++ b/apps/web/src/routes/(marketing)/features/+page.svelte
@@ -22,7 +22,7 @@
     <!-- Header -->
     <header class="mb-20 text-center">
       <a
-        href="{base}/"
+        href="{base}/?ref=features"
         class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] mb-8 transition-colors"
       >
         <span class="icon-[lucide--arrow-left] w-3 h-3"></span>
@@ -97,7 +97,7 @@
           with absolute privacy and smart tools.
         </p>
         <a
-          href="{base}/"
+          href="{base}/?ref=features"
           class="inline-block px-12 py-5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/90 hover:shadow-[0_0_40px_var(--color-accent-primary)] transition-all active:scale-95"
         >
           Enter the Codex

--- a/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
+++ b/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
@@ -157,7 +157,7 @@
     <!-- Header Navigation -->
     <nav class="flex justify-between items-center mb-16">
       <a
-        href="{base}/"
+        href="{base}/?ref=landing"
         class="font-mono text-xs uppercase tracking-[0.2em] text-theme-primary hover:opacity-80 transition-opacity flex items-center gap-2"
       >
         <span class="icon-[lucide--shield] w-4 h-4"></span>
@@ -194,7 +194,7 @@
 
       <div class="flex flex-wrap justify-center gap-4">
         <a
-          href="{base}/"
+          href="{base}/?ref=landing"
           class="px-8 py-4 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-widest text-xs rounded-lg hover:bg-theme-primary/95 transition-all shadow-lg hover:shadow-theme-primary/20 active:scale-95"
         >
           Enter the Codex
@@ -382,7 +382,7 @@
         </p>
         <div class="flex flex-wrap justify-center gap-4">
           <a
-            href="{base}/"
+            href="{base}/?ref=landing"
             class="px-12 py-5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-[0.2em] text-sm rounded-lg hover:bg-theme-primary/90 hover:shadow-[0_0_40px_var(--color-accent-primary)] transition-all active:scale-95"
           >
             Create Your Vault

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -439,7 +439,7 @@
       </nav>
       <div>
         <a
-          href="{base}/"
+          href="{base}/?ref=import-nav"
           class="px-5 py-2.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
           id="nav-cta-btn"
         >

--- a/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
+++ b/apps/web/src/routes/(marketing)/responsible-ai-worldbuilding/+page.svelte
@@ -201,7 +201,7 @@
       </nav>
       <div>
         <a
-          href="{base}/"
+          href="{base}/?ref=ra-pillar-nav"
           class="px-5 py-2.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
           id="nav-cta-btn"
         >
@@ -517,7 +517,7 @@
       </p>
       <div class="flex flex-wrap justify-center gap-4">
         <a
-          href="{base}/"
+          href="{base}/?ref=ra-pillar-footer"
           class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase tracking-widest text-xs rounded-xl shadow-lg hover:brightness-110 active:scale-95 transition-all"
           id="footer-cta-btn"
         >

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -320,7 +320,7 @@
   <section class="border-b border-theme-border/60 px-6 py-14 md:py-18">
     <div class="max-w-6xl mx-auto">
       <a
-        href="{base}/"
+        href="{base}/?ref=tools"
         class="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-theme-muted hover:text-theme-primary transition-colors mb-8"
       >
         <span class="icon-[lucide--arrow-left] h-4 w-4"></span>

--- a/apps/web/src/routes/(marketing)/worldbuilding-tool/+page.svelte
+++ b/apps/web/src/routes/(marketing)/worldbuilding-tool/+page.svelte
@@ -62,7 +62,7 @@
     </p>
     <div class="flex flex-wrap justify-center gap-4">
       <a
-        href="{base}/"
+        href="{base}/?ref=worldbuilding-tool"
         class="px-8 py-3.5 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-xs rounded-lg hover:brightness-110 transition-all"
       >
         Enter Workspace


### PR DESCRIPTION
## Summary

- Adds `?ref=<source>` params to all marketing → app CTAs for funnel tracking via CF Web Analytics
- Strips `ref`, `utm_source`, `utm_medium`, `utm_campaign` on app entry via `history.replaceState` — CF logs the full URL, users never see the param
- Extends the existing `utm_source` pattern already in the importer redirect

## Ref values

| Source | Ref |
|--------|-----|
| RA pillar page nav | `ra-pillar-nav` |
| RA pillar page footer | `ra-pillar-footer` |
| RA blog article footer | `ra-blog` |
| Comparison page nav | `vs-nav` |
| Comparison page hero | `vs-hero` |
| Comparison page footer | `vs-footer` |
| Solution page nav | `solution-nav` |
| Solution page hero | `solution-hero` |
| Solution page footer | `solution-footer` |
| Import page nav | `import-nav` |
| Import flow redirect | `utm_source=importer-<slug>` (pre-existing) |

## No new dependencies
CF Web Analytics already captures full URLs — no analytics vendor needed.

Closes #1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)