### PR TITLE
feat(seo): add BlogPosting JSON-LD to all blog articles

### DIFF
--- a/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/blog/[slug]/+page.svelte
@@ -4,12 +4,38 @@
   import ArticleRenderer from "$lib/components/blog/ArticleRenderer.svelte";
   import ResponsibleAISeriesNav from "$lib/components/blog/ResponsibleAISeriesNav.svelte";
   import { RA_SERIES_SLUGS } from "$lib/content/responsible-ai-series";
+  import { safeJsonLd } from "$lib/utils/json-ld";
 
   let { data } = $props();
   const article = $derived(data.article);
   const isRASeries = $derived(RA_SERIES_SLUGS.has(article.slug));
   const articleContent = $derived(
     article.content.replace(/^#[^\n]+\n/, "").trimStart(),
+  );
+
+  const jsonLdString = $derived(
+    safeJsonLd({
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: article.title,
+      description: article.description,
+      datePublished: article.publishedAt,
+      dateModified: article.publishedAt,
+      url: data.canonicalUrl,
+      mainEntityOfPage: { "@type": "WebPage", "@id": data.canonicalUrl },
+      author: {
+        "@type": "Organization",
+        name: "Codex Cryptica",
+        url: "https://codexcryptica.com",
+      },
+      publisher: {
+        "@type": "Organization",
+        name: "Codex Cryptica",
+        url: "https://codexcryptica.com",
+      },
+      articleSection: "Worldbuilding & RPG Tools",
+      keywords: article.keywords.join(", "),
+    }),
   );
 </script>
 
@@ -24,6 +50,10 @@
   <meta property="og:description" content={article.description} />
   <meta property="og:type" content="article" />
   <meta property="article:published_time" content={article.publishedAt} />
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${jsonLdString}</scr` +
+    `ipt>`}
 </svelte:head>
 
 <div


### PR DESCRIPTION
## Summary

- Adds `BlogPosting` JSON-LD structured data to every blog article via the shared `blog/[slug]/+page.svelte`
- Pillar page already had `FAQPage` JSON-LD — no change needed there
- Uses the existing `safeJsonLd` util consistent with `SEOPageLayout` and `SEOGeneratorLayout`

## Fields included

`headline`, `description`, `datePublished`, `dateModified`, `url`, `mainEntityOfPage`, `author` (Organization), `publisher` (Organization), `articleSection`, `keywords`

## Acceptance criteria

- [x] All 7 RA series articles include valid `BlogPosting` JSON-LD
- [x] All other blog articles also benefit (shared template)
- [x] Canonical URLs match `data.canonicalUrl`
- [x] Pillar page `FAQPage` JSON-LD already present

Closes #1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)