### PR TITLE
feat(seo): add migration strips and cross-links between vs and import pages

### DIFF
--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -610,10 +610,17 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     introText:
       "Both Obsidian and Codex Cryptica offer powerful local-first markdown linking, but they target different goals. Obsidian is a general-purpose note-taking application requiring multiple community plugins to manage campaigns, whereas Codex Cryptica is built from the ground up for TTRPG mechanics, maps, timelines, and relationships.",
     ctaText: "Try Codex Cryptica",
+    secondaryCtaText: "Import Obsidian Vault",
+    secondaryCtaHref: "/import/obsidian-vault",
     keywords: [
       "codex cryptica vs obsidian",
       "obsidian rpg campaign manager",
       "best obsidian alternative for dnd",
+    ],
+    migrationStrip: [
+      { icon: "icon-[lucide--folder-open]", label: "Obsidian Vault" },
+      { icon: "icon-[lucide--file-text]", label: "Plain Markdown Files" },
+      { icon: "icon-[lucide--network]", label: "Interactive Entity Graph" },
     ],
     features: [
       {
@@ -682,6 +689,7 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       },
     ],
     relatedLinks: [
+      { href: "/import/obsidian-vault", label: "Import Obsidian vault" },
       { href: "/vs/world-anvil", label: "vs World Anvil" },
       {
         href: "/solutions/local-first-worldbuilding-tool",
@@ -816,10 +824,17 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     introText:
       "LegendKeeper is a fast, beautifully designed campaign manager, but it is a closed cloud service that requires paid hosting. Codex Cryptica brings the same fluid, interactive wiki experience directly to your browser as a local-first, privacy-respecting tool.",
     ctaText: "Try Private Wiki",
+    secondaryCtaText: "Import LegendKeeper Export",
+    secondaryCtaHref: "/import/legendkeeper-json",
     keywords: [
       "codex cryptica vs legendkeeper",
       "legendkeeper alternative",
       "free campaign wiki",
+    ],
+    migrationStrip: [
+      { icon: "icon-[lucide--cloud-download]", label: "LegendKeeper Export" },
+      { icon: "icon-[lucide--file-text]", label: "Plain Markdown Files" },
+      { icon: "icon-[lucide--network]", label: "Interactive Entity Graph" },
     ],
     features: [
       {
@@ -879,6 +894,10 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       },
     ],
     relatedLinks: [
+      {
+        href: "/import/legendkeeper-json",
+        label: "Import LegendKeeper export",
+      },
       { href: "/vs/world-anvil", label: "vs World Anvil" },
       { href: "/vs/obsidian", label: "vs Obsidian" },
       {
@@ -899,11 +918,18 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     introText:
       "Kanka is a popular cloud-hosted campaign management platform with strong sharing features, but it stores all your world data on remote servers and restricts some features behind paid tiers. Codex Cryptica offers the same rich wiki and relationship graph as a fully local, free, offline-first alternative.",
     ctaText: "Try Free Local Vault",
+    secondaryCtaText: "Import Kanka Export",
+    secondaryCtaHref: "/import/kanka-json",
     keywords: [
       "codex cryptica vs kanka",
       "kanka alternative",
       "kanka rpg campaign manager",
       "free kanka alternative",
+    ],
+    migrationStrip: [
+      { icon: "icon-[lucide--cloud-download]", label: "Kanka JSON Export" },
+      { icon: "icon-[lucide--file-text]", label: "Plain Markdown Files" },
+      { icon: "icon-[lucide--network]", label: "Interactive Entity Graph" },
     ],
     features: [
       {
@@ -960,6 +986,7 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     verdict:
       "Kanka excels at team-shared cloud wikis, but if you value offline access, data privacy, and no subscription fees, Codex Cryptica delivers a richer local experience with the same wiki depth and no monthly cost.",
     relatedLinks: [
+      { href: "/import/kanka-json", label: "Import Kanka export" },
       { href: "/vs/world-anvil", label: "vs World Anvil" },
       { href: "/vs/obsidian", label: "vs Obsidian" },
       { href: "/solutions/local-first-rpg", label: "Local-first RPG" },
@@ -1194,6 +1221,13 @@ export const importsConfig: Record<string, SEOImportPageData> = {
           "No, Codex is free and open-source. All parsing and vault generation is computed local-first in your browser.",
       },
     ],
+    relatedLinks: [
+      { href: "/vs/obsidian", label: "Codex vs Obsidian" },
+      {
+        href: "/solutions/local-first-worldbuilding-tool",
+        label: "Local-first worldbuilding",
+      },
+    ],
   },
   "world-anvil-export": {
     slug: "world-anvil-export",
@@ -1245,6 +1279,10 @@ export const importsConfig: Record<string, SEOImportPageData> = {
       },
     ],
     aiTrustSection: true,
+    relatedLinks: [
+      { href: "/vs/world-anvil", label: "Codex vs World Anvil" },
+      { href: "/solutions/local-first-rpg", label: "Local-first RPG" },
+    ],
   },
   "kanka-json": {
     slug: "kanka-json",
@@ -1290,6 +1328,10 @@ export const importsConfig: Record<string, SEOImportPageData> = {
         answer:
           "The importer extracts map coordinates and pin descriptions, letting you map locations inside Codex's spatial canvases.",
       },
+    ],
+    relatedLinks: [
+      { href: "/vs/kanka-alternative", label: "Codex vs Kanka" },
+      { href: "/solutions/local-first-rpg", label: "Local-first RPG" },
     ],
   },
   "legendkeeper-json": {
@@ -1340,6 +1382,13 @@ export const importsConfig: Record<string, SEOImportPageData> = {
         question: "Do my map pins translate to Codex?",
         answer:
           "Yes, the coordinates and wiki linkages are extracted and can be mapped directly onto the Codex campaign canvas.",
+      },
+    ],
+    relatedLinks: [
+      { href: "/vs/legendkeeper", label: "Codex vs LegendKeeper" },
+      {
+        href: "/solutions/offline-rpg-campaign-manager",
+        label: "Offline campaign manager",
       },
     ],
   },

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -735,6 +735,32 @@
         {/each}
       </div>
     </section>
+
+    {#if pageData.relatedLinks && pageData.relatedLinks.length > 0}
+      <section class="border-t border-theme-border/30 py-10">
+        <div class="max-w-4xl mx-auto px-6">
+          <h2
+            class="font-header text-sm uppercase tracking-[0.2em] text-theme-muted mb-6 text-center"
+          >
+            Related Pages
+          </h2>
+          <div class="flex flex-wrap justify-center gap-3">
+            {#each pageData.relatedLinks as link (link.href)}
+              <a
+                href="{base}{link.href}"
+                class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-theme-border/60 bg-theme-surface/30 text-xs font-bold uppercase tracking-wider text-theme-muted hover:text-theme-primary hover:border-theme-primary/40 transition-colors"
+              >
+                <span
+                  class="icon-[lucide--arrow-right] w-3 h-3"
+                  aria-hidden="true"
+                ></span>
+                {link.label}
+              </a>
+            {/each}
+          </div>
+        </div>
+      </section>
+    {/if}
   </main>
 
   <!-- Marketing Footer -->

--- a/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/import/[slug]/+page.svelte
@@ -690,6 +690,32 @@
       </section>
     {/if}
 
+    {#if pageData.relatedLinks && pageData.relatedLinks.length > 0}
+      <section class="border-t border-theme-border/30 py-10">
+        <div class="max-w-4xl mx-auto px-6">
+          <h2
+            class="font-header text-sm uppercase tracking-[0.2em] text-theme-muted mb-6 text-center"
+          >
+            Related Pages
+          </h2>
+          <div class="flex flex-wrap justify-center gap-3">
+            {#each pageData.relatedLinks as link (link.href)}
+              <a
+                href="{base}{link.href}"
+                class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-theme-border/60 bg-theme-surface/30 text-xs font-bold uppercase tracking-wider text-theme-muted hover:text-theme-primary hover:border-theme-primary/40 transition-colors"
+              >
+                <span
+                  class="icon-[lucide--arrow-right] w-3 h-3"
+                  aria-hidden="true"
+                ></span>
+                {link.label}
+              </a>
+            {/each}
+          </div>
+        </div>
+      </section>
+    {/if}
+
     <!-- Responsible AI Trust Banner -->
     {#if pageData.aiTrustSection}
       <section class="border-t border-theme-border/60 mt-16 pt-10 text-center">
@@ -735,32 +761,6 @@
         {/each}
       </div>
     </section>
-
-    {#if pageData.relatedLinks && pageData.relatedLinks.length > 0}
-      <section class="border-t border-theme-border/30 py-10">
-        <div class="max-w-4xl mx-auto px-6">
-          <h2
-            class="font-header text-sm uppercase tracking-[0.2em] text-theme-muted mb-6 text-center"
-          >
-            Related Pages
-          </h2>
-          <div class="flex flex-wrap justify-center gap-3">
-            {#each pageData.relatedLinks as link (link.href)}
-              <a
-                href="{base}{link.href}"
-                class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-theme-border/60 bg-theme-surface/30 text-xs font-bold uppercase tracking-wider text-theme-muted hover:text-theme-primary hover:border-theme-primary/40 transition-colors"
-              >
-                <span
-                  class="icon-[lucide--arrow-right] w-3 h-3"
-                  aria-hidden="true"
-                ></span>
-                {link.label}
-              </a>
-            {/each}
-          </div>
-        </div>
-      </section>
-    {/if}
   </main>
 
   <!-- Marketing Footer -->

--- a/apps/web/src/routes/(marketing)/import/[slug]/import.test.ts
+++ b/apps/web/src/routes/(marketing)/import/[slug]/import.test.ts
@@ -175,4 +175,85 @@ describe("Imports SvelteKit Route", () => {
       expect(importsConfig["world-anvil-export"].aiTrustSection).toBe(true);
     });
   });
+
+  describe("Related Pages section", () => {
+    afterEach(() => {
+      document.head.innerHTML = "";
+    });
+
+    it("renders related links when relatedLinks is provided", () => {
+      const mockPageData = {
+        slug: "obsidian-vault",
+        competitorName: "Obsidian",
+        title: "T",
+        description: "D",
+        h1: "H",
+        subheading: "S",
+        introText: "I",
+        ctaText: "C",
+        keywords: [],
+        features: [],
+        faq: [],
+        relatedLinks: [
+          { href: "/vs/obsidian", label: "Codex vs Obsidian" },
+          {
+            href: "/solutions/local-first-worldbuilding-tool",
+            label: "Local-first worldbuilding",
+          },
+        ],
+      };
+
+      render(Page, { props: { data: { importPage: mockPageData } } });
+
+      expect(screen.getByText("Related Pages")).toBeTruthy();
+      const link = screen.getByRole("link", { name: /codex vs obsidian/i });
+      expect(link.getAttribute("href")).toBe("/vs/obsidian");
+    });
+
+    it("does not render the related pages section when relatedLinks is absent", () => {
+      const mockPageData = {
+        slug: "obsidian-vault",
+        competitorName: "Obsidian",
+        title: "T",
+        description: "D",
+        h1: "H",
+        subheading: "S",
+        introText: "I",
+        ctaText: "C",
+        keywords: [],
+        features: [],
+        faq: [],
+      };
+
+      render(Page, { props: { data: { importPage: mockPageData } } });
+
+      expect(screen.queryByText("Related Pages")).toBeNull();
+    });
+
+    it("import configs have relatedLinks pointing to their vs counterpart", async () => {
+      const { importsConfig } = (await vi.importActual(
+        "$lib/config/seo-pages",
+      )) as typeof import("$lib/config/seo-pages");
+      expect(
+        importsConfig["obsidian-vault"].relatedLinks?.some(
+          (l) => l.href === "/vs/obsidian",
+        ),
+      ).toBe(true);
+      expect(
+        importsConfig["world-anvil-export"].relatedLinks?.some(
+          (l) => l.href === "/vs/world-anvil",
+        ),
+      ).toBe(true);
+      expect(
+        importsConfig["kanka-json"].relatedLinks?.some(
+          (l) => l.href === "/vs/kanka-alternative",
+        ),
+      ).toBe(true);
+      expect(
+        importsConfig["legendkeeper-json"].relatedLinks?.some(
+          (l) => l.href === "/vs/legendkeeper",
+        ),
+      ).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Strengthens the switching journey between comparison and import pages by wiring them together bidirectionally.

**vs/ pages (Obsidian, LegendKeeper, Kanka):**
- Added `secondaryCtaText` / `secondaryCtaHref` pointing to their respective import page
- Added `migrationStrip` (3-step visual flow) matching the World Anvil pattern
- Added import page link to `relatedLinks`

**import/ pages (all 4):**
- Added `relatedLinks` pointing back to the corresponding `/vs/` comparison page + a relevant solution page
- Added `relatedLinks` rendering to the import page template (was missing entirely)

World Anvil already had all of this — this PR brings the other 3 competitors to parity.

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)