### PR TITLE
:recycle: Remove E2E-only flags from production code (#1169)

### DIFF
--- a/apps/web/src/lib/app/init/app-init.test.ts
+++ b/apps/web/src/lib/app/init/app-init.test.ts
@@ -234,20 +234,14 @@ describe("app-init", () => {
   });
 
   describe("setupWindowGlobals", () => {
-    it("should attach context to window if special env (__E2E__)", () => {
-      (window as any).__E2E__ = true;
-
+    it("should attach context to window in special env (DEV)", () => {
       const mockContext = { searchStore: { name: "search" } };
       setupWindowGlobals(mockContext as any);
 
       expect((window as any).searchStore).toBe(mockContext.searchStore);
-
-      delete (window as any).__E2E__;
     });
 
     it("should handle dynamic imports in setupWindowGlobals", async () => {
-      (window as any).__E2E__ = true;
-
       // We don't necessarily need to mock the modules if we just want to hit the lines,
       // but wait for the promises to settle.
       setupWindowGlobals({} as any);
@@ -256,7 +250,6 @@ describe("app-init", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       // Just verifying it doesn't crash is often enough for these lazy loads in init
-      delete (window as any).__E2E__;
     });
   });
 

--- a/apps/web/src/lib/app/init/app-init.ts
+++ b/apps/web/src/lib/app/init/app-init.ts
@@ -147,9 +147,7 @@ export function setupWindowGlobals(context: {
   if (!browser) return;
 
   const isSpecialEnv =
-    import.meta.env.DEV ||
-    (typeof window !== "undefined" && (window as any).__E2E__) ||
-    import.meta.env.VITE_STAGING === "true";
+    import.meta.env.DEV || import.meta.env.VITE_STAGING === "true";
 
   if (!isSpecialEnv) return;
 

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -110,7 +110,7 @@ export class GraphViewController {
       instance.on("select unselect", "node", updateSelectionCount);
       updateSelectionCount();
 
-      if (import.meta.env.DEV || (window as any).__E2E__) {
+      if (import.meta.env.DEV) {
         (window as any).cy = instance;
       }
 

--- a/apps/web/src/lib/components/help/TourOverlay.svelte
+++ b/apps/web/src/lib/components/help/TourOverlay.svelte
@@ -56,12 +56,6 @@
     }
   };
 
-  // Derived values for the mask
-  const isDisabled = $derived.by(() => {
-    if (typeof window === "undefined") return false;
-    return (window as any).DISABLE_ONBOARDING;
-  });
-
   let maskStyle = $derived.by(() => {
     if (!targetRect) return "";
 
@@ -111,7 +105,7 @@
   });
 </script>
 
-{#if helpStore.activeTour && !isDisabled}
+{#if helpStore.activeTour}
   {#if targetRect}
     <div
       class="fixed inset-0 z-[var(--z-index-overlay-max,150)] bg-black/60 backdrop-blur-[2px] transition-all duration-300"

--- a/apps/web/src/lib/components/layout/OracleSidebarProvider.svelte
+++ b/apps/web/src/lib/components/layout/OracleSidebarProvider.svelte
@@ -5,9 +5,7 @@
   let OracleSidebarPanel = $state<any>(null);
 
   const isSpecialEnv =
-    import.meta.env.DEV ||
-    (typeof window !== "undefined" && (window as any).__E2E__) ||
-    import.meta.env.VITE_STAGING === "true";
+    import.meta.env.DEV || import.meta.env.VITE_STAGING === "true";
 
   $effect(() => {
     if (layoutUIStore.activeSidebarTool === "oracle" && !OracleSidebarPanel) {

--- a/apps/web/src/lib/components/layout/SidebarPanelHost.svelte
+++ b/apps/web/src/lib/components/layout/SidebarPanelHost.svelte
@@ -12,9 +12,7 @@
   let EntityExplorer = $state<any>(null);
 
   const isSpecialEnv =
-    import.meta.env.DEV ||
-    (typeof window !== "undefined" && (window as any).__E2E__) ||
-    import.meta.env.VITE_STAGING === "true";
+    import.meta.env.DEV || import.meta.env.VITE_STAGING === "true";
 
   const logError = (name: string, error: any) => {
     if (isSpecialEnv) {

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -19,9 +19,7 @@
   const isLoginRoute = $derived(page.url.pathname === `${base}/login`);
 
   const isSpecialEnv =
-    import.meta.env.DEV ||
-    (typeof window !== "undefined" && (window as any).__E2E__) ||
-    import.meta.env.VITE_STAGING === "true";
+    import.meta.env.DEV || import.meta.env.VITE_STAGING === "true";
 
   const loadModal = async (
     loader: () => Promise<{ default: any }>,

--- a/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
+++ b/apps/web/src/lib/components/oracle/OracleSidebarPanel.svelte
@@ -32,15 +32,6 @@
 
   onMount(() => {
     // Show hint on first open
-    const isTesting =
-      typeof window !== "undefined" &&
-      ((window as any).DISABLE_ONBOARDING || (window as any).__E2E__);
-
-    if (isTesting) {
-      showHint = false;
-      return;
-    }
-
     const hasSeenHint = localStorage.getItem(HINT_KEYS.ORACLE_CONNECTION);
     if (!hasSeenHint) {
       showHint = true;

--- a/apps/web/src/lib/stores/categories.svelte.ts
+++ b/apps/web/src/lib/stores/categories.svelte.ts
@@ -96,10 +96,7 @@ export class CategoryStore {
 
 export const categories = new CategoryStore();
 
-if (
-  typeof window !== "undefined" &&
-  (import.meta.env.DEV || (window as any).__E2E__)
-) {
+if (typeof window !== "undefined" && import.meta.env.DEV) {
   (window as any).categories = categories;
   debugStore.log(
     "[CategoryStore] Module loaded, categories attached to window",

--- a/apps/web/src/lib/stores/debug.svelte.ts
+++ b/apps/web/src/lib/stores/debug.svelte.ts
@@ -27,10 +27,7 @@ export class DebugStore {
   private addLog(level: LogEntry["level"], message: string, data?: any) {
     const newLog = { timestamp: Date.now(), level, message, data };
     this.logs = [newLog, ...this.logs].slice(0, 500);
-    if (
-      import.meta.env.DEV ||
-      (typeof window !== "undefined" && (window as any).__E2E__)
-    ) {
+    if (import.meta.env.DEV) {
       const method =
         level === "error" ? "error" : level === "warn" ? "warn" : "log";
       if (data) {

--- a/apps/web/src/lib/stores/help.svelte.ts
+++ b/apps/web/src/lib/stores/help.svelte.ts
@@ -161,8 +161,6 @@ export class HelpStore {
   // --- Tour Methods ---
 
   startTour(id: string) {
-    if (browser && (window as any).DISABLE_ONBOARDING) return;
-
     if (id === "initial-onboarding") {
       // Dismiss landing page and close settings modal to ensure the tour is visible
       this.onboardingStore.dismissedLandingPage = true;

--- a/apps/web/src/lib/stores/help.test.ts
+++ b/apps/web/src/lib/stores/help.test.ts
@@ -37,12 +37,9 @@ describe("HelpStore", () => {
     );
 
     // Test that it uses the injected UI store
-    const original = (window as any).DISABLE_ONBOARDING;
-    (window as any).DISABLE_ONBOARDING = false;
     store.startTour("initial-onboarding");
     expect(mockOnboardingStore.dismissedLandingPage).toBe(true);
     expect(mockModalUIStore.closeSettings).toHaveBeenCalled();
-    (window as any).DISABLE_ONBOARDING = original;
   });
 
   it("should initialize with all help articles", () => {

--- a/apps/web/src/lib/stores/import-queue.svelte.ts
+++ b/apps/web/src/lib/stores/import-queue.svelte.ts
@@ -72,9 +72,6 @@ class ImportQueueStore {
 
 export const importQueue = new ImportQueueStore();
 
-if (
-  typeof window !== "undefined" &&
-  (import.meta.env.DEV || (window as any).__E2E__)
-) {
+if (typeof window !== "undefined" && import.meta.env.DEV) {
   (window as any).importQueue = importQueue;
 }

--- a/apps/web/src/lib/stores/map-registry.svelte.ts
+++ b/apps/web/src/lib/stores/map-registry.svelte.ts
@@ -65,10 +65,7 @@ class MapRegistryStore {
     const activeVaultId = vaultRegistry.activeVaultId;
     if (!activeVaultId || !vaultRegistry.rootHandle || !this.saveQueue) return;
 
-    if (
-      sessionModeStore.isDemoMode &&
-      !(typeof window !== "undefined" && (window as any).__E2E__)
-    ) {
+    if (sessionModeStore.isDemoMode) {
       notificationStore.notify("Deletion is disabled in Demo Mode.", "info");
       return;
     }

--- a/apps/web/src/lib/stores/theme.svelte.ts
+++ b/apps/web/src/lib/stores/theme.svelte.ts
@@ -549,9 +549,6 @@ export const themeStore: ThemeStore =
   (globalThis as any)[THEME_KEY] ??
   ((globalThis as any)[THEME_KEY] = new ThemeStore());
 
-if (
-  typeof window !== "undefined" &&
-  (import.meta.env.DEV || (window as any).__E2E__)
-) {
+if (typeof window !== "undefined" && import.meta.env.DEV) {
   (window as any).themeStore = themeStore;
 }

--- a/apps/web/src/lib/stores/timeline.svelte.ts
+++ b/apps/web/src/lib/stores/timeline.svelte.ts
@@ -135,9 +135,6 @@ class TimelineStore {
 
 export const timelineStore = new TimelineStore();
 
-if (
-  typeof window !== "undefined" &&
-  (import.meta.env.DEV || (window as any).__E2E__)
-) {
+if (typeof window !== "undefined" && import.meta.env.DEV) {
   (window as any).timelineStore = timelineStore;
 }

--- a/apps/web/src/lib/stores/vault.svelte.ts
+++ b/apps/web/src/lib/stores/vault.svelte.ts
@@ -555,10 +555,7 @@ export const vault: VaultStore =
   (globalThis as any)[VAULT_KEY] ??
   ((globalThis as any)[VAULT_KEY] = new VaultStore());
 
-if (
-  typeof window !== "undefined" &&
-  (import.meta.env.DEV || (window as any).__E2E__)
-) {
+if (typeof window !== "undefined" && import.meta.env.DEV) {
   (window as any).vault = vault;
   debugStore.log("[VaultStore] Module loaded, vault attached to window");
 }

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -134,11 +134,9 @@
     // This layout only serves workspace routes — always boot except on landing page
     const isLandingPage = page.url.pathname === `${base}/`;
     const shouldShowLanding = onboardingStore.isLandingPageVisible;
-    const isTesting =
-      typeof window !== "undefined" && (window as any).DISABLE_ONBOARDING;
 
     if (!hasBooted) {
-      if (!isLandingPage || !shouldShowLanding || isTesting || isPopup) {
+      if (!isLandingPage || !shouldShowLanding || isPopup) {
         hasBooted = bootSystem({
           categories,
           vault,
@@ -190,9 +188,7 @@
 
   async function loadFeatureWindowGlobals() {
     const isSpecialEnv =
-      import.meta.env.DEV ||
-      (typeof window !== "undefined" && (window as any).__E2E__) ||
-      import.meta.env.VITE_STAGING === "true";
+      import.meta.env.DEV || import.meta.env.VITE_STAGING === "true";
 
     if (!isSpecialEnv) return {};
 
@@ -266,15 +262,11 @@
     if (vault.isInitialized && !onboardingStore.isLandingPageVisible) {
       if (
         !helpStore.hasSeen("initial-onboarding") &&
-        !(window as any).DISABLE_ONBOARDING &&
         !page.url.searchParams.has("demo")
       ) {
-        const isTesting =
-          typeof window !== "undefined" && (window as any).DISABLE_ONBOARDING;
         if (
           vault.allEntities.length === 0 &&
           !sessionModeStore.isDemoMode &&
-          !isTesting &&
           !onboardingStore.dismissedLandingPage
         ) {
           demoService.startDemo("fantasy");

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -50,9 +50,7 @@
   ];
 
   const isSpecialEnv =
-    import.meta.env.DEV ||
-    (typeof window !== "undefined" && (window as any).__E2E__) ||
-    import.meta.env.VITE_STAGING === "true";
+    import.meta.env.DEV || import.meta.env.VITE_STAGING === "true";
 
   const demoThemes = [
     "vampire",

--- a/apps/web/tests/ai-disabled.spec.ts
+++ b/apps/web/tests/ai-disabled.spec.ts
@@ -9,11 +9,6 @@ test.describe("AI Disabled", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("http://localhost:5173/");
     await page.waitForFunction(() => (window as any).vault?.status === "idle");

--- a/apps/web/tests/ai-disabled.spec.ts
+++ b/apps/web/tests/ai-disabled.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("AI Disabled", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/ai-regeneration.spec.ts
+++ b/apps/web/tests/ai-regeneration.spec.ts
@@ -10,7 +10,6 @@ test.describe("AI Entity Regeneration", () => {
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
-        localStorage.setItem("codex_skip_landing", "true");
         localStorage.setItem("codex_ai_disabled", "false");
       } catch {
         /* ignore */

--- a/apps/web/tests/ai-regeneration.spec.ts
+++ b/apps/web/tests/ai-regeneration.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("AI Entity Regeneration", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/better-imports.spec.ts
+++ b/apps/web/tests/better-imports.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Better Imports E2E", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/better-imports.spec.ts
+++ b/apps/web/tests/better-imports.spec.ts
@@ -9,11 +9,6 @@ test.describe("Better Imports E2E", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).showDirectoryPicker = async () => ({
         kind: "directory",
         name: "test-vault",

--- a/apps/web/tests/bulk-labels.spec.ts
+++ b/apps/web/tests/bulk-labels.spec.ts
@@ -9,8 +9,11 @@ test.describe("Bulk Labeling and Selection Actions", () => {
       } catch {
         /* ignore */
       }
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
     });
 
     await page.goto("/");

--- a/apps/web/tests/bulk-labels.spec.ts
+++ b/apps/web/tests/bulk-labels.spec.ts
@@ -9,7 +9,6 @@ test.describe("Bulk Labeling and Selection Actions", () => {
       } catch {
         /* ignore */
       }
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),

--- a/apps/web/tests/cache-persistence.spec.ts
+++ b/apps/web/tests/cache-persistence.spec.ts
@@ -43,11 +43,6 @@ test.describe("CacheService persistence (set + bulkSet)", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/cache-persistence.spec.ts
+++ b/apps/web/tests/cache-persistence.spec.ts
@@ -38,8 +38,11 @@ test.describe("CacheService persistence (set + bulkSet)", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/calendar-picker.spec.ts
+++ b/apps/web/tests/calendar-picker.spec.ts
@@ -44,11 +44,6 @@ test.describe("Campaign Date Picker E2E", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).DISABLE_ERROR_OVERLAY = true;
       (window as any).showDirectoryPicker = async () => ({
         kind: "directory",

--- a/apps/web/tests/calendar-picker.spec.ts
+++ b/apps/web/tests/calendar-picker.spec.ts
@@ -39,8 +39,11 @@ const clickNodeProgrammatically = async (page: Page, label: string) => {
 test.describe("Campaign Date Picker E2E", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).__E2E__ = true;
-      (window as any).DISABLE_ONBOARDING = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/canvas-add-context-menu.spec.ts
+++ b/apps/web/tests/canvas-add-context-menu.spec.ts
@@ -6,8 +6,11 @@ test.describe("Add to Canvas - Context Menu", () => {
   test.beforeEach(async ({ page }) => {
     // Inject global flag BEFORE goto so +layout.svelte sees it immediately
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/canvas-add-context-menu.spec.ts
+++ b/apps/web/tests/canvas-add-context-menu.spec.ts
@@ -11,11 +11,6 @@ test.describe("Add to Canvas - Context Menu", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     // Navigate to graph view

--- a/apps/web/tests/canvas.spec.ts
+++ b/apps/web/tests/canvas.spec.ts
@@ -9,11 +9,6 @@ test.describe("Spatial Canvas", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/canvas");

--- a/apps/web/tests/canvas.spec.ts
+++ b/apps/web/tests/canvas.spec.ts
@@ -4,8 +4,11 @@ test.describe("Spatial Canvas", () => {
   test.beforeEach(async ({ page }) => {
     // Inject global flag BEFORE goto so +layout.svelte sees it immediately
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/categories.spec.ts
+++ b/apps/web/tests/categories.spec.ts
@@ -8,11 +8,6 @@ test.describe("Category Architecture Modal", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/categories.spec.ts
+++ b/apps/web/tests/categories.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Category Architecture Modal", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/category-filter.spec.ts
+++ b/apps/web/tests/category-filter.spec.ts
@@ -16,8 +16,11 @@ test.describe("Category Filter", () => {
       } catch {
         /* ignore */
       }
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).showDirectoryPicker = async () => {
         return {
           kind: "directory",

--- a/apps/web/tests/category-filter.spec.ts
+++ b/apps/web/tests/category-filter.spec.ts
@@ -16,7 +16,6 @@ test.describe("Category Filter", () => {
       } catch {
         /* ignore */
       }
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
@@ -79,11 +78,6 @@ test.describe("Category Filter", () => {
     await page.waitForFunction(() => !!(window as any).uiStore);
     await page.evaluate(() => {
       (window as any).uiStore.dismissedLandingPage = true;
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.reload({ waitUntil: "load" });
     await expect(page.getByTestId("graph-canvas")).toBeVisible({

--- a/apps/web/tests/changelog.spec.ts
+++ b/apps/web/tests/changelog.spec.ts
@@ -13,7 +13,6 @@ test.describe("Changelog System", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       localStorage.setItem("codex_last_seen_version", "0.16.5");
-      localStorage.setItem("codex_skip_landing", "true");
     });
 
     await page.goto("/");
@@ -39,7 +38,6 @@ test.describe("Changelog System", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
@@ -47,7 +45,6 @@ test.describe("Changelog System", () => {
       // Stored version is 0.17.0, current app is 0.17.37.
       // Because minor is the same, it should NOT pop up.
       localStorage.setItem("codex_last_seen_version", "0.17.0");
-      localStorage.setItem("codex_skip_landing", "true");
     });
 
     await page.goto("/");

--- a/apps/web/tests/changelog.spec.ts
+++ b/apps/web/tests/changelog.spec.ts
@@ -7,8 +7,11 @@ test.describe("Changelog System", () => {
   }) => {
     // 1. Setup with an older MINOR version in localStorage
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       localStorage.setItem("codex_last_seen_version", "0.16.5");
       localStorage.setItem("codex_skip_landing", "true");
     });
@@ -36,8 +39,11 @@ test.describe("Changelog System", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       // Stored version is 0.17.0, current app is 0.17.37.
       // Because minor is the same, it should NOT pop up.
       localStorage.setItem("codex_last_seen_version", "0.17.0");

--- a/apps/web/tests/debug-vault.spec.ts
+++ b/apps/web/tests/debug-vault.spec.ts
@@ -6,8 +6,11 @@ test.describe("Vault Management Debug", () => {
     page.on("console", (msg) => console.log(`[BROWSER]: ${msg.text()}`));
 
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/debug-vault.spec.ts
+++ b/apps/web/tests/debug-vault.spec.ts
@@ -11,11 +11,6 @@ test.describe("Vault Management Debug", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("/");
     await expect(page.getByTestId("graph-canvas")).toBeVisible({

--- a/apps/web/tests/demo-mode.spec.ts
+++ b/apps/web/tests/demo-mode.spec.ts
@@ -75,13 +75,7 @@ test.describe("Interactive Demo Mode", () => {
 
   test("should start theme-specific demo via URL", async ({ page }) => {
     // For URL-based demo, we want to bypass landing page
-    await page.addInitScript(() => {
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
-    });
+    await page.addInitScript(() => {});
 
     await page.goto("/?demo=vampire&s=" + Date.now());
     await page.waitForFunction(

--- a/apps/web/tests/demo-mode.spec.ts
+++ b/apps/web/tests/demo-mode.spec.ts
@@ -6,8 +6,11 @@ test.describe("Interactive Demo Mode", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.removeItem("codex_was_converted");

--- a/apps/web/tests/dice-modal.spec.ts
+++ b/apps/web/tests/dice-modal.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Dice Modal UI and Isolation", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/dice-modal.spec.ts
+++ b/apps/web/tests/dice-modal.spec.ts
@@ -8,11 +8,6 @@ test.describe("Dice Modal UI and Isolation", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/dice-roll.spec.ts
+++ b/apps/web/tests/dice-roll.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Dice Rolling (Oracle Command)", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/dice-roll.spec.ts
+++ b/apps/web/tests/dice-roll.spec.ts
@@ -9,11 +9,6 @@ test.describe("Dice Rolling (Oracle Command)", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
-      try {
         localStorage.setItem("codex_lite_mode", "true");
       } catch {
         /* ignore */

--- a/apps/web/tests/draw-autocomplete.spec.ts
+++ b/apps/web/tests/draw-autocomplete.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Draw Command Autocomplete", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/draw-autocomplete.spec.ts
+++ b/apps/web/tests/draw-autocomplete.spec.ts
@@ -9,11 +9,6 @@ test.describe("Draw Command Autocomplete", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("http://localhost:5173/");
 

--- a/apps/web/tests/draw-button.spec.ts
+++ b/apps/web/tests/draw-button.spec.ts
@@ -9,11 +9,6 @@ test.describe("Advanced Draw Button", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("http://localhost:5173/");
 

--- a/apps/web/tests/draw-button.spec.ts
+++ b/apps/web/tests/draw-button.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Advanced Draw Button", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/explorer-sidebar.spec.ts
+++ b/apps/web/tests/explorer-sidebar.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Entity Explorer Sidebar", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/explorer-sidebar.spec.ts
+++ b/apps/web/tests/explorer-sidebar.spec.ts
@@ -8,11 +8,6 @@ test.describe("Entity Explorer Sidebar", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     // Seed a known entity and dismiss front page for testing focus mode

--- a/apps/web/tests/find-button.spec.ts
+++ b/apps/web/tests/find-button.spec.ts
@@ -9,11 +9,6 @@ test.describe("Find in Graph Button", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/find-button.spec.ts
+++ b/apps/web/tests/find-button.spec.ts
@@ -4,8 +4,11 @@ test.describe("Find in Graph Button", () => {
   test("should center the graph on the node when clicked", async ({ page }) => {
     page.on("console", (msg) => console.log(`[PAGE] ${msg.text()}`));
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/fog-of-war.spec.ts
+++ b/apps/web/tests/fog-of-war.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Fog of War", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/fog-of-war.spec.ts
+++ b/apps/web/tests/fog-of-war.spec.ts
@@ -8,11 +8,6 @@ test.describe("Fog of War", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("./");

--- a/apps/web/tests/fp-screenshot.spec.ts
+++ b/apps/web/tests/fp-screenshot.spec.ts
@@ -2,7 +2,11 @@ import { test } from "@playwright/test";
 
 test("screenshot front page", async ({ page }) => {
   await page.addInitScript(() => {
-    (window as any).DISABLE_ONBOARDING = true;
+    localStorage.setItem("codex_skip_landing", "true");
+    localStorage.setItem(
+      "codex-cryptica-help-state",
+      JSON.stringify({ completedTours: ["initial-onboarding"] }),
+    );
   });
   await page.goto("http://localhost:5174");
   await page.waitForLoadState("networkidle");

--- a/apps/web/tests/graph-canvas-sync.spec.ts
+++ b/apps/web/tests/graph-canvas-sync.spec.ts
@@ -9,7 +9,6 @@ test.describe("Cross-View Deletion Sync (Graph to Canvas)", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      localStorage.setItem("codex_skip_landing", "true");
     });
 
     // Start on the graph view

--- a/apps/web/tests/graph-canvas-sync.spec.ts
+++ b/apps/web/tests/graph-canvas-sync.spec.ts
@@ -4,8 +4,11 @@ test.describe("Cross-View Deletion Sync (Graph to Canvas)", () => {
   test.beforeEach(async ({ page }) => {
     // Inject global flag BEFORE goto so +layout.svelte sees it immediately
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       localStorage.setItem("codex_skip_landing", "true");
     });
 

--- a/apps/web/tests/graph-category-menu.spec.ts
+++ b/apps/web/tests/graph-category-menu.spec.ts
@@ -2,11 +2,6 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Graph Category Context Menu", () => {
   test.beforeEach(async ({ page }) => {
-    // Inject E2E flag
-    await page.addInitScript(() => {
-      (window as any).__E2E__ = true;
-    });
-
     await page.goto("/vault/default");
     // Wait for graph to load and settle
     await page.waitForSelector("canvas");

--- a/apps/web/tests/graph-connections.spec.ts
+++ b/apps/web/tests/graph-connections.spec.ts
@@ -5,8 +5,11 @@ test.describe("Graph Connection Labels & Colors", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/graph-connections.spec.ts
+++ b/apps/web/tests/graph-connections.spec.ts
@@ -10,11 +10,6 @@ test.describe("Graph Connection Labels & Colors", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/graph-deletion.spec.ts
+++ b/apps/web/tests/graph-deletion.spec.ts
@@ -8,11 +8,6 @@ test.describe("Graph Deletion and UI Safety", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/graph-deletion.spec.ts
+++ b/apps/web/tests/graph-deletion.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Graph Deletion and UI Safety", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/graph-fit.spec.ts
+++ b/apps/web/tests/graph-fit.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Graph Fit to Screen", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
     });
   });
 

--- a/apps/web/tests/graph-focus.spec.ts
+++ b/apps/web/tests/graph-focus.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Graph Focus Mode", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/graph-focus.spec.ts
+++ b/apps/web/tests/graph-focus.spec.ts
@@ -8,11 +8,6 @@ test.describe("Graph Focus Mode", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("http://localhost:5173/");

--- a/apps/web/tests/graph-image-gen.spec.ts
+++ b/apps/web/tests/graph-image-gen.spec.ts
@@ -2,10 +2,6 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Graph Image Generation Context Menu", () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      (window as any).__E2E__ = true;
-    });
-
     await page.goto("/vault/default");
     await page.waitForSelector("canvas");
     await page.waitForTimeout(2000);

--- a/apps/web/tests/graph-initial-load.spec.ts
+++ b/apps/web/tests/graph-initial-load.spec.ts
@@ -10,11 +10,6 @@ test.describe("Graph Initial Load", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     page.on("console", (msg) => {

--- a/apps/web/tests/graph-initial-load.spec.ts
+++ b/apps/web/tests/graph-initial-load.spec.ts
@@ -5,8 +5,11 @@ test.describe("Graph Initial Load", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/graph-interaction.spec.ts
+++ b/apps/web/tests/graph-interaction.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Graph Keyboard Interactions", () => {
   test("should toggle connect mode with 'C' key", async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {
@@ -39,8 +42,11 @@ test.describe("Graph Keyboard Interactions", () => {
 
   test("should exit connect mode with 'Escape' key", async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/graph-interaction.spec.ts
+++ b/apps/web/tests/graph-interaction.spec.ts
@@ -8,11 +8,6 @@ test.describe("Graph Keyboard Interactions", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");
@@ -42,16 +37,10 @@ test.describe("Graph Keyboard Interactions", () => {
 
   test("should exit connect mode with 'Escape' key", async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/graph-persistence.spec.ts
+++ b/apps/web/tests/graph-persistence.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Graph Deletion Persistence", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       localStorage.setItem("codex_skip_landing", "true");
     });
 

--- a/apps/web/tests/graph-persistence.spec.ts
+++ b/apps/web/tests/graph-persistence.spec.ts
@@ -8,7 +8,6 @@ test.describe("Graph Deletion Persistence", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      localStorage.setItem("codex_skip_landing", "true");
     });
 
     await page.goto("/");

--- a/apps/web/tests/graph-sync.spec.ts
+++ b/apps/web/tests/graph-sync.spec.ts
@@ -8,11 +8,6 @@ test.describe("Graph Synchronization Loop", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("http://localhost:5173/");
     // Wait for auto-init

--- a/apps/web/tests/graph-sync.spec.ts
+++ b/apps/web/tests/graph-sync.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Graph Synchronization Loop", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/graph-zen-mode.spec.ts
+++ b/apps/web/tests/graph-zen-mode.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Graph Zen Mode", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       localStorage.setItem("codex_skip_landing", "true");
     });
 

--- a/apps/web/tests/graph-zen-mode.spec.ts
+++ b/apps/web/tests/graph-zen-mode.spec.ts
@@ -8,7 +8,6 @@ test.describe("Graph Zen Mode", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      localStorage.setItem("codex_skip_landing", "true");
     });
 
     await page.goto("/");

--- a/apps/web/tests/guest-login-a11y.spec.ts
+++ b/apps/web/tests/guest-login-a11y.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Guest Login Modal Accessibility", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/guest-login-a11y.spec.ts
+++ b/apps/web/tests/guest-login-a11y.spec.ts
@@ -8,11 +8,6 @@ test.describe("Guest Login Modal Accessibility", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
 
       // Mock PeerJS connection to trigger the GuestLoginModal
       (window as any).Peer = class MockPeer {

--- a/apps/web/tests/guest-mode.spec.ts
+++ b/apps/web/tests/guest-mode.spec.ts
@@ -42,11 +42,6 @@ test.describe("Guest Mode (P2P Share)", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
 
       // Mock the PeerJS constructor and its methods
       (window as any).Peer = class MockPeer {

--- a/apps/web/tests/guest-mode.spec.ts
+++ b/apps/web/tests/guest-mode.spec.ts
@@ -37,8 +37,11 @@ test.describe("Guest Mode (P2P Share)", () => {
   test.beforeEach(async ({ page }) => {
     // Mock PeerJS connection in Playwright's browser context
     await page.addInitScript((data) => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/help-links.spec.ts
+++ b/apps/web/tests/help-links.spec.ts
@@ -12,11 +12,6 @@ test.describe("Direct Help Links", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
   });
 

--- a/apps/web/tests/help-links.spec.ts
+++ b/apps/web/tests/help-links.spec.ts
@@ -7,8 +7,11 @@ test.describe("Direct Help Links", () => {
 
     // Disable onboarding to access main UI
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/help-onboarding.spec.ts
+++ b/apps/web/tests/help-onboarding.spec.ts
@@ -2,12 +2,9 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Help Onboarding Walkthrough", () => {
   test.beforeEach(async ({ page }) => {
-    // Ensure clean state and force onboarding
-    await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = false;
-      (window as any).__E2E__ = true;
-    });
-
+    // This suite intentionally exercises the real onboarding tour, so it does
+    // NOT seed onboarding-complete state. It clears storage and force-starts the
+    // tour below.
     await page.goto("/");
     // Clear localStorage after initial load to reset state, but don't put it in initScript
     // so it doesn't clear on subsequent reloads within the same test.

--- a/apps/web/tests/help-system.spec.ts
+++ b/apps/web/tests/help-system.spec.ts
@@ -4,8 +4,11 @@ test.describe("Help Center System", () => {
   test.beforeEach(async ({ page }) => {
     // Disable onboarding to access main UI
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/help-system.spec.ts
+++ b/apps/web/tests/help-system.spec.ts
@@ -9,11 +9,6 @@ test.describe("Help Center System", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("/");
     await page.waitForFunction(() => (window as any).uiStore !== undefined);

--- a/apps/web/tests/image-gen.spec.ts
+++ b/apps/web/tests/image-gen.spec.ts
@@ -8,11 +8,6 @@ test.describe("Oracle Image Generation", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       // Suppress Oracle onboarding overlay
       try {
         localStorage.setItem("codex_oracle_onboarding_dismissed", "true");

--- a/apps/web/tests/image-gen.spec.ts
+++ b/apps/web/tests/image-gen.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Image Generation", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/import-progress.spec.ts
+++ b/apps/web/tests/import-progress.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Import Progress Management E2E", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/import-progress.spec.ts
+++ b/apps/web/tests/import-progress.spec.ts
@@ -8,11 +8,6 @@ test.describe("Import Progress Management E2E", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).DISABLE_ERROR_OVERLAY = true;
       // Mock the API key to allow import to proceed
       (window as any).__SHARED_GEMINI_KEY__ = "test-key-mock";

--- a/apps/web/tests/importer-e2e.spec.ts
+++ b/apps/web/tests/importer-e2e.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Intelligent Importer E2E", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/importer-e2e.spec.ts
+++ b/apps/web/tests/importer-e2e.spec.ts
@@ -9,11 +9,6 @@ test.describe("Intelligent Importer E2E", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       // Mock directory picker
       (window as any).showDirectoryPicker = async () => ({
         kind: "directory",

--- a/apps/web/tests/labels.spec.ts
+++ b/apps/web/tests/labels.spec.ts
@@ -8,7 +8,6 @@ test.describe("Entity Labeling System", () => {
       } catch {
         /* ignore */
       }
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),

--- a/apps/web/tests/labels.spec.ts
+++ b/apps/web/tests/labels.spec.ts
@@ -8,8 +8,11 @@ test.describe("Entity Labeling System", () => {
       } catch {
         /* ignore */
       }
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).showDirectoryPicker = async () => {
         console.log("PLAYWRIGHT_MOCK: showDirectoryPicker called");
         return {

--- a/apps/web/tests/map.spec.ts
+++ b/apps/web/tests/map.spec.ts
@@ -8,8 +8,11 @@ test.describe("Map Mode", () => {
     });
 
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
     });
 
     // Start with a clean demo

--- a/apps/web/tests/map.spec.ts
+++ b/apps/web/tests/map.spec.ts
@@ -175,21 +175,25 @@ test.describe("Map Mode", () => {
   });
 
   test("should allow deleting a map via Zen Mode", async ({ page }) => {
-    // Navigate to home and ensure vault is initialized
-    await page.goto("/?demo=fantasy");
+    // Use a real (non-demo) vault: map deletion is intentionally disabled in
+    // Demo Mode (mapRegistry.deleteMap early-returns), so seed a real entity.
+    await page.goto("/");
     await page.waitForFunction(
-      () => (window as any).vault?.isInitialized === true,
+      () =>
+        (window as any).vault?.status === "idle" &&
+        typeof (window as any).uiStore?.openZenMode === "function",
       { timeout: 20000 },
     );
 
-    // Select the first available entity and open Zen Mode programmatically directly to the map tab
-    await page.evaluate(() => {
-      const entities = (window as any).vault.entities;
-      const entityId = Object.keys(entities)[0];
-      if (entityId) {
-        (window as any).uiStore.openZenMode(entityId, "map");
-      }
-    });
+    // Create an entity and open Zen Mode directly on its map tab
+    const entityId = await page.evaluate(
+      async () =>
+        await (window as any).vault.createEntity("character", "Map Hero", {}),
+    );
+    await page.evaluate(
+      (id) => (window as any).uiStore.openZenMode(id, "map"),
+      entityId,
+    );
 
     // 1. Confirm that the map is empty initially for this character
     // Check if the modal itself is even there
@@ -212,9 +216,9 @@ test.describe("Map Mode", () => {
     const deleteBtn = page.getByRole("button", { name: "Delete map" });
     await expect(deleteBtn).toBeVisible({ timeout: 20000 });
 
-    // 5. Click delete and handle the confirm dialog
-    page.once("dialog", (dialog) => dialog.accept());
+    // 5. Click delete and confirm via the custom confirmation modal
     await deleteBtn.click();
+    await page.getByRole("button", { name: "Confirm" }).click();
 
     // 6. Verify the map was deleted and the upload button is back
     const uploadLabelFinal = page.locator('label:has-text("Upload Map")');

--- a/apps/web/tests/markdown-editor.spec.ts
+++ b/apps/web/tests/markdown-editor.spec.ts
@@ -2,7 +2,13 @@ import { expect, test } from "@playwright/test";
 
 test.describe("MarkdownEditor", () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => ((window as any).DISABLE_ONBOARDING = true));
+    await page.addInitScript(() => {
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
+    });
     await page.goto("/test/markdown-editor");
   });
 

--- a/apps/web/tests/minimap.spec.ts
+++ b/apps/web/tests/minimap.spec.ts
@@ -4,8 +4,11 @@ test.describe("Minimap Navigation", () => {
   test.beforeEach(async ({ page }) => {
     // 1. Mock initialization to ensure a consistent graph state
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/minimap.spec.ts
+++ b/apps/web/tests/minimap.spec.ts
@@ -9,11 +9,6 @@ test.describe("Minimap Navigation", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       const applyMocks = () => {
         if ((window as any).vault) {
           (window as any).vault.isAuthorized = true;

--- a/apps/web/tests/mobile-explorer-scrolling.spec.ts
+++ b/apps/web/tests/mobile-explorer-scrolling.spec.ts
@@ -6,8 +6,11 @@ test.describe("Mobile Explorer Scrolling", () => {
     await page.setViewportSize({ width: 375, height: 667 });
 
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/mobile-explorer-scrolling.spec.ts
+++ b/apps/web/tests/mobile-explorer-scrolling.spec.ts
@@ -11,11 +11,6 @@ test.describe("Mobile Explorer Scrolling", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/mobile-graph-zen.spec.ts
+++ b/apps/web/tests/mobile-graph-zen.spec.ts
@@ -6,8 +6,11 @@ test.describe("Mobile Graph Zen Mode", () => {
     await page.setViewportSize({ width: 375, height: 667 });
 
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       localStorage.setItem("codex_skip_landing", "true");
     });
 

--- a/apps/web/tests/mobile-graph-zen.spec.ts
+++ b/apps/web/tests/mobile-graph-zen.spec.ts
@@ -11,7 +11,6 @@ test.describe("Mobile Graph Zen Mode", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      localStorage.setItem("codex_skip_landing", "true");
     });
 
     await page.goto("/");

--- a/apps/web/tests/mobile-ux-009.spec.ts
+++ b/apps/web/tests/mobile-ux-009.spec.ts
@@ -14,11 +14,6 @@ test.describe("Mobile UX - 009 Feature Requirements", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       const files = [
         {
           name: "TestEntity.md",

--- a/apps/web/tests/mobile-ux-009.spec.ts
+++ b/apps/web/tests/mobile-ux-009.spec.ts
@@ -9,8 +9,11 @@ test.describe("Mobile UX - 009 Feature Requirements", () => {
   test.beforeEach(async ({ page }) => {
     // Mock File System Access API for vault
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/mobile-ux-fixes.spec.ts
+++ b/apps/web/tests/mobile-ux-fixes.spec.ts
@@ -9,11 +9,6 @@ test.describe("Mobile UX Fixes", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("/");
 

--- a/apps/web/tests/mobile-ux-fixes.spec.ts
+++ b/apps/web/tests/mobile-ux-fixes.spec.ts
@@ -4,8 +4,11 @@ test.describe("Mobile UX Fixes", () => {
   test.beforeEach(async ({ page }) => {
     // Mock init
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/node-merging.spec.ts
+++ b/apps/web/tests/node-merging.spec.ts
@@ -9,11 +9,6 @@ test.describe("Node Merging", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     if (process.env.PWDEBUG || process.env.DEBUG_E2E_LOGS) {
@@ -279,7 +274,6 @@ test.describe("Node Merging", () => {
 
           throw error;
         }
-        localStorage.setItem("codex_skip_landing", "true");
       });
       await page.reload();
       await page.waitForFunction(

--- a/apps/web/tests/node-merging.spec.ts
+++ b/apps/web/tests/node-merging.spec.ts
@@ -4,8 +4,11 @@ test.describe("Node Merging", () => {
   test.beforeEach(async ({ page }) => {
     // Disable onboarding to access main UI
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/node-read-mode.spec.ts
+++ b/apps/web/tests/node-read-mode.spec.ts
@@ -9,11 +9,6 @@ test.describe("Node Read Mode", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("http://localhost:5173/");
     // Wait for vault to be ready

--- a/apps/web/tests/node-read-mode.spec.ts
+++ b/apps/web/tests/node-read-mode.spec.ts
@@ -4,8 +4,11 @@ test.describe("Node Read Mode", () => {
   test.beforeEach(async ({ page }) => {
     // Disable onboarding to avoid popup interference
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/oracle-clear.spec.ts
+++ b/apps/web/tests/oracle-clear.spec.ts
@@ -8,11 +8,6 @@ test.describe("Oracle Clear Chat", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       window.confirm = () => true;
     });

--- a/apps/web/tests/oracle-clear.spec.ts
+++ b/apps/web/tests/oracle-clear.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Clear Chat", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/oracle-commands.spec.ts
+++ b/apps/web/tests/oracle-commands.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Chat Commands", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/oracle-commands.spec.ts
+++ b/apps/web/tests/oracle-commands.spec.ts
@@ -8,11 +8,6 @@ test.describe("Oracle Chat Commands", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("http://localhost:5173/");
 

--- a/apps/web/tests/oracle-image-save.spec.ts
+++ b/apps/web/tests/oracle-image-save.spec.ts
@@ -9,11 +9,6 @@ test.describe("Oracle Image Save to Entity", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/oracle-image-save.spec.ts
+++ b/apps/web/tests/oracle-image-save.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Image Save to Entity", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/oracle-merge.spec.ts
+++ b/apps/web/tests/oracle-merge.spec.ts
@@ -6,8 +6,11 @@ test.describe("Oracle Merge Command E2E", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
 
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/oracle-merge.spec.ts
+++ b/apps/web/tests/oracle-merge.spec.ts
@@ -13,7 +13,6 @@ test.describe("Oracle Merge Command E2E", () => {
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
-        localStorage.setItem("codex_skip_landing", "true");
         localStorage.setItem("oracle-hint-seen", "true");
       } catch {
         /* ignore */

--- a/apps/web/tests/oracle-parsing.spec.ts
+++ b/apps/web/tests/oracle-parsing.spec.ts
@@ -10,7 +10,6 @@ test.describe("Oracle Response Parsing & Smart Apply", () => {
       );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
-        localStorage.setItem("codex_skip_landing", "true");
         localStorage.setItem("oracle-hint-seen", "true");
       } catch {
         /* ignore */

--- a/apps/web/tests/oracle-parsing.spec.ts
+++ b/apps/web/tests/oracle-parsing.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Response Parsing & Smart Apply", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
       try {
         localStorage.setItem("codex_skip_landing", "true");

--- a/apps/web/tests/oracle-refinement.spec.ts
+++ b/apps/web/tests/oracle-refinement.spec.ts
@@ -10,11 +10,6 @@ test.describe("Oracle UI Refinement", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).__SHARED_GEMINI_KEY__ = "fake-shared-key";
       // Mock window.showDirectoryPicker
       // @ts-expect-error - Mock browser API

--- a/apps/web/tests/oracle-refinement.spec.ts
+++ b/apps/web/tests/oracle-refinement.spec.ts
@@ -5,8 +5,11 @@ test.describe("Oracle UI Refinement", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/oracle-sidebar.spec.ts
+++ b/apps/web/tests/oracle-sidebar.spec.ts
@@ -9,7 +9,6 @@ test.describe("Oracle Sidebar", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       try {
-        localStorage.setItem("codex_skip_landing", "true");
         localStorage.setItem("oracle-hint-seen", "true");
       } catch {
         /* ignore */

--- a/apps/web/tests/oracle-sidebar.spec.ts
+++ b/apps/web/tests/oracle-sidebar.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Sidebar", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
         localStorage.setItem("oracle-hint-seen", "true");

--- a/apps/web/tests/oracle-ui.spec.ts
+++ b/apps/web/tests/oracle-ui.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle UI - Elastic Input", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/oracle-ui.spec.ts
+++ b/apps/web/tests/oracle-ui.spec.ts
@@ -8,11 +8,6 @@ test.describe("Oracle UI - Elastic Input", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
     });
     await page.goto("http://localhost:5173/");

--- a/apps/web/tests/oracle-undo.spec.ts
+++ b/apps/web/tests/oracle-undo.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Undo", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).__E2E__ = true;
-      (window as any).DISABLE_ONBOARDING = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
         localStorage.setItem("oracle-hint-seen", "true");

--- a/apps/web/tests/oracle-undo.spec.ts
+++ b/apps/web/tests/oracle-undo.spec.ts
@@ -9,7 +9,6 @@ test.describe("Oracle Undo", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       try {
-        localStorage.setItem("codex_skip_landing", "true");
         localStorage.setItem("oracle-hint-seen", "true");
       } catch {
         /* ignore */

--- a/apps/web/tests/oracle-wizard.spec.ts
+++ b/apps/web/tests/oracle-wizard.spec.ts
@@ -8,11 +8,6 @@ test.describe("Oracle Connection Wizard", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).__SHARED_GEMINI_KEY__ = "fake-key";
     });
     await page.goto("http://localhost:5173/");

--- a/apps/web/tests/oracle-wizard.spec.ts
+++ b/apps/web/tests/oracle-wizard.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Oracle Connection Wizard", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/orbit.spec.ts
+++ b/apps/web/tests/orbit.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Orbit Layout", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/orbit.spec.ts
+++ b/apps/web/tests/orbit.spec.ts
@@ -8,11 +8,6 @@ test.describe("Orbit Layout", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
   });
 

--- a/apps/web/tests/p2p-image-sync.spec.ts
+++ b/apps/web/tests/p2p-image-sync.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("P2P Image Sync", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/p2p-image-sync.spec.ts
+++ b/apps/web/tests/p2p-image-sync.spec.ts
@@ -8,11 +8,6 @@ test.describe("P2P Image Sync", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
 
       // Mock Peer
       (window as any).Peer = class MockPeer {

--- a/apps/web/tests/proposer-e2e.spec.ts
+++ b/apps/web/tests/proposer-e2e.spec.ts
@@ -54,11 +54,6 @@ test.describe("Connections Proposer E2E", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       (window as any).__SHARED_GEMINI_KEY__ = "mock-api-key";
     });
 

--- a/apps/web/tests/proposer-e2e.spec.ts
+++ b/apps/web/tests/proposer-e2e.spec.ts
@@ -49,8 +49,11 @@ test.describe("Connections Proposer E2E", () => {
     });
 
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/rich-text.spec.ts
+++ b/apps/web/tests/rich-text.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Rich Text Editor", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/rich-text.spec.ts
+++ b/apps/web/tests/rich-text.spec.ts
@@ -8,11 +8,6 @@ test.describe("Rich Text Editor", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
   });
 

--- a/apps/web/tests/search.spec.ts
+++ b/apps/web/tests/search.spec.ts
@@ -2,7 +2,13 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Fuzzy Search", () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => ((window as any).DISABLE_ONBOARDING = true));
+    await page.addInitScript(() => {
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
+    });
     // Mock File System Access API and IndexedDB
     await page.addInitScript(() => {
       // Intercept IndexedDB to handle DataCloneError with mock handles

--- a/apps/web/tests/selection-connector.spec.ts
+++ b/apps/web/tests/selection-connector.spec.ts
@@ -5,8 +5,11 @@ test.describe("Selection Connector", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {
@@ -123,8 +126,11 @@ test.describe("Selection Connector", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/selection-connector.spec.ts
+++ b/apps/web/tests/selection-connector.spec.ts
@@ -10,11 +10,6 @@ test.describe("Selection Connector", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");
@@ -126,16 +121,10 @@ test.describe("Selection Connector", () => {
     page,
   }) => {
     await page.addInitScript(() => {
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
       try {
         localStorage.setItem("codex_last_connection_label", "Old Friend");
       } catch {

--- a/apps/web/tests/settings.spec.ts
+++ b/apps/web/tests/settings.spec.ts
@@ -3,7 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Settings Modal", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         (window as any).localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/settings.spec.ts
+++ b/apps/web/tests/settings.spec.ts
@@ -3,7 +3,6 @@ import { test, expect } from "@playwright/test";
 test.describe("Settings Modal", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),

--- a/apps/web/tests/staging-indicator.spec.ts
+++ b/apps/web/tests/staging-indicator.spec.ts
@@ -2,10 +2,6 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Staging Indicator", () => {
   test.beforeEach(async ({ page }) => {
-    // Enable E2E access to uiStore
-    await page.addInitScript(() => {
-      (window as any).__E2E__ = true;
-    });
     await page.goto("/");
     await page.waitForFunction(() => (window as any).uiStore !== undefined);
   });

--- a/apps/web/tests/sync-directional.spec.ts
+++ b/apps/web/tests/sync-directional.spec.ts
@@ -8,11 +8,6 @@ test.describe("Directional Vault Sync UI", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     await page.goto("/");

--- a/apps/web/tests/sync-directional.spec.ts
+++ b/apps/web/tests/sync-directional.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Directional Vault Sync UI", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/sync-reminder.spec.ts
+++ b/apps/web/tests/sync-reminder.spec.ts
@@ -8,8 +8,11 @@ test.describe("Sync Reminder System", () => {
       } catch {
         /* ignore */
       }
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
     });
 
     await page.goto("/");

--- a/apps/web/tests/sync-reminder.spec.ts
+++ b/apps/web/tests/sync-reminder.spec.ts
@@ -8,7 +8,6 @@ test.describe("Sync Reminder System", () => {
       } catch {
         /* ignore */
       }
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),

--- a/apps/web/tests/test-helpers.ts
+++ b/apps/web/tests/test-helpers.ts
@@ -1,16 +1,29 @@
 import { expect, type Page } from "@playwright/test";
 
+/**
+ * Seed real onboarding-complete state so tours/demo/landing don't auto-trigger.
+ * Replaces the former `window.DISABLE_ONBOARDING` / `window.__E2E__` test globals
+ * by writing the same persisted keys the app reads on boot:
+ *  - codex_skip_landing -> onboarding store skips the landing page (so it boots)
+ *  - codex-cryptica-help-state -> help store marks the onboarding tour as seen,
+ *    which suppresses the auto tour/demo trigger
+ * Pass to `page.addInitScript` so it runs before the app boots on every navigation.
+ */
+export function seedOnboardingComplete() {
+  try {
+    localStorage.setItem("codex_skip_landing", "true");
+    localStorage.setItem(
+      "codex-cryptica-help-state",
+      JSON.stringify({ completedTours: ["initial-onboarding"] }),
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
 /** Shared setup for vault E2E tests */
 export async function setupVaultPage(page: Page) {
-  await page.addInitScript(() => {
-    (window as any).DISABLE_ONBOARDING = true;
-    (window as any).__E2E__ = true;
-    try {
-      localStorage.setItem("codex_skip_landing", "true");
-    } catch {
-      /* ignore */
-    }
-  });
+  await page.addInitScript(seedOnboardingComplete);
 
   await page.goto("/");
   // Wait for vault initialization (OPFS auto-load)

--- a/apps/web/tests/theme-persistence.spec.ts
+++ b/apps/web/tests/theme-persistence.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Campaign-Specific Theme Persistence", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/theme-persistence.spec.ts
+++ b/apps/web/tests/theme-persistence.spec.ts
@@ -8,11 +8,6 @@ test.describe("Campaign-Specific Theme Persistence", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
 
     if (process.env.PW_DEBUG_CONSOLE === "1") {

--- a/apps/web/tests/themes.spec.ts
+++ b/apps/web/tests/themes.spec.ts
@@ -3,11 +3,12 @@ import { test, expect } from "@playwright/test";
 test.describe("Visual Styling Templates", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
       try {
         localStorage.setItem("codex_skip_landing", "true");
-        localStorage.setItem("codex_dismissed_landing", "true");
+        localStorage.setItem(
+          "codex-cryptica-help-state",
+          JSON.stringify({ completedTours: ["initial-onboarding"] }),
+        );
         localStorage.setItem(
           "codex_world_page_dismissed_at",
           Date.now().toString(),
@@ -158,13 +159,9 @@ test.describe("Visual Styling Templates", () => {
   });
 
   test("Welcome page uses theme-aware styling", async ({ page }) => {
-    // 1. Ensure we are on the landing page (reload to reset dismissed state if needed, though beforeEach handles visiting /)
-    // The beforeEach disables onboarding but doesn't explicitly dismiss the landing page, so it should be visible if not skipped.
-    // However, our beforeEach sets DISABLE_ONBOARDING = true. Let's check if that affects the landing page.
-    // Looking at +page.svelte: !isGuestMode && uiStore.isLandingPageVisible
-    // uiStore.isLandingPageVisible depends on skipWelcomeScreen and dismissedLandingPage.
-    // We need to ensure we haven't set 'codex_skip_landing' in localStorage.
-
+    // The beforeEach seeds codex_skip_landing/dismissed_landing to hide the
+    // landing page. This test needs it visible, so override those keys to false
+    // and reload before asserting on the landing layer.
     await page.addInitScript(() => {
       try {
         localStorage.setItem("codex_skip_landing", "false");

--- a/apps/web/tests/timeline-a11y.spec.ts
+++ b/apps/web/tests/timeline-a11y.spec.ts
@@ -3,9 +3,12 @@ import { test, expect } from "@playwright/test";
 test.describe("Timeline Accessibility", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).DISABLE_ERROR_OVERLAY = true;
-      (window as any).__E2E__ = true;
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/timeline-a11y.spec.ts
+++ b/apps/web/tests/timeline-a11y.spec.ts
@@ -9,11 +9,6 @@ test.describe("Timeline Accessibility", () => {
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
       (window as any).DISABLE_ERROR_OVERLAY = true;
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
 
       // Mock IDB to prevent errors
       const originalPut = IDBObjectStore.prototype.put;

--- a/apps/web/tests/timeline.spec.ts
+++ b/apps/web/tests/timeline.spec.ts
@@ -8,11 +8,6 @@ test.describe("World Timeline - Graph Integration", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
 
       // Mock IDB to prevent errors
       const originalPut = IDBObjectStore.prototype.put;

--- a/apps/web/tests/timeline.spec.ts
+++ b/apps/web/tests/timeline.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("World Timeline - Graph Integration", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/vault-controls-sync.spec.ts
+++ b/apps/web/tests/vault-controls-sync.spec.ts
@@ -3,7 +3,13 @@ import { test, expect } from "@playwright/test";
 test.describe("Vault Controls Sync Button", () => {
   test.beforeEach(async ({ page }) => {
     // Basic setup to ensure we're on a page with VaultControls
-    await page.addInitScript(() => ((window as any).DISABLE_ONBOARDING = true));
+    await page.addInitScript(() => {
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
+    });
 
     // Start a demo to ensure we have a populated vault and VaultControls are visible
     // Using URL param is more reliable than evaluating window.demoService

--- a/apps/web/tests/vault-delete.spec.ts
+++ b/apps/web/tests/vault-delete.spec.ts
@@ -3,7 +3,6 @@ import { test, expect } from "@playwright/test";
 test.describe("Vault Node Deletion", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      localStorage.setItem("codex_skip_landing", "true");
       localStorage.setItem(
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),

--- a/apps/web/tests/vault-delete.spec.ts
+++ b/apps/web/tests/vault-delete.spec.ts
@@ -3,7 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Vault Node Deletion", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         (window as any).localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/vault-import.spec.ts
+++ b/apps/web/tests/vault-import.spec.ts
@@ -4,8 +4,11 @@ test.describe("Vault Import E2E", () => {
   test.beforeEach(async ({ page }) => {
     // Mock the File System Access API
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/vault-import.spec.ts
+++ b/apps/web/tests/vault-import.spec.ts
@@ -9,11 +9,6 @@ test.describe("Vault Import E2E", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
 
       // Mock directory structure
       const mockFiles = [

--- a/apps/web/tests/vault-management.spec.ts
+++ b/apps/web/tests/vault-management.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Vault Management", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/vault-management.spec.ts
+++ b/apps/web/tests/vault-management.spec.ts
@@ -8,11 +8,6 @@ test.describe("Vault Management", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("/");
     await expect(page.getByTestId("graph-canvas")).toBeVisible({

--- a/apps/web/tests/vault-switch.spec.ts
+++ b/apps/web/tests/vault-switch.spec.ts
@@ -8,11 +8,6 @@ test.describe("Vault Switching", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     // Add page error listener
     page.on("pageerror", (err) => console.log(`PAGE ERROR: ${err.message}`));

--- a/apps/web/tests/vault-switch.spec.ts
+++ b/apps/web/tests/vault-switch.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Vault Switching", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/vault-switcher-a11y.spec.ts
+++ b/apps/web/tests/vault-switcher-a11y.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Vault Switching Accessibility", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       try {
         localStorage.setItem("codex_skip_landing", "true");
       } catch {

--- a/apps/web/tests/vault-switcher-a11y.spec.ts
+++ b/apps/web/tests/vault-switcher-a11y.spec.ts
@@ -8,11 +8,6 @@ test.describe("Vault Switching Accessibility", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      try {
-        localStorage.setItem("codex_skip_landing", "true");
-      } catch {
-        /* ignore */
-      }
     });
     await page.goto("/");
     await page.waitForFunction(() => (window as any).vault?.status === "idle");

--- a/apps/web/tests/zen-mode-labels.spec.ts
+++ b/apps/web/tests/zen-mode-labels.spec.ts
@@ -8,7 +8,6 @@ test.describe("Zen Mode Label Management", () => {
         "codex-cryptica-help-state",
         JSON.stringify({ completedTours: ["initial-onboarding"] }),
       );
-      localStorage.setItem("codex_skip_landing", "true");
     });
 
     await page.goto("/");

--- a/apps/web/tests/zen-mode-labels.spec.ts
+++ b/apps/web/tests/zen-mode-labels.spec.ts
@@ -3,8 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Zen Mode Label Management", () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       localStorage.setItem("codex_skip_landing", "true");
     });
 

--- a/scripts/blog-screenshots/README.md
+++ b/scripts/blog-screenshots/README.md
@@ -67,12 +67,14 @@ test.describe("Blog Screenshots: <Your Blog Title>", () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    // Skip onboarding and set up clean state
+    // Skip onboarding and set up clean state via real persisted state
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
       (window as any).__SHARED_GEMINI_KEY__ = "fake-test-key";
       localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
     });
     await page.goto("http://localhost:5173/");
 

--- a/scripts/blog-screenshots/front-page.spec.ts
+++ b/scripts/blog-screenshots/front-page.spec.ts
@@ -124,8 +124,10 @@ The frontier city of Valdris balances on a cracked moonlit coast, where treaty h
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-test-key";
       localStorage.setItem("codex_skip_landing", "true");
       localStorage.removeItem("codex_active_vault_id");

--- a/scripts/blog-screenshots/how-import-works.spec.ts
+++ b/scripts/blog-screenshots/how-import-works.spec.ts
@@ -13,8 +13,10 @@ test.describe("Blog Screenshots: How Import Works", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).DISABLE_ERROR_OVERLAY = true;
       (window as any).importQueue = { activeItemChunks: {} };
       localStorage.setItem("codex_skip_landing", "true");

--- a/scripts/blog-screenshots/oracle-capabilities.spec.ts
+++ b/scripts/blog-screenshots/oracle-capabilities.spec.ts
@@ -17,8 +17,10 @@ test.describe("Blog Screenshots: Oracle Capabilities", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      (window as any).DISABLE_ONBOARDING = true;
-      (window as any).__E2E__ = true;
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
       (window as any).__SHARED_GEMINI_KEY__ = "fake-test-key";
       localStorage.setItem("codex_skip_landing", "true");
     });


### PR DESCRIPTION
Closes #1169.

## What

Removes all production-code branching on the test-only globals `window.__E2E__`
and `window.DISABLE_ONBOARDING`. Test-harness behavior now lives in the Playwright
helpers as real, production-neutral state.

## Why

Production code branching on E2E globals makes runtime behavior harder to reason
about and risks test assumptions leaking into the app.

## Production changes (15 files)

- **13 `import.meta.env.DEV || __E2E__` debug/exposure gates** → `import.meta.env.DEV`.
  Playwright runs against the Vite **dev server**, so `DEV` is already `true`
  during E2E — this is behavior-neutral.
- **`map-registry`**: demo-mode delete guard no longer has an `__E2E__` escape hatch.
- **5 `DISABLE_ONBOARDING` checks** removed (tour/demo autostart, tour overlay,
  oracle hint, layout boot). The app now relies on its real onboarding state.

## Test changes

- New `seedOnboardingComplete()` in `tests/test-helpers.ts` seeds real persisted
  state (`codex_skip_landing` + marking the onboarding tour seen via
  `codex-cryptica-help-state`).
- ~80 specs migrated off inline `__E2E__` / `DISABLE_ONBOARDING` assignments to
  the real-state seeding. `help-onboarding.spec.ts` (exercises the real tour) and
  `themes.spec.ts` (needs the landing page visible) handled individually.

## Acceptance criteria

- [x] No production source file branches on `__E2E__` / `DISABLE_ONBOARDING`
      (`rg` over `src/` is clean; only a doc comment in test-helpers mentions them).
- [x] E2E setup still works via Playwright helpers.
- [x] Test-only markers confined to `tests/`.

## Verification

- `svelte-check`: 0 errors · `eslint`: clean · unit tests: 27 passed.
- E2E behavior-sensitive subset matches the `staging` baseline exactly — the
  repo's pre-existing E2E failures (vault-delete, oracle-sidebar, minimap, map,
  graph context-menus, etc.) are unchanged; **no new failures** introduced
  (each confirmed by stashing and re-running on baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)