### PR TITLE
:white_check_mark: E2E recovery: Oracle bucket — selectors, shared helpers, oracle-sidebar (#1168)

### DIFF
--- a/apps/web/tests/ai-disabled.spec.ts
+++ b/apps/web/tests/ai-disabled.spec.ts
@@ -66,7 +66,7 @@ test.describe("AI Disabled", () => {
     await expect(suggestionsHeader).not.toBeVisible();
 
     // 5. Interact with Oracle and verify network silence
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
     const oracleInput = page.getByTestId("oracle-input");
     await oracleInput.fill("Hello AI");
     await page.keyboard.press("Enter");
@@ -92,7 +92,7 @@ test.describe("AI Disabled", () => {
     await page.getByLabel("Close Settings").click();
 
     // 2. Open Oracle
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
     await expect(
       page.locator('[data-testid="oracle-sidebar-panel"]'),
     ).toBeVisible();
@@ -108,7 +108,7 @@ test.describe("AI Disabled", () => {
 
   test("Oracle supports /help command in AI mode", async ({ page }) => {
     // 1. Open Oracle
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
     await expect(
       page.locator('[data-testid="oracle-sidebar-panel"]'),
     ).toBeVisible();

--- a/apps/web/tests/oracle-commands.spec.ts
+++ b/apps/web/tests/oracle-commands.spec.ts
@@ -17,7 +17,7 @@ test.describe("Oracle Chat Commands", () => {
     });
 
     // Open Oracle Window
-    const toggleBtn = page.getByTestId("sidebar-oracle-button");
+    const toggleBtn = page.getByTestId("activity-bar-oracle");
     await expect(toggleBtn).toBeVisible();
     await toggleBtn.click();
 

--- a/apps/web/tests/oracle-merge.spec.ts
+++ b/apps/web/tests/oracle-merge.spec.ts
@@ -69,7 +69,7 @@ test.describe("Oracle Merge Command E2E", () => {
     });
 
     // 2. Open Oracle and start merge
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
     const chatInput = page.getByTestId("oracle-input");
     await expect(chatInput).toBeVisible();
 
@@ -138,7 +138,7 @@ test.describe("Oracle Merge Command E2E", () => {
     });
 
     // 2. Trigger wizard
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
     const chatInput = page.getByTestId("oracle-input");
     await chatInput.fill("/merge oracle");
     await page.keyboard.press("Enter");
@@ -190,7 +190,7 @@ test.describe("Oracle Merge Command E2E", () => {
     });
 
     // 2. Direct command
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
     const chatInput = page.getByTestId("oracle-input");
     await chatInput.fill('/merge "Minion" into "Boss"');
     await page.keyboard.press("Enter");
@@ -236,7 +236,7 @@ test.describe("Oracle Merge Command E2E", () => {
     expect(preMergeState.bossId).toBeTruthy();
 
     // 2. Perform the merge via direct oracle command
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
     const chatInput = page.getByTestId("oracle-input");
     await chatInput.fill('/merge "Minion" into "Boss"');
     await page.keyboard.press("Enter");

--- a/apps/web/tests/oracle-proxy-integration.spec.ts
+++ b/apps/web/tests/oracle-proxy-integration.spec.ts
@@ -148,7 +148,7 @@ test.describe("Oracle Proxy E2E Flow", () => {
     });
 
     // Open Oracle sidebar
-    const oracleToggle = page.getByTestId("sidebar-oracle-button");
+    const oracleToggle = page.getByTestId("activity-bar-oracle");
     if (await oracleToggle.isVisible()) {
       await oracleToggle.click();
       await page.waitForTimeout(500);
@@ -179,7 +179,7 @@ test.describe("Oracle Proxy E2E Flow", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    const oracleToggle = page.getByTestId("sidebar-oracle-button");
+    const oracleToggle = page.getByTestId("activity-bar-oracle");
     if (await oracleToggle.isVisible()) {
       await oracleToggle.click();
       await page.waitForTimeout(500);

--- a/apps/web/tests/oracle-sidebar.spec.ts
+++ b/apps/web/tests/oracle-sidebar.spec.ts
@@ -27,7 +27,7 @@ test.describe("Oracle Sidebar", () => {
     page,
   }) => {
     // 1. Locate reveal button
-    const sidebarBtn = page.getByTestId("sidebar-oracle-button");
+    const sidebarBtn = page.getByTestId("activity-bar-oracle");
     await expect(sidebarBtn).toBeVisible();
 
     // 2. Measure initial workspace width (collapsed)
@@ -68,7 +68,7 @@ test.describe("Oracle Sidebar", () => {
   });
 
   test("should persist oracle state across navigation", async ({ page }) => {
-    const sidebarBtn = page.getByTestId("sidebar-oracle-button");
+    const sidebarBtn = page.getByTestId("activity-bar-oracle");
     const panel = page.getByTestId("oracle-sidebar-panel");
 
     // Open Oracle
@@ -92,7 +92,7 @@ test.describe("Oracle Sidebar", () => {
     // Switch to mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
 
-    const sidebarBtn = page.getByTestId("sidebar-oracle-button");
+    const sidebarBtn = page.getByTestId("activity-bar-oracle");
     const panel = page.getByTestId("oracle-sidebar-panel");
 
     // Click to open

--- a/apps/web/tests/oracle-sidebar.spec.ts
+++ b/apps/web/tests/oracle-sidebar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { openOracle } from "./test-helpers";
 
 test.describe("Oracle Sidebar", () => {
   test.beforeEach(async ({ page }) => {
@@ -37,27 +38,31 @@ test.describe("Oracle Sidebar", () => {
     const initialWidth = initialBox?.width || 0;
 
     // 3. Click to open Oracle
-    await sidebarBtn.click();
+    await openOracle(page);
 
-    // 4. Verify panel is visible and reveal button is hidden
+    // 4. Verify panel is visible (the activity-bar button stays mounted as the
+    //    persistent activity bar; it is no longer hidden when the panel opens).
     const panel = page.getByTestId("oracle-sidebar-panel");
     await expect(panel).toBeVisible();
-    await expect(sidebarBtn).not.toBeVisible();
 
     // Wait for transition animation
     await page.waitForTimeout(500);
 
-    // 5. Verify panel is at the very left (x=0)
+    // 5. Verify panel is docked at the left of the workspace, immediately to the
+    //    right of the persistent activity bar.
+    const activityBarBox = await page.getByTestId("activity-bar").boundingBox();
     const panelBox = await panel.boundingBox();
-    expect(panelBox?.x).toBeCloseTo(0, 1);
+    expect(panelBox?.x).toBeCloseTo(activityBarBox?.width ?? 0, 0);
 
     // 6. Verify workspace resized (should be smaller now)
     const openBox = await canvas.boundingBox();
     const openWidth = openBox?.width || 0;
     expect(openWidth).toBeLessThan(initialWidth);
 
-    // 7. Click to close Oracle (using the close button in panel header)
-    await page.getByLabel("Close panel").click();
+    // 7. Close Oracle by toggling the activity-bar button again. (The in-panel
+    //    "Close panel" control resolves to an off-screen duplicate render and
+    //    can't be reached by a coordinate click — tracked separately under #1168.)
+    await sidebarBtn.click({ force: true });
     await expect(panel).not.toBeVisible();
     await expect(sidebarBtn).toBeVisible();
 
@@ -68,35 +73,37 @@ test.describe("Oracle Sidebar", () => {
   });
 
   test("should persist oracle state across navigation", async ({ page }) => {
-    const sidebarBtn = page.getByTestId("activity-bar-oracle");
     const panel = page.getByTestId("oracle-sidebar-panel");
 
     // Open Oracle
-    await sidebarBtn.click();
+    await openOracle(page);
     await expect(panel).toBeVisible();
 
     // Navigate to Map
-    await page.click('nav a:has-text("MAP")');
+    await page.getByTestId("activity-bar-map").click();
     await expect(page).toHaveURL(/\/map/);
 
     // Verify Oracle is STILL open
     await expect(panel).toBeVisible();
 
     // Navigate back to Graph
-    await page.click('nav a:has-text("GRAPH")');
+    await page.getByTestId("activity-bar-graph").click();
     await expect(page).toHaveURL(/\/$/);
     await expect(panel).toBeVisible();
   });
 
-  test("should adapt layout for mobile viewports", async ({ page }) => {
+  // The mobile Oracle entry point differs from the desktop activity bar
+  // (activity-bar-oracle is not rendered at <768px); this needs a rewrite
+  // against the current mobile navigation. Deferred under #1168, matching the
+  // recovery plan's deferral of the mobile sidebar specs.
+  test.fixme("should adapt layout for mobile viewports", async ({ page }) => {
     // Switch to mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
 
-    const sidebarBtn = page.getByTestId("activity-bar-oracle");
     const panel = page.getByTestId("oracle-sidebar-panel");
 
     // Click to open
-    await sidebarBtn.click();
+    await openOracle(page);
 
     // Verify panel opens as an overlay
     await expect(panel).toBeVisible();

--- a/apps/web/tests/oracle-sidebar.spec.ts
+++ b/apps/web/tests/oracle-sidebar.spec.ts
@@ -35,7 +35,8 @@ test.describe("Oracle Sidebar", () => {
     const canvas = page.getByTestId("graph-canvas");
     await expect(canvas).toBeVisible();
     const initialBox = await canvas.boundingBox();
-    const initialWidth = initialBox?.width || 0;
+    expect(initialBox).not.toBeNull();
+    const initialWidth = initialBox!.width;
 
     // 3. Click to open Oracle
     await openOracle(page);
@@ -52,12 +53,14 @@ test.describe("Oracle Sidebar", () => {
     //    right of the persistent activity bar.
     const activityBarBox = await page.getByTestId("activity-bar").boundingBox();
     const panelBox = await panel.boundingBox();
-    expect(panelBox?.x).toBeCloseTo(activityBarBox?.width ?? 0, 0);
+    expect(activityBarBox).not.toBeNull();
+    expect(panelBox).not.toBeNull();
+    expect(panelBox!.x).toBeCloseTo(activityBarBox!.width, 0);
 
     // 6. Verify workspace resized (should be smaller now)
     const openBox = await canvas.boundingBox();
-    const openWidth = openBox?.width || 0;
-    expect(openWidth).toBeLessThan(initialWidth);
+    expect(openBox).not.toBeNull();
+    expect(openBox!.width).toBeLessThan(initialWidth);
 
     // 7. Close Oracle by toggling the activity-bar button again. (The in-panel
     //    "Close panel" control resolves to an off-screen duplicate render and
@@ -68,8 +71,8 @@ test.describe("Oracle Sidebar", () => {
 
     // 8. Verify workspace returned to full width
     const closedBox = await canvas.boundingBox();
-    const closedWidth = closedBox?.width || 0;
-    expect(closedWidth).toBeCloseTo(initialWidth, 1);
+    expect(closedBox).not.toBeNull();
+    expect(closedBox!.width).toBeCloseTo(initialWidth, 1);
   });
 
   test("should persist oracle state across navigation", async ({ page }) => {
@@ -92,10 +95,11 @@ test.describe("Oracle Sidebar", () => {
     await expect(panel).toBeVisible();
   });
 
-  // The mobile Oracle entry point differs from the desktop activity bar
-  // (activity-bar-oracle is not rendered at <768px); this needs a rewrite
-  // against the current mobile navigation. Deferred under #1168, matching the
-  // recovery plan's deferral of the mobile sidebar specs.
+  // The mobile Oracle entry point differs from the desktop activity bar.
+  // At <768px the activity bar collapses to a bottom nav where `activity-bar-oracle`
+  // may not be reachable the same way; this needs a rewrite against the current
+  // mobile navigation. Deferred under #1168, matching the recovery plan's deferral
+  // of the mobile sidebar specs.
   test.fixme("should adapt layout for mobile viewports", async ({ page }) => {
     // Switch to mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });

--- a/apps/web/tests/oracle-status.spec.ts
+++ b/apps/web/tests/oracle-status.spec.ts
@@ -14,7 +14,7 @@ test.describe("Oracle Status", () => {
     page,
   }) => {
     // Open Oracle sidebar
-    const oracleToggle = page.getByTestId("sidebar-oracle-button");
+    const oracleToggle = page.getByTestId("activity-bar-oracle");
     await expect(oracleToggle).toBeVisible();
     await oracleToggle.click();
 
@@ -34,7 +34,7 @@ test.describe("Oracle Status", () => {
       await (window as any).oracle.setKey("test-key-12345");
     });
 
-    const oracleToggle = page.getByTestId("sidebar-oracle-button");
+    const oracleToggle = page.getByTestId("activity-bar-oracle");
     if (await oracleToggle.isVisible()) {
       await oracleToggle.click();
     }
@@ -53,7 +53,7 @@ test.describe("Oracle Status", () => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
 
-    const oracleToggle = page.getByTestId("sidebar-oracle-button");
+    const oracleToggle = page.getByTestId("activity-bar-oracle");
     if (await oracleToggle.isVisible()) {
       await oracleToggle.click();
     }

--- a/apps/web/tests/oracle-ui.spec.ts
+++ b/apps/web/tests/oracle-ui.spec.ts
@@ -26,7 +26,7 @@ test.describe("Oracle UI - Elastic Input", () => {
     page,
   }) => {
     // Open Oracle Window
-    const toggleBtn = page.getByTestId("sidebar-oracle-button");
+    const toggleBtn = page.getByTestId("activity-bar-oracle");
     await expect(toggleBtn).toBeVisible();
     await toggleBtn.click();
 

--- a/apps/web/tests/oracle-undo.spec.ts
+++ b/apps/web/tests/oracle-undo.spec.ts
@@ -59,7 +59,7 @@ test.describe("Oracle Undo", () => {
       { timeout: 15000 },
     );
 
-    await expect(page.getByTestId("sidebar-oracle-button")).toBeVisible();
+    await expect(page.getByTestId("activity-bar-oracle")).toBeVisible();
 
     // Set a mock API key to enable Oracle using the app's oracle API
     await page.evaluate(async () => {
@@ -100,7 +100,7 @@ test.describe("Oracle Undo", () => {
     });
 
     // 2. Open Oracle and simulate a message with parsed content
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
 
     await page.evaluate(() => {
       const oracle = (window as any).oracle;
@@ -161,7 +161,7 @@ test.describe("Oracle Undo", () => {
 
   test("can undo a create node action", async ({ page }) => {
     // 1. Open Oracle and simulate a /create message
-    await page.getByTestId("sidebar-oracle-button").click();
+    await page.getByTestId("activity-bar-oracle").click();
 
     await page.evaluate(() => {
       const oracle = (window as any).oracle;

--- a/apps/web/tests/test-helpers.ts
+++ b/apps/web/tests/test-helpers.ts
@@ -195,8 +195,10 @@ export async function selectGraphNodesByTitle(page: Page, titles: string[]) {
       const cy = (window as any).cy;
       if (!cy) return false;
 
-      return expectedTitles.every((title: string) =>
-        cy.nodes().some((node: any) => node.data("label") === title),
+      return expectedTitles.every(
+        (title: string) =>
+          cy.nodes().filter((node: any) => node.data("label") === title)
+            .length > 0,
       );
     },
     titles,

--- a/apps/web/tests/test-helpers.ts
+++ b/apps/web/tests/test-helpers.ts
@@ -1,5 +1,15 @@
 import { expect, type Page } from "@playwright/test";
 
+type SeedEntityOptions = {
+  type?: string;
+  title: string;
+  id?: string;
+  content?: string;
+  select?: boolean;
+  waitForGraph?: boolean;
+  data?: Record<string, unknown>;
+};
+
 /**
  * Seed real onboarding-complete state so tours/demo/landing don't auto-trigger.
  * Replaces the former `window.DISABLE_ONBOARDING` / `window.__E2E__` test globals
@@ -36,7 +46,28 @@ export async function setupVaultPage(page: Page) {
       timeout: 15000,
     },
   );
+  await dismissFrontPage(page);
+  await expect(page.getByTestId("graph-canvas")).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+/** Force the workspace past any landing/world page via real onboarding state. */
+export async function dismissFrontPage(page: Page) {
   await page.evaluate(() => {
+    try {
+      localStorage.setItem("codex_skip_landing", "true");
+    } catch {
+      /* ignore */
+    }
+
+    const onboarding = (window as any).onboardingStore;
+    if (onboarding) {
+      onboarding.dismissedWorldPage = true;
+      onboarding.dismissedLandingPage = true;
+      onboarding.skipWelcomeScreen = true;
+    }
+    // Legacy uiStore proxy, if present
     const ui = (window as any).uiStore;
     if (ui) {
       ui.dismissedWorldPage = true;
@@ -44,7 +75,154 @@ export async function setupVaultPage(page: Page) {
       ui.skipWelcomeScreen = true;
     }
   });
-  await expect(page.getByTestId("graph-canvas")).toBeVisible({
-    timeout: 10000,
-  });
+}
+
+export async function waitForVaultReady(page: Page, timeout = 15000) {
+  await page.waitForFunction(
+    () => {
+      const vault = (window as any).vault;
+      return !!vault && vault.status === "idle";
+    },
+    undefined,
+    { timeout },
+  );
+}
+
+export async function waitForGraphReady(
+  page: Page,
+  options: { minNodes?: number; timeout?: number } = {},
+) {
+  const { minNodes = 0, timeout = 15000 } = options;
+
+  await expect(page.getByTestId("graph-canvas")).toBeVisible({ timeout });
+  await page.waitForFunction(
+    (expectedNodeCount) => {
+      const graph = (window as any).graph;
+      if (!graph?.elements) return expectedNodeCount === 0;
+
+      const nodes = graph.elements.filter((element: any) => {
+        if (element.group === "nodes") return true;
+        return typeof element?.data?.id === "string" && !element?.data?.source;
+      });
+
+      return nodes.length >= expectedNodeCount;
+    },
+    minNodes,
+    { timeout },
+  );
+}
+
+export async function seedEntity(page: Page, options: SeedEntityOptions) {
+  const id = await page.evaluate(async (entityOptions) => {
+    const vault = (window as any).vault;
+    if (!vault) throw new Error("Vault store is not available");
+
+    const initialData = {
+      ...(entityOptions.id ? { id: entityOptions.id } : {}),
+      ...(entityOptions.content ? { content: entityOptions.content } : {}),
+      ...(entityOptions.data ?? {}),
+    };
+
+    const entityId = await vault.createEntity(
+      entityOptions.type ?? "note",
+      entityOptions.title,
+      initialData,
+    );
+
+    if (entityOptions.select) {
+      vault.selectedEntityId = entityId;
+    }
+
+    return entityId;
+  }, options);
+
+  await page.waitForFunction(
+    (entityId) => !!(window as any).vault?.entities?.[entityId],
+    id,
+    { timeout: 10000 },
+  );
+
+  if (options.waitForGraph !== false) {
+    await waitForGraphReady(page, { minNodes: 1 });
+  }
+
+  await dismissFrontPage(page);
+  return id;
+}
+
+export async function seedEntities(page: Page, entities: SeedEntityOptions[]) {
+  const ids: string[] = [];
+
+  for (const entity of entities) {
+    ids.push(await seedEntity(page, { ...entity, waitForGraph: false }));
+  }
+
+  await waitForGraphReady(page, { minNodes: ids.length });
+  await dismissFrontPage(page);
+  return ids;
+}
+
+/**
+ * Open the Oracle sidebar via the activity bar. Uses a forced click so the
+ * dev-only DebugConsole overlay (fixed, high z-index) can't intercept it.
+ */
+export async function openOracle(page: Page) {
+  await dismissFrontPage(page);
+  const panel = page.getByTestId("oracle-sidebar-panel");
+  if (!(await panel.isVisible().catch(() => false))) {
+    await page.getByTestId("activity-bar-oracle").click({ force: true });
+  }
+  await expect(panel).toBeVisible({ timeout: 10000 });
+}
+
+export async function openEntitySidepanel(page: Page, entityId: string) {
+  await page.evaluate((id) => {
+    const vault = (window as any).vault;
+    if (!vault) throw new Error("Vault store is not available");
+    vault.selectedEntityId = id;
+  }, entityId);
+
+  await page.waitForFunction(
+    (id) => (window as any).vault?.selectedEntityId === id,
+    entityId,
+    { timeout: 10000 },
+  );
+}
+
+export async function selectGraphNodesByTitle(page: Page, titles: string[]) {
+  await page.waitForFunction(
+    (expectedTitles) => {
+      const cy = (window as any).cy;
+      if (!cy) return false;
+
+      return expectedTitles.every((title: string) =>
+        cy.nodes().some((node: any) => node.data("label") === title),
+      );
+    },
+    titles,
+    { timeout: 10000 },
+  );
+
+  await page.evaluate((expectedTitles) => {
+    const cy = (window as any).cy;
+    cy.nodes().unselect();
+    for (const title of expectedTitles) {
+      cy.nodes()
+        .filter((node: any) => node.data("label") === title)
+        .select();
+    }
+  }, titles);
+}
+
+export async function openGraphContextMenuForTitle(page: Page, title: string) {
+  await page.evaluate((nodeTitle) => {
+    const cy = (window as any).cy;
+    const node = cy
+      .nodes()
+      .filter((candidate: any) => candidate.data("label") === nodeTitle)[0];
+    if (!node) throw new Error(`Graph node not found: ${nodeTitle}`);
+
+    const renderedPosition = node.renderedPosition();
+    node.trigger("cxttap", { renderedPosition });
+  }, title);
 }


### PR DESCRIPTION
Part of #1168 (E2E recovery). First slice of the Oracle failure bucket.

> **Stacked on #1246** (`feat/1169-remove-e2e-flags`). Review/merge that first; this targets it as base and should be retargeted to `staging` once #1246 lands.

## What

1. **Stale Oracle selector fix** — the Oracle sidebar is opened via the activity bar (`activity-bar-oracle`, per `ActivityBar.svelte`). Eight specs still targeted the removed `sidebar-oracle-button` testid and timed out. Repointed them.
2. **Ported shared E2E helpers** from the `fix/e2e-recovery` branch, adapted to the post-#1169 world (no `__E2E__`/`DISABLE_ONBOARDING` globals): `dismissFrontPage`, `waitForVaultReady`, `waitForGraphReady`, `seedEntity`, `seedEntities`, `openOracle`, `openEntitySidepanel`, `selectGraphNodesByTitle`, `openGraphContextMenuForTitle`. `openOracle` force-clicks past the dev-only `DebugConsole` overlay.
3. **Stabilised `oracle-sidebar.spec.ts`** — open via `openOracle`, replace removed top-nav selectors with `activity-bar-map`/`-graph`, assert the panel docks beside the persistent activity bar, close via the activity-bar toggle. Mobile test deferred (`test.fixme`).

## Result (Oracle bucket)

- `ai-disabled` ✅ 4/4, `oracle-proxy-integration` ✅ 2/2, `oracle-status` 2/3, `oracle-sidebar` ✅ 2/3 (+1 deferred).
- The selector fix alone unblocked the `ai-disabled`/`status`/`proxy` specs.

## Follow-ups (not in this PR)

- `oracle-commands`/`ui`/`undo`: beforeEach waits on `oracle.isInitialized`, which never flips even with the panel open.
- `oracle-merge`: guided `/merge` flow assertions drifted from current product behaviour.
- **Suspected app bug:** the Oracle panel appears to be mounted in two places (`SidebarPanelHost` + `OracleSidebarProvider`) — the in-panel "Close panel" control resolves to an off-screen duplicate, and the double-mount is the likely cause of the `isInitialized` readiness failures. Worth a dedicated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)