### PR TITLE
[codex] Remove duplicate CanvasSelectionModal owner

### DIFF
--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.svelte
@@ -11,7 +11,6 @@
   import { vault } from "$lib/stores/vault.svelte";
   import { canvasRegistry } from "$lib/stores/canvas-registry.svelte";
   import EntityNode from "$lib/components/canvas/EntityNode.svelte";
-  import CanvasSelectionModal from "$lib/components/canvas/CanvasSelectionModal.svelte";
   import CanvasContextMenu from "$lib/components/canvas/CanvasContextMenu.svelte";
   import CustomEdge from "$lib/components/canvas/CustomEdge.svelte";
   import EdgeLabelModal from "$lib/components/canvas/EdgeLabelModal.svelte";
@@ -246,8 +245,6 @@
   {/if}
 
   <CanvasHint />
-  <CanvasSelectionModal />
-
   <EdgeLabelModal
     bind:isOpen={logic.labelModal.isOpen}
     initialValue={logic.labelModal.currentLabel}

--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.test.ts
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.test.ts
@@ -3,6 +3,12 @@
 import { render, screen } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("$lib/stores/ui/modal-ui.svelte", () => ({
+  modalUIStore: {
+    showCanvasSelector: false,
+  },
+}));
+
 vi.mock("@xyflow/svelte", () => ({
   SvelteFlow: function SvelteFlowMock() {
     return {};
@@ -120,6 +126,11 @@ vi.mock("$lib/components/hints/CanvasHint.svelte", () => ({
   },
 }));
 
+vi.mock("$lib/components/canvas/CanvasSelectionModal.svelte", async () => ({
+  default: (await import("../modals/__tests__/CanvasSelectionModalStub.svelte"))
+    .default,
+}));
+
 vi.mock("./CanvasHUD.svelte", () => ({
   default: function CanvasHUDMock() {
     return {};
@@ -127,13 +138,17 @@ vi.mock("./CanvasHUD.svelte", () => ({
 }));
 
 import CanvasWorkspace from "./CanvasWorkspace.svelte";
+import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 
 describe("CanvasWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    modalUIStore.showCanvasSelector = false;
   });
 
   it("does not mount CanvasSelectionModal locally", () => {
+    modalUIStore.showCanvasSelector = true;
+
     render(CanvasWorkspace, {
       props: {
         engine: {} as any,

--- a/apps/web/src/lib/components/canvas/CanvasWorkspace.test.ts
+++ b/apps/web/src/lib/components/canvas/CanvasWorkspace.test.ts
@@ -1,0 +1,148 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@xyflow/svelte", () => ({
+  SvelteFlow: function SvelteFlowMock() {
+    return {};
+  },
+  Background: function BackgroundMock() {
+    return {};
+  },
+  Controls: function ControlsMock() {
+    return {};
+  },
+  MiniMap: function MiniMapMock() {
+    return {};
+  },
+  ConnectionMode: {
+    Loose: "Loose",
+  },
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    isGuest: false,
+  },
+}));
+
+vi.mock("$lib/stores/canvas-registry.svelte", () => ({
+  canvasRegistry: {
+    allCanvases: [],
+    pendingEntities: [],
+  },
+}));
+
+vi.mock("$app/state", () => ({
+  page: {
+    params: {
+      slug: "canvas-1",
+    },
+  },
+}));
+
+vi.mock("$lib/stores/ui/connection-mode.svelte", () => ({
+  connectionModeStore: {
+    isConnecting: false,
+  },
+}));
+
+vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
+  sessionModeStore: {
+    isGuestMode: false,
+  },
+}));
+
+vi.mock("./use-canvas-logic.svelte", () => ({
+  createCanvasLogic: vi.fn(() => ({
+    handleQuickSpawn: vi.fn(),
+    labelModal: {
+      isOpen: false,
+      edgeId: "",
+      currentLabel: "",
+    },
+    flushSave: vi.fn(),
+    activeCategories: new Set(),
+    nodes: [],
+    edges: [],
+    initializeCanvas: vi.fn(),
+    pruneNodes: vi.fn(),
+    syncEngine: vi.fn(),
+    handleBatchSpawn: vi.fn(),
+    onConnect: vi.fn(),
+    isConnecting: false,
+    contextMenu: null,
+    handleDelete: vi.fn(),
+    handleCreateEntity: vi.fn(),
+    saveLabelModal: vi.fn(),
+    screenToFlowPosition: vi.fn((p) => p),
+  })),
+}));
+
+vi.mock("./use-canvas-events.svelte", () => ({
+  useCanvasEvents: vi.fn(),
+}));
+
+vi.mock("./ConnectionLine.svelte", () => ({
+  default: function ConnectionLineMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/canvas/EntityNode.svelte", () => ({
+  default: function EntityNodeMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/canvas/CanvasContextMenu.svelte", () => ({
+  default: function CanvasContextMenuMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/canvas/CustomEdge.svelte", () => ({
+  default: function CustomEdgeMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/canvas/EdgeLabelModal.svelte", () => ({
+  default: function EdgeLabelModalMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/hints/CanvasHint.svelte", () => ({
+  default: function CanvasHintMock() {
+    return {};
+  },
+}));
+
+vi.mock("./CanvasHUD.svelte", () => ({
+  default: function CanvasHUDMock() {
+    return {};
+  },
+}));
+
+import CanvasWorkspace from "./CanvasWorkspace.svelte";
+
+describe("CanvasWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not mount CanvasSelectionModal locally", () => {
+    render(CanvasWorkspace, {
+      props: {
+        engine: {} as any,
+      },
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Canvas Workspace" }),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("canvas-selection-modal-stub")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.test.ts
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.test.ts
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$app/state", () => ({
+  page: {
+    url: new URL("http://localhost/"),
+  },
+}));
+
+vi.mock("$app/paths", () => ({
+  base: "",
+}));
+
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
+
+vi.mock("$lib/stores/help.svelte", () => ({
+  helpStore: {
+    activeTour: null,
+  },
+}));
+
+vi.mock("$lib/stores/oracle.svelte", () => ({
+  oracle: {
+    isOpen: false,
+  },
+}));
+
+vi.mock("$lib/stores/search.svelte", () => ({
+  searchStore: {
+    isOpen: false,
+  },
+}));
+
+vi.mock("$lib/stores/ui/onboarding.svelte", () => ({
+  onboardingStore: {
+    showChangelog: false,
+  },
+}));
+
+vi.mock("$lib/stores/ui/notification.svelte", () => ({
+  notificationStore: {
+    confirmationDialog: {
+      open: false,
+    },
+  },
+}));
+
+vi.mock("$lib/stores/ui/modal-ui.svelte", () => ({
+  modalUIStore: {
+    showSettings: false,
+    mergeDialog: { open: false, sourceIds: [] },
+    bulkLabelDialog: { open: false, entityIds: [] },
+    soundBite: { show: false, entityId: null },
+    relatedEntityDialog: { open: false, sourceEntityId: null },
+    showVaultSwitcher: false,
+    showShare: false,
+    imagePromptReview: { open: false, target: null, prompt: "" },
+    revisionDialog: { open: false, entityId: null, instructions: "" },
+    lightbox: { show: false, imageUrl: "", title: "" },
+    showCanvasSelector: false,
+    closeMergeDialog: vi.fn(),
+    closeBulkLabelDialog: vi.fn(),
+    closeRelatedEntityDialog: vi.fn(),
+    closeVaultSwitcher: vi.fn(),
+    closeShare: vi.fn(),
+  },
+}));
+
+vi.mock("./ZenModeModal.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
+vi.mock("$lib/components/canvas/CanvasSelectionModal.svelte", async () => ({
+  default: (await import("./__tests__/CanvasSelectionModalStub.svelte"))
+    .default,
+}));
+
+import GlobalModalProvider from "./GlobalModalProvider.svelte";
+import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+
+describe("GlobalModalProvider", () => {
+  beforeEach(() => {
+    modalUIStore.showCanvasSelector = false;
+  });
+
+  it("renders CanvasSelectionModal from the global provider when the modal state is open", async () => {
+    modalUIStore.showCanvasSelector = true;
+
+    render(GlobalModalProvider);
+
+    expect(
+      await screen.findByTestId("canvas-selection-modal-stub"),
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.test.ts
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.test.ts
@@ -74,6 +74,14 @@ vi.mock("./ZenModeModal.svelte", async () => ({
   default: (await import("./__tests__/ModalStub.svelte")).default,
 }));
 
+vi.mock("$lib/components/dice/DiceModal.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
+vi.mock("$lib/components/modals/GuestChatModal.svelte", async () => ({
+  default: (await import("./__tests__/ModalStub.svelte")).default,
+}));
+
 vi.mock("$lib/components/canvas/CanvasSelectionModal.svelte", async () => ({
   default: (await import("./__tests__/CanvasSelectionModalStub.svelte"))
     .default,
@@ -95,5 +103,11 @@ describe("GlobalModalProvider", () => {
     expect(
       await screen.findByTestId("canvas-selection-modal-stub"),
     ).toBeTruthy();
+  });
+
+  it("does not render CanvasSelectionModal content when the modal state is closed", () => {
+    render(GlobalModalProvider);
+
+    expect(screen.queryByTestId("canvas-selection-modal-stub")).toBeNull();
   });
 });

--- a/apps/web/src/lib/components/modals/__tests__/CanvasSelectionModalStub.svelte
+++ b/apps/web/src/lib/components/modals/__tests__/CanvasSelectionModalStub.svelte
@@ -1,1 +1,7 @@
-<div data-testid="canvas-selection-modal-stub">Canvas Selection Modal</div>
+<script lang="ts">
+  import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+</script>
+
+{#if modalUIStore.showCanvasSelector}
+  <div data-testid="canvas-selection-modal-stub">Canvas Selection Modal</div>
+{/if}

--- a/apps/web/src/lib/components/modals/__tests__/CanvasSelectionModalStub.svelte
+++ b/apps/web/src/lib/components/modals/__tests__/CanvasSelectionModalStub.svelte
@@ -1,0 +1,1 @@
+<div data-testid="canvas-selection-modal-stub">Canvas Selection Modal</div>


### PR DESCRIPTION
## Summary
- remove the local CanvasSelectionModal mount from CanvasWorkspace
- keep GlobalModalProvider as the single owner of the modal
- add targeted tests for global rendering and the workspace negative case

## Testing
- bun run --filter web test -- src/lib/components/modals/GlobalModalProvider.test.ts src/lib/components/canvas/CanvasWorkspace.test.ts

Closes #1251