### PR TITLE
[codex] Remove duplicate ShareModal owner

### DIFF
--- a/apps/web/src/lib/stores/map/map-page-controller.svelte.ts
+++ b/apps/web/src/lib/stores/map/map-page-controller.svelte.ts
@@ -1,6 +1,7 @@
 import { mapStore as defaultMapStore } from "$lib/stores/map.svelte";
 import { mapSession as defaultMapSession } from "$lib/stores/map-session.svelte";
 import { vault as defaultVault } from "$lib/stores/vault.svelte";
+import { modalUIStore as defaultModalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 import { notificationStore as defaultNotificationStore } from "$lib/stores/ui/notification.svelte";
 import { sessionModeStore as defaultSessionModeStore } from "$lib/stores/ui/session-mode.svelte";
 import { layoutUIStore as defaultLayoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
@@ -51,6 +52,10 @@ type MapPageNotificationStore = {
   notify(message: string, type?: "success" | "info" | "error"): void;
 };
 
+type MapPageModalStore = {
+  openShare(): void;
+};
+
 type MapPageSessionModeStore = {
   isGuestMode: boolean;
 };
@@ -64,6 +69,7 @@ export interface MapPageControllerDependencies {
   mapStore?: MapPageMapStore;
   mapSession?: MapPageSession;
   vault?: MapPageVault;
+  modalUIStore?: MapPageModalStore;
   notificationStore?: MapPageNotificationStore;
   sessionModeStore?: MapPageSessionModeStore;
   layoutUIStore?: MapPageLayoutStore;
@@ -73,6 +79,7 @@ export class MapPageController {
   private mapStore: MapPageMapStore = defaultMapStore;
   private mapSession: MapPageSession = defaultMapSession;
   private vault: MapPageVault = defaultVault;
+  private modalUIStore: MapPageModalStore = defaultModalUIStore;
   private notificationStore: MapPageNotificationStore =
     defaultNotificationStore;
   private sessionModeStore: MapPageSessionModeStore = defaultSessionModeStore;
@@ -81,7 +88,6 @@ export class MapPageController {
 
   isDragging = $state(false);
   showUpload = $state(false);
-  showVttShare = $state(false);
   mapName = $state("");
   files = $state<FileList | null>(null);
 
@@ -103,6 +109,7 @@ export class MapPageController {
     this.mapStore = deps.mapStore ?? defaultMapStore;
     this.mapSession = deps.mapSession ?? defaultMapSession;
     this.vault = deps.vault ?? defaultVault;
+    this.modalUIStore = deps.modalUIStore ?? defaultModalUIStore;
     this.notificationStore = deps.notificationStore ?? defaultNotificationStore;
     this.sessionModeStore = deps.sessionModeStore ?? defaultSessionModeStore;
     this.layoutUIStore = deps.layoutUIStore ?? defaultLayoutUIStore;
@@ -117,6 +124,10 @@ export class MapPageController {
 
   setVttChatSidebarCollapsed(collapsed: boolean) {
     this.layoutUIStore.toggleVttChatSidebar(collapsed);
+  }
+
+  openShareModal() {
+    this.modalUIStore.openShare();
   }
 
   handleEntityDragStart(event: DragEvent, entityId: string) {

--- a/apps/web/src/lib/stores/map/map-page-controller.test.ts
+++ b/apps/web/src/lib/stores/map/map-page-controller.test.ts
@@ -18,6 +18,10 @@ vi.mock("$lib/stores/ui/notification.svelte", () => ({
   notificationStore: {},
 }));
 
+vi.mock("$lib/stores/ui/modal-ui.svelte", () => ({
+  modalUIStore: {},
+}));
+
 vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
   sessionModeStore: {},
 }));
@@ -108,6 +112,9 @@ function createController(overrides: Record<string, unknown> = {}) {
   const notificationStore = {
     notify: vi.fn(),
   };
+  const modalUIStore = {
+    openShare: vi.fn(),
+  };
   const sessionModeStore = {
     isGuestMode: false,
   };
@@ -122,6 +129,7 @@ function createController(overrides: Record<string, unknown> = {}) {
     mapStore,
     mapSession,
     vault,
+    modalUIStore,
     notificationStore,
     sessionModeStore,
     layoutUIStore,
@@ -133,6 +141,7 @@ function createController(overrides: Record<string, unknown> = {}) {
     mapStore,
     mapSession,
     vault,
+    modalUIStore,
     notificationStore,
     sessionModeStore,
     layoutUIStore,
@@ -260,5 +269,13 @@ describe("MapPageController", () => {
     expect(controller.showUpload).toBe(false);
     expect(controller.mapName).toBe("");
     expect(controller.files).toBeNull();
+  });
+
+  it("routes map share actions through the global modal store", () => {
+    const { controller, modalUIStore } = createController();
+
+    controller.openShareModal();
+
+    expect(modalUIStore.openShare).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/routes/(app)/map/+page.svelte
+++ b/apps/web/src/routes/(app)/map/+page.svelte
@@ -4,7 +4,6 @@
   import MapView from "$lib/components/map/MapView.svelte";
   import MapVTTControlsHUD from "$lib/components/map/MapVTTControlsHUD.svelte";
   import VTTGridColorMenu from "$lib/components/map/VTTGridColorMenu.svelte";
-  import ShareModal from "$lib/components/ShareModal.svelte";
   import TokenAddDialog from "$lib/components/vtt/TokenAddDialog.svelte";
   import MapVTTSidebar from "$lib/components/vtt/MapVTTSidebar.svelte";
   import {
@@ -57,7 +56,7 @@
           onEntityDragStart={(event, entityId) =>
             controller.handleEntityDragStart(event, entityId)}
           onEntityDragEnd={() => controller.handleEntityDragEnd()}
-          onShare={() => (controller.showVttShare = true)}
+          onShare={() => controller.openShareModal()}
         />
       {/if}
 
@@ -68,9 +67,6 @@
       <MapVTTControlsHUD chatSidebarOffset={controller.chatSidebarOffset} />
       <TokenAddDialog />
     </MapView>
-    {#if controller.showVttShare}
-      <ShareModal close={() => (controller.showVttShare = false)} />
-    {/if}
 
     <VTTGridColorMenu />
   {:else if sessionModeStore.isGuestMode}

--- a/apps/web/src/routes/(app)/map/map-page.test.ts
+++ b/apps/web/src/routes/(app)/map/map-page.test.ts
@@ -1,0 +1,149 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+
+const controllerState = vi.hoisted(() => ({
+  activeMap: { id: "map-1" },
+  showInitiativePanel: false,
+  hasSelectedToken: false,
+  vttEntityCount: 2,
+  chatSidebarOffset: "20rem",
+  showUpload: false,
+  showVttShare: true,
+  mapName: "",
+  files: null,
+  isDragging: false,
+  openShareModal: vi.fn(),
+  handleEntityDragStart: vi.fn(),
+  handleEntityDragEnd: vi.fn(),
+  onDragOver: vi.fn(),
+  onDragLeave: vi.fn(),
+  onDrop: vi.fn(),
+  handleUpload: vi.fn(),
+  cancelUpload: vi.fn(),
+  syncActiveVault: vi.fn(),
+  setVttChatSidebarCollapsed: vi.fn(),
+}));
+
+vi.mock("$lib/stores/map/map-page-controller.svelte", () => ({
+  MapPageController: class MapPageControllerMock {
+    activeMap = controllerState.activeMap;
+    showInitiativePanel = controllerState.showInitiativePanel;
+    hasSelectedToken = controllerState.hasSelectedToken;
+    vttEntityCount = controllerState.vttEntityCount;
+    chatSidebarOffset = controllerState.chatSidebarOffset;
+    showUpload = controllerState.showUpload;
+    showVttShare = controllerState.showVttShare;
+    mapName = controllerState.mapName;
+    files = controllerState.files;
+    isDragging = controllerState.isDragging;
+    openShareModal = controllerState.openShareModal;
+    handleEntityDragStart = controllerState.handleEntityDragStart;
+    handleEntityDragEnd = controllerState.handleEntityDragEnd;
+    onDragOver = controllerState.onDragOver;
+    onDragLeave = controllerState.onDragLeave;
+    onDrop = controllerState.onDrop;
+    handleUpload = controllerState.handleUpload;
+    cancelUpload = controllerState.cancelUpload;
+    syncActiveVault = controllerState.syncActiveVault;
+    setVttChatSidebarCollapsed = controllerState.setVttChatSidebarCollapsed;
+  },
+}));
+
+vi.mock("$lib/components/map/MapHUD.svelte", () => ({
+  default: function MapHUDMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/map/MapUploadOverlay.svelte", () => ({
+  default: function MapUploadOverlayMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/map/MapView.svelte", () => ({
+  default: function MapViewMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/map/MapVTTControlsHUD.svelte", () => ({
+  default: function MapVTTControlsHUDMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/map/VTTGridColorMenu.svelte", () => ({
+  default: function VTTGridColorMenuMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/vtt/TokenAddDialog.svelte", () => ({
+  default: function TokenAddDialogMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/vtt/MapVTTSidebar.svelte", () => ({
+  default: function MapVTTSidebarMock() {
+    return {};
+  },
+}));
+
+vi.mock("$lib/components/ShareModal.svelte", async () => ({
+  default: (await import("$lib/components/modals/__tests__/ModalStub.svelte"))
+    .default,
+}));
+
+vi.mock("$lib/stores/map.svelte", () => ({
+  mapStore: {
+    activeMap: { id: "map-1" },
+  },
+}));
+
+vi.mock("$lib/stores/map-session.svelte", () => ({
+  mapSession: {
+    vttEnabled: true,
+  },
+}));
+
+vi.mock("$lib/stores/vault.svelte", () => ({
+  vault: {
+    activeVaultId: "vault-1",
+  },
+}));
+
+vi.mock("$lib/stores/ui/notification.svelte", () => ({
+  notificationStore: {},
+}));
+
+vi.mock("$lib/stores/ui/session-mode.svelte", () => ({
+  sessionModeStore: {
+    isGuestMode: false,
+  },
+}));
+
+vi.mock("$lib/stores/ui/modal-ui.svelte", () => ({
+  modalUIStore: {
+    openZenMode: vi.fn(),
+  },
+}));
+
+vi.mock("$lib/stores/ui/layout-ui.svelte", () => ({
+  layoutUIStore: {
+    vttChatSidebarCollapsed: false,
+  },
+}));
+
+import MapPage from "./+page.svelte";
+
+describe("map/+page", () => {
+  it("does not mount ShareModal locally even if a controller-local share flag exists", () => {
+    render(MapPage);
+
+    expect(screen.queryByTestId("modal-stub")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- remove the map-local ShareModal mount and its controller-local open state
- route VTT share actions through the global modal store so ShareModal has a single owner
- add targeted tests for the global open path wiring and the map-page no-local-mount regression

## Testing
- bun run --filter web test -- src/lib/stores/map/map-page-controller.test.ts src/routes/'(app)'/map/map-page.test.ts

Closes #1253