### PR TITLE
feat(generators): Kingdom Generator + Nation Generator

### DIFF
--- a/apps/web/src/lib/components/seo/KingdomFormFields.svelte
+++ b/apps/web/src/lib/components/seo/KingdomFormFields.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import { kingdomConfig } from "$lib/services/seo/generator-engine";
+
+  let {
+    polityType = $bindable(kingdomConfig.polityTypes[0]),
+    governmentStyle = $bindable(kingdomConfig.governmentStyles[0]),
+    geography = $bindable(kingdomConfig.geographies[0]),
+    scale = $bindable(kingdomConfig.scales[2]),
+    conflictLevel = $bindable(kingdomConfig.conflictLevels[0]),
+    magicLevel = $bindable(kingdomConfig.magicLevels[2]),
+    campaignContext = $bindable(""),
+    onSurprise = undefined,
+  }: {
+    polityType: string;
+    governmentStyle: string;
+    geography: string;
+    scale: string;
+    conflictLevel: string;
+    magicLevel: string;
+    campaignContext: string;
+    onSurprise?: () => void;
+  } = $props();
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+
+  function pick<T>(arr: T[]): T {
+    return arr[Math.floor(Math.random() * arr.length)];
+  }
+</script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="kingdom-polity-select" class={labelClass}>Polity type</label>
+  <select
+    id="kingdom-polity-select"
+    bind:value={polityType}
+    class={selectClass}
+  >
+    {#each kingdomConfig.polityTypes as t (t)}
+      <option value={t}>{t}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="kingdom-govt-select" class={labelClass}>Government style</label>
+  <select
+    id="kingdom-govt-select"
+    bind:value={governmentStyle}
+    class={selectClass}
+  >
+    {#each kingdomConfig.governmentStyles as g (g)}
+      <option value={g}>{g}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="kingdom-geo-select" class={labelClass}>Geography</label>
+  <select id="kingdom-geo-select" bind:value={geography} class={selectClass}>
+    {#each kingdomConfig.geographies as g (g)}
+      <option value={g}>{g}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="kingdom-scale-select" class={labelClass}>Scale</label>
+  <select id="kingdom-scale-select" bind:value={scale} class={selectClass}>
+    {#each kingdomConfig.scales as s (s)}
+      <option value={s}>{s}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="kingdom-conflict-select" class={labelClass}>Conflict level</label>
+  <select
+    id="kingdom-conflict-select"
+    bind:value={conflictLevel}
+    class={selectClass}
+  >
+    {#each kingdomConfig.conflictLevels as c (c)}
+      <option value={c}>{c}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="kingdom-magic-select" class={labelClass}>Magic level</label>
+  <select id="kingdom-magic-select" bind:value={magicLevel} class={selectClass}>
+    {#each kingdomConfig.magicLevels as m (m)}
+      <option value={m}>{m}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="kingdom-context" class={labelClass}
+    >Campaign context (optional)</label
+  >
+  <textarea
+    id="kingdom-context"
+    bind:value={campaignContext}
+    maxlength="240"
+    rows="4"
+    aria-describedby="kingdom-context-help"
+    class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+  ></textarea>
+  <p
+    id="kingdom-context-help"
+    class="text-[10px] text-theme-text/60 leading-relaxed"
+  >
+    Add a campaign name, ongoing conflict, or political tension to aim the realm
+    at your table.
+  </p>
+</div>
+
+<div class="pt-2 flex justify-end">
+  <button
+    type="button"
+    onclick={() => {
+      polityType = pick(kingdomConfig.polityTypes);
+      governmentStyle = pick(kingdomConfig.governmentStyles);
+      geography = pick(kingdomConfig.geographies);
+      scale = pick(kingdomConfig.scales);
+      conflictLevel = pick(kingdomConfig.conflictLevels);
+      magicLevel = pick(kingdomConfig.magicLevels);
+      if (onSurprise) onSurprise();
+    }}
+    class="flex items-center gap-1.5 px-3 py-1.5 bg-theme-surface/60 border border-theme-border/60 rounded-lg text-[10px] font-bold uppercase tracking-wider text-theme-text hover:bg-theme-primary hover:text-theme-bg hover:border-theme-primary transition-all cursor-pointer"
+  >
+    <span class="icon-[lucide--dices] w-3.5 h-3.5"></span>
+    Surprise Me
+  </button>
+</div>

--- a/apps/web/src/lib/components/seo/NationFormFields.svelte
+++ b/apps/web/src/lib/components/seo/NationFormFields.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import { nationConfig } from "$lib/services/seo/generator-engine";
+
+  let {
+    genre = $bindable(nationConfig.genres[0]),
+    polityType = $bindable(
+      nationConfig.polityTypesByGenre[nationConfig.genres[0]][0],
+    ),
+    governmentStyle = $bindable(nationConfig.governmentStyles[0]),
+    scale = $bindable(nationConfig.scales[2]),
+    conflictLevel = $bindable(nationConfig.conflictLevels[0]),
+    campaignContext = $bindable(""),
+    onSurprise = undefined,
+  }: {
+    genre: string;
+    polityType: string;
+    governmentStyle: string;
+    scale: string;
+    conflictLevel: string;
+    campaignContext: string;
+    onSurprise?: () => void;
+  } = $props();
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+
+  let polityTypes = $derived(
+    nationConfig.polityTypesByGenre[genre] ??
+      nationConfig.polityTypesByGenre["Fantasy"],
+  );
+
+  $effect(() => {
+    if (!polityTypes.includes(polityType)) {
+      polityType = polityTypes[0];
+    }
+  });
+
+  function pick<T>(arr: T[]): T {
+    return arr[Math.floor(Math.random() * arr.length)];
+  }
+</script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="nation-genre-select" class={labelClass}>Genre / Setting</label>
+  <select id="nation-genre-select" bind:value={genre} class={selectClass}>
+    {#each nationConfig.genres as g (g)}
+      <option value={g}>{g}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="nation-polity-select" class={labelClass}>Polity type</label>
+  <select id="nation-polity-select" bind:value={polityType} class={selectClass}>
+    {#each polityTypes as t (t)}
+      <option value={t}>{t}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="nation-govt-select" class={labelClass}>Government style</label>
+  <select
+    id="nation-govt-select"
+    bind:value={governmentStyle}
+    class={selectClass}
+  >
+    {#each nationConfig.governmentStyles as g (g)}
+      <option value={g}>{g}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="nation-scale-select" class={labelClass}>Scale</label>
+  <select id="nation-scale-select" bind:value={scale} class={selectClass}>
+    {#each nationConfig.scales as s (s)}
+      <option value={s}>{s}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="nation-conflict-select" class={labelClass}>Conflict level</label>
+  <select
+    id="nation-conflict-select"
+    bind:value={conflictLevel}
+    class={selectClass}
+  >
+    {#each nationConfig.conflictLevels as c (c)}
+      <option value={c}>{c}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="nation-context" class={labelClass}
+    >Campaign context (optional)</label
+  >
+  <textarea
+    id="nation-context"
+    bind:value={campaignContext}
+    maxlength="240"
+    rows="4"
+    aria-describedby="nation-context-help"
+    class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+  ></textarea>
+  <p
+    id="nation-context-help"
+    class="text-[10px] text-theme-text/60 leading-relaxed"
+  >
+    Add a campaign name, ongoing conflict, or political tension to aim the state
+    at your table.
+  </p>
+</div>
+
+<div class="pt-2 flex justify-end">
+  <button
+    type="button"
+    onclick={() => {
+      genre = pick(nationConfig.genres);
+      const newPolityTypes =
+        nationConfig.polityTypesByGenre[genre] ??
+        nationConfig.polityTypesByGenre["Fantasy"];
+      polityType = pick(newPolityTypes);
+      governmentStyle = pick(nationConfig.governmentStyles);
+      scale = pick(nationConfig.scales);
+      conflictLevel = pick(nationConfig.conflictLevels);
+      if (onSurprise) onSurprise();
+    }}
+    class="flex items-center gap-1.5 px-3 py-1.5 bg-theme-surface/60 border border-theme-border/60 rounded-lg text-[10px] font-bold uppercase tracking-wider text-theme-text hover:bg-theme-primary hover:text-theme-bg hover:border-theme-primary transition-all cursor-pointer"
+  >
+    <span class="icon-[lucide--dices] w-3.5 h-3.5"></span>
+    Surprise Me
+  </button>
+</div>

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -570,4 +570,177 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.labels).toContain("tavern-generator");
     });
   });
+
+  describe("generateKingdom", () => {
+    it("should generate a kingdom using local fallback when useAI is false", async () => {
+      const res = await engine.generateKingdom({
+        polityType: "Kingdom",
+        governmentStyle: "Hereditary dynasty",
+        geography: "Temperate highlands",
+        scale: "Mid-sized nation",
+        conflictLevel: "Simmering tensions",
+        magicLevel: "Common but regulated",
+        useAI: false,
+      });
+
+      expect(res.type).toBe("faction");
+      expect(res.title).toBeDefined();
+      expect(res.title).not.toMatch(/The .* The /);
+      expect(res.summary).toContain("kingdom");
+      expect(res.content).toContain("### The Realm");
+      expect(res.content).toContain("### Government & Power");
+      expect(res.lore).toContain("### At a Glance");
+      expect(res.lore).toContain("### Major Factions");
+      expect(res.lore).toContain("### Rumours & Hooks");
+      expect(res.lore).toContain("### Entity Seeds");
+      expect(res.labels).toContain("kingdom-generator");
+      expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should include campaign context in local fallback output", async () => {
+      const res = await engine.generateKingdom({
+        polityType: "Empire",
+        campaignContext: "a crumbling empire on the edge of civil war",
+        useAI: false,
+      });
+
+      expect(res.content).toContain(
+        "a crumbling empire on the edge of civil war",
+      );
+    });
+
+    it("should call clientManager when useAI is true and succeed", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "The Kingdom of Vaelthorn",
+                summary: "A mid-sized kingdom held together by old oaths.",
+                content: "### The Realm\nAI content.",
+                lore: "### At a Glance\nAI lore.",
+                labels: ["rpg-kingdom", "kingdom-generator", "imported-draft"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generateKingdom({
+        polityType: "Kingdom",
+        campaignContext: "a succession crisis",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("a succession crisis"),
+      );
+      expect(res.title).toBe("The Kingdom of Vaelthorn");
+      expect(res.labels).toContain("kingdom-generator");
+    });
+
+    it("should fall back to local tables if AI call fails", async () => {
+      mockClientManager.getModel.mockRejectedValue(new Error("Network Error"));
+
+      const res = await engine.generateKingdom({
+        polityType: "Duchy",
+        useAI: true,
+      });
+
+      expect(res.type).toBe("faction");
+      expect(res.labels).toContain("kingdom-generator");
+    });
+  });
+
+  describe("generateNation", () => {
+    it("should generate a nation using local fallback when useAI is false", async () => {
+      const res = await engine.generateNation({
+        genre: "Cyberpunk",
+        polityType: "Megacorp-State",
+        governmentStyle: "Corporate board",
+        scale: "Mid-sized nation",
+        conflictLevel: "Simmering tensions",
+        useAI: false,
+      });
+
+      expect(res.type).toBe("faction");
+      expect(res.title).toBeDefined();
+      expect(res.summary).toContain("megacorp-state");
+      expect(res.content).toContain("### The State");
+      expect(res.content).toContain("### Power Structure");
+      expect(res.lore).toContain("### At a Glance");
+      expect(res.lore).toContain("### Power Blocs");
+      expect(res.lore).toContain("### Rumours & Hooks");
+      expect(res.lore).toContain("### Entity Seeds");
+      expect(res.labels).toContain("nation-generator");
+      expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should include campaign context in local fallback output", async () => {
+      const res = await engine.generateNation({
+        genre: "Sci-Fi",
+        polityType: "Interstellar Federation",
+        campaignContext: "a collapsing interstellar federation",
+        useAI: false,
+      });
+
+      expect(res.content).toContain("a collapsing interstellar federation");
+    });
+
+    it("should use genre-appropriate polity types", async () => {
+      const res = await engine.generateNation({
+        genre: "Western",
+        polityType: "Outlaw Republic",
+        useAI: false,
+      });
+
+      expect(res.summary).toContain("outlaw republic");
+    });
+
+    it("should call clientManager when useAI is true and succeed", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "Axiom Industrial Authority",
+                summary:
+                  "A cyberpunk megacorp-state controlling three districts.",
+                content: "### The State\nAI content.",
+                lore: "### At a Glance\nAI lore.",
+                labels: ["rpg-nation", "nation-generator", "imported-draft"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generateNation({
+        genre: "Cyberpunk",
+        polityType: "Megacorp-State",
+        campaignContext: "a corp war over water rights",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("a corp war over water rights"),
+      );
+      expect(res.title).toBe("Axiom Industrial Authority");
+      expect(res.labels).toContain("nation-generator");
+    });
+
+    it("should fall back to local tables if AI call fails", async () => {
+      mockClientManager.getModel.mockRejectedValue(new Error("Network Error"));
+
+      const res = await engine.generateNation({
+        genre: "Fantasy",
+        useAI: true,
+      });
+
+      expect(res.type).toBe("faction");
+      expect(res.labels).toContain("nation-generator");
+    });
+  });
 });

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -1251,6 +1251,146 @@ export const socialHubConfig = {
   ],
 };
 
+export const nationConfig = {
+  genres: [
+    "Fantasy",
+    "Dark Fantasy",
+    "Pirate",
+    "Cyberpunk",
+    "Sci-Fi",
+    "Modern",
+    "Horror",
+    "Post-Apocalyptic",
+    "Western",
+  ],
+  polityTypesByGenre: {
+    Fantasy: [
+      "Kingdom",
+      "Empire",
+      "City-State",
+      "Duchy",
+      "Theocracy",
+      "Tribal Confederation",
+      "Republic",
+      "Protectorate",
+    ],
+    "Dark Fantasy": [
+      "Cursed Realm",
+      "Necromancer's Domain",
+      "Warlord Territory",
+      "Fallen Empire",
+      "Plague State",
+    ],
+    Pirate: [
+      "Free Port",
+      "Pirate Confederation",
+      "Merchant Republic",
+      "Privateer Kingdom",
+      "Smuggler's Haven",
+    ],
+    Cyberpunk: [
+      "Megacorp-State",
+      "Gang Territory",
+      "Free Zone",
+      "Corporate Enclave",
+      "Tech Oligarchy",
+    ],
+    "Sci-Fi": [
+      "Interstellar Federation",
+      "Colony Authority",
+      "Trade Consortium",
+      "Military Junta",
+      "Hive Mind Territory",
+    ],
+    Modern: [
+      "Nation-State",
+      "Autonomous Region",
+      "Rogue State",
+      "International Bloc",
+      "Failed State",
+    ],
+    Horror: [
+      "Cursed Domain",
+      "Cult Territory",
+      "Isolated Community",
+      "Shadow Government",
+      "Quarantine Zone",
+    ],
+    "Post-Apocalyptic": [
+      "Warlord Territory",
+      "Survivor Settlement",
+      "Cult Domain",
+      "Scavenger Confederation",
+      "Bunker State",
+    ],
+    Western: [
+      "Territory",
+      "Frontier Confederation",
+      "Railroad Authority",
+      "Outlaw Republic",
+      "Native Nation",
+    ],
+  } as Record<string, string[]>,
+  governmentStyles: [
+    "Hereditary dynasty",
+    "Elected council",
+    "Military dictatorship",
+    "Theocratic rule",
+    "Oligarchy",
+    "Constitutional government",
+    "Tribal / clan elders",
+    "Corporate board",
+    "Revolutionary committee",
+  ],
+  scales: [
+    "City-state (single settlement)",
+    "Small region (handful of towns)",
+    "Mid-sized nation",
+    "Large empire (many provinces)",
+    "Continent-spanning dominion",
+  ],
+  conflictLevels: [
+    "At peace",
+    "Simmering tensions",
+    "Open conflict",
+    "Total war",
+    "Post-war recovery",
+  ],
+  troubles: [
+    "The ruling class is fracturing over a succession crisis",
+    "A powerful faction is quietly positioning to seize control",
+    "An economic collapse is being hidden from the public",
+    "A border dispute is being deliberately escalated by a third party",
+    "A secret the ruler is keeping could delegitimise the entire state",
+    "An internal resistance movement is closer to open revolt than anyone admits",
+  ],
+};
+
+export const kingdomConfig = {
+  polityTypes: nationConfig.polityTypesByGenre["Fantasy"],
+  governmentStyles: nationConfig.governmentStyles.slice(0, 6),
+  geographies: [
+    "Temperate highlands",
+    "Coastal plains",
+    "Dense forest",
+    "Arid desert",
+    "Arctic tundra",
+    "Island archipelago",
+    "River delta",
+    "Mountain range",
+  ],
+  scales: nationConfig.scales,
+  conflictLevels: nationConfig.conflictLevels,
+  magicLevels: [
+    "No magic",
+    "Rare and feared",
+    "Common but regulated",
+    "Widely practiced",
+    "Magic-dependent society",
+  ],
+  troubles: nationConfig.troubles,
+};
+
 export interface GeneratorOutput {
   type:
     | "character"
@@ -2914,6 +3054,323 @@ Use ${tavernName} as a home base, a rumour hub, or a pressure point. The trouble
       content,
       lore,
       labels: ["rpg-location", "tavern-generator", "imported-draft"],
+      status: "active",
+    };
+  }
+
+  async generateKingdom(
+    options: {
+      polityType?: string;
+      governmentStyle?: string;
+      geography?: string;
+      scale?: string;
+      conflictLevel?: string;
+      magicLevel?: string;
+      campaignContext?: string;
+      useAI?: boolean;
+    } = {},
+  ): Promise<GeneratorOutput> {
+    const polityType =
+      options.polityType ||
+      kingdomConfig.polityTypes[
+        Math.floor(Math.random() * kingdomConfig.polityTypes.length)
+      ];
+    const governmentStyle =
+      options.governmentStyle ||
+      kingdomConfig.governmentStyles[
+        Math.floor(Math.random() * kingdomConfig.governmentStyles.length)
+      ];
+    const geography =
+      options.geography ||
+      kingdomConfig.geographies[
+        Math.floor(Math.random() * kingdomConfig.geographies.length)
+      ];
+    const scale = options.scale || kingdomConfig.scales[2];
+    const conflictLevel =
+      options.conflictLevel ||
+      kingdomConfig.conflictLevels[
+        Math.floor(Math.random() * kingdomConfig.conflictLevels.length)
+      ];
+    const magicLevel = options.magicLevel || kingdomConfig.magicLevels[2];
+    const campaignContext = options.campaignContext?.trim();
+    const varianceSeed = Math.floor(Math.random() * 99991) + 10;
+
+    if (options.useAI !== false) {
+      try {
+        const systemInstruction = `You are an expert RPG campaign writer. You generate immediately usable fantasy kingdoms and political entities for tabletop GMs in JSON format.
+
+OUTPUT FORMAT — return ONLY a valid JSON object, no markdown fences:
+{
+  "title": "The realm's name — invented, fantasy-appropriate, not a generic placeholder",
+  "summary": "One sentence: the kingdom's defining character and why a GM should use it.",
+  "content": "Markdown. Use exactly these four section headers in order: '### The Realm', '### Government & Power', '### Society & Culture', '### How to use it at the table'. Each section: 3-5 tight sentences. Include campaign context if provided.",
+  "lore": "Markdown. Use EXACTLY this structure:\\n### At a Glance\\n- **Polity Type**: ${polityType}\\n- **Ruler**: invented name and one-line description\\n- **Capital**: invented name and one-line description\\n- **Scale**: population/territory summary\\n- **Magic Level**: ${magicLevel}\\n- **Conflict Level**: ${conflictLevel}\\n- **Hidden Problem**: the tension simmering beneath the surface\\n- **Immediate Hook**: one-sentence GM hook\\n### Major Factions\\n- **Name**: one-line description (2-3 factions)\\n### Rumours & Hooks\\n- short hook (2-3 bullet points)\\n### Entity Seeds\\n- list of 4-5 Codex entity types (e.g. '**Character**: The regent', '**Faction**: The merchant guild', '**Location**: The capital city')",
+  "labels": ["2-4 lowercase tags, plus 'rpg-kingdom', 'kingdom-generator', 'imported-draft'"]
+}
+
+QUALITY RULES:
+- The ruler must have a name, a defining trait, and a secret motive.
+- Each faction should have a clear agenda that creates tension with another faction.
+- Rumours should be specific and actionable — something a party could investigate.
+- Entity seeds should suggest concrete Codex entries a GM would actually create.
+- All names must be invented — avoid generic English words as names.`;
+
+        const userMessage = `Generate a fantasy kingdom. Variation seed: ${varianceSeed}.
+- Polity Type: ${polityType}
+- Government Style: ${governmentStyle}
+- Geography: ${geography}
+- Scale: ${scale}
+- Conflict Level: ${conflictLevel}
+- Magic Level: ${magicLevel}${campaignContext ? `\n- Campaign Context: ${campaignContext}` : ""}`;
+
+        const model = await this.clientManager.getModel(
+          "",
+          "gemini-3.1-flash-lite",
+          systemInstruction,
+        );
+        const response = await model.generateContent(userMessage);
+        const text = response.response.text().trim();
+        const cleanText = text
+          .replace(/^```json\s*/i, "")
+          .replace(/```$/, "")
+          .trim();
+        const data = JSON.parse(cleanText);
+
+        return {
+          type: "faction",
+          title: data.title || "The Unnamed Realm",
+          summary: data.summary || "",
+          content: data.content || "",
+          lore: data.lore || "",
+          labels: Array.isArray(data.labels)
+            ? data.labels
+            : ["rpg-kingdom", "kingdom-generator", "imported-draft"],
+          status: "active",
+        };
+      } catch (err) {
+        console.warn(
+          "AI generation failed, falling back to local tables:",
+          err,
+        );
+      }
+    }
+
+    // Local fallback
+    const trouble =
+      kingdomConfig.troubles[
+        Math.floor(Math.random() * kingdomConfig.troubles.length)
+      ];
+    const rulerName = this.generateName();
+    const factionName1 = `The ${this.generateName()} ${["Order", "Council", "League", "Brotherhood", "Guild"][Math.floor(Math.random() * 5)]}`;
+    const factionName2 = `The ${this.generateName()} ${["Compact", "Circle", "Assembly", "Society", "House"][Math.floor(Math.random() * 5)]}`;
+    const rawName = this.generateName().replace(/\s+The\s+\S+$/, "");
+    const realmName = `The ${["Kingdom", "Realm", "Domain", "Dominion", "Principality"][Math.floor(Math.random() * 5)]} of ${rawName}`;
+    const capitalName = this.generateName().replace(/\s+The\s+\S+$/, "");
+
+    const summary = `A ${conflictLevel.toLowerCase()} ${polityType.toLowerCase()} set in ${geography.toLowerCase()}, ruled by a ${governmentStyle.toLowerCase()}.`;
+
+    const content = `### The Realm
+${realmName} is a ${scale.toLowerCase()} ${polityType.toLowerCase()} occupying ${geography.toLowerCase()} terrain. Its capital, ${capitalName}, serves as the seat of power and the heart of its culture.${campaignContext ? ` In ${campaignContext}, it sits at the centre of the main conflict.` : ""}
+
+### Government & Power
+${rulerName} leads through a system of ${governmentStyle.toLowerCase()}. The realm's magic level is ${magicLevel.toLowerCase()}, which shapes both its military capability and its social order. ${trouble}.
+
+### Society & Culture
+The population lives under the tension of a realm at ${conflictLevel.toLowerCase()}. Loyalty is currency, and old alliances are being quietly renegotiated. The ruling class projects stability but its grip is tested daily.
+
+### How to use it at the table
+Use ${realmName} as the political backdrop for a campaign, the origin of a patron, or the prize in a succession conflict. The hidden trouble gives any visit the potential to escalate into something bigger.`;
+
+    const lore = `### At a Glance
+- **Polity Type**: ${polityType}
+- **Ruler**: ${rulerName} — calculating, cautious, and sitting on a secret
+- **Capital**: ${capitalName} — walled, busy, and watched
+- **Scale**: ${scale}
+- **Magic Level**: ${magicLevel}
+- **Conflict Level**: ${conflictLevel}
+- **Hidden Problem**: ${trouble}
+- **Immediate Hook**: A royal messenger arrived three days ago and has not been seen since
+
+### Major Factions
+- **${factionName1}**: Controls access to the realm's key resource and wants more influence at court
+- **${factionName2}**: Opposes the current ruler — quietly, for now
+
+### Rumours & Hooks
+- The ruler has been sending unmarked correspondence to a foreign power
+- A border garrison was found abandoned — no bodies, no signs of battle
+- ${factionName1} is recruiting outside its usual membership
+
+### Entity Seeds
+- **Character**: ${rulerName} (ruler)
+- **Faction**: ${factionName1}
+- **Faction**: ${factionName2}
+- **Location**: ${capitalName} (capital)
+- **Event**: The hidden crisis behind ${trouble.split("—")[0].trim()}`;
+
+    return {
+      type: "faction",
+      title: realmName,
+      summary,
+      content,
+      lore,
+      labels: ["rpg-kingdom", "kingdom-generator", "imported-draft"],
+      status: "active",
+    };
+  }
+
+  async generateNation(
+    options: {
+      genre?: string;
+      polityType?: string;
+      governmentStyle?: string;
+      scale?: string;
+      conflictLevel?: string;
+      campaignContext?: string;
+      useAI?: boolean;
+    } = {},
+  ): Promise<GeneratorOutput> {
+    const genre =
+      options.genre ||
+      nationConfig.genres[
+        Math.floor(Math.random() * nationConfig.genres.length)
+      ];
+    const polityTypes =
+      nationConfig.polityTypesByGenre[genre] ??
+      nationConfig.polityTypesByGenre["Fantasy"];
+    const polityType =
+      options.polityType ||
+      polityTypes[Math.floor(Math.random() * polityTypes.length)];
+    const governmentStyle =
+      options.governmentStyle ||
+      nationConfig.governmentStyles[
+        Math.floor(Math.random() * nationConfig.governmentStyles.length)
+      ];
+    const scale = options.scale || nationConfig.scales[2];
+    const conflictLevel =
+      options.conflictLevel ||
+      nationConfig.conflictLevels[
+        Math.floor(Math.random() * nationConfig.conflictLevels.length)
+      ];
+    const campaignContext = options.campaignContext?.trim();
+    const varianceSeed = Math.floor(Math.random() * 99991) + 10;
+
+    if (options.useAI !== false) {
+      try {
+        const systemInstruction = `You are an expert RPG campaign writer. You generate immediately usable political entities for tabletop GMs in JSON format. You write in the register of the specified genre — a cyberpunk megacorp-state reads nothing like a fantasy kingdom.
+
+OUTPUT FORMAT — return ONLY a valid JSON object, no markdown fences:
+{
+  "title": "The entity's name — genre-appropriate and invented",
+  "summary": "One sentence: the entity's defining character and why a GM should use it.",
+  "content": "Markdown. Use exactly these four section headers in order: '### The State', '### Power Structure', '### Society & Tensions', '### How to use it at the table'. Each section: 3-5 tight sentences. Write in the genre's register. Include campaign context if provided.",
+  "lore": "Markdown. Use EXACTLY this structure:\\n### At a Glance\\n- **Type**: polity type\\n- **Leader / Authority**: name and one-line description (genre-appropriate)\\n- **Centre of Power**: name and one-line description\\n- **Scale**: territory/population summary\\n- **Conflict Level**: current state\\n- **Hidden Problem**: the tension simmering beneath the surface\\n- **Immediate Hook**: one-sentence GM hook\\n### Power Blocs\\n- **Name**: one-line description (2-3 factions/blocs)\\n### Rumours & Hooks\\n- short hook (2-3 bullet points)\\n### Entity Seeds\\n- list of 4-5 Codex entity types that naturally emerge from this state",
+  "labels": ["2-4 lowercase genre-appropriate tags, plus 'rpg-nation', 'nation-generator', 'imported-draft'"]
+}
+
+QUALITY RULES:
+- Everything — names, concerns, technology, terminology — must fit the genre.
+- The leader/authority must have a name, a defining trait, and a secret motive.
+- Each power bloc should have an agenda that creates tension.
+- Rumours should be specific and actionable.
+- Entity seeds should suggest concrete Codex entries a GM would actually create.`;
+
+        const userMessage = `Generate a political entity. Variation seed: ${varianceSeed}.
+- Genre / Setting: ${genre}
+- Polity Type: ${polityType}
+- Government Style: ${governmentStyle}
+- Scale: ${scale}
+- Conflict Level: ${conflictLevel}${campaignContext ? `\n- Campaign Context: ${campaignContext}` : ""}`;
+
+        const model = await this.clientManager.getModel(
+          "",
+          "gemini-3.1-flash-lite",
+          systemInstruction,
+        );
+        const response = await model.generateContent(userMessage);
+        const text = response.response.text().trim();
+        const cleanText = text
+          .replace(/^```json\s*/i, "")
+          .replace(/```$/, "")
+          .trim();
+        const data = JSON.parse(cleanText);
+
+        return {
+          type: "faction",
+          title: data.title || "The Unnamed State",
+          summary: data.summary || "",
+          content: data.content || "",
+          lore: data.lore || "",
+          labels: Array.isArray(data.labels)
+            ? data.labels
+            : ["rpg-nation", "nation-generator", "imported-draft"],
+          status: "active",
+        };
+      } catch (err) {
+        console.warn(
+          "AI generation failed, falling back to local tables:",
+          err,
+        );
+      }
+    }
+
+    // Local fallback
+    const trouble =
+      nationConfig.troubles[
+        Math.floor(Math.random() * nationConfig.troubles.length)
+      ];
+    const leaderName = this.generateName();
+    const bloc1 = `The ${this.generateName()} ${["Bloc", "Council", "Front", "Syndicate", "Coalition"][Math.floor(Math.random() * 5)]}`;
+    const bloc2 = `The ${this.generateName()} ${["Faction", "Assembly", "Circle", "Committee", "Network"][Math.floor(Math.random() * 5)]}`;
+    const rawName = this.generateName().replace(/\s+The\s+\S+$/, "");
+    const stateName = `${rawName} ${polityType}`;
+    const capitalName = this.generateName().replace(/\s+The\s+\S+$/, "");
+
+    const summary = `A ${conflictLevel.toLowerCase()} ${polityType.toLowerCase()} operating under ${governmentStyle.toLowerCase()}.`;
+
+    const content = `### The State
+${stateName} is a ${scale.toLowerCase()} ${polityType.toLowerCase()} under ${governmentStyle.toLowerCase()}. Its centre of power, ${capitalName}, is where decisions are made and deals are struck.${campaignContext ? ` In ${campaignContext}, it is a key player in the main conflict.` : ""}
+
+### Power Structure
+${leaderName} holds authority, but that authority is contested. ${trouble}. Those closest to power know the cracks are showing.
+
+### Society & Tensions
+The population lives under a state at ${conflictLevel.toLowerCase()}. Loyalty is shifting, old alliances are being renegotiated, and the ruling structure is projecting strength it may not have.
+
+### How to use it at the table
+Use ${stateName} as a campaign backdrop, the source of a mission, or the prize in a power struggle. The hidden problem gives any encounter with its institutions the potential to spiral.`;
+
+    const lore = `### At a Glance
+- **Type**: ${polityType}
+- **Leader / Authority**: ${leaderName} — in control, for now
+- **Centre of Power**: ${capitalName}
+- **Scale**: ${scale}
+- **Conflict Level**: ${conflictLevel}
+- **Hidden Problem**: ${trouble}
+- **Immediate Hook**: A key official has gone silent — their office is stonewalling
+
+### Power Blocs
+- **${bloc1}**: Controls a critical resource or access point; wants formal recognition
+- **${bloc2}**: Opposes the current leadership — quietly building leverage
+
+### Rumours & Hooks
+- ${leaderName} has been meeting with representatives of a rival power in secret
+- A key installation went dark last week; the official explanation doesn't add up
+- ${bloc1} is moving money through channels it has no business using
+
+### Entity Seeds
+- **Character**: ${leaderName} (leader)
+- **Faction**: ${bloc1}
+- **Faction**: ${bloc2}
+- **Location**: ${capitalName} (centre of power)
+- **Event**: The crisis behind ${trouble.split(" ")[0].toLowerCase()} ${trouble.split(" ")[1] ?? ""}`;
+
+    return {
+      type: "faction",
+      title: stateName,
+      summary,
+      content,
+      lore,
+      labels: ["rpg-nation", "nation-generator", "imported-draft"],
       status: "active",
     };
   }

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -1368,7 +1368,7 @@ export const nationConfig = {
 
 export const kingdomConfig = {
   polityTypes: nationConfig.polityTypesByGenre["Fantasy"],
-  governmentStyles: nationConfig.governmentStyles.slice(0, 6),
+  governmentStyles: nationConfig.governmentStyles.slice(0, 7),
   geographies: [
     "Temperate highlands",
     "Coastal plains",
@@ -3362,7 +3362,7 @@ Use ${stateName} as a campaign backdrop, the source of a mission, or the prize i
 - **Faction**: ${bloc1}
 - **Faction**: ${bloc2}
 - **Location**: ${capitalName} (centre of power)
-- **Event**: The crisis behind ${trouble.split(" ")[0].toLowerCase()} ${trouble.split(" ")[1] ?? ""}`;
+- **Event**: The crisis — ${trouble}`;
 
     return {
       type: "faction",

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -6,6 +6,8 @@
   import QuestFormFields from "$lib/components/seo/QuestFormFields.svelte";
   import TavernFormFields from "$lib/components/seo/TavernFormFields.svelte";
   import SocialHubFormFields from "$lib/components/seo/SocialHubFormFields.svelte";
+  import KingdomFormFields from "$lib/components/seo/KingdomFormFields.svelte";
+  import NationFormFields from "$lib/components/seo/NationFormFields.svelte";
   import {
     generatorEngine,
     npcThemeConfig,
@@ -14,6 +16,8 @@
     factionConfig,
     questConfig,
     socialHubConfig,
+    kingdomConfig,
+    nationConfig,
     themeIdToLabel,
     type GeneratorOutput,
   } from "$lib/services/seo/generator-engine";
@@ -99,6 +103,28 @@
         "Create a campaign-ready social venue for any genre. Pick your setting, venue type, and atmosphere — get a named location with regulars, rumours, and a hidden problem.",
       canonicalPath: "/generators/social-hub",
     },
+    kingdom: {
+      pageTitle:
+        "Kingdom Generator | Free Fantasy Realm & Empire Creator | Codex Cryptica",
+      metaDescription:
+        "Generate a detailed fantasy kingdom or empire with ruler, factions, geography, conflict, and adventure hooks. Works without login. Save into your Codex Cryptica campaign vault.",
+      introTitle: "Kingdom Generator",
+      eyebrow: "Kingdom Generator",
+      introText:
+        "Create a campaign-ready fantasy realm with a ruler, major factions, internal tensions, and adventure hooks. Works without login, then imports into your local vault.",
+      canonicalPath: "/generators/kingdom",
+    },
+    nation: {
+      pageTitle:
+        "Nation Generator | RPG Political Entity Creator for Any Genre | Codex Cryptica",
+      metaDescription:
+        "Generate a political entity for any RPG genre — fantasy kingdoms, cyberpunk megacorp-states, sci-fi federations, post-apoc warlord territories. Works without login.",
+      introTitle: "Nation Generator",
+      eyebrow: "Nation Generator",
+      introText:
+        "Create a campaign-ready political entity for any genre. Pick your setting and polity type — get a named state with power blocs, internal tensions, and adventure hooks.",
+      canonicalPath: "/generators/nation",
+    },
     tavern: {
       pageTitle:
         "Tavern Generator | Free RPG Inn & Alehouse Creator | Codex Cryptica",
@@ -161,6 +187,25 @@
     campaignContext: "",
   });
 
+  let kingdom = $state({
+    polityType: kingdomConfig.polityTypes[0],
+    governmentStyle: kingdomConfig.governmentStyles[0],
+    geography: kingdomConfig.geographies[0],
+    scale: kingdomConfig.scales[2],
+    conflictLevel: kingdomConfig.conflictLevels[0],
+    magicLevel: kingdomConfig.magicLevels[2],
+    campaignContext: "",
+  });
+
+  let nation = $state({
+    genre: nationConfig.genres[0],
+    polityType: nationConfig.polityTypesByGenre[nationConfig.genres[0]][0],
+    governmentStyle: nationConfig.governmentStyles[0],
+    scale: nationConfig.scales[2],
+    conflictLevel: nationConfig.conflictLevels[0],
+    campaignContext: "",
+  });
+
   let socialHub = $state({
     genre: socialHubConfig.genres[0],
     venueType: socialHubConfig.venueTypesByGenre[socialHubConfig.genres[0]][0],
@@ -190,6 +235,8 @@
     else if (data.slug === "faction") faction.theme = activeTheme;
     else if (data.slug === "social-hub")
       activeTheme = socialHubGenreToTheme[socialHub.genre] ?? "Classic Fantasy";
+    else if (data.slug === "nation")
+      activeTheme = socialHubGenreToTheme[nation.genre] ?? "Classic Fantasy";
   });
 
   onMount(() => {
@@ -212,6 +259,10 @@
       return generatorEngine.generateQuestHook({ ...quest, useAI });
     } else if (data.slug === "tavern") {
       return generatorEngine.generateTavern({ ...tavern, useAI });
+    } else if (data.slug === "kingdom") {
+      return generatorEngine.generateKingdom({ ...kingdom, useAI });
+    } else if (data.slug === "nation") {
+      return generatorEngine.generateNation({ ...nation, useAI });
     } else if (data.slug === "social-hub") {
       return generatorEngine.generateSocialHub({ ...socialHub, useAI });
     } else {
@@ -261,6 +312,28 @@
       labels: ["rpg-faction", "Guild", "Mercantile"],
       status: "draft",
     },
+    kingdom: {
+      type: "faction",
+      title: "The Kingdom of Vaelthorn",
+      summary:
+        "A mid-sized kingdom held together by old oaths and a ruler who is running out of allies.",
+      content:
+        "### The Realm\nVaelthorn spans three river valleys and two mountain passes. Its capital has stood for four centuries, though the walls have not been tested in a generation.\n\n### Government & Power\nKing Aldren rules through a council of six noble houses — three of which are quietly negotiating a change of leadership.",
+      lore: "",
+      labels: ["rpg-kingdom", "kingdom-generator", "imported-draft"],
+      status: "draft",
+    },
+    nation: {
+      type: "faction",
+      title: "Axiom Industrial Authority",
+      summary:
+        "A cyberpunk megacorp-state that controls three districts and is aggressively expanding into a fourth.",
+      content:
+        "### The State\nAxiom controls food, water, and network access across its territory. Citizens are employees. Dissent is a performance review issue.\n\n### Power Structure\nCEO-Governor Reyes holds executive authority but the board is restless.",
+      lore: "",
+      labels: ["rpg-nation", "nation-generator", "imported-draft"],
+      status: "draft",
+    },
     "social-hub": {
       type: "location",
       title: "Reyes' Noodle Hole",
@@ -303,7 +376,8 @@
   bind:theme={activeTheme}
   isThemeCustomizable={data.slug === "faction" ||
     data.slug === "npc" ||
-    data.slug === "social-hub"}
+    data.slug === "social-hub" ||
+    data.slug === "nation"}
   {generate}
   {initialDraft}
 >
@@ -388,6 +462,27 @@
         bind:twist={quest.twist}
         bind:reward={quest.reward}
         bind:campaignContext={quest.campaignContext}
+      />
+    {:else if data.slug === "kingdom"}
+      <KingdomFormFields
+        bind:polityType={kingdom.polityType}
+        bind:governmentStyle={kingdom.governmentStyle}
+        bind:geography={kingdom.geography}
+        bind:scale={kingdom.scale}
+        bind:conflictLevel={kingdom.conflictLevel}
+        bind:magicLevel={kingdom.magicLevel}
+        bind:campaignContext={kingdom.campaignContext}
+        onSurprise={trigger}
+      />
+    {:else if data.slug === "nation"}
+      <NationFormFields
+        bind:genre={nation.genre}
+        bind:polityType={nation.polityType}
+        bind:governmentStyle={nation.governmentStyle}
+        bind:scale={nation.scale}
+        bind:conflictLevel={nation.conflictLevel}
+        bind:campaignContext={nation.campaignContext}
+        onSurprise={trigger}
       />
     {:else if data.slug === "social-hub"}
       <SocialHubFormFields

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.ts
@@ -12,6 +12,8 @@ const validSlugs = new Set([
   "item",
   "tavern",
   "social-hub",
+  "kingdom",
+  "nation",
 ]);
 
 export const load: PageLoad = ({ params }) => {
@@ -27,7 +29,9 @@ export const load: PageLoad = ({ params }) => {
       | "quest"
       | "item"
       | "tavern"
-      | "social-hub",
+      | "social-hub"
+      | "kingdom"
+      | "nation",
   };
 };
 
@@ -41,5 +45,7 @@ export const entries: EntryGenerator = () => {
     { slug: "item" },
     { slug: "tavern" },
     { slug: "social-hub" },
+    { slug: "kingdom" },
+    { slug: "nation" },
   ];
 };

--- a/apps/web/src/routes/(marketing)/generators/[slug]/generators.test.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/generators.test.ts
@@ -29,6 +29,8 @@ describe("Generators SvelteKit Route", () => {
         { slug: "item" },
         { slug: "tavern" },
         { slug: "social-hub" },
+        { slug: "kingdom" },
+        { slug: "nation" },
       ]);
     });
   });

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -115,6 +115,20 @@
                 "Generate a social gathering venue for any genre — cyberpunk dive bars, western saloons, sci-fi cantinas, and more.",
               icon: "icon-[lucide--map-pin]",
             },
+            {
+              href: "/generators/kingdom",
+              label: "Kingdom Generator",
+              summary:
+                "Generate a fantasy kingdom or empire with ruler, factions, geography, conflict level, and adventure hooks.",
+              icon: "icon-[lucide--crown]",
+            },
+            {
+              href: "/generators/nation",
+              label: "Nation Generator",
+              summary:
+                "Generate a political entity for any genre — fantasy empires, cyberpunk megacorp-states, sci-fi federations, and more.",
+              icon: "icon-[lucide--globe]",
+            },
           ],
         },
       ],

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -93,6 +93,8 @@ export async function GET() {
     "faction",
     "tavern",
     "social-hub",
+    "kingdom",
+    "nation",
   ].map((slug) => ({
     path: `/generators/${slug}`,
     changefreq: "monthly",


### PR DESCRIPTION
## Summary

Same split as Tavern / Social Hub Generator:

- **`/generators/kingdom`** — fantasy-only Kingdom Generator with its own AI prompt, polity types, geography, magic level, and government style selectors
- **`/generators/nation`** — genre-agnostic Nation Generator covering 9 settings (Fantasy → Western) with reactive polity types and UI theme switching per genre

Both added to `/tools` page and sitemap. `nationConfig` and `kingdomConfig` follow the same shared-config pattern as `socialHubConfig`.

Closes #1256, closes #1262

## Test plan

- [ ] `/generators/kingdom` renders and generates a fantasy kingdom
- [ ] `/generators/nation` renders and generates output for all 9 genres
- [ ] Switching genre on Nation Generator updates polity types reactively
- [ ] UI theme switches when genre changes on Nation Generator
- [ ] Surprise Me works on both generators
- [ ] `/tools` shows both new cards
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)