### PR TITLE
refactor(generator-engine): split god file + improve name diversity

### DIFF
--- a/apps/web/src/lib/services/seo/generators/kingdom-nation.ts
+++ b/apps/web/src/lib/services/seo/generators/kingdom-nation.ts
@@ -1,5 +1,67 @@
 import type { DefaultAIClientManager } from "$lib/services/ai/client-manager";
-import { type GeneratorOutput, generateName } from "./base";
+import { type GeneratorOutput, generateName, pickFrom } from "./base";
+
+const REALM_ROOTS = [
+  "Ashenveil",
+  "Stonemark",
+  "Duskwall",
+  "Irongate",
+  "Coldmere",
+  "Blackthorn",
+  "Salthaven",
+  "Greymarch",
+  "Embervale",
+  "Cinderfall",
+  "Hollowreach",
+  "Dunmere",
+  "Thornwall",
+  "Wraithfen",
+  "Brokenridge",
+  "Dawnspire",
+  "Moorholt",
+  "Saltfang",
+  "Stormbreak",
+  "Halveth",
+  "Vorreth",
+  "Kaelthas",
+  "Myreth",
+  "Vorath",
+  "Dunrath",
+  "Solvane",
+  "Krethis",
+  "Aelvorn",
+  "Norrith",
+  "Caldreth",
+];
+
+const CAPITAL_WORDS = [
+  "Veth",
+  "Dorn",
+  "Rath",
+  "Moor",
+  "Holt",
+  "Fen",
+  "Wick",
+  "Crest",
+  "Gate",
+  "Hold",
+  "Keep",
+  "Reach",
+  "Wall",
+  "Ford",
+  "Vale",
+];
+
+function buildRealmName(polityType: string): string {
+  const root = pickFrom(REALM_ROOTS);
+  return `The ${root} ${polityType}`;
+}
+
+function buildCapitalName(): string {
+  const a = pickFrom(REALM_ROOTS).replace(/\s.*/, "").slice(0, 5);
+  const b = pickFrom(CAPITAL_WORDS);
+  return `${a}${b.toLowerCase()}`;
+}
 
 export const nationConfig = {
   genres: [
@@ -185,7 +247,7 @@ export async function generateKingdom(
 
 OUTPUT FORMAT — return ONLY a valid JSON object, no markdown fences:
 {
-  "title": "The realm's name — invented, fantasy-appropriate, not a generic placeholder",
+  "title": "The realm's name — invented. Use one of: a compound place-word ('Ashenveil Kingdom', 'Stonemark Empire'), an ancient-sounding root ('Kaelthas', 'Vorath'), or a short descriptive ('The Iron March', 'The Sundered Coast'). Avoid 'Eldoria', 'Arandor', 'Valdris', and any name that sounds like a stock fantasy placeholder.",
   "summary": "One sentence: the kingdom's defining character and why a GM should use it.",
   "content": "Markdown. Use exactly these four section headers in order: '### The Realm', '### Government & Power', '### Society & Culture', '### How to use it at the table'. Each section: 3-5 tight sentences. Include campaign context if provided.",
   "lore": "Markdown. Use EXACTLY this structure:\\n### At a Glance\\n- **Polity Type**: ${polityType}\\n- **Ruler**: invented name and one-line description\\n- **Capital**: invented name and one-line description\\n- **Scale**: population/territory summary\\n- **Magic Level**: ${magicLevel}\\n- **Conflict Level**: ${conflictLevel}\\n- **Hidden Problem**: the tension simmering beneath the surface\\n- **Immediate Hook**: one-sentence GM hook\\n### Major Factions\\n- **Name**: one-line description (2-3 factions)\\n### Rumours & Hooks\\n- short hook (2-3 bullet points)\\n### Entity Seeds\\n- list of 4-5 Codex entity types (e.g. '**Character**: The regent', '**Faction**: The merchant guild', '**Location**: The capital city')",
@@ -199,13 +261,19 @@ QUALITY RULES:
 - Entity seeds should suggest concrete Codex entries a GM would actually create.
 - All names must be invented — avoid generic English words as names.`;
 
+      const namingStyles = [
+        "Use a compound place-word as the realm name (e.g. 'Ashenveil Kingdom', 'Irongate Empire', 'Duskwall Duchy').",
+        "Use an ancient-sounding invented root as the realm name (e.g. 'Kaelthas', 'Vorath', 'Myreth Dominion').",
+        "Use a short descriptive phrase as the realm name (e.g. 'The Iron March', 'The Sundered Coast', 'The Pale Reach').",
+      ];
       const userMessage = `Generate a fantasy kingdom. Variation seed: ${varianceSeed}.
 - Polity Type: ${polityType}
 - Government Style: ${governmentStyle}
 - Geography: ${geography}
 - Scale: ${scale}
 - Conflict Level: ${conflictLevel}
-- Magic Level: ${magicLevel}${campaignContext ? `\n- Campaign Context: ${campaignContext}` : ""}`;
+- Magic Level: ${magicLevel}${campaignContext ? `\n- Campaign Context: ${campaignContext}` : ""}
+- Naming Directive: ${namingStyles[Math.floor(Math.random() * namingStyles.length)]}`;
 
       const model = await clientManager.getModel(
         "",
@@ -241,11 +309,10 @@ QUALITY RULES:
       Math.floor(Math.random() * kingdomConfig.troubles.length)
     ];
   const rulerName = generateName();
-  const factionName1 = `The ${generateName()} ${["Order", "Council", "League", "Brotherhood", "Guild"][Math.floor(Math.random() * 5)]}`;
-  const factionName2 = `The ${generateName()} ${["Compact", "Circle", "Assembly", "Society", "House"][Math.floor(Math.random() * 5)]}`;
-  const rawName = generateName().replace(/\s+The\s+\S+$/, "");
-  const realmName = `The ${["Kingdom", "Realm", "Domain", "Dominion", "Principality"][Math.floor(Math.random() * 5)]} of ${rawName}`;
-  const capitalName = generateName().replace(/\s+The\s+\S+$/, "");
+  const factionName1 = `The ${generateName()} ${pickFrom(["Order", "Council", "League", "Brotherhood", "Guild"])}`;
+  const factionName2 = `The ${generateName()} ${pickFrom(["Compact", "Circle", "Assembly", "Society", "House"])}`;
+  const realmName = buildRealmName(polityType);
+  const capitalName = buildCapitalName();
 
   const summary = `A ${conflictLevel.toLowerCase()} ${polityType.toLowerCase()} set in ${geography.toLowerCase()}, ruled by a ${governmentStyle.toLowerCase()}.`;
 
@@ -339,7 +406,7 @@ export async function generateNation(
 
 OUTPUT FORMAT — return ONLY a valid JSON object, no markdown fences:
 {
-  "title": "The entity's name — genre-appropriate and invented",
+  "title": "The entity's name — genre-appropriate and invented. Fantasy: compound place-word or ancient-sounding root. Cyberpunk: corp acronym or district name. Sci-Fi: designation or colonial name. Avoid generic placeholders like 'Eldoria', 'The Republic', or 'New Earth'.",
   "summary": "One sentence: the entity's defining character and why a GM should use it.",
   "content": "Markdown. Use exactly these four section headers in order: '### The State', '### Power Structure', '### Society & Tensions', '### How to use it at the table'. Each section: 3-5 tight sentences. Write in the genre's register. Include campaign context if provided.",
   "lore": "Markdown. Use EXACTLY this structure:\\n### At a Glance\\n- **Type**: polity type\\n- **Leader / Authority**: name and one-line description (genre-appropriate)\\n- **Centre of Power**: name and one-line description\\n- **Scale**: territory/population summary\\n- **Conflict Level**: current state\\n- **Hidden Problem**: the tension simmering beneath the surface\\n- **Immediate Hook**: one-sentence GM hook\\n### Power Blocs\\n- **Name**: one-line description (2-3 factions/blocs)\\n### Rumours & Hooks\\n- short hook (2-3 bullet points)\\n### Entity Seeds\\n- list of 4-5 Codex entity types that naturally emerge from this state",
@@ -394,11 +461,10 @@ QUALITY RULES:
       Math.floor(Math.random() * nationConfig.troubles.length)
     ];
   const leaderName = generateName();
-  const bloc1 = `The ${generateName()} ${["Bloc", "Council", "Front", "Syndicate", "Coalition"][Math.floor(Math.random() * 5)]}`;
-  const bloc2 = `The ${generateName()} ${["Faction", "Assembly", "Circle", "Committee", "Network"][Math.floor(Math.random() * 5)]}`;
-  const rawName = generateName().replace(/\s+The\s+\S+$/, "");
-  const stateName = `${rawName} ${polityType}`;
-  const capitalName = generateName().replace(/\s+The\s+\S+$/, "");
+  const bloc1 = `The ${generateName()} ${pickFrom(["Bloc", "Council", "Front", "Syndicate", "Coalition"])}`;
+  const bloc2 = `The ${generateName()} ${pickFrom(["Faction", "Assembly", "Circle", "Committee", "Network"])}`;
+  const stateName = buildRealmName(polityType);
+  const capitalName = buildCapitalName();
 
   const summary = `A ${conflictLevel.toLowerCase()} ${polityType.toLowerCase()} operating under ${governmentStyle.toLowerCase()}.`;
 

--- a/apps/web/src/lib/services/seo/generators/kingdom-nation.ts
+++ b/apps/web/src/lib/services/seo/generators/kingdom-nation.ts
@@ -463,8 +463,14 @@ QUALITY RULES:
   const leaderName = generateName();
   const bloc1 = `The ${generateName()} ${pickFrom(["Bloc", "Council", "Front", "Syndicate", "Coalition"])}`;
   const bloc2 = `The ${generateName()} ${pickFrom(["Faction", "Assembly", "Circle", "Committee", "Network"])}`;
-  const stateName = buildRealmName(polityType);
-  const capitalName = buildCapitalName();
+  const isFantasyGenre =
+    genre === "Fantasy" || genre === "Dark Fantasy" || genre === "Pirate";
+  const stateName = isFantasyGenre
+    ? buildRealmName(polityType)
+    : `${generateName().split(" ")[0]} ${polityType}`;
+  const capitalName = isFantasyGenre
+    ? buildCapitalName()
+    : generateName().split(" ")[0];
 
   const summary = `A ${conflictLevel.toLowerCase()} ${polityType.toLowerCase()} operating under ${governmentStyle.toLowerCase()}.`;
 

--- a/apps/web/src/lib/services/seo/generators/social-hub.ts
+++ b/apps/web/src/lib/services/seo/generators/social-hub.ts
@@ -1,5 +1,70 @@
 import type { DefaultAIClientManager } from "$lib/services/ai/client-manager";
-import { type GeneratorOutput, generateName } from "./base";
+import { type GeneratorOutput, generateName, pickFrom } from "./base";
+
+const VENUE_ADJECTIVES = [
+  "Sullen",
+  "Hollow",
+  "Gilded",
+  "Rusted",
+  "Crooked",
+  "Dented",
+  "Ashen",
+  "Salted",
+  "Blackened",
+  "Broken",
+  "Mended",
+  "Tarnished",
+  "Pale",
+  "Sunken",
+  "Knotted",
+  "Scorched",
+  "Pitted",
+  "Leaning",
+  "Weathered",
+  "Splintered",
+  "Salted",
+  "Cracked",
+  "Smoked",
+  "Bitter",
+  "Coppery",
+  "Hammered",
+  "Bolted",
+  "Warped",
+  "Tarred",
+  "Lopsided",
+];
+
+const VENUE_NOUNS = [
+  "Flagon",
+  "Anvil",
+  "Lantern",
+  "Cauldron",
+  "Chain",
+  "Barrel",
+  "Bell",
+  "Crow",
+  "Hound",
+  "Kettle",
+  "Nail",
+  "Rope",
+  "Spoke",
+  "Tide",
+  "Torch",
+  "Wheel",
+  "Clasp",
+  "Rivet",
+  "Whetstone",
+  "Tallow",
+  "Spit",
+  "Hook",
+  "Peg",
+  "Gust",
+  "Ember",
+];
+
+function buildTavernName(): string {
+  return `The ${pickFrom(VENUE_ADJECTIVES)} ${pickFrom(VENUE_NOUNS)}`;
+}
 
 export const socialHubConfig = {
   genres: [
@@ -216,7 +281,7 @@ export async function generateSocialHub(
 
 OUTPUT FORMAT — return ONLY a valid JSON object, no markdown fences:
 {
-  "title": "The venue's name — genre-appropriate (a cyberpunk dive has a neon handle, a fantasy inn has 'The X Y' naming, a western saloon uses frontier naming, etc.)",
+  "title": "The venue's name — genre-appropriate and specific. Fantasy: worn adjective + mundane noun (e.g. 'The Sullen Lantern', 'The Dented Kettle'). Cyberpunk: handle or moniker. Western: frontier object or ironic phrase. Avoid stock names like The Golden Goblet, The Silver Stag, The Prancing Pony.",
   "summary": "One sentence: the venue's character and why a GM should use it.",
   "content": "Markdown. Use exactly these four section headers in order: '### The Place', '### The People', '### The Trouble', '### How to use it at the table'. Each section: 2-4 tight sentences. Write in the genre's register. Include campaign context if provided.",
   "lore": "Markdown. Use EXACTLY this structure:\\n### At a Glance\\n- **Type**: venue type\\n- **Atmosphere**: mood and feel\\n- **Owner / Operator**: name and one-line description (genre-appropriate)\\n- **Signature Drink or Service**: specific invented item or service\\n- **Hidden Problem**: the trouble simmering beneath the surface\\n- **Immediate Hook**: one-sentence GM hook\\n### Notable Regulars\\n- **Name**: one-line description (2-3 regulars, genre-appropriate)\\n### Rumours\\n- short rumour (2-3 rumours as bullet points)\\n### Entity Seeds\\n- list of 3-4 Codex entity types that naturally emerge from this venue (e.g. '**Location**: The back room')",
@@ -273,27 +338,26 @@ QUALITY RULES:
   const ownerName = generateName();
   const patron1 = generateName();
   const patron2 = generateName();
-  const rawName = generateName().replace(/\s+The\s+\S+$/, "");
 
-  const fantasyLikeSuffixes = ["Arms", "Rest", "Tap", "Lodge", "House"];
-  const cyberpunkSuffixes = ["Node", "Den", "Hub", "Spot", "Joint"];
-  const westernSuffixes = ["Saloon", "House", "Post", "Room", "Bar"];
   const suffixMap: Record<string, string[]> = {
-    Fantasy: fantasyLikeSuffixes,
-    "Dark Fantasy": fantasyLikeSuffixes,
+    Fantasy: ["Arms", "Rest", "Tap", "Lodge", "House"],
+    "Dark Fantasy": ["Hollow", "Den", "Haunt", "Cellar", "Pit"],
     Pirate: ["Cove", "Hole", "Deck", "Anchor", "Port"],
-    Cyberpunk: cyberpunkSuffixes,
+    Cyberpunk: ["Node", "Den", "Hub", "Spot", "Joint"],
     "Sci-Fi": ["Bay", "Dock", "Zone", "Platform", "Hub"],
     Modern: ["Bar", "Lounge", "Spot", "Place", "Corner"],
     Horror: ["Den", "Hollow", "Parlour", "Chamber", "Haunt"],
     "Post-Apocalyptic": ["Shack", "Hole", "Stop", "Den", "Post"],
-    Western: westernSuffixes,
+    Western: ["Saloon", "House", "Post", "Room", "Bar"],
   };
-  const suffixes = suffixMap[genre] ?? fantasyLikeSuffixes;
+  const suffixes = suffixMap[genre] ?? suffixMap["Fantasy"];
+  const suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
+  const adj = pickFrom(VENUE_ADJECTIVES);
+  const noun = pickFrom(VENUE_NOUNS);
   const venueName =
     genre === "Cyberpunk" || genre === "Sci-Fi"
-      ? `${rawName}'s ${suffixes[Math.floor(Math.random() * suffixes.length)]}`
-      : `The ${rawName} ${suffixes[Math.floor(Math.random() * suffixes.length)]}`;
+      ? `${ownerName.split(" ")[0]}'s ${suffix}`
+      : `The ${adj} ${noun}`;
 
   const summary = `A ${atmosphere.toLowerCase()} ${venueType.toLowerCase()} serving ${clientele.toLowerCase()}.`;
 
@@ -383,11 +447,11 @@ export async function generateTavern(
   const campaignContext = options.campaignContext?.trim();
 
   const namingStyles = [
-    "Name it after an animal and a colour or material (e.g. 'The Copper Boar').",
-    "Name it after an object associated with the owner's past — a weapon, trade tool, or keepsake.",
-    "Use a short ironic phrase that locals find funny (e.g. 'The Honest Scales').",
-    "Name it after a local legend, battle, or geographical feature specific to the setting.",
-    "Use a two-word compound that evokes the atmosphere — one noun, one adjective (e.g. 'The Sullen Lantern').",
+    "Name it after an animal and a worn or unlikely material (e.g. 'The Tin Boar', 'The Pitted Heron').",
+    "Name it after a physical object associated with the owner's past — a weapon, trade tool, or keepsake (e.g. 'The Broken Spoke', 'The Dented Kettle').",
+    "Use a short ironic or sardonic phrase (e.g. 'The Honest Scales', 'The Fair Price', 'The Warm Welcome').",
+    "Name it after an obscure local legend, a minor battle, or a peculiar geographical feature — not a generic landmark.",
+    "Use a two-word compound that evokes the atmosphere — a worn adjective plus a mundane noun (e.g. 'The Sullen Lantern', 'The Leaning Barrel', 'The Scorched Bell').",
   ];
   const varianceSeed = Math.floor(Math.random() * 99991) + 10;
 
@@ -409,7 +473,9 @@ QUALITY RULES:
 - Each patron should feel like a distinct person with a reason to be there.
 - Rumours should be specific, not generic ('a merchant was poisoned last week' beats 'strange things have been happening').
 - Entity seeds should suggest concrete Codex entries a GM could create.
-- Place names and NPC names must be invented — avoid Oakhaven, Millbrook, Riverdale, and generic monosyllable English surnames.`;
+- Place names and NPC names must be invented — avoid Oakhaven, Millbrook, Riverdale, and generic monosyllable English surnames.
+- Never use: The Prancing Pony, The Silver Stag, The Golden Goblet, The Wandering Wizard, The Rusty Sword, The Dragon's Den, The Black Cat, The Red Lion, or any name that reads like a stock fantasy placeholder.
+- Prefer names with a specific, slightly worn quality — something that feels like it was named by a local, not by a committee.`;
 
       const userMessage = `Generate a tavern. Variation seed: ${varianceSeed}.
 - Type: ${tavernType}
@@ -455,8 +521,7 @@ QUALITY RULES:
   const ownerName = generateName();
   const patron1 = generateName();
   const patron2 = generateName();
-  const rawName = generateName().replace(/\s+The\s+\S+$/, "");
-  const tavernName = `The ${rawName} ${["Arms", "Rest", "Tap", "Lodge", "House"][Math.floor(Math.random() * 5)]}`;
+  const tavernName = buildTavernName();
 
   const summary = `A ${atmosphere.toLowerCase()} ${tavernType.toLowerCase()} serving ${clientele.toLowerCase()} in a ${settlementType.toLowerCase()}.`;
 

--- a/apps/web/src/lib/services/seo/generators/social-hub.ts
+++ b/apps/web/src/lib/services/seo/generators/social-hub.ts
@@ -22,7 +22,6 @@ const VENUE_ADJECTIVES = [
   "Leaning",
   "Weathered",
   "Splintered",
-  "Salted",
   "Cracked",
   "Smoked",
   "Bitter",
@@ -339,25 +338,14 @@ QUALITY RULES:
   const patron1 = generateName();
   const patron2 = generateName();
 
-  const suffixMap: Record<string, string[]> = {
-    Fantasy: ["Arms", "Rest", "Tap", "Lodge", "House"],
-    "Dark Fantasy": ["Hollow", "Den", "Haunt", "Cellar", "Pit"],
-    Pirate: ["Cove", "Hole", "Deck", "Anchor", "Port"],
+  const techSuffixes: Record<string, string[]> = {
     Cyberpunk: ["Node", "Den", "Hub", "Spot", "Joint"],
     "Sci-Fi": ["Bay", "Dock", "Zone", "Platform", "Hub"],
-    Modern: ["Bar", "Lounge", "Spot", "Place", "Corner"],
-    Horror: ["Den", "Hollow", "Parlour", "Chamber", "Haunt"],
-    "Post-Apocalyptic": ["Shack", "Hole", "Stop", "Den", "Post"],
-    Western: ["Saloon", "House", "Post", "Room", "Bar"],
   };
-  const suffixes = suffixMap[genre] ?? suffixMap["Fantasy"];
-  const suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
-  const adj = pickFrom(VENUE_ADJECTIVES);
-  const noun = pickFrom(VENUE_NOUNS);
-  const venueName =
-    genre === "Cyberpunk" || genre === "Sci-Fi"
-      ? `${ownerName.split(" ")[0]}'s ${suffix}`
-      : `The ${adj} ${noun}`;
+  const isTechGenre = genre === "Cyberpunk" || genre === "Sci-Fi";
+  const venueName = isTechGenre
+    ? `${ownerName.split(" ")[0]}'s ${pickFrom(techSuffixes[genre])}`
+    : `The ${pickFrom(VENUE_ADJECTIVES)} ${pickFrom(VENUE_NOUNS)}`;
 
   const summary = `A ${atmosphere.toLowerCase()} ${venueType.toLowerCase()} serving ${clientele.toLowerCase()}.`;
 


### PR DESCRIPTION
## Summary

- Extracts the 3384-line `generator-engine.ts` monolith into 9 focused sub-modules under `src/lib/services/seo/generators/` (max 578 lines each), with `generator-engine.ts` reduced to a ~100-line barrel + `DefaultGeneratorEngine` facade
- Fixes two kingdom/nation generator bugs found in review: missing "Tribal / clan elders" government style, and truncated nation entity seed text
- Fixes `Immediate Hook` capitalisation inconsistency in faction local-fallback lore
- Adds dedicated name tables (`VENUE_ADJECTIVES/NOUNS`, `REALM_ROOTS/CAPITAL_WORDS`) and rotating naming directives so tavern, social hub, kingdom, and nation generators produce specific, non-repeating names instead of reusing the character name generator
- Adds explicit blacklists in AI system instructions to prevent stock fantasy names (The Golden Goblet, Eldoria, etc.)

## Test plan

- [ ] All existing tests pass (0 errors, 0 type errors)
- [ ] Generate a tavern several times — names should vary and avoid clichés
- [ ] Generate a kingdom/nation several times — realm names should use compound place-words or ancient roots, not generic English
- [ ] Verify all generator pages still load and produce output (NPC, Faction, Vampire Clan, Settlement, Magic Item, Quest, Names, Social Hub, Tavern, Kingdom, Nation)
- [ ] AI fallback path: confirm `DefaultGeneratorEngine` facade delegates correctly to sub-modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)