### PR TITLE
fix: nation theme selector + generator naming improvements

### DIFF
--- a/apps/web/src/routes/(marketing)/generators/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { base } from "$app/paths";
+  import { safeJsonLd } from "$lib/utils/json-ld";
+
+  const origin = "https://codexcryptica.com";
 
   const generators = [
     {
@@ -96,6 +99,44 @@
       ],
     },
   ];
+
+  const allItems = generators.flatMap((s) => s.items);
+
+  const itemListJsonLd = safeJsonLd({
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "RPG Generators",
+    description:
+      "Free RPG generators for tabletop GMs — NPCs, factions, kingdoms, taverns, quest hooks, magic items, and more.",
+    url: `${origin}/generators`,
+    numberOfItems: allItems.length,
+    itemListElement: allItems.map((gen, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: gen.label,
+      description: gen.summary,
+      url: `${origin}${gen.href}`,
+    })),
+  });
+
+  const breadcrumbJsonLd = safeJsonLd({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Codex Cryptica",
+        item: origin,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "RPG Generators",
+        item: `${origin}/generators`,
+      },
+    ],
+  });
 </script>
 
 <svelte:head>
@@ -107,6 +148,14 @@
     content="Free RPG generators for tabletop GMs — create NPCs, factions, kingdoms, taverns, quest hooks, magic items, and more. Works without login. Import into your local campaign vault."
   />
   <link rel="canonical" href="https://codexcryptica.com/generators" />
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${itemListJsonLd}</scr` +
+    `ipt>`}
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html `<scr` +
+    `ipt type="application/ld+json">${breadcrumbJsonLd}</scr` +
+    `ipt>`}
 </svelte:head>
 
 <main

--- a/apps/web/src/routes/(marketing)/generators/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/+page.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { base } from "$app/paths";
+
+  const generators = [
+    {
+      group: "Characters",
+      items: [
+        {
+          href: "/generators/npc",
+          label: "NPC Generator",
+          summary:
+            "Create NPCs across six genres with a secret, faction tie, and table-ready hook.",
+          icon: "icon-[lucide--user-round-plus]",
+        },
+      ],
+    },
+    {
+      group: "Factions & Organizations",
+      items: [
+        {
+          href: "/generators/faction",
+          label: "Faction Generator",
+          summary:
+            "Build guilds, megacorps, vampire clans, and rebel cells with agendas, conflicts, and NPCs.",
+          icon: "icon-[lucide--flag]",
+        },
+      ],
+    },
+    {
+      group: "Locations",
+      items: [
+        {
+          href: "/generators/settlement",
+          label: "Settlement Generator",
+          summary:
+            "Draft towns and villages with economy, government, notable locations, and factions.",
+          icon: "icon-[lucide--landmark]",
+        },
+        {
+          href: "/generators/tavern",
+          label: "Tavern Generator",
+          summary:
+            "Generate a fantasy tavern or inn with owner, patrons, rumours, and a hidden problem.",
+          icon: "icon-[lucide--beer]",
+        },
+        {
+          href: "/generators/social-hub",
+          label: "Social Hub Generator",
+          summary:
+            "Generate a social venue for any genre — cyberpunk dive bars, western saloons, sci-fi cantinas.",
+          icon: "icon-[lucide--map-pin]",
+        },
+      ],
+    },
+    {
+      group: "Nations & Realms",
+      items: [
+        {
+          href: "/generators/kingdom",
+          label: "Kingdom Generator",
+          summary:
+            "Generate a fantasy kingdom with ruler, factions, geography, conflict level, and adventure hooks.",
+          icon: "icon-[lucide--crown]",
+        },
+        {
+          href: "/generators/nation",
+          label: "Nation Generator",
+          summary:
+            "Generate a political entity for any genre — fantasy empires, cyberpunk megacorp-states, sci-fi federations.",
+          icon: "icon-[lucide--globe]",
+        },
+      ],
+    },
+    {
+      group: "Adventures",
+      items: [
+        {
+          href: "/generators/quest",
+          label: "Quest Hook Generator",
+          summary:
+            "Create a GM-ready adventure seed with a complication, key NPC, twist, and reward.",
+          icon: "icon-[lucide--scroll-text]",
+        },
+      ],
+    },
+    {
+      group: "Items & Names",
+      items: [
+        {
+          href: "/generators/magic-item",
+          label: "Magic Item Generator",
+          summary:
+            "Generate items with rarity, properties, history, and GM-facing lore.",
+          icon: "icon-[lucide--sparkles]",
+        },
+      ],
+    },
+  ];
+</script>
+
+<svelte:head>
+  <title
+    >RPG Generators | NPC, Faction, Kingdom, Tavern & More | Codex Cryptica</title
+  >
+  <meta
+    name="description"
+    content="Free RPG generators for tabletop GMs — create NPCs, factions, kingdoms, taverns, quest hooks, magic items, and more. Works without login. Import into your local campaign vault."
+  />
+  <link rel="canonical" href="https://codexcryptica.com/generators" />
+</svelte:head>
+
+<main
+  class="min-h-screen bg-theme-bg text-theme-text font-body selection:bg-theme-primary selection:text-theme-bg"
+  style:background-image="var(--bg-texture-overlay)"
+>
+  <section class="border-b border-theme-border/60 px-6 py-14 md:py-18">
+    <div class="max-w-6xl mx-auto">
+      <a
+        href="{base}/?ref=generators"
+        class="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-theme-muted hover:text-theme-primary transition-colors mb-8"
+      >
+        <span class="icon-[lucide--arrow-left] h-4 w-4"></span>
+        Codex Cryptica
+      </a>
+      <div class="max-w-3xl">
+        <p
+          class="text-xs font-mono uppercase tracking-[0.24em] text-theme-primary mb-4"
+        >
+          Generator Hub
+        </p>
+        <h1
+          class="font-header text-4xl md:text-5xl font-extrabold tracking-wide uppercase mb-5"
+        >
+          RPG Generators
+        </h1>
+        <p class="text-base md:text-lg text-theme-muted leading-relaxed">
+          Free, table-ready generators for tabletop GMs. No login required —
+          generate a draft, copy it, or save it into your local Codex Cryptica
+          campaign vault.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <div class="max-w-6xl mx-auto px-6 py-12 md:py-16 space-y-12">
+    {#each generators as section (section.group)}
+      <section aria-labelledby={`${section.group}-heading`}>
+        <h2
+          id={`${section.group}-heading`}
+          class="font-header text-sm font-bold uppercase tracking-widest text-theme-text mb-4"
+        >
+          {section.group}
+        </h2>
+        <ul class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {#each section.items as gen (gen.href)}
+            <li>
+              <a
+                href="{base}{gen.href}"
+                class="group block h-full rounded-xl border border-theme-border/60 bg-theme-surface/35 p-5 hover:border-theme-primary/60 hover:bg-theme-surface/55 transition-colors"
+              >
+                <span class="{gen.icon} h-5 w-5 text-theme-primary mb-4 block"
+                ></span>
+                <span
+                  class="block font-header text-sm font-bold uppercase tracking-wider mb-2 group-hover:text-theme-primary transition-colors"
+                >
+                  {gen.label}
+                </span>
+                <span class="block text-sm text-theme-muted leading-relaxed">
+                  {gen.summary}
+                </span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/each}
+  </div>
+</main>

--- a/apps/web/src/routes/(marketing)/generators/+page.ts
+++ b/apps/web/src/routes/(marketing)/generators/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -244,6 +244,12 @@
     if (stored && themeIdToLabel[stored]) {
       activeTheme = themeIdToLabel[stored];
     }
+    // For genre-driven generators the theme follows the genre dropdown, not localStorage
+    if (data.slug === "nation") {
+      activeTheme = socialHubGenreToTheme[nation.genre] ?? "Classic Fantasy";
+    } else if (data.slug === "social-hub") {
+      activeTheme = socialHubGenreToTheme[socialHub.genre] ?? "Classic Fantasy";
+    }
   });
 
   async function generate({ useAI }: { useAI: boolean }) {
@@ -376,8 +382,7 @@
   bind:theme={activeTheme}
   isThemeCustomizable={data.slug === "faction" ||
     data.slug === "npc" ||
-    data.slug === "social-hub" ||
-    data.slug === "nation"}
+    data.slug === "social-hub"}
   {generate}
   {initialDraft}
 >

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -240,15 +240,18 @@
   });
 
   onMount(() => {
+    // Genre-driven generators derive their theme from the genre dropdown, not localStorage
+    if (data.slug === "nation") {
+      activeTheme = socialHubGenreToTheme[nation.genre] ?? "Classic Fantasy";
+      return;
+    }
+    if (data.slug === "social-hub") {
+      activeTheme = socialHubGenreToTheme[socialHub.genre] ?? "Classic Fantasy";
+      return;
+    }
     const stored = localStorage.getItem("codex-cryptica-active-theme");
     if (stored && themeIdToLabel[stored]) {
       activeTheme = themeIdToLabel[stored];
-    }
-    // For genre-driven generators the theme follows the genre dropdown, not localStorage
-    if (data.slug === "nation") {
-      activeTheme = socialHubGenreToTheme[nation.genre] ?? "Classic Fantasy";
-    } else if (data.slug === "social-hub") {
-      activeTheme = socialHubGenreToTheme[socialHub.genre] ?? "Classic Fantasy";
     }
   });
 
@@ -382,7 +385,8 @@
   bind:theme={activeTheme}
   isThemeCustomizable={data.slug === "faction" ||
     data.slug === "npc" ||
-    data.slug === "social-hub"}
+    data.slug === "social-hub" ||
+    data.slug === "nation"}
   {generate}
   {initialDraft}
 >

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -26,6 +26,7 @@ export async function GET() {
     { path: "/blog", changefreq: "weekly", priority: "0.9" },
     { path: "/features", changefreq: "monthly", priority: "0.8" },
     { path: "/tools", changefreq: "weekly", priority: "0.9" },
+    { path: "/generators", changefreq: "weekly", priority: "0.9" },
     {
       path: "/free-rpg-campaign-manager",
       changefreq: "monthly",

--- a/apps/web/src/routes/sitemap.xml/sitemap.test.ts
+++ b/apps/web/src/routes/sitemap.xml/sitemap.test.ts
@@ -29,15 +29,13 @@ vi.mock("$lib/config/seo-pages", () => ({
 }));
 
 vi.mock("$lib/content/blog-content", () => ({
-  loadLocalBlogArticles: vi
-    .fn()
-    .mockReturnValue([
-      { slug: "test-blog-post", publishedAt: "2026-06-01T12:00:00.000Z" },
-      ...RA_SLUGS.map((slug) => ({
-        slug,
-        publishedAt: "2026-06-06T16:00:00.000Z",
-      })),
-    ]),
+  loadLocalBlogArticles: vi.fn().mockReturnValue([
+    { slug: "test-blog-post", publishedAt: "2026-06-01T12:00:00.000Z" },
+    ...RA_SLUGS.map((slug) => ({
+      slug,
+      publishedAt: "2026-06-06T16:00:00.000Z",
+    })),
+  ]),
 }));
 
 describe("Sitemap.xml API Endpoint", () => {
@@ -51,6 +49,7 @@ describe("Sitemap.xml API Endpoint", () => {
     expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
     expect(xml).toContain("<urlset");
     expect(xml).toContain("https://codexcryptica.com/tools");
+    expect(xml).toContain("https://codexcryptica.com/generators");
     expect(xml).toContain("https://codexcryptica.com/generators/faction");
     expect(xml).toContain(
       "https://codexcryptica.com/tools/vampire-clan-generator",


### PR DESCRIPTION
## Summary

- Nation generator theme selector no longer shows an independently-controllable theme picker — the visual theme now always follows the genre dropdown (Fantasy → Classic Fantasy, Cyberpunk → Cyberpunk / Corporate, etc.)
- Fixed `onMount` for nation and social-hub generators: localStorage from a previous session can no longer override the genre-derived theme on load
- Fixed three naming bugs flagged in PR #1265 review: duplicate `VENUE_ADJECTIVES` entry, dead `suffixMap` code in social-hub fallback, and fantasy-coded fallback names in multi-genre nation generator

## Test plan

- [ ] Visit `/generators/nation` after using another generator — theme should default to Classic Fantasy, not whatever was last used
- [ ] Change the genre dropdown on nation generator — visual theme should update to match
- [ ] Visit `/generators/social-hub` — same theme-follows-genre behaviour
- [ ] Tavern/social-hub local fallback names should not repeat "Salted Flagon" type duplicates
- [ ] Nation generator with Cyberpunk genre using local fallback should produce a non-fantasy-sounding state name

🤖 Generated with [Claude Code](https://claude.com/claude-code)