### PR TITLE
fix: Surprise Me preserves genre on nation & social-hub generators

### DIFF
--- a/apps/web/src/lib/components/seo/NationFormFields.svelte
+++ b/apps/web/src/lib/components/seo/NationFormFields.svelte
@@ -120,11 +120,10 @@
   <button
     type="button"
     onclick={() => {
-      genre = pick(nationConfig.genres);
-      const newPolityTypes =
+      const currentPolityTypes =
         nationConfig.polityTypesByGenre[genre] ??
         nationConfig.polityTypesByGenre["Fantasy"];
-      polityType = pick(newPolityTypes);
+      polityType = pick(currentPolityTypes);
       governmentStyle = pick(nationConfig.governmentStyles);
       scale = pick(nationConfig.scales);
       conflictLevel = pick(nationConfig.conflictLevels);

--- a/apps/web/src/lib/components/seo/SocialHubFormFields.svelte
+++ b/apps/web/src/lib/components/seo/SocialHubFormFields.svelte
@@ -127,11 +127,10 @@
   <button
     type="button"
     onclick={() => {
-      genre = pick(socialHubConfig.genres);
-      const newVenueTypes =
+      const currentVenueTypes =
         socialHubConfig.venueTypesByGenre[genre] ??
         socialHubConfig.venueTypesByGenre["Fantasy"];
-      venueType = pick(newVenueTypes);
+      venueType = pick(currentVenueTypes);
       atmosphere = pick(socialHubConfig.atmospheres);
       wealthLevel = pick(socialHubConfig.wealthLevels);
       const newClienteles =


### PR DESCRIPTION
## Summary

- Surprise Me on the Nation generator no longer randomises the genre — it keeps the user's selected genre and only randomises polity type, government style, scale, and conflict level
- Same fix applied to Social Hub: genre is preserved; venue type and clientele randomise within the current genre, atmosphere randomises from the global list (it is genre-agnostic by design)

## Why

Genre is the user's primary creative intent (e.g. "I want Cyberpunk nations"). Randomising it on every Surprise Me click forced them to reset it manually each time they wanted to generate variations within the same setting.

## Test plan

- [ ] Nation generator: set genre to Cyberpunk, click Surprise Me several times — genre should stay Cyberpunk, other fields should change
- [ ] Social Hub: set genre to Western, click Surprise Me — genre stays Western, venue type and clientele randomise within Western options, atmosphere picks from the global list

🤖 Generated with [Claude Code](https://claude.com/claude-code)