### PR TITLE
:bug: Only open folder picker on user-initiated syncs

### DIFF
--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -402,6 +402,9 @@ export class SyncStore {
           }
         },
         () => this.checkForConflicts(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       if (this.isStale(vaultIdAtStart)) return;
@@ -479,6 +482,9 @@ export class SyncStore {
           }
         },
         () => this.checkForConflicts(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       if (this.isStale(vaultIdAtStart)) return;

--- a/packages/vault-engine/src/sync-coordinator.test.ts
+++ b/packages/vault-engine/src/sync-coordinator.test.ts
@@ -111,6 +111,9 @@ describe("SyncCoordinator", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       // The loop for await (const _ of localHandle) will trigger the error
@@ -134,10 +137,36 @@ describe("SyncCoordinator", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       expect(mockLocal.requestPermission).not.toHaveBeenCalled();
       expect(mockIO.showDirectoryPicker).toHaveBeenCalled();
+    });
+
+    it("should not open the directory picker on non-interactive syncs", async () => {
+      mockIO.getLocalHandle.mockResolvedValue(null);
+      const onStateChange = vi.fn();
+
+      await coordinator.syncWithLocalFolder(
+        "v1",
+        {} as any,
+        "pull",
+        {},
+        vi.fn(),
+        onStateChange,
+        vi.fn(),
+      );
+
+      expect(mockIO.showDirectoryPicker).not.toHaveBeenCalled();
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "error",
+          errorMessage: expect.stringContaining("Folder link lost"),
+        }),
+      );
     });
 
     it("should handle save queue timeout", async () => {

--- a/packages/vault-engine/src/sync-coordinator.ts
+++ b/packages/vault-engine/src/sync-coordinator.ts
@@ -218,6 +218,7 @@ export class SyncCoordinator {
     checkForConflicts: () => Promise<void>,
     signal?: AbortSignal,
     onProgress?: (stats: any) => void,
+    options?: { interactive?: boolean },
   ) {
     return this.syncWithLocalFolder(
       activeVaultId,
@@ -229,6 +230,7 @@ export class SyncCoordinator {
       checkForConflicts,
       signal,
       onProgress,
+      options,
     );
   }
 
@@ -246,6 +248,7 @@ export class SyncCoordinator {
     checkForConflicts: () => Promise<void>,
     signal?: AbortSignal,
     onProgress?: (stats: any) => void,
+    options?: { interactive?: boolean },
   ) {
     return this.syncWithLocalFolder(
       activeVaultId,
@@ -257,6 +260,7 @@ export class SyncCoordinator {
       checkForConflicts,
       signal,
       onProgress,
+      options,
     );
   }
 
@@ -275,6 +279,7 @@ export class SyncCoordinator {
     checkForConflicts: () => Promise<void>,
     signal?: AbortSignal,
     onProgress?: (stats: any) => void,
+    options?: { interactive?: boolean },
   ) {
     if (!opfsHandle) return;
     if (signal?.aborted) return;
@@ -314,6 +319,18 @@ export class SyncCoordinator {
     }
 
     if (!localHandle) {
+      // Browsers only allow the directory picker inside a user gesture, so a
+      // background sync must not attempt to prompt — it would throw a raw
+      // SecurityError. Surface an actionable message instead.
+      if (!options?.interactive) {
+        onStateChange({
+          status: "error",
+          syncType: null,
+          errorMessage:
+            "Folder link lost. Use the sync button to reconnect this vault to its local folder.",
+        });
+        return;
+      }
       try {
         this.notifier.alert(
           "Please select a local folder to link this vault with. This is required to establish or reconnect a lost folder link.",
@@ -325,7 +342,10 @@ export class SyncCoordinator {
         onStateChange({
           status: "error",
           syncType: null,
-          errorMessage: "Failed to select folder: " + _err.message,
+          errorMessage:
+            _err.name === "SecurityError"
+              ? "The browser blocked the folder picker. Click the sync button again to choose your folder."
+              : "Failed to select folder: " + _err.message,
         });
         return;
       }


### PR DESCRIPTION
Fixes #1270

The reported error — *"Failed to select folder: Failed to execute 'showDirectoryPicker' on 'Window': Must be handling a user gesture to show a file picker"* — happened when a **background** sync (e.g. vault load) found the stored local folder handle missing or permission-revoked. The sync coordinator then called `window.alert()` followed by `showDirectoryPicker()`, which browsers reject outside a user gesture, and the raw exception text landed in the error banner.

## Fix
- `syncWithLocalFolder`/`push`/`pull` accept an `options.interactive` flag (default `false`)
- Non-interactive syncs no longer alert or open the picker; they set a friendly, actionable error instead: *"Folder link lost. Use the sync button to reconnect this vault to its local folder."*
- User-initiated syncs (`saveToFolder`/`loadFromFolder`) pass `interactive: true` and keep the reconnect-picker flow; if the browser still blocks the picker, the message is now human-readable
- New test: non-interactive sync with no handle never calls the picker and reports the friendly error; existing picker-fallback tests updated to the interactive path

Tests: vault-engine 79 ✅, web vault stores 279 ✅, svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)