### PR TITLE
:bug: Only open folder picker on user-initiated syncs (v2)

### DIFF
--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -272,14 +272,16 @@ export class SyncStore {
                 }
               },
               () => this.checkForConflicts(),
-              signal,
-              (stats: any) => {
-                if (
-                  this.deps.activeVaultId() === vaultIdAtStart &&
-                  !signal.aborted
-                ) {
-                  this.syncStats = { ...this.syncStats, ...stats };
-                }
+              {
+                signal,
+                onProgress: (stats: any) => {
+                  if (
+                    this.deps.activeVaultId() === vaultIdAtStart &&
+                    !signal.aborted
+                  ) {
+                    this.syncStats = { ...this.syncStats, ...stats };
+                  }
+                },
               },
             );
             if (signal.aborted) return;
@@ -402,8 +404,6 @@ export class SyncStore {
           }
         },
         () => this.checkForConflicts(),
-        undefined,
-        undefined,
         { interactive: true },
       );
 
@@ -482,8 +482,6 @@ export class SyncStore {
           }
         },
         () => this.checkForConflicts(),
-        undefined,
-        undefined,
         { interactive: true },
       );
 

--- a/apps/web/src/lib/stores/vault/sync-store.svelte.ts
+++ b/apps/web/src/lib/stores/vault/sync-store.svelte.ts
@@ -402,6 +402,9 @@ export class SyncStore {
           }
         },
         () => this.checkForConflicts(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       if (this.isStale(vaultIdAtStart)) return;
@@ -479,6 +482,9 @@ export class SyncStore {
           }
         },
         () => this.checkForConflicts(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       if (this.isStale(vaultIdAtStart)) return;

--- a/apps/web/tests/sync-folder-link-lost.spec.ts
+++ b/apps/web/tests/sync-folder-link-lost.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+// Regression test for #1270: when a vault's stored local folder handle is
+// stale (folder deleted / permission lost), a background sync must NOT try to
+// open the directory picker — browsers reject it outside a user gesture with
+// a raw SecurityError. Instead the sync surfaces an actionable error message.
+test.describe("Sync with lost folder link", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem("codex_skip_landing", "true");
+        localStorage.setItem(
+          "codex-cryptica-help-state",
+          JSON.stringify({ completedTours: ["initial-onboarding"] }),
+        );
+      } catch {
+        /* ignore */
+      }
+      // Track picker invocations and simulate the browser's gesture guard.
+      (window as any).__pickerCalls = 0;
+      (window as any).showDirectoryPicker = () => {
+        (window as any).__pickerCalls++;
+        const err = new Error(
+          "Failed to execute 'showDirectoryPicker' on 'Window': Must be handling a user gesture to show a file picker.",
+        );
+        err.name = "SecurityError";
+        return Promise.reject(err);
+      };
+    });
+
+    await page.goto("/");
+    await page.waitForFunction(
+      () => (window as any).vault?.isInitialized === true,
+    );
+  });
+
+  test("background sync reports a friendly error instead of opening the picker", async ({
+    page,
+  }) => {
+    // Seed a stale folder handle: a real OPFS directory handle stored in IDB,
+    // whose underlying directory is then removed so validation throws
+    // NotFoundError — the same state as a lost local folder link.
+    await page.evaluate(async () => {
+      const vaultId = (window as any).vault.activeVaultId;
+      const root = await navigator.storage.getDirectory();
+      const stale = await root.getDirectoryHandle("__stale_link_test__", {
+        create: true,
+      });
+      await new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open("CodexCryptica");
+        req.onerror = () => reject(req.error);
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction("settings", "readwrite");
+          tx.objectStore("settings").put(stale, `folderHandle_${vaultId}`);
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error);
+        };
+      });
+      await root.removeEntry("__stale_link_test__", { recursive: true });
+    });
+
+    // Reload: vault init triggers the background pull sync.
+    await page.reload();
+    await page.waitForFunction(
+      () => (window as any).vault?.isInitialized === true,
+    );
+
+    // The sync should fail with the actionable message…
+    await page.waitForFunction(
+      () =>
+        ((window as any).vault?.errorMessage ?? "").includes(
+          "Folder link lost",
+        ),
+      undefined,
+      { timeout: 15000 },
+    );
+
+    const state = await page.evaluate(() => ({
+      errorMessage: (window as any).vault.errorMessage as string,
+      pickerCalls: (window as any).__pickerCalls as number,
+    }));
+
+    // …never the raw browser SecurityError…
+    expect(state.errorMessage).not.toContain("user gesture");
+    expect(state.errorMessage).toContain("Folder link lost");
+    // …and the picker must never have been attempted without a gesture.
+    expect(state.pickerCalls).toBe(0);
+  });
+});

--- a/packages/vault-engine/src/sync-coordinator.test.ts
+++ b/packages/vault-engine/src/sync-coordinator.test.ts
@@ -111,6 +111,9 @@ describe("SyncCoordinator", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       // The loop for await (const _ of localHandle) will trigger the error
@@ -134,10 +137,36 @@ describe("SyncCoordinator", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
+        undefined,
+        undefined,
+        { interactive: true },
       );
 
       expect(mockLocal.requestPermission).not.toHaveBeenCalled();
       expect(mockIO.showDirectoryPicker).toHaveBeenCalled();
+    });
+
+    it("should not open the directory picker on non-interactive syncs", async () => {
+      mockIO.getLocalHandle.mockResolvedValue(null);
+      const onStateChange = vi.fn();
+
+      await coordinator.syncWithLocalFolder(
+        "v1",
+        {} as any,
+        "pull",
+        {},
+        vi.fn(),
+        onStateChange,
+        vi.fn(),
+      );
+
+      expect(mockIO.showDirectoryPicker).not.toHaveBeenCalled();
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "error",
+          errorMessage: expect.stringContaining("Folder link lost"),
+        }),
+      );
     });
 
     it("should handle save queue timeout", async () => {

--- a/packages/vault-engine/src/sync-coordinator.test.ts
+++ b/packages/vault-engine/src/sync-coordinator.test.ts
@@ -111,8 +111,6 @@ describe("SyncCoordinator", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
-        undefined,
-        undefined,
         { interactive: true },
       );
 
@@ -137,8 +135,6 @@ describe("SyncCoordinator", () => {
         vi.fn(),
         vi.fn(),
         vi.fn(),
-        undefined,
-        undefined,
         { interactive: true },
       );
 

--- a/packages/vault-engine/src/sync-coordinator.test.ts
+++ b/packages/vault-engine/src/sync-coordinator.test.ts
@@ -165,6 +165,28 @@ describe("SyncCoordinator", () => {
       );
     });
 
+    it("should honor an AbortSignal passed as the legacy trailing argument", async () => {
+      mockIO.getLocalHandle.mockResolvedValue(null);
+      const onStateChange = vi.fn();
+      const controller = new AbortController();
+      controller.abort();
+
+      await coordinator.syncWithLocalFolder(
+        "v1",
+        {} as any,
+        "pull",
+        {},
+        vi.fn(),
+        onStateChange,
+        vi.fn(),
+        controller.signal as any,
+      );
+
+      // Aborted before doing anything: no error state, no picker.
+      expect(onStateChange).not.toHaveBeenCalled();
+      expect(mockIO.showDirectoryPicker).not.toHaveBeenCalled();
+    });
+
     it("should handle save queue timeout", async () => {
       mockIO.getLocalHandle.mockResolvedValue({
         values: () => ({ next: vi.fn().mockResolvedValue({}) }),

--- a/packages/vault-engine/src/sync-coordinator.ts
+++ b/packages/vault-engine/src/sync-coordinator.ts
@@ -216,9 +216,11 @@ export class SyncCoordinator {
       failedFiles?: { path: string; error: string }[];
     }) => void,
     checkForConflicts: () => Promise<void>,
-    signal?: AbortSignal,
-    onProgress?: (stats: any) => void,
-    options?: { interactive?: boolean },
+    options?: {
+      signal?: AbortSignal;
+      onProgress?: (stats: any) => void;
+      interactive?: boolean;
+    },
   ) {
     return this.syncWithLocalFolder(
       activeVaultId,
@@ -228,8 +230,6 @@ export class SyncCoordinator {
       waitForSaves,
       onStateChange,
       checkForConflicts,
-      signal,
-      onProgress,
       options,
     );
   }
@@ -246,9 +246,11 @@ export class SyncCoordinator {
       failedFiles?: { path: string; error: string }[];
     }) => void,
     checkForConflicts: () => Promise<void>,
-    signal?: AbortSignal,
-    onProgress?: (stats: any) => void,
-    options?: { interactive?: boolean },
+    options?: {
+      signal?: AbortSignal;
+      onProgress?: (stats: any) => void;
+      interactive?: boolean;
+    },
   ) {
     return this.syncWithLocalFolder(
       activeVaultId,
@@ -258,8 +260,6 @@ export class SyncCoordinator {
       waitForSaves,
       onStateChange,
       checkForConflicts,
-      signal,
-      onProgress,
       options,
     );
   }
@@ -277,10 +277,13 @@ export class SyncCoordinator {
       failedFiles?: { path: string; error: string }[];
     }) => void,
     checkForConflicts: () => Promise<void>,
-    signal?: AbortSignal,
-    onProgress?: (stats: any) => void,
-    options?: { interactive?: boolean },
+    options?: {
+      signal?: AbortSignal;
+      onProgress?: (stats: any) => void;
+      interactive?: boolean;
+    },
   ) {
+    const { signal, onProgress, interactive } = options ?? {};
     if (!opfsHandle) return;
     if (signal?.aborted) return;
 
@@ -322,7 +325,7 @@ export class SyncCoordinator {
       // Browsers only allow the directory picker inside a user gesture, so a
       // background sync must not attempt to prompt — it would throw a raw
       // SecurityError. Surface an actionable message instead.
-      if (!options?.interactive) {
+      if (!interactive) {
         onStateChange({
           status: "error",
           syncType: null,

--- a/packages/vault-engine/src/sync-coordinator.ts
+++ b/packages/vault-engine/src/sync-coordinator.ts
@@ -218,6 +218,7 @@ export class SyncCoordinator {
     checkForConflicts: () => Promise<void>,
     signal?: AbortSignal,
     onProgress?: (stats: any) => void,
+    options?: { interactive?: boolean },
   ) {
     return this.syncWithLocalFolder(
       activeVaultId,
@@ -229,6 +230,7 @@ export class SyncCoordinator {
       checkForConflicts,
       signal,
       onProgress,
+      options,
     );
   }
 
@@ -246,6 +248,7 @@ export class SyncCoordinator {
     checkForConflicts: () => Promise<void>,
     signal?: AbortSignal,
     onProgress?: (stats: any) => void,
+    options?: { interactive?: boolean },
   ) {
     return this.syncWithLocalFolder(
       activeVaultId,
@@ -257,6 +260,7 @@ export class SyncCoordinator {
       checkForConflicts,
       signal,
       onProgress,
+      options,
     );
   }
 
@@ -275,6 +279,7 @@ export class SyncCoordinator {
     checkForConflicts: () => Promise<void>,
     signal?: AbortSignal,
     onProgress?: (stats: any) => void,
+    options?: { interactive?: boolean },
   ) {
     if (!opfsHandle) return;
     if (signal?.aborted) return;
@@ -314,6 +319,18 @@ export class SyncCoordinator {
     }
 
     if (!localHandle) {
+      // Browsers only allow the directory picker inside a user gesture, so a
+      // background sync must not attempt to prompt — it would throw a raw
+      // SecurityError. Surface an actionable message instead.
+      if (!options?.interactive) {
+        onStateChange({
+          status: "error",
+          syncType: null,
+          errorMessage:
+            "Folder link lost. Use the sync button to reconnect this vault to its local folder.",
+        });
+        return;
+      }
       try {
         this.notifier.alert(
           "Please select a local folder to link this vault with. This is required to establish or reconnect a lost folder link.",
@@ -325,7 +342,10 @@ export class SyncCoordinator {
         onStateChange({
           status: "error",
           syncType: null,
-          errorMessage: "Failed to select folder: " + _err.message,
+          errorMessage:
+            _err.name === "SecurityError"
+              ? "The browser blocked the folder picker. Click the sync button again to choose your folder."
+              : "Failed to select folder: " + _err.message,
         });
         return;
       }

--- a/packages/vault-engine/src/sync-coordinator.ts
+++ b/packages/vault-engine/src/sync-coordinator.ts
@@ -283,7 +283,11 @@ export class SyncCoordinator {
       interactive?: boolean;
     },
   ) {
-    const { signal, onProgress, interactive } = options ?? {};
+    // Defend against legacy/JS callers that still pass an AbortSignal as the
+    // trailing argument (the old positional signature) — treat it as { signal }
+    // rather than silently dropping it.
+    const { signal, onProgress, interactive } =
+      options instanceof AbortSignal ? { signal: options } : (options ?? {});
     if (!opfsHandle) return;
     if (signal?.aborted) return;
 


### PR DESCRIPTION
Re-lands #1281 (fixes #1270) — the original merge was reverted on staging; this branch reapplies it and addresses the Copilot review comments.

## The fix (unchanged from #1281)
Background syncs no longer call `window.alert()` + `showDirectoryPicker()` when the stored folder handle is lost — browsers reject the picker outside a user gesture, which produced the raw *"Must be handling a user gesture to show a file picker"* banner. Non-interactive syncs now surface: *"Folder link lost. Use the sync button to reconnect this vault to its local folder."* User-initiated syncs keep the reconnect-picker flow with a readable fallback message.

## Review feedback addressed
`syncWithLocalFolder`/`push`/`pull` now take a single trailing options object `{ signal?, onProgress?, interactive? }` instead of three positional optionals — no more `undefined, undefined, { interactive: true }` placeholders at call sites.

Tests: vault-engine 79 ✅ (incl. non-interactive-never-prompts test), web vault stores 279 ✅, svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)