### PR TITLE
Fix vampire generator document layout for #1271

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -9,6 +9,7 @@
   import { safeJsonLd } from "$lib/utils/json-ld";
   import { renderMarkdown as renderMd } from "$lib/utils/markdown";
   import { SESSION_DRAFTS_KEY } from "$lib/services/seo/generators/session-context";
+  import { getGeneratorDocumentLayout } from "$lib/components/seo/generator-document-layout";
 
   let {
     canonicalPath,
@@ -109,6 +110,8 @@
   const generatedSingular = $derived(
     eyebrow.replace(/\s*Generator\s*/i, "").trim() || "Draft",
   );
+
+  const documentLayout = $derived(getGeneratorDocumentLayout(generatedData));
 
   $effect(() => {
     if (browser && isThemeCustomizable && activeThemeId) {
@@ -672,7 +675,7 @@
                 : 'space-y-4'}"
               data-theme={worldTheme}
             >
-              {@html renderMarkdown(generatedData.content || "")}
+              {@html renderMarkdown(documentLayout.content)}
             </div>
           </div>
         {:else}
@@ -708,7 +711,7 @@
               in:fade={{ duration: 250 }}
               class="seo-md text-sm leading-relaxed text-theme-text/80"
             >
-              {@html renderLore(generatedData.lore || "")}
+              {@html renderLore(documentLayout.lore)}
             </div>
           {:else}
             <div

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -331,13 +331,13 @@
   function addToSessionHub() {
     if (!generatedData) return;
     const content = generatedData.summary
-      ? `*${generatedData.summary}*\n\n${generatedData.content}`
-      : generatedData.content;
+      ? `*${generatedData.summary}*\n\n${documentLayout.content}`
+      : documentLayout.content;
     const newDraft: SessionDraft = {
       type: generatedData.type,
       title: generatedData.title,
       content,
-      lore: generatedData.lore,
+      lore: documentLayout.lore,
       labels: generatedData.labels,
       status: generatedData.status,
     };
@@ -377,13 +377,13 @@
 
     try {
       const content = generatedData.summary
-        ? `*${generatedData.summary}*\n\n${generatedData.content}`
-        : generatedData.content;
+        ? `*${generatedData.summary}*\n\n${documentLayout.content}`
+        : documentLayout.content;
       const payload = {
         type: generatedData.type,
         title: generatedData.title,
         content,
-        lore: generatedData.lore,
+        lore: documentLayout.lore,
         labels: generatedData.labels,
         status: generatedData.status,
       };
@@ -405,9 +405,9 @@
       generatedData.summary ? `*${generatedData.summary}*` : "",
       `Labels: ${generatedData.labels.join(", ")}`,
       "",
-      generatedData.content,
+      documentLayout.content,
       "",
-      generatedData.lore,
+      documentLayout.lore,
     ]
       .filter((line) => line !== undefined)
       .join("\n")

--- a/apps/web/src/lib/components/seo/generator-document-layout.test.ts
+++ b/apps/web/src/lib/components/seo/generator-document-layout.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { getGeneratorDocumentLayout } from "./generator-document-layout";
+
+describe("getGeneratorDocumentLayout", () => {
+  it("moves vampire clan prose sections into the main document", () => {
+    const layout = getGeneratorDocumentLayout({
+      type: "faction",
+      title: "House Vey",
+      content: "### Overview\nThe clan rules from the shadows.",
+      lore: `### GM Reference Information
+- **Faction Type**: Vampire Clan
+
+### Dark Agenda
+Turn the bishop into a thrall.
+
+### Internal Conflict
+The younger brood want open war.
+
+### Notable NPCs
+- **Sire Morcant**: Old monster with brittle patience.
+
+### Rival Faction
+The Black Thurible hunts them.
+
+### Adventure Hook
+The clan needs a relic recovered before dawn.`,
+      labels: ["rpg-faction", "vampire-clan", "imported-draft"],
+      status: "active",
+    });
+
+    expect(layout.content).toContain("### Overview");
+    expect(layout.content).toContain("### Dark Agenda");
+    expect(layout.content).toContain("### Internal Conflict");
+    expect(layout.content).toContain("### Notable NPCs");
+    expect(layout.lore).toContain("### GM Reference Information");
+    expect(layout.lore).toContain("### Rival Faction");
+    expect(layout.lore).toContain("### Adventure Hook");
+    expect(layout.lore).not.toContain("### Dark Agenda");
+    expect(layout.lore).not.toContain("### Internal Conflict");
+    expect(layout.lore).not.toContain("### Notable NPCs");
+  });
+
+  it("leaves non-vampire generator content unchanged", () => {
+    const layout = getGeneratorDocumentLayout({
+      type: "faction",
+      title: "The Argent Loom",
+      content: "### What they control\nThe canal gates.",
+      lore: "### At the Table\n- **Base**: The old mint",
+      labels: ["rpg-faction", "faction-generator", "imported-draft"],
+      status: "active",
+    });
+
+    expect(layout.content).toBe("### What they control\nThe canal gates.");
+    expect(layout.lore).toBe("### At the Table\n- **Base**: The old mint");
+  });
+});

--- a/apps/web/src/lib/components/seo/generator-document-layout.test.ts
+++ b/apps/web/src/lib/components/seo/generator-document-layout.test.ts
@@ -28,16 +28,20 @@ The clan needs a relic recovered before dawn.`,
       status: "active",
     });
 
+    // All prose sections move into the main document
     expect(layout.content).toContain("### Overview");
     expect(layout.content).toContain("### Dark Agenda");
     expect(layout.content).toContain("### Internal Conflict");
     expect(layout.content).toContain("### Notable NPCs");
+    expect(layout.content).toContain("### Rival Faction");
+    expect(layout.content).toContain("### Adventure Hook");
+    // Rail contains only the compact stat block
     expect(layout.lore).toContain("### GM Reference Information");
-    expect(layout.lore).toContain("### Rival Faction");
-    expect(layout.lore).toContain("### Adventure Hook");
     expect(layout.lore).not.toContain("### Dark Agenda");
     expect(layout.lore).not.toContain("### Internal Conflict");
     expect(layout.lore).not.toContain("### Notable NPCs");
+    expect(layout.lore).not.toContain("### Rival Faction");
+    expect(layout.lore).not.toContain("### Adventure Hook");
   });
 
   it("leaves non-vampire generator content unchanged", () => {

--- a/apps/web/src/lib/components/seo/generator-document-layout.ts
+++ b/apps/web/src/lib/components/seo/generator-document-layout.ts
@@ -1,0 +1,82 @@
+import type { GeneratorOutput } from "$lib/services/seo/generator-engine";
+
+const VAMPIRE_MAIN_DOCUMENT_SECTIONS = new Set([
+  "Dark Agenda",
+  "Internal Conflict",
+  "Notable NPCs",
+]);
+
+interface MarkdownSection {
+  heading: string;
+  body: string;
+}
+
+function splitMarkdownSections(markdown: string): MarkdownSection[] {
+  const normalized = markdown.trim();
+  if (!normalized) return [];
+
+  const matches = Array.from(normalized.matchAll(/^###\s+(.+)$/gm));
+  if (matches.length === 0) {
+    return [];
+  }
+
+  return matches.map((match, index) => {
+    const heading = match[1]?.trim() ?? "";
+    const start = match.index ?? 0;
+    const end =
+      index + 1 < matches.length
+        ? (matches[index + 1].index ?? normalized.length)
+        : normalized.length;
+
+    return {
+      heading,
+      body: normalized.slice(start, end).trim(),
+    };
+  });
+}
+
+export function getGeneratorDocumentLayout(
+  generatedData: GeneratorOutput | null,
+) {
+  if (!generatedData) {
+    return { content: "", lore: "" };
+  }
+
+  const labels = Array.isArray(generatedData.labels)
+    ? generatedData.labels
+    : [];
+
+  if (!labels.includes("vampire-clan")) {
+    return {
+      content: generatedData.content || "",
+      lore: generatedData.lore || "",
+    };
+  }
+
+  const loreSections = splitMarkdownSections(generatedData.lore || "");
+  if (loreSections.length === 0) {
+    return {
+      content: generatedData.content || "",
+      lore: generatedData.lore || "",
+    };
+  }
+
+  const mainDocumentSections: string[] = [];
+  const railSections: string[] = [];
+
+  for (const section of loreSections) {
+    if (VAMPIRE_MAIN_DOCUMENT_SECTIONS.has(section.heading)) {
+      mainDocumentSections.push(section.body);
+    } else {
+      railSections.push(section.body);
+    }
+  }
+
+  return {
+    content: [generatedData.content, ...mainDocumentSections]
+      .filter(Boolean)
+      .join("\n\n")
+      .trim(),
+    lore: railSections.join("\n\n").trim(),
+  };
+}

--- a/apps/web/src/lib/components/seo/generator-document-layout.ts
+++ b/apps/web/src/lib/components/seo/generator-document-layout.ts
@@ -1,10 +1,7 @@
 import type { GeneratorOutput } from "$lib/services/seo/generator-engine";
 
-const VAMPIRE_MAIN_DOCUMENT_SECTIONS = new Set([
-  "Dark Agenda",
-  "Internal Conflict",
-  "Notable NPCs",
-]);
+// Only compact label/value stat blocks belong in the rail; everything else is prose.
+const VAMPIRE_RAIL_SECTIONS = new Set(["GM Reference Information"]);
 
 interface MarkdownSection {
   heading: string;
@@ -65,10 +62,10 @@ export function getGeneratorDocumentLayout(
   const railSections: string[] = [];
 
   for (const section of loreSections) {
-    if (VAMPIRE_MAIN_DOCUMENT_SECTIONS.has(section.heading)) {
-      mainDocumentSections.push(section.body);
-    } else {
+    if (VAMPIRE_RAIL_SECTIONS.has(section.heading)) {
       railSections.push(section.body);
+    } else {
+      mainDocumentSections.push(section.body);
     }
   }
 


### PR DESCRIPTION
## Summary
- move vampire-clan prose sections out of the right rail and into the main generated document
- keep the right rail focused on compact GM reference content
- add a reusable layout helper plus tests for vampire-specific and unchanged generator behavior

## Why
Implements #1271 under the UI/UX polish epic #1278.

The vampire-clan generator was rendering narrative sections like `Dark Agenda`, `Internal Conflict`, and `Notable NPCs` in the GM rail, which made the center document feel incomplete. This change reassigns those sections to the main document while preserving a compact right rail.

## Follow-up
A broader follow-up issue is tracked in #1283 for generalizing this content split pattern across other generators.

## Verification
- `bun run --filter web test -- src/lib/components/seo/SEOGeneratorLayout.test.ts src/lib/components/seo/generator-document-layout.test.ts src/lib/services/seo/generator-engine.test.ts`
- `bun run --filter web lint -- src/lib/components/seo/SEOGeneratorLayout.svelte src/lib/components/seo/generator-document-layout.ts src/lib/components/seo/generator-document-layout.test.ts`
- `bun run lint`
- pre-push checks passed via `bun run --filter '*' lint -- --cache --cache-strategy content` and `bun run --filter '*' test -- --changed`

## Notes
- repo-wide `bun run test` still reports existing unrelated web-suite environment teardown issues outside this change set