### PR TITLE
Generator UX polish — #1272 #1273 #1274 #1275 #1276 #1277 #1279

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -519,46 +519,16 @@
     </div>
   </header>
 
-  <!-- Compact Explainer / CTA Strip -->
+  <!-- Compact Explainer Strip — no duplicate generate CTA (#1274) -->
   <div
-    class="w-full border-b border-theme-border/30 bg-theme-surface/10 py-5 px-6"
+    class="w-full border-b border-theme-border/30 bg-theme-surface/10 py-4 px-6"
   >
-    <div
-      class="max-w-6xl mx-auto flex flex-col sm:flex-row sm:items-center justify-between gap-4"
-    >
-      <div>
-        <p
-          class="text-xs font-bold text-theme-primary uppercase tracking-widest font-header"
-        >
-          Generate campaign-ready {generatedNoun} in seconds.
-        </p>
-        <p
-          class="text-[10px] text-theme-text/85 tracking-wider uppercase font-header mt-1"
-        >
-          No account required. Results save directly to your local Codex vault.
-        </p>
-      </div>
-      <button
-        type="button"
-        onclick={() => void handleGenerate()}
-        disabled={isGenerating}
-        aria-busy={isGenerating}
-        class="px-4 py-2 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all flex items-center gap-1.5 disabled:opacity-50"
-        id="strip-generate-btn"
-        title="Generate a new draft using your current form inputs"
+    <div class="max-w-6xl mx-auto">
+      <p
+        class="text-xs font-bold text-theme-muted uppercase tracking-widest font-header"
       >
-        {#if isGenerating}
-          <span
-            class="icon-[lucide--loader-2] animate-spin w-3.5 h-3.5"
-            aria-hidden="true"
-          ></span>
-          Forging...
-        {:else}
-          <span class="icon-[lucide--dice-5] w-3.5 h-3.5" aria-hidden="true"
-          ></span>
-          Generate {generatedSingular}
-        {/if}
-      </button>
+        Generate campaign-ready {generatedNoun} in seconds — no account required.
+      </p>
     </div>
   </div>
 
@@ -601,7 +571,7 @@
             <div class="border-b border-theme-border/60 pb-4 mb-6">
               <div class="flex items-start gap-3 flex-wrap">
                 <h2
-                  class="font-header font-extrabold text-2xl md:text-3xl tracking-wide uppercase text-theme-primary"
+                  class="font-header font-bold text-xl md:text-2xl tracking-wide text-theme-text/95"
                 >
                   {generatedData.title}
                 </h2>
@@ -702,14 +672,20 @@
 
     <!-- At the Table Column: rendered third in DOM, positioned on the right on desktop -->
     <div class="lg:col-span-3 order-3 lg:order-3">
+      <!-- Mobile label — hidden on lg where the sticky card makes the context clear -->
+      <p
+        class="lg:hidden text-[10px] font-bold uppercase tracking-widest font-header text-theme-muted mb-2"
+      >
+        GM Reference
+      </p>
       <div class="sticky top-24 flex flex-col gap-6">
         <div
-          class="p-5 bg-theme-surface/20 border border-theme-border/40 rounded-2xl shadow-sm"
+          class="p-5 bg-theme-surface/45 border border-theme-border/40 rounded-2xl shadow-sm backdrop-blur-sm"
         >
           {#if generatedData}
             <div
               in:fade={{ duration: 250 }}
-              class="seo-md text-sm leading-relaxed text-theme-text/80"
+              class="seo-rail seo-md text-sm leading-relaxed text-theme-text/80"
             >
               {@html renderLore(documentLayout.lore)}
             </div>
@@ -739,7 +715,7 @@
             class="flex items-center justify-between border-b border-theme-border/60 pb-2"
           >
             <h3
-              class="font-header font-bold text-xs uppercase tracking-wider text-theme-primary"
+              class="font-header font-bold text-xs uppercase tracking-wider text-theme-text/70"
             >
               Session Hub
             </h3>
@@ -881,23 +857,29 @@
             {/if}
           </button>
 
-          <div class="flex items-center gap-2 pt-1">
-            <input
-              type="checkbox"
-              id="ai-toggle"
-              bind:checked={useAI}
-              class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none"
-            />
-            <label
-              for="ai-toggle"
-              class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
-              title="When enabled, an AI writes richer, unique lore. When off, drafts are built from local tables — fast and fully offline."
-            >
-              <span
-                class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
-              ></span>
-              AI Lore Co-Author Mode
-            </label>
+          <div class="flex flex-col gap-1 pt-1">
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="ai-toggle"
+                bind:checked={useAI}
+                class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none flex-shrink-0"
+              />
+              <label
+                for="ai-toggle"
+                class="text-[10px] font-bold uppercase tracking-wider text-theme-muted cursor-pointer flex items-center gap-1"
+              >
+                <span
+                  class="icon-[lucide--sparkles] text-theme-primary w-3.5 h-3.5"
+                ></span>
+                AI Lore Co-Author Mode
+              </label>
+            </div>
+            <p class="text-[9px] text-theme-muted/70 leading-snug pl-6">
+              {useAI
+                ? "AI writes unique, rich lore on each generate."
+                : "Fast offline mode — local tables only, no AI."}
+            </p>
           </div>
         </form>
 
@@ -1065,12 +1047,13 @@
       color-mix(in srgb, var(--color-border) 40%, transparent);
     padding-bottom: 0.25rem;
   }
+  /* Desaturated heading — primary actions keep saturated red (#1272) */
   .seo-md :global(h3) {
     font-family: var(--font-header);
     font-weight: 700;
     font-size: 1rem;
     margin: 1rem 0 0.5rem;
-    color: var(--color-primary);
+    color: color-mix(in srgb, var(--color-primary) 65%, var(--color-text));
   }
   .seo-md :global(ul) {
     list-style: disc;
@@ -1083,5 +1066,24 @@
     text-shadow: 0 0 10px
       color-mix(in srgb, var(--color-primary) 70%, transparent);
     filter: brightness(1.2);
+  }
+  /* Rail stat block — compact heading scale, muted palette (#1276) */
+  .seo-rail.seo-md :global(h3) {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: color-mix(in srgb, var(--color-text) 65%, transparent);
+    margin: 0.875rem 0 0.375rem;
+    border-bottom: none;
+  }
+  .seo-rail.seo-md :global(h2) {
+    font-size: 0.8125rem;
+    border-bottom: 1px solid
+      color-mix(in srgb, var(--color-border) 30%, transparent);
+    margin: 1rem 0 0.5rem;
+    color: color-mix(in srgb, var(--color-text) 75%, transparent);
+  }
+  .seo-rail.seo-md :global(strong) {
+    color: color-mix(in srgb, var(--color-text) 80%, transparent);
   }
 </style>

--- a/apps/web/src/lib/components/seo/VampireFormFields.svelte
+++ b/apps/web/src/lib/components/seo/VampireFormFields.svelte
@@ -21,6 +21,11 @@
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
     "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+  const hintClass = "text-[9px] text-theme-muted/75 leading-snug";
+
+  function getParenthetical(val: string) {
+    return val.match(/\(([^)]+)\)/)?.[1] ?? "";
+  }
 </script>
 
 <div class="flex flex-col gap-1.5">
@@ -69,6 +74,9 @@
       <option value={f}>{f}</option>
     {/each}
   </select>
+  {#if getParenthetical(feedingHabit)}
+    <p class={hintClass}>{getParenthetical(feedingHabit)}</p>
+  {/if}
 </div>
 
 <div class="flex flex-col gap-1.5">
@@ -85,6 +93,9 @@
       <option value={w}>{w}</option>
     {/each}
   </select>
+  {#if getParenthetical(weakness)}
+    <p class={hintClass}>{getParenthetical(weakness)}</p>
+  {/if}
 </div>
 
 <div class="flex flex-col gap-1.5">


### PR DESCRIPTION
Closes #1272 #1273 #1274 #1275 #1276 #1277 #1279 (sub-issues of #1278).

Note: #1271 was addressed in PR #1284 (already merged).

## Changes

**#1274 — Consolidate competing CTAs**
- Removed the duplicate "Generate X" button from the explainer strip. The sidebar form is now the single generate CTA per page state, matching the spec: Generate (pre) → Save to Codex (post).

**#1272 — Red colour hierarchy**
- Entity title: no longer uppercase/red/extrabold — now `text-theme-text/95 font-bold text-xl` (less "warning sign", more tome)
- `h3` headings in generated doc: desaturated via `color-mix(primary 65%, text)` instead of full primary
- Session Hub heading: muted to `text-theme-text/70`

**#1275 — Sidebar polish**
- AI toggle: added a reactive one-liner below the label ("AI writes unique, rich lore" / "Fast offline mode — local tables only, no AI.") that flips with the toggle state
- Checkbox has `flex-shrink-0` so it can't detach from its label at narrow widths

**#1273 — Truncated select labels**
- `VampireFormFields`: shows the parenthetical hint text (the mechanical payload) below the feeding habit and weakness selects whenever the selected option contains `(…)`

**#1276 — Unify rail stat block styling**
- Added `.seo-rail.seo-md` CSS overrides: h3 → `0.75rem uppercase muted`, h2 → `0.8125rem`, strong → `muted` — rail headings are now clearly smaller and secondary to the document column

**#1277 — Texture contrast**
- Rail card: `bg-theme-surface/20` → `bg-theme-surface/45` + `backdrop-blur-sm` to reduce texture bleed behind stat block text

**#1279 — Responsive layout**
- Added a mobile-only "GM Reference" label above the rail column (hidden on `lg:`) so users on narrow screens understand the column is secondary reference material
- The strip CTA removal (#1274) also eliminates the duplicate primary action on mobile

## Test plan
- [ ] Vampire Clan generator: no generate button in the explainer strip
- [ ] Entity title renders in mixed-case (not SHOUTED) and is not red
- [ ] Document h3 headings use a slightly desaturated red tone
- [ ] Generate / Save to Codex buttons remain full saturated red (primary actions)
- [ ] AI toggle shows the correct hint line and it flips when toggled
- [ ] Weakness / feeding habit selects show the parenthetical below on selection
- [ ] Right-rail headings are noticeably smaller than the center-column headings
- [ ] On mobile, "GM Reference" label appears above the stat block section
- [ ] All other generators unaffected (NPC, Quest, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)