### PR TITLE
fix: address PR #1285 unresolved review comments

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -863,6 +863,7 @@
                 type="checkbox"
                 id="ai-toggle"
                 bind:checked={useAI}
+                aria-describedby="ai-toggle-hint"
                 class="w-4 h-4 rounded border-theme-border/60 bg-theme-bg/60 text-theme-primary focus:ring-theme-primary/40 focus:outline-none flex-shrink-0"
               />
               <label
@@ -875,7 +876,10 @@
                 AI Lore Co-Author Mode
               </label>
             </div>
-            <p class="text-[9px] text-theme-muted/70 leading-snug pl-6">
+            <p
+              id="ai-toggle-hint"
+              class="text-[9px] text-theme-muted/70 leading-snug pl-6"
+            >
               {useAI
                 ? "AI writes unique, rich lore on each generate."
                 : "Fast offline mode — local tables only, no AI."}
@@ -1068,6 +1072,11 @@
     filter: brightness(1.2);
   }
   /* Rail stat block — compact heading scale, muted palette (#1276) */
+  .seo-rail.seo-md :global(.seo-label) {
+    color: color-mix(in srgb, var(--color-text) 60%, transparent);
+    text-shadow: none;
+    filter: none;
+  }
   .seo-rail.seo-md :global(h3) {
     font-size: 0.75rem;
     text-transform: uppercase;

--- a/apps/web/src/lib/components/seo/VampireFormFields.svelte
+++ b/apps/web/src/lib/components/seo/VampireFormFields.svelte
@@ -26,6 +26,9 @@
   function getParenthetical(val: string) {
     return val.match(/\(([^)]+)\)/)?.[1] ?? "";
   }
+
+  const feedingHint = $derived(getParenthetical(feedingHabit));
+  const weaknessHint = $derived(getParenthetical(weakness));
 </script>
 
 <div class="flex flex-col gap-1.5">
@@ -74,8 +77,8 @@
       <option value={f}>{f}</option>
     {/each}
   </select>
-  {#if getParenthetical(feedingHabit)}
-    <p class={hintClass}>{getParenthetical(feedingHabit)}</p>
+  {#if feedingHint}
+    <p class={hintClass}>{feedingHint}</p>
   {/if}
 </div>
 
@@ -93,8 +96,8 @@
       <option value={w}>{w}</option>
     {/each}
   </select>
-  {#if getParenthetical(weakness)}
-    <p class={hintClass}>{getParenthetical(weakness)}</p>
+  {#if weaknessHint}
+    <p class={hintClass}>{weaknessHint}</p>
   {/if}
 </div>
 

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -263,6 +263,11 @@ describe("DefaultGeneratorEngine", () => {
       });
 
       expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(mockClientManager.getModel).toHaveBeenCalledWith(
+        "",
+        "gemini-3.1-flash-lite",
+        "You are an assistant that generates detailed RPG campaign elements in JSON format.",
+      );
       expect(mockModel.generateContent).toHaveBeenCalledWith(
         expect.stringContaining("an ancient cathedral ruin"),
       );

--- a/apps/web/src/lib/services/seo/generators/faction.ts
+++ b/apps/web/src/lib/services/seo/generators/faction.ts
@@ -606,7 +606,7 @@ Return only the JSON object. Do not include markdown code block formatting like 
 
       const model = await clientManager.getModel(
         "",
-        "gemini-1.5-flash",
+        "gemini-3.1-flash-lite",
         "You are an assistant that generates detailed RPG campaign elements in JSON format.",
       );
       const response = await model.generateContent(prompt);

--- a/apps/web/src/routes/(marketing)/tools/vampire-clan-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/vampire-clan-generator/+page.svelte
@@ -79,6 +79,8 @@
   introTitle="Vampire Clan Generator"
   introText="Create undead factions with bloodlines, feeding habits, dark agendas, and table-ready hooks. Works without login, then imports into your local Codex vault."
   worldTheme="horror"
+  isThemeCustomizable={true}
+  theme="Vampire / Gothic Noir"
   {relatedLinks}
   {faqs}
   {generate}


### PR DESCRIPTION
Addresses the four unresolved Copilot comments from PR #1285.

## Changes

**`VampireFormFields.svelte`** — `getParenthetical` called twice per select
- Replaced with `$derived` runes (`feedingHint`, `weaknessHint`) computed once in script; template uses the derived values directly

**`SEOGeneratorLayout.svelte`** — AI toggle helper text not programmatically associated
- Added `aria-describedby="ai-toggle-hint"` on the checkbox input and `id="ai-toggle-hint"` on the helper `<p>`

**`SEOGeneratorLayout.svelte`** — `.seo-label` still fully saturated red in GM Reference rail
- Added `.seo-rail.seo-md :global(.seo-label)` override: muted text color, `text-shadow: none`, `filter: none`

**`faction.ts` / `generator-engine.test.ts`** — AI model bump
- `generateVampireClan` now uses `gemini-3.1-flash-lite` instead of `gemini-1.5-flash` (deprecated); test updated to assert the new model name

**`vampire-clan-generator/+page.svelte`** — missing blood.svg background
- Added `isThemeCustomizable={true}` + `theme="Vampire / Gothic Noir"` so the horror theme (and its blood.svg texture) is actually forced on page load, matching the faction/NPC generator pages

## Test plan
- [ ] Vampire generator: feeding habit / weakness selects still show parenthetical hints on selection
- [ ] AI toggle: screen reader announces helper text with the checkbox
- [ ] GM Reference rail: stat block micro-labels render muted (not saturated red)
- [ ] Primary document column labels unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
