### PR TITLE
🎨 Palette: Add focus visible styles for keyboard navigation in Layout and Modals

### DIFF
--- a/apps/web/src/lib/components/layout/AppFooter.svelte
+++ b/apps/web/src/lib/components/layout/AppFooter.svelte
@@ -18,7 +18,7 @@
         href={PATREON_URL}
         target="_blank"
         rel="noopener noreferrer"
-        class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+        class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
         >Support on Patreon</a
       >
     {/if}
@@ -27,47 +27,47 @@
         href={DISCORD_URL}
         target="_blank"
         rel="noopener noreferrer"
-        class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+        class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
         >Discord</a
       >
     {/if}
     <a
       href="{base}/features"
-      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
       >Features</a
     >
     <a
       href="{base}/tools"
-      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
       >Tools</a
     >
     <a
       href="{base}/blog"
-      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
       >Blog</a
     >
     <a
       href="{base}/responsible-ai-worldbuilding"
-      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
       >Responsible AI</a
     >
     <button
       onclick={() => modalUIStore.openSettings("help")}
-      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest cursor-pointer"
+      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest cursor-pointer focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
       >Help</button
     >
     <a
       href="{base}/privacy"
       target="_blank"
       rel="noopener noreferrer"
-      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
       >Privacy Policy</a
     >
     <a
       href="{base}/terms"
       target="_blank"
       rel="noopener noreferrer"
-      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest"
+      class="text-[10px] font-sans text-chrome-muted hover:text-chrome-text transition-colors uppercase tracking-widest focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded"
       >Terms of Service</a
     >
   </div>

--- a/apps/web/src/lib/components/layout/NotificationToast.svelte
+++ b/apps/web/src/lib/components/layout/NotificationToast.svelte
@@ -52,7 +52,7 @@
     {/if}
     <button
       type="button"
-      class="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-current/20 opacity-70 transition hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-current/40"
+      class="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-current/20 opacity-70 transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/40"
       aria-label="Dismiss notification"
       title="Dismiss"
       onclick={() => notificationStore.clearNotification()}

--- a/apps/web/src/lib/components/modals/ConfirmationModal.svelte
+++ b/apps/web/src/lib/components/modals/ConfirmationModal.svelte
@@ -83,17 +83,17 @@
       <!-- Actions -->
       <div class="flex flex-col gap-3 p-8">
         <button
-          class={`w-full rounded-xl px-6 py-3 text-xs font-bold uppercase tracking-widest transition-all ${
+          class={`w-full rounded-xl px-6 py-3 text-xs font-bold uppercase tracking-widest transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-surface ${
             dialog.isDangerous
-              ? "bg-red-600 text-white border border-red-600 hover:bg-red-700 shadow-[0_0_20px_rgba(220,38,38,0.25)]"
-              : "bg-theme-primary text-theme-bg border border-theme-primary hover:bg-theme-secondary hover:border-theme-secondary shadow-[0_0_20px_rgba(var(--color-theme-primary-rgb),0.25)]"
+              ? "bg-red-600 text-white border border-red-600 hover:bg-red-700 shadow-[0_0_20px_rgba(220,38,38,0.25)] focus-visible:ring-red-400"
+              : "bg-theme-primary text-theme-bg border border-theme-primary hover:bg-theme-secondary hover:border-theme-secondary shadow-[0_0_20px_rgba(var(--color-theme-primary-rgb),0.25)] focus-visible:ring-theme-primary"
           }`}
           onclick={handleConfirm}
         >
           {dialog.confirmLabel || "Confirm"}
         </button>
         <button
-          class="w-full rounded-xl border border-theme-border bg-theme-bg/50 px-6 py-3 text-xs font-bold uppercase tracking-widest text-theme-muted transition-all hover:bg-theme-bg hover:text-theme-text"
+          class="w-full rounded-xl border border-theme-border bg-theme-bg/50 px-6 py-3 text-xs font-bold uppercase tracking-widest text-theme-muted transition-all hover:bg-theme-bg hover:text-theme-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-2 focus-visible:ring-offset-theme-surface"
           onclick={handleCancel}
         >
           {dialog.cancelLabel || "Cancel"}


### PR DESCRIPTION
### What
Added `focus-visible` utility classes to interactive elements across three key layout/modal components (`AppFooter`, `ConfirmationModal`, and `NotificationToast`).

### Why
Keyboard users rely on visual focus indicators to navigate the interface. Relying only on standard styling, or styling that activates on regular mouse interactions (like standard `focus:`), creates a confusing or inaccessible experience. Utilizing `focus-visible` ensures that elements receive prominent focus rings specifically when navigated to via keyboard (Tab key), improving screen reader and keyboard-only accessibility without compromising the aesthetic for mouse users.

### Accessibility
- **AppFooter**: Replaced simple hover transitions with `focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none rounded` for all navigation links and the help button.
- **ConfirmationModal**: Replaced missing focus styles on the Confirm and Cancel buttons with explicit `focus-visible:ring-offset-2` and color-appropriate rings (red for dangerous actions, theme-primary for standard).
- **NotificationToast**: Switched from standard `focus:ring-2` to `focus-visible:ring-2` to prevent the focus ring from displaying during standard mouse click dismissals while preserving it for keyboard navigation.

---
*PR created automatically by Jules for task [13613706583110881036](https://jules.google.com/task/13613706583110881036) started by @eserlan*