### PR TITLE
fix: blood.svg splatter invisible behind page-background dimming overlay

### DIFF
--- a/apps/web/static/themes/blood.svg
+++ b/apps/web/static/themes/blood.svg
@@ -13,7 +13,7 @@
     </filter>
     
     <pattern id="blood-spatter" x="0" y="0" width="300" height="300" patternUnits="userSpaceOnUse">
-      <g fill="#5e0b0b" opacity="0.4" filter="url(#roughEdge)">
+      <g fill="#8a1414" opacity="0.75" filter="url(#roughEdge)">
         <!-- Splatter 1: Top Left -->
         <circle cx="60" cy="60" r="14"/>
         <circle cx="35" cy="45" r="4"/>


### PR DESCRIPTION
Follow-up to #1286. The horror theme (blood.svg texture) is now correctly forced on the vampire clan generator, but the splatter itself was invisible.

## Why

The page background renders `--bg-texture-overlay`, which layers a 50% background-color gradient over the texture. With the old SVG values (`#5e0b0b` fill at `0.4` opacity) the final rendered splatter was ~`rgb(19,2,2)` against a `rgb(5,5,5)` background — a sub-perceptual difference.

## Change

`blood.svg` splatter group: fill `#5e0b0b` → `#8a1414`, opacity `0.4` → `0.75`. Final rendered color ≈ `rgb(54,10,10)` — visible but still moody.

The rotated variants (`blood-90/180/270.svg`) are untouched: they're used as graph node backgrounds without the dimming gradient.

## Test plan
- [ ] /tools/vampire-clan-generator shows visible dark-red splatter on the page background
- [ ] Main app horror theme background not overpowering
- [ ] horror_light appearance still looks reasonable (splatter over cream background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)