### PR TITLE
:sparkles: Add create-entity CTA to graph and explorer empty states

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -444,7 +444,9 @@
         <EmptyState
           icon="icon-[lucide--network]"
           headline="Your graph is empty"
-          body="Create your first entity to see it appear here."
+          body={vault.isGuest
+            ? "Nothing has been shared with you yet."
+            : "Create your first entity to see it appear here."}
           cta={vault.isGuest ? undefined : "＋ Create your first entity"}
           onCta={vault.isGuest
             ? undefined

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -440,11 +440,17 @@
       class="absolute inset-0 flex items-center justify-center pointer-events-none"
       data-testid="graph-empty-state"
     >
-      <EmptyState
-        icon="icon-[lucide--network]"
-        headline="Your graph is empty"
-        body="Add entities in the explorer to see them appear here."
-      />
+      <div class="pointer-events-auto">
+        <EmptyState
+          icon="icon-[lucide--network]"
+          headline="Your graph is empty"
+          body="Create your first entity to see it appear here."
+          cta={vault.isGuest ? undefined : "＋ Create your first entity"}
+          onCta={vault.isGuest
+            ? undefined
+            : () => modalUIStore.requestCreateEntity()}
+        />
+      </div>
     </div>
   {/if}
 

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -27,10 +27,11 @@
   let draftContent = $state("");
 
   // Open the create form when an empty-state CTA (graph/explorer) requests it.
-  let lastCreateRequest = modalUIStore.createEntityRequests;
+  // The flag latches in the store so a request raised before this component
+  // mounts (mobile drawer closed) is consumed once the drawer opens.
   $effect(() => {
-    if (modalUIStore.createEntityRequests !== lastCreateRequest) {
-      lastCreateRequest = modalUIStore.createEntityRequests;
+    if (modalUIStore.pendingCreateEntity) {
+      modalUIStore.pendingCreateEntity = false;
       if (!vault.isGuest) {
         createError = null;
         showForm = true;

--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -26,6 +26,18 @@
   let useTemplate = $state(true);
   let draftContent = $state("");
 
+  // Open the create form when an empty-state CTA (graph/explorer) requests it.
+  let lastCreateRequest = modalUIStore.createEntityRequests;
+  $effect(() => {
+    if (modalUIStore.createEntityRequests !== lastCreateRequest) {
+      lastCreateRequest = modalUIStore.createEntityRequests;
+      if (!vault.isGuest) {
+        createError = null;
+        showForm = true;
+      }
+    }
+  });
+
   $effect(() => {
     const draft = proposerStore.draftEntity;
     if (draft) {

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -11,6 +11,7 @@
   import EntityListSearch from "./EntityListSearch.svelte";
   import EntityListFilterBar from "./EntityListFilterBar.svelte";
   import EmptyState from "$lib/components/ui/EmptyState.svelte";
+  import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 
   let {
     onSelect,
@@ -342,6 +343,10 @@
               icon="icon-[lucide--ghost]"
               headline="No entities yet"
               body="Create your first entity to start building your vault."
+              cta={vault.isGuest ? undefined : "＋ Create your first entity"}
+              onCta={vault.isGuest
+                ? undefined
+                : () => modalUIStore.requestCreateEntity()}
             />
           {:else}
             <EmptyState

--- a/apps/web/src/lib/components/explorer/EntityList.svelte
+++ b/apps/web/src/lib/components/explorer/EntityList.svelte
@@ -342,7 +342,9 @@
             <EmptyState
               icon="icon-[lucide--ghost]"
               headline="No entities yet"
-              body="Create your first entity to start building your vault."
+              body={vault.isGuest
+                ? "Nothing has been shared with you yet."
+                : "Create your first entity to start building your vault."}
               cta={vault.isGuest ? undefined : "＋ Create your first entity"}
               onCta={vault.isGuest
                 ? undefined

--- a/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
@@ -18,6 +18,10 @@ export class ModalUIStore {
   isImporting = $state(false);
   showDiceModal = $state(false);
 
+  // Incremented to signal that the entity-creation form should open
+  // (VaultControls listens; the app layout opens the mobile drawer first).
+  createEntityRequests = $state(0);
+
   showZenMode = $state(false);
   zenModeEntityId = $state<string | null>(null);
   zenModeActiveTab = $state<"overview" | "map" | "chats">("overview");
@@ -154,6 +158,10 @@ export class ModalUIStore {
 
   closeRelatedEntityDialog() {
     this.relatedEntityDialog = { open: false, sourceEntityId: null };
+  }
+
+  requestCreateEntity() {
+    this.createEntityRequests++;
   }
 
   openVaultSwitcher(intent: "create" | "open" | null = null) {

--- a/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
@@ -18,9 +18,10 @@ export class ModalUIStore {
   isImporting = $state(false);
   showDiceModal = $state(false);
 
-  // Incremented to signal that the entity-creation form should open
-  // (VaultControls listens; the app layout opens the mobile drawer first).
-  createEntityRequests = $state(0);
+  // Set to signal that the entity-creation form should open. A latching flag
+  // (not a counter) because on mobile VaultControls mounts only after the
+  // drawer opens, so it must be able to consume a request raised pre-mount.
+  pendingCreateEntity = $state(false);
 
   showZenMode = $state(false);
   zenModeEntityId = $state<string | null>(null);
@@ -161,7 +162,7 @@ export class ModalUIStore {
   }
 
   requestCreateEntity() {
-    this.createEntityRequests++;
+    this.pendingCreateEntity = true;
   }
 
   openVaultSwitcher(intent: "create" | "open" | null = null) {
@@ -297,6 +298,6 @@ export class ModalUIStore {
 // cached instance that predates the current class definition — which would
 // cause new properties to be undefined and their reactive assignments to be
 // silently dropped.
-const KEY = "__codex_modal_ui_store__v6__";
+const KEY = "__codex_modal_ui_store__v7__";
 export const modalUIStore: ModalUIStore =
   (globalThis as any)[KEY] ?? ((globalThis as any)[KEY] = new ModalUIStore());

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -401,14 +401,10 @@
   // On mobile, the entity-creation form lives in the drawer (VaultControls),
   // so a create request must also open the drawer and dismiss the full-screen
   // explorer that would otherwise cover it.
-  let lastCreateEntityRequest = modalUIStore.createEntityRequests;
   $effect(() => {
-    if (modalUIStore.createEntityRequests !== lastCreateEntityRequest) {
-      lastCreateEntityRequest = modalUIStore.createEntityRequests;
-      if (layoutUIStore.isMobile) {
-        layoutUIStore.closeSidebar();
-        isMobileMenuOpen = true;
-      }
+    if (modalUIStore.pendingCreateEntity && layoutUIStore.isMobile) {
+      layoutUIStore.closeSidebar();
+      isMobileMenuOpen = true;
     }
   });
 

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -398,6 +398,20 @@
     }
   });
 
+  // On mobile, the entity-creation form lives in the drawer (VaultControls),
+  // so a create request must also open the drawer and dismiss the full-screen
+  // explorer that would otherwise cover it.
+  let lastCreateEntityRequest = modalUIStore.createEntityRequests;
+  $effect(() => {
+    if (modalUIStore.createEntityRequests !== lastCreateEntityRequest) {
+      lastCreateEntityRequest = modalUIStore.createEntityRequests;
+      if (layoutUIStore.isMobile) {
+        layoutUIStore.closeSidebar();
+        isMobileMenuOpen = true;
+      }
+    }
+  });
+
   // Keyboard Shortcuts
   const handleKeydown = useGlobalShortcuts({
     searchStore,


### PR DESCRIPTION
Closes #1292. Part of the mobile first-time UX work tracked in #1291 (step 1 of 7).

## Problem
A new user (especially on mobile) had no reachable way to create their first entity: the graph empty state pointed at the explorer, the explorer empty state said "create your first entity" with no button, and the actual form was buried in the hamburger drawer.

## Changes
- `modalUIStore.requestCreateEntity()` — a counter signal any surface can fire
- `VaultControls` opens its "New Entity" form when the signal fires (skipped for guests)
- App layout: on mobile, the signal closes the full-screen sidebar and opens the drawer so the form is actually visible
- Graph empty state: "＋ Create your first entity" CTA (hidden for guests); copy no longer references "the explorer"
- Explorer empty state: same CTA (hidden for guests)

`EmptyState` already supported `cta`/`onCta`, so no component API changes.

## Testing
- `svelte-check`: 0 errors
- vitest: explorer, graph, layout, and ui-store suites pass (137 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)