### PR TITLE
:sparkles: Surface demo Save/Exit controls in a mobile banner

### DIFF
--- a/apps/web/src/lib/components/layout/MobileDemoBanner.svelte
+++ b/apps/web/src/lib/components/layout/MobileDemoBanner.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { demoService } from "$lib/services/demo";
+  import { themeStore } from "$lib/stores/theme.svelte";
+  import { notificationStore } from "$lib/stores/ui/notification.svelte";
+
+  let isSaving = $state(false);
+
+  const handleSave = async () => {
+    if (isSaving) return;
+    isSaving = true;
+    try {
+      await demoService.convertToWorld();
+    } catch (error) {
+      console.error(`Failed to save ${themeStore.jargon.vault}:`, error);
+      notificationStore.notify(
+        `Failed to save ${themeStore.jargon.vault}. Please try again.`,
+        "error",
+      );
+    } finally {
+      isSaving = false;
+    }
+  };
+</script>
+
+<!-- Mobile-only demo banner: on small screens the demo Save/Exit controls in
+     VaultControls are buried in the hamburger drawer, so surface them here. -->
+<div
+  class="md:hidden flex items-center gap-2 px-3 py-2 bg-chrome-surface border-b border-chrome-accent/40"
+  data-testid="mobile-demo-banner"
+  role="status"
+>
+  <span
+    class="shrink-0 px-1.5 py-0.5 border border-chrome-accent bg-chrome-accent/10 text-chrome-accent rounded text-[9px] font-bold tracking-tighter"
+  >
+    DEMO
+  </span>
+  <button
+    class="flex-1 min-h-[36px] flex items-center justify-center gap-2 rounded bg-chrome-accent text-chrome-bg font-bold text-[11px] tracking-widest uppercase transition active:scale-95 disabled:opacity-60"
+    onclick={handleSave}
+    disabled={isSaving}
+    data-testid="mobile-save-as-campaign-button"
+    aria-label={`Save as ${themeStore.jargon.vault}`}
+  >
+    <span class="icon-[lucide--save] w-3.5 h-3.5"></span>
+    {isSaving ? "SAVING…" : `SAVE AS ${themeStore.jargon.vault.toUpperCase()}`}
+  </button>
+  <button
+    class="shrink-0 min-h-[36px] px-3 flex items-center gap-1.5 rounded border border-chrome-border text-chrome-muted font-bold text-[11px] tracking-widest uppercase transition active:scale-95"
+    onclick={() => demoService.exitDemo()}
+    data-testid="mobile-exit-demo-button"
+    aria-label="Exit Demo"
+  >
+    <span class="icon-[lucide--log-out] w-3.5 h-3.5"></span>
+    EXIT
+  </button>
+</div>

--- a/apps/web/src/lib/components/layout/MobileDemoBanner.svelte
+++ b/apps/web/src/lib/components/layout/MobileDemoBanner.svelte
@@ -27,8 +27,10 @@
 <div
   class="md:hidden flex items-center gap-2 px-3 py-2 bg-chrome-surface border-b border-chrome-accent/40"
   data-testid="mobile-demo-banner"
-  role="status"
 >
+  <div class="sr-only" role="status">
+    Demo mode active. Save as {themeStore.jargon.vault} or exit.
+  </div>
   <span
     class="shrink-0 px-1.5 py-0.5 border border-chrome-accent bg-chrome-accent/10 text-chrome-accent rounded text-[9px] font-bold tracking-tighter"
   >
@@ -38,15 +40,24 @@
     class="flex-1 min-h-[36px] flex items-center justify-center gap-2 rounded bg-chrome-accent text-chrome-bg font-bold text-[11px] tracking-widest uppercase transition active:scale-95 disabled:opacity-60"
     onclick={handleSave}
     disabled={isSaving}
+    aria-busy={isSaving}
     data-testid="mobile-save-as-campaign-button"
     aria-label={`Save as ${themeStore.jargon.vault}`}
   >
-    <span class="icon-[lucide--save] w-3.5 h-3.5"></span>
+    {#if isSaving}
+      <span
+        class="icon-[lucide--loader-2] w-3.5 h-3.5 animate-spin"
+        aria-hidden="true"
+      ></span>
+    {:else}
+      <span class="icon-[lucide--save] w-3.5 h-3.5"></span>
+    {/if}
     {isSaving ? "SAVING…" : `SAVE AS ${themeStore.jargon.vault.toUpperCase()}`}
   </button>
   <button
-    class="shrink-0 min-h-[36px] px-3 flex items-center gap-1.5 rounded border border-chrome-border text-chrome-muted font-bold text-[11px] tracking-widest uppercase transition active:scale-95"
+    class="shrink-0 min-h-[36px] px-3 flex items-center gap-1.5 rounded border border-chrome-border text-chrome-muted font-bold text-[11px] tracking-widest uppercase transition active:scale-95 disabled:opacity-60"
     onclick={() => demoService.exitDemo()}
+    disabled={isSaving}
     data-testid="mobile-exit-demo-button"
     aria-label="Exit Demo"
   >

--- a/apps/web/src/lib/components/layout/MobileDemoBanner.test.ts
+++ b/apps/web/src/lib/components/layout/MobileDemoBanner.test.ts
@@ -1,0 +1,93 @@
+/** @vitest-environment jsdom */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MobileDemoBanner from "./MobileDemoBanner.svelte";
+
+const mockConvertToWorld = vi.fn();
+const mockExitDemo = vi.fn();
+
+vi.mock("$lib/services/demo", () => ({
+  demoService: {
+    convertToWorld: () => mockConvertToWorld(),
+    exitDemo: () => mockExitDemo(),
+  },
+}));
+
+vi.mock("$lib/stores/theme.svelte", () => ({
+  themeStore: {
+    jargon: {
+      vault: "campaign",
+    },
+  },
+}));
+
+const mockNotify = vi.fn();
+vi.mock("$lib/stores/ui/notification.svelte", () => ({
+  notificationStore: {
+    notify: (...args: any[]) => mockNotify(...args),
+  },
+}));
+
+describe("MobileDemoBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders correctly with DEMO tag, Save and Exit buttons", () => {
+    render(MobileDemoBanner);
+
+    expect(screen.getByText("DEMO")).toBeTruthy();
+    expect(screen.getByTestId("mobile-save-as-campaign-button")).toBeTruthy();
+    expect(screen.getByTestId("mobile-exit-demo-button")).toBeTruthy();
+  });
+
+  it("calls convertToWorld when save button is clicked", async () => {
+    mockConvertToWorld.mockResolvedValue(undefined);
+    render(MobileDemoBanner);
+
+    const saveBtn = screen.getByTestId("mobile-save-as-campaign-button");
+    await fireEvent.click(saveBtn);
+
+    expect(mockConvertToWorld).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both buttons and sets aria-busy during conversion", async () => {
+    let resolveConversion: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+      resolveConversion = resolve;
+    });
+    mockConvertToWorld.mockReturnValue(promise);
+
+    render(MobileDemoBanner);
+
+    const saveBtn = screen.getByTestId(
+      "mobile-save-as-campaign-button",
+    ) as HTMLButtonElement;
+    const exitBtn = screen.getByTestId(
+      "mobile-exit-demo-button",
+    ) as HTMLButtonElement;
+
+    await fireEvent.click(saveBtn);
+
+    // Buttons should be disabled and aria-busy should be set
+    expect(saveBtn.disabled).toBe(true);
+    expect(saveBtn.getAttribute("aria-busy")).toBe("true");
+    expect(exitBtn.disabled).toBe(true);
+
+    // Resolve conversion
+    resolveConversion();
+    await waitFor(() => {
+      expect(saveBtn.disabled).toBe(false);
+    });
+  });
+
+  it("calls exitDemo when exit button is clicked", async () => {
+    render(MobileDemoBanner);
+
+    const exitBtn = screen.getByTestId("mobile-exit-demo-button");
+    await fireEvent.click(exitBtn);
+
+    expect(mockExitDemo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -29,6 +29,7 @@
   import FatalErrorOverlay from "$lib/components/layout/FatalErrorOverlay.svelte";
   import ActivityBar from "$lib/components/layout/ActivityBar.svelte";
   import SidebarPanelHost from "$lib/components/layout/SidebarPanelHost.svelte";
+  import MobileDemoBanner from "$lib/components/layout/MobileDemoBanner.svelte";
   import GlobalModalProvider from "$lib/components/modals/GlobalModalProvider.svelte";
   import GuestSessionBootstrap from "$lib/components/vtt/GuestSessionBootstrap.svelte";
   import QuickNoteScratchpad from "$lib/components/quicknote/QuickNoteScratchpad.svelte";
@@ -431,6 +432,9 @@
 
     {#if !isPopup && !isVttFullscreen && !isZenPopout}
       <AppHeader bind:isMobileMenuOpen bind:headerEl />
+      {#if sessionModeStore.isDemoMode}
+        <MobileDemoBanner />
+      {/if}
     {/if}
 
     <div


### PR DESCRIPTION
Closes #1293. Part of the mobile first-time UX work tracked in #1291 (step 2 of 7).

## Problem
On mobile, "Save as campaign" and "Exit Demo" only existed inside `VaultControls`, which renders in the hamburger drawer — the demo → vault conversion funnel was effectively desktop-only, and mobile users had no visible indication they were in a demo.

## Changes
- New `MobileDemoBanner.svelte`: slim mobile-only (`md:hidden`) banner under the header with a DEMO badge, a primary "Save as {vault}" button, and an Exit button. Reuses `demoService.convertToWorld()` / `exitDemo()` with the same error handling as the desktop controls, plus a saving/disabled state.
- Rendered in the app layout whenever `sessionModeStore.isDemoMode` is true (skipped for popup/VTT/zen views).

Desktop behavior unchanged (banner hidden at `md+`, where the header VaultControls already show these actions).

## Testing
- `svelte-check`: 0 errors
- layout component vitest suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)