### PR TITLE
feat: mobile create-entity bottom sheet

### DIFF
--- a/apps/web/src/lib/components/VaultControls.svelte
+++ b/apps/web/src/lib/components/VaultControls.svelte
@@ -9,6 +9,7 @@
   import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
   import { notificationStore } from "$lib/stores/ui/notification.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+  import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
   import { openImportWindow } from "$lib/stores/ui/navigation";
   import { entityTemplateService } from "$lib/services/EntityTemplateService.svelte";
   import { proposerStore } from "$lib/stores/proposer.svelte";
@@ -26,11 +27,11 @@
   let useTemplate = $state(true);
   let draftContent = $state("");
 
-  // Open the create form when an empty-state CTA (graph/explorer) requests it.
-  // The flag latches in the store so a request raised before this component
-  // mounts (mobile drawer closed) is consumed once the drawer opens.
+  // Open the create form when an empty-state CTA requests it.
+  // On mobile, the layout intercepts this flag first and opens a bottom sheet;
+  // skip here so the flag isn't consumed before the layout effect runs.
   $effect(() => {
-    if (modalUIStore.pendingCreateEntity) {
+    if (modalUIStore.pendingCreateEntity && !layoutUIStore.isMobile) {
       modalUIStore.pendingCreateEntity = false;
       if (!vault.isGuest) {
         createError = null;

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.svelte
@@ -94,6 +94,14 @@
       {/await}
     {/if}
 
+    {#if modalUIStore.showMobileCreateSheet}
+      {#await loadModal(() => import("./MobileCreateEntitySheet.svelte"), "MobileCreateEntitySheet") then MobileCreateEntitySheet}
+        {#if MobileCreateEntitySheet}
+          <MobileCreateEntitySheet />
+        {/if}
+      {/await}
+    {/if}
+
     {#if notificationStore.confirmationDialog.open}
       {#await loadModal(() => import("./ConfirmationModal.svelte"), "ConfirmationModal") then ConfirmationModal}
         {#if ConfirmationModal}

--- a/apps/web/src/lib/components/modals/GlobalModalProvider.test.ts
+++ b/apps/web/src/lib/components/modals/GlobalModalProvider.test.ts
@@ -62,6 +62,7 @@ vi.mock("$lib/stores/ui/modal-ui.svelte", () => ({
     revisionDialog: { open: false, entityId: null, instructions: "" },
     lightbox: { show: false, imageUrl: "", title: "" },
     showCanvasSelector: false,
+    showMobileCreateSheet: false,
     closeMergeDialog: vi.fn(),
     closeBulkLabelDialog: vi.fn(),
     closeRelatedEntityDialog: vi.fn(),
@@ -87,12 +88,18 @@ vi.mock("$lib/components/canvas/CanvasSelectionModal.svelte", async () => ({
     .default,
 }));
 
+vi.mock("./MobileCreateEntitySheet.svelte", async () => ({
+  default: (await import("./__tests__/MobileCreateEntitySheetStub.svelte"))
+    .default,
+}));
+
 import GlobalModalProvider from "./GlobalModalProvider.svelte";
 import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
 
 describe("GlobalModalProvider", () => {
   beforeEach(() => {
     modalUIStore.showCanvasSelector = false;
+    modalUIStore.showMobileCreateSheet = false;
   });
 
   it("renders CanvasSelectionModal from the global provider when the modal state is open", async () => {
@@ -109,5 +116,21 @@ describe("GlobalModalProvider", () => {
     render(GlobalModalProvider);
 
     expect(screen.queryByTestId("canvas-selection-modal-stub")).toBeNull();
+  });
+
+  it("renders MobileCreateEntitySheet when showMobileCreateSheet is true", async () => {
+    modalUIStore.showMobileCreateSheet = true;
+
+    render(GlobalModalProvider);
+
+    expect(
+      await screen.findByTestId("mobile-create-entity-sheet-stub"),
+    ).toBeTruthy();
+  });
+
+  it("does not render MobileCreateEntitySheet when showMobileCreateSheet is false", () => {
+    render(GlobalModalProvider);
+
+    expect(screen.queryByTestId("mobile-create-entity-sheet-stub")).toBeNull();
   });
 });

--- a/apps/web/src/lib/components/modals/MobileCreateEntitySheet.svelte
+++ b/apps/web/src/lib/components/modals/MobileCreateEntitySheet.svelte
@@ -5,22 +5,25 @@
   import { categories } from "$lib/stores/categories.svelte";
   import { themeStore } from "$lib/stores/theme.svelte";
   import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+  import { focusTrap } from "$lib/actions/focusTrap";
   import { entityTemplateService } from "$lib/services/EntityTemplateService.svelte";
   import { proposerStore } from "$lib/stores/proposer.svelte";
 
   let newTitle = $state("");
   let newType = $state<string>("character");
+  let draftContent = $state("");
   let isCreating = $state(false);
   let createError = $state<string | null>(null);
   let useTemplate = $state(true);
   let inputEl = $state<HTMLInputElement | undefined>();
 
-  // Consume draft from proposer (e.g. AI-suggested entity)
+  // Consume draft from proposer (e.g. AI-suggested entity), including body content
   $effect(() => {
     const draft = proposerStore.draftEntity;
     if (draft && modalUIStore.showMobileCreateSheet) {
       newTitle = draft.title || "";
       newType = draft.type || "character";
+      draftContent = draft.content || "";
       proposerStore.clearDraftEntity();
     }
   });
@@ -33,18 +36,23 @@
     }
   });
 
-  // Autofocus input when sheet opens
+  // Autofocus input when sheet opens; reset all fields on close
   $effect(() => {
     if (modalUIStore.showMobileCreateSheet) {
       setTimeout(() => inputEl?.focus(), 100);
     } else {
       newTitle = "";
+      draftContent = "";
       createError = null;
     }
   });
 
   function close() {
     modalUIStore.showMobileCreateSheet = false;
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") close();
   }
 
   const handleCreate = async () => {
@@ -65,6 +73,13 @@
         );
         resolvedContent = entityTemplateService.extractSummary(resolvedLore);
       }
+      // Prepend AI draft content, matching VaultControls behaviour
+      if (draftContent) {
+        resolvedContent =
+          draftContent + (resolvedContent ? "\n\n" + resolvedContent : "");
+        resolvedLore =
+          draftContent + (resolvedLore ? "\n\n" + resolvedLore : "");
+      }
       const id = await vault.createEntity(newType, newTitle, {
         content: resolvedContent,
         lore: resolvedLore,
@@ -78,6 +93,8 @@
     }
   };
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <!-- Backdrop -->
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
@@ -95,6 +112,8 @@
   aria-modal="true"
   aria-label="Create {themeStore.jargon.entity}"
   data-testid="mobile-create-entity-sheet"
+  tabindex="-1"
+  use:focusTrap
   transition:fly={{ y: 400, duration: 700, easing: quintOut }}
 >
   <!-- Drag handle -->
@@ -147,6 +166,21 @@
           OPEN
         </button>
       </div>
+    </div>
+  {:else if vault.isGuest}
+    <!-- Guest mode — read-only, cannot create -->
+    <div class="px-5 pb-8 pt-2 flex flex-col gap-4 items-center text-center">
+      <span class="icon-[lucide--lock] w-8 h-8 text-chrome-muted"></span>
+      <p class="text-sm text-chrome-muted">
+        Guests cannot create entries. Exit guest mode to manage your own vault.
+      </p>
+      <button
+        type="button"
+        class="px-4 py-2.5 rounded border border-chrome-border text-chrome-muted text-sm font-bold tracking-wider hover:border-chrome-accent hover:text-chrome-text transition-colors"
+        onclick={close}
+      >
+        CLOSE
+      </button>
     </div>
   {:else}
     <!-- Create form -->

--- a/apps/web/src/lib/components/modals/MobileCreateEntitySheet.svelte
+++ b/apps/web/src/lib/components/modals/MobileCreateEntitySheet.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+  import { fly, fade } from "svelte/transition";
+  import { quintOut } from "svelte/easing";
+  import { vault } from "$lib/stores/vault.svelte";
+  import { categories } from "$lib/stores/categories.svelte";
+  import { themeStore } from "$lib/stores/theme.svelte";
+  import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+  import { entityTemplateService } from "$lib/services/EntityTemplateService.svelte";
+  import { proposerStore } from "$lib/stores/proposer.svelte";
+
+  let newTitle = $state("");
+  let newType = $state<string>("character");
+  let isCreating = $state(false);
+  let createError = $state<string | null>(null);
+  let useTemplate = $state(true);
+  let inputEl = $state<HTMLInputElement | undefined>();
+
+  // Consume draft from proposer (e.g. AI-suggested entity)
+  $effect(() => {
+    const draft = proposerStore.draftEntity;
+    if (draft && modalUIStore.showMobileCreateSheet) {
+      newTitle = draft.title || "";
+      newType = draft.type || "character";
+      proposerStore.clearDraftEntity();
+    }
+  });
+
+  // Ensure newType is valid when categories load
+  $effect(() => {
+    if (categories.list.length > 0) {
+      const valid = categories.list.some((c) => c.id === newType);
+      if (!valid) newType = categories.list[0].id;
+    }
+  });
+
+  // Autofocus input when sheet opens
+  $effect(() => {
+    if (modalUIStore.showMobileCreateSheet) {
+      setTimeout(() => inputEl?.focus(), 100);
+    } else {
+      newTitle = "";
+      createError = null;
+    }
+  });
+
+  function close() {
+    modalUIStore.showMobileCreateSheet = false;
+  }
+
+  const handleCreate = async () => {
+    if (!newTitle.trim() || isCreating) return;
+    isCreating = true;
+    createError = null;
+    try {
+      let resolvedLore = "";
+      let resolvedContent = "";
+      if (useTemplate) {
+        const folderHandle = await vault.getActiveFolderHandle();
+        const vaultHandle = await vault.getActiveVaultHandle();
+        const customTemplatesDirHandle = folderHandle ?? vaultHandle;
+        resolvedLore = await entityTemplateService.resolveTemplate(
+          newType,
+          themeStore.worldThemeId,
+          customTemplatesDirHandle,
+        );
+        resolvedContent = entityTemplateService.extractSummary(resolvedLore);
+      }
+      const id = await vault.createEntity(newType, newTitle, {
+        content: resolvedContent,
+        lore: resolvedLore,
+      });
+      vault.selectedEntityId = id;
+      close();
+    } catch (err: unknown) {
+      createError = err instanceof Error ? err.message : String(err);
+    } finally {
+      isCreating = false;
+    }
+  };
+</script>
+
+<!-- Backdrop -->
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div
+  class="fixed inset-0 z-[90] bg-black/30"
+  onclick={close}
+  aria-hidden="true"
+  transition:fade={{ duration: 500 }}
+></div>
+
+<!-- Sheet -->
+<div
+  class="fixed bottom-0 left-0 right-0 z-[91] bg-chrome-surface border-t border-chrome-border rounded-t-2xl shadow-2xl"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Create {themeStore.jargon.entity}"
+  data-testid="mobile-create-entity-sheet"
+  transition:fly={{ y: 400, duration: 700, easing: quintOut }}
+>
+  <!-- Drag handle -->
+  <div class="flex justify-center pt-3 pb-1">
+    <div class="w-10 h-1 rounded-full bg-chrome-border"></div>
+  </div>
+
+  <div class="px-5 pb-2 pt-1 flex items-center justify-between">
+    <h2 class="text-sm font-bold tracking-widest text-chrome-text uppercase">
+      New {themeStore.jargon.entity}
+    </h2>
+    <button
+      type="button"
+      class="p-1.5 rounded-full text-chrome-muted hover:text-chrome-text hover:bg-chrome-bg transition-colors"
+      onclick={close}
+      aria-label="Cancel"
+    >
+      <span class="icon-[heroicons--x-mark] w-5 h-5 block"></span>
+    </button>
+  </div>
+
+  {#if !vault.isInitialized}
+    <!-- No vault open state -->
+    <div class="px-5 pb-8 pt-2 flex flex-col gap-4 items-center text-center">
+      <span class="icon-[lucide--database] w-8 h-8 text-chrome-muted"></span>
+      <p class="text-sm text-chrome-muted">
+        Open a {themeStore.jargon.vault} first to start creating entries.
+      </p>
+      <div class="flex gap-3">
+        <button
+          type="button"
+          class="flex items-center gap-2 px-4 py-2.5 rounded border border-chrome-accent text-chrome-accent text-sm font-bold tracking-wider hover:bg-chrome-accent/10 transition-colors"
+          onclick={() => {
+            close();
+            modalUIStore.openVaultSwitcher("create");
+          }}
+        >
+          <span class="icon-[lucide--plus] w-4 h-4"></span>
+          NEW {themeStore.jargon.vault.toUpperCase()}
+        </button>
+        <button
+          type="button"
+          class="flex items-center gap-2 px-4 py-2.5 rounded border border-chrome-border text-chrome-muted text-sm font-bold tracking-wider hover:border-chrome-accent hover:text-chrome-text transition-colors"
+          onclick={() => {
+            close();
+            modalUIStore.openVaultSwitcher("open");
+          }}
+        >
+          <span class="icon-[lucide--folder-open] w-4 h-4"></span>
+          OPEN
+        </button>
+      </div>
+    </div>
+  {:else}
+    <!-- Create form -->
+    <form
+      class="px-5 pb-8 pt-2 flex flex-col gap-3"
+      onsubmit={(e) => {
+        e.preventDefault();
+        handleCreate();
+      }}
+    >
+      <input
+        bind:this={inputEl}
+        bind:value={newTitle}
+        placeholder="{themeStore.jargon.entity} title..."
+        aria-label="New {themeStore.jargon.entity} title"
+        data-testid="mobile-create-entity-title"
+        class="w-full px-4 py-3 text-base bg-chrome-bg border border-chrome-border text-chrome-text rounded-lg focus:outline-none focus:border-chrome-accent placeholder-chrome-muted/50"
+        aria-invalid={!!createError}
+      />
+
+      <select
+        bind:value={newType}
+        aria-label="Entity type"
+        class="w-full px-4 py-3 text-sm bg-chrome-bg border border-chrome-border text-chrome-text rounded-lg focus:outline-none focus:border-chrome-accent"
+      >
+        {#each categories.list as cat}
+          <option value={cat.id}>{cat.label}</option>
+        {/each}
+      </select>
+
+      <label
+        class="flex items-center gap-3 cursor-pointer select-none text-sm text-chrome-muted"
+      >
+        <input type="checkbox" bind:checked={useTemplate} class="sr-only" />
+        <div
+          class="w-9 h-5 rounded-full relative transition-colors border {useTemplate
+            ? 'bg-chrome-accent/20 border-chrome-accent/60'
+            : 'bg-chrome-bg border-chrome-border'}"
+        >
+          <div
+            class="absolute top-0.5 left-0.5 w-3.5 h-3.5 rounded-full transition-all {useTemplate
+              ? 'translate-x-4 bg-chrome-accent'
+              : 'bg-chrome-muted'}"
+          ></div>
+        </div>
+        Start from default format
+      </label>
+
+      {#if createError}
+        <p class="text-xs text-red-400 text-center" role="alert">
+          {createError}
+        </p>
+      {/if}
+
+      <div class="flex gap-3">
+        <button
+          type="button"
+          class="flex-1 py-3 rounded-lg border border-chrome-border text-chrome-muted font-bold tracking-widest text-sm hover:border-chrome-accent hover:text-chrome-text transition-colors"
+          onclick={close}
+        >
+          CANCEL
+        </button>
+        <button
+          type="submit"
+          class="flex-[2] py-3 rounded-lg bg-chrome-accent text-chrome-bg font-bold tracking-widest text-sm transition-opacity {!newTitle.trim() ||
+          isCreating
+            ? 'opacity-50 cursor-not-allowed'
+            : 'hover:bg-chrome-accent/90'}"
+          aria-disabled={!newTitle.trim() || isCreating}
+          aria-busy={isCreating}
+          data-testid="mobile-create-entity-submit"
+        >
+          {#if isCreating}
+            <span
+              class="icon-[lucide--loader-2] w-4 h-4 animate-spin inline-block mr-2"
+            ></span>
+            ADDING...
+          {:else}
+            ADD {themeStore.jargon.entity.toUpperCase()}
+          {/if}
+        </button>
+      </div>
+    </form>
+  {/if}
+</div>

--- a/apps/web/src/lib/components/modals/__tests__/MobileCreateEntitySheetStub.svelte
+++ b/apps/web/src/lib/components/modals/__tests__/MobileCreateEntitySheetStub.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { modalUIStore } from "$lib/stores/ui/modal-ui.svelte";
+</script>
+
+{#if modalUIStore.showMobileCreateSheet}
+  <div data-testid="mobile-create-entity-sheet-stub">
+    Mobile Create Entity Sheet
+  </div>
+{/if}

--- a/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
+++ b/apps/web/src/lib/stores/ui/modal-ui.svelte.ts
@@ -23,6 +23,9 @@ export class ModalUIStore {
   // drawer opens, so it must be able to consume a request raised pre-mount.
   pendingCreateEntity = $state(false);
 
+  // Mobile-only bottom sheet for creating entities
+  showMobileCreateSheet = $state(false);
+
   showZenMode = $state(false);
   zenModeEntityId = $state<string | null>(null);
   zenModeActiveTab = $state<"overview" | "map" | "chats">("overview");
@@ -276,6 +279,7 @@ export class ModalUIStore {
 
   get isAnyModalOpen() {
     return (
+      this.showMobileCreateSheet ||
       this.showSettings ||
       this.showZenMode ||
       this.showDiceModal ||
@@ -298,6 +302,6 @@ export class ModalUIStore {
 // cached instance that predates the current class definition — which would
 // cause new properties to be undefined and their reactive assignments to be
 // silently dropped.
-const KEY = "__codex_modal_ui_store__v7__";
+const KEY = "__codex_modal_ui_store__v8__";
 export const modalUIStore: ModalUIStore =
   (globalThis as any)[KEY] ?? ((globalThis as any)[KEY] = new ModalUIStore());

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -404,13 +404,11 @@
     }
   });
 
-  // On mobile, the entity-creation form lives in the drawer (VaultControls),
-  // so a create request must also open the drawer and dismiss the full-screen
-  // explorer that would otherwise cover it.
+  // On mobile, show a dedicated bottom sheet instead of opening the drawer.
   $effect(() => {
     if (modalUIStore.pendingCreateEntity && layoutUIStore.isMobile) {
-      layoutUIStore.closeSidebar();
-      isMobileMenuOpen = true;
+      modalUIStore.pendingCreateEntity = false;
+      modalUIStore.showMobileCreateSheet = true;
     }
   });
 


### PR DESCRIPTION
## Summary

- Tapping "+ Create Your First Entity" on mobile now opens a dedicated bottom sheet instead of silently opening the hamburger drawer (which showed nothing because `VaultControls` guards its form behind `vault.isInitialized`)
- Sheet slides up with a 700ms `quintOut` ease and a light 30% backdrop so the background remains visible
- No-vault state shows **New Vault** / **Open** buttons inline so users can get started immediately
- Cancel button in header (×) and alongside the Add button
- `VaultControls` skips consuming `pendingCreateEntity` on mobile so the layout effect intercepts it first; desktop create flow is unchanged

## Test plan

- [ ] Mobile: tap "+ Create Your First Entity" on empty graph → sheet slides up
- [ ] Sheet with no vault open → shows "Open a Vault first" + New/Open buttons
- [ ] Sheet with vault open → shows title input, type selector, Cancel + Add
- [ ] Cancel (×) and CANCEL button both dismiss the sheet
- [ ] Desktop: "+ Create Your First Entity" still opens inline form in header (unchanged)
- [ ] Creating an entity from the sheet navigates to it and closes the sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)