### PR TITLE
:sparkles: add standalone Surprise Me random idea generator (#1309)

### DIFF
--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -29,6 +29,7 @@
     variant = "default",
     generateLabel = undefined,
     inputHint = "Set your inputs — your draft updates to the right",
+    onLinkToHub = undefined,
   }: {
     canonicalPath?: string;
     pageTitle?: string;
@@ -47,6 +48,7 @@
     variant?: "default" | "names";
     generateLabel?: string;
     inputHint?: string;
+    onLinkToHub?: () => void;
   } = $props();
 
   const HIDDEN_TAGS = new Set([
@@ -352,6 +354,7 @@
     if (!exists) {
       saveSessionDrafts([...sessionDrafts, newDraft]);
     }
+    onLinkToHub?.();
   }
 
   function removeFromSessionHub(title: string) {

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -27,6 +27,8 @@
     worldTheme = "workspace",
     initialDraft = null,
     variant = "default",
+    generateLabel = undefined,
+    inputHint = "Set your inputs — your draft updates to the right",
   }: {
     canonicalPath?: string;
     pageTitle?: string;
@@ -43,6 +45,8 @@
     worldTheme?: string;
     initialDraft?: GeneratorOutput | null;
     variant?: "default" | "names";
+    generateLabel?: string;
+    inputHint?: string;
   } = $props();
 
   const HIDDEN_TAGS = new Set([
@@ -820,12 +824,14 @@
         <p class="text-sm text-theme-text/70 leading-relaxed mb-4">
           {introText}
         </p>
-        <p
-          class="text-[9px] text-theme-text/45 uppercase tracking-widest font-header mb-4 flex items-center gap-1.5"
-        >
-          <span class="icon-[lucide--arrow-right] w-3 h-3"></span>
-          Set your inputs — your draft updates to the right
-        </p>
+        {#if inputHint}
+          <p
+            class="text-[9px] text-theme-text/45 uppercase tracking-widest font-header mb-4 flex items-center gap-1.5"
+          >
+            <span class="icon-[lucide--arrow-right] w-3 h-3"></span>
+            {inputHint}
+          </p>
+        {/if}
 
         <form
           class="space-y-4"
@@ -853,7 +859,7 @@
               ></span>
               Forging...
             {:else}
-              Generate {generatedSingular}
+              {generateLabel ?? `Generate ${generatedSingular}`}
             {/if}
           </button>
 

--- a/apps/web/src/lib/services/seo/random-idea.test.ts
+++ b/apps/web/src/lib/services/seo/random-idea.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect, vi } from "vitest";
 import {
   randomIdeaCategories,
   pickNextCategory,
+  pickRandomIdeaTheme,
+  themeToHubGenre,
   type RandomIdeaCategory,
 } from "./random-idea";
 import type { DefaultGeneratorEngine } from "./generator-engine";
+import { factionConfig } from "./generators/faction";
+import { npcThemeConfig } from "./generators/npc";
+import { socialHubConfig } from "./generators/social-hub";
+import { nationConfig } from "./generators/kingdom-nation";
 
 describe("randomIdeaCategories", () => {
   it("contains exactly the standalone generator pool", () => {
@@ -24,7 +30,7 @@ describe("randomIdeaCategories", () => {
     expect(keys).not.toContain("session-context");
   });
 
-  it("dispatches each category to the matching engine method with randomised inputs", async () => {
+  it("dispatches each category to the matching engine method with the given theme", async () => {
     const engine = {
       generateFaction: vi.fn().mockResolvedValue("faction-result"),
       generateNation: vi.fn().mockResolvedValue("nation-result"),
@@ -32,26 +38,55 @@ describe("randomIdeaCategories", () => {
       generateQuestHook: vi.fn().mockResolvedValue("quest-result"),
       generateSocialHub: vi.fn().mockResolvedValue("social-hub-result"),
     } as unknown as DefaultGeneratorEngine;
+    const theme = "Cyberpunk / Corporate";
 
     for (const category of randomIdeaCategories) {
-      await category.generate(engine, true);
+      await category.generate(engine, true, theme);
     }
 
-    expect(engine.generateFaction).toHaveBeenCalledWith(
-      expect.objectContaining({ useAI: true, theme: expect.any(String) }),
-    );
-    expect(engine.generateNation).toHaveBeenCalledWith({ useAI: true });
+    expect(engine.generateFaction).toHaveBeenCalledWith({
+      useAI: true,
+      theme,
+    });
+    expect(engine.generateNation).toHaveBeenCalledWith({
+      useAI: true,
+      genre: "Cyberpunk",
+    });
     expect(engine.generateNPC).toHaveBeenCalledWith(
       expect.objectContaining({
         useAI: true,
-        theme: expect.any(String),
+        theme,
         ancestry: expect.any(String),
         role: expect.any(String),
         alignment: expect.any(String),
       }),
     );
-    expect(engine.generateQuestHook).toHaveBeenCalledWith({ useAI: true });
-    expect(engine.generateSocialHub).toHaveBeenCalledWith({ useAI: true });
+    expect(engine.generateQuestHook).toHaveBeenCalledWith({
+      useAI: true,
+      genre: "Cyberpunk",
+    });
+    expect(engine.generateSocialHub).toHaveBeenCalledWith({
+      useAI: true,
+      genre: "Cyberpunk",
+    });
+  });
+
+  it("rolls NPC inputs from the given theme's tables", async () => {
+    const engine = {
+      generateNPC: vi.fn().mockResolvedValue("npc-result"),
+    } as unknown as DefaultGeneratorEngine;
+    const theme = "Post-Apocalyptic";
+    const npc = randomIdeaCategories.find((c) => c.key === "npc")!;
+
+    await npc.generate(engine, true, theme);
+
+    const options = (engine.generateNPC as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(npcThemeConfig.ancestries[theme]).toContain(options.ancestry);
+    expect(npcThemeConfig.roles[theme]).toContain(options.role);
+    expect(npcThemeConfig.moralities[theme].map((m) => m.id)).toContain(
+      options.alignment,
+    );
   });
 
   it("forwards useAI false to the engine", async () => {
@@ -60,9 +95,31 @@ describe("randomIdeaCategories", () => {
     } as unknown as DefaultGeneratorEngine;
     const quest = randomIdeaCategories.find((c) => c.key === "quest")!;
 
-    await quest.generate(engine, false);
+    await quest.generate(engine, false, "Classic Fantasy");
 
-    expect(engine.generateQuestHook).toHaveBeenCalledWith({ useAI: false });
+    expect(engine.generateQuestHook).toHaveBeenCalledWith(
+      expect.objectContaining({ useAI: false }),
+    );
+  });
+});
+
+describe("themeToHubGenre", () => {
+  it("maps every canonical theme to a valid social hub and nation genre", () => {
+    for (const theme of factionConfig.themes) {
+      const genre = themeToHubGenre[theme];
+      expect(genre, `missing genre mapping for theme: ${theme}`).toBeDefined();
+      expect(socialHubConfig.genres).toContain(genre);
+      expect(nationConfig.genres).toContain(genre);
+    }
+  });
+});
+
+describe("pickRandomIdeaTheme", () => {
+  it("picks from the canonical theme list", () => {
+    expect(pickRandomIdeaTheme(() => 0)).toBe(factionConfig.themes[0]);
+    expect(pickRandomIdeaTheme(() => 0.999)).toBe(
+      factionConfig.themes[factionConfig.themes.length - 1],
+    );
   });
 });
 

--- a/apps/web/src/lib/services/seo/random-idea.test.ts
+++ b/apps/web/src/lib/services/seo/random-idea.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  randomIdeaCategories,
+  pickNextCategory,
+  type RandomIdeaCategory,
+} from "./random-idea";
+import type { DefaultGeneratorEngine } from "./generator-engine";
+
+describe("randomIdeaCategories", () => {
+  it("contains exactly the standalone generator pool", () => {
+    expect(randomIdeaCategories.map((c) => c.key).sort()).toEqual([
+      "faction",
+      "nation",
+      "npc",
+      "quest",
+      "social-hub",
+    ]);
+  });
+
+  it("never includes name generators or context-dependent generators", () => {
+    const keys = randomIdeaCategories.map((c) => c.key as string);
+    expect(keys).not.toContain("names");
+    expect(keys).not.toContain("fantasy-names");
+    expect(keys).not.toContain("session-context");
+  });
+
+  it("dispatches each category to the matching engine method with randomised inputs", async () => {
+    const engine = {
+      generateFaction: vi.fn().mockResolvedValue("faction-result"),
+      generateNation: vi.fn().mockResolvedValue("nation-result"),
+      generateNPC: vi.fn().mockResolvedValue("npc-result"),
+      generateQuestHook: vi.fn().mockResolvedValue("quest-result"),
+      generateSocialHub: vi.fn().mockResolvedValue("social-hub-result"),
+    } as unknown as DefaultGeneratorEngine;
+
+    for (const category of randomIdeaCategories) {
+      await category.generate(engine, true);
+    }
+
+    expect(engine.generateFaction).toHaveBeenCalledWith(
+      expect.objectContaining({ useAI: true, theme: expect.any(String) }),
+    );
+    expect(engine.generateNation).toHaveBeenCalledWith({ useAI: true });
+    expect(engine.generateNPC).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useAI: true,
+        theme: expect.any(String),
+        ancestry: expect.any(String),
+        role: expect.any(String),
+        alignment: expect.any(String),
+      }),
+    );
+    expect(engine.generateQuestHook).toHaveBeenCalledWith({ useAI: true });
+    expect(engine.generateSocialHub).toHaveBeenCalledWith({ useAI: true });
+  });
+
+  it("forwards useAI false to the engine", async () => {
+    const engine = {
+      generateQuestHook: vi.fn().mockResolvedValue("quest-result"),
+    } as unknown as DefaultGeneratorEngine;
+    const quest = randomIdeaCategories.find((c) => c.key === "quest")!;
+
+    await quest.generate(engine, false);
+
+    expect(engine.generateQuestHook).toHaveBeenCalledWith({ useAI: false });
+  });
+});
+
+describe("pickNextCategory", () => {
+  const byKey = (key: RandomIdeaCategory["key"]) =>
+    randomIdeaCategories.find((c) => c.key === key)!;
+
+  it("picks from the full pool on the first roll", () => {
+    expect(pickNextCategory(null, false, () => 0)).toBe(
+      randomIdeaCategories[0],
+    );
+    expect(pickNextCategory(null, false, () => 0.999)).toBe(
+      randomIdeaCategories[randomIdeaCategories.length - 1],
+    );
+  });
+
+  it("keeps the current category for the regenerate-category flow", () => {
+    const current = byKey("quest");
+    expect(pickNextCategory(current, true)).toBe(current);
+  });
+
+  it("falls back to a random pick when keep is requested without a current category", () => {
+    expect(pickNextCategory(null, true, () => 0)).toBe(randomIdeaCategories[0]);
+  });
+
+  it("never repeats the current category on reroll everything", () => {
+    const current = byKey("faction");
+    for (let i = 0; i < 50; i++) {
+      expect(pickNextCategory(current, false).key).not.toBe("faction");
+    }
+  });
+});

--- a/apps/web/src/lib/services/seo/random-idea.ts
+++ b/apps/web/src/lib/services/seo/random-idea.ts
@@ -1,0 +1,73 @@
+import type { DefaultGeneratorEngine } from "./generator-engine";
+import { pickFrom, type GeneratorOutput } from "./generators/base";
+import { factionConfig } from "./generators/faction";
+import { npcThemeConfig } from "./generators/npc";
+
+export interface RandomIdeaCategory {
+  key: "faction" | "nation" | "npc" | "quest" | "social-hub";
+  label: string;
+  generate: (
+    engine: DefaultGeneratorEngine,
+    useAI: boolean,
+  ) => Promise<GeneratorOutput>;
+}
+
+// The Surprise Me pool: standalone generators only. Name generators and
+// anything needing vault/archive/session context stay out by construction.
+// Every input a user would normally pick on the generator page is rolled
+// randomly here — the engine already randomises any omitted option.
+export const randomIdeaCategories: RandomIdeaCategory[] = [
+  {
+    key: "faction",
+    label: "Faction",
+    generate: (engine, useAI) =>
+      engine.generateFaction({ theme: pickFrom(factionConfig.themes), useAI }),
+  },
+  {
+    key: "nation",
+    label: "Kingdom & Nation",
+    generate: (engine, useAI) => engine.generateNation({ useAI }),
+  },
+  {
+    key: "npc",
+    label: "NPC",
+    generate: (engine, useAI) => {
+      const theme = pickFrom(factionConfig.themes);
+      return engine.generateNPC({
+        theme,
+        ancestry: pickFrom(npcThemeConfig.ancestries[theme]),
+        role: pickFrom(npcThemeConfig.roles[theme]),
+        alignment: pickFrom(npcThemeConfig.moralities[theme]).id,
+        useAI,
+      });
+    },
+  },
+  {
+    key: "quest",
+    label: "Quest Hook",
+    generate: (engine, useAI) => engine.generateQuestHook({ useAI }),
+  },
+  {
+    key: "social-hub",
+    label: "Social Hub",
+    generate: (engine, useAI) => engine.generateSocialHub({ useAI }),
+  },
+];
+
+/**
+ * Picks the category for the next roll.
+ * - "Regenerate [Category]" flow: keep === true returns the current category.
+ * - "Reroll Everything" flow: picks a random category, never repeating the
+ *   current one so a reroll always visibly changes the idea type.
+ */
+export function pickNextCategory(
+  current: RandomIdeaCategory | null,
+  keep: boolean,
+  random: () => number = Math.random,
+): RandomIdeaCategory {
+  if (keep && current) return current;
+  const pool = current
+    ? randomIdeaCategories.filter((c) => c.key !== current.key)
+    : randomIdeaCategories;
+  return pool[Math.floor(random() * pool.length)];
+}

--- a/apps/web/src/lib/services/seo/random-idea.ts
+++ b/apps/web/src/lib/services/seo/random-idea.ts
@@ -2,6 +2,7 @@ import type { DefaultGeneratorEngine } from "./generator-engine";
 import { pickFrom, type GeneratorOutput } from "./generators/base";
 import { factionConfig } from "./generators/faction";
 import { npcThemeConfig } from "./generators/npc";
+import { themeToQuestGenre } from "./generators/quest";
 
 export interface RandomIdeaCategory {
   key: "faction" | "nation" | "npc" | "quest" | "social-hub";
@@ -9,48 +10,70 @@ export interface RandomIdeaCategory {
   generate: (
     engine: DefaultGeneratorEngine,
     useAI: boolean,
+    theme: string,
   ) => Promise<GeneratorOutput>;
+}
+
+// Canonical themes are factionConfig.themes; nation and social-hub speak the
+// shared genre vocabulary instead, so map theme -> genre for those.
+export const themeToHubGenre: Record<string, string> = {
+  "Classic Fantasy": "Fantasy",
+  "Cyberpunk / Corporate": "Cyberpunk",
+  "Vampire / Gothic Noir": "Horror",
+  "Sci-Fi / Space Opera": "Sci-Fi",
+  "Modern Conspiracy": "Modern",
+  "Post-Apocalyptic": "Post-Apocalyptic",
+};
+
+export function pickRandomIdeaTheme(
+  random: () => number = Math.random,
+): string {
+  return factionConfig.themes[
+    Math.floor(random() * factionConfig.themes.length)
+  ];
 }
 
 // The Surprise Me pool: standalone generators only. Name generators and
 // anything needing vault/archive/session context stay out by construction.
 // Every input a user would normally pick on the generator page is rolled
-// randomly here — the engine already randomises any omitted option.
+// randomly here — the engine already randomises any omitted option. The
+// theme is rolled (or locked) by the caller so a session can stay coherent.
 export const randomIdeaCategories: RandomIdeaCategory[] = [
   {
     key: "faction",
     label: "Faction",
-    generate: (engine, useAI) =>
-      engine.generateFaction({ theme: pickFrom(factionConfig.themes), useAI }),
+    generate: (engine, useAI, theme) =>
+      engine.generateFaction({ theme, useAI }),
   },
   {
     key: "nation",
     label: "Kingdom & Nation",
-    generate: (engine, useAI) => engine.generateNation({ useAI }),
+    generate: (engine, useAI, theme) =>
+      engine.generateNation({ genre: themeToHubGenre[theme], useAI }),
   },
   {
     key: "npc",
     label: "NPC",
-    generate: (engine, useAI) => {
-      const theme = pickFrom(factionConfig.themes);
-      return engine.generateNPC({
+    generate: (engine, useAI, theme) =>
+      engine.generateNPC({
         theme,
         ancestry: pickFrom(npcThemeConfig.ancestries[theme]),
         role: pickFrom(npcThemeConfig.roles[theme]),
         alignment: pickFrom(npcThemeConfig.moralities[theme]).id,
         useAI,
-      });
-    },
+      }),
   },
   {
     key: "quest",
     label: "Quest Hook",
-    generate: (engine, useAI) => engine.generateQuestHook({ useAI }),
+    generate: (engine, useAI, theme) =>
+      engine.generateQuestHook({ genre: themeToQuestGenre[theme], useAI }),
   },
   {
     key: "social-hub",
     label: "Social Hub",
-    generate: (engine, useAI) => engine.generateSocialHub({ useAI }),
+    generate: (engine, useAI, theme) =>
+      engine.generateSocialHub({ genre: themeToHubGenre[theme], useAI }),
   },
 ];
 

--- a/apps/web/src/routes/(marketing)/generators/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/+page.svelte
@@ -109,6 +109,13 @@
             "Generate a political entity for any genre — fantasy empires, cyberpunk megacorp-states, sci-fi federations.",
           icon: "icon-[lucide--globe]",
         },
+        {
+          href: "/generators/random",
+          label: "Surprise Me",
+          summary:
+            "Not sure what you need? Spin the idea machine — a random faction, realm, NPC, quest hook, or venue.",
+          icon: "icon-[lucide--dices]",
+        },
       ],
     },
   ];

--- a/apps/web/src/routes/(marketing)/generators/random/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/random/+page.svelte
@@ -7,10 +7,13 @@
     pickNextCategory,
     type RandomIdeaCategory,
   } from "$lib/services/seo/random-idea";
+  import type { GeneratorOutput } from "$lib/services/seo/generator-engine";
 
   let currentCategory = $state<RandomIdeaCategory | null>(null);
   let rollingLabel = $state<string | null>(null);
+  let inFlight = $state(false);
   let keepCategory = false;
+  let pending: Promise<GeneratorOutput> | null = null;
 
   const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -33,16 +36,27 @@
     await sleep(300);
   }
 
-  async function generate({ useAI }: { useAI: boolean }) {
-    const keep = keepCategory;
-    keepCategory = false;
-    const next = pickNextCategory(currentCategory, keep);
-    if (!keep) {
-      await animateSelection(next);
-    }
-    currentCategory = next;
-    rollingLabel = null;
-    return next.generate(generatorEngine, useAI);
+  // Serialise rolls: extra triggers while one is in flight (double-clicks,
+  // Enter on the form) just share the pending result instead of racing the
+  // category/animation state.
+  function generate({ useAI }: { useAI: boolean }) {
+    if (pending) return pending;
+    inFlight = true;
+    pending = (async () => {
+      const keep = keepCategory;
+      keepCategory = false;
+      const next = pickNextCategory(currentCategory, keep);
+      if (!keep) {
+        await animateSelection(next);
+      }
+      currentCategory = next;
+      rollingLabel = null;
+      return next.generate(generatorEngine, useAI);
+    })().finally(() => {
+      pending = null;
+      inFlight = false;
+    });
+    return pending;
   }
 </script>
 
@@ -83,11 +97,12 @@
     {#if currentCategory && !rollingLabel}
       <button
         type="button"
+        disabled={inFlight}
         onclick={() => {
           keepCategory = true;
           trigger();
         }}
-        class="w-full py-2.5 bg-theme-surface border border-theme-primary/40 text-theme-primary font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:bg-theme-primary/10 transition-all"
+        class="w-full py-2.5 bg-theme-surface border border-theme-primary/40 text-theme-primary font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:bg-theme-primary/10 transition-all disabled:opacity-50"
         id="regenerate-category-btn"
         title="Keep this idea type and roll a fresh one"
       >

--- a/apps/web/src/routes/(marketing)/generators/random/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/random/+page.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import SEOGeneratorLayout from "$lib/components/seo/SEOGeneratorLayout.svelte";
+  import { generatorEngine } from "$lib/services/seo/generator-engine";
+  import {
+    randomIdeaCategories,
+    pickNextCategory,
+    type RandomIdeaCategory,
+  } from "$lib/services/seo/random-idea";
+
+  let currentCategory = $state<RandomIdeaCategory | null>(null);
+  let rollingLabel = $state<string | null>(null);
+  let keepCategory = false;
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  // A short text-cycle through the idea types before the pick settles —
+  // playful spark, not a slot machine. Skipped for reduced-motion users.
+  async function animateSelection(chosen: RandomIdeaCategory) {
+    if (
+      !browser ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+    const labels = randomIdeaCategories.map((c) => c.label);
+    const start = Math.floor(Math.random() * labels.length);
+    for (let i = 0; i < labels.length; i++) {
+      rollingLabel = labels[(start + i) % labels.length];
+      await sleep(90 + i * 30);
+    }
+    rollingLabel = chosen.label;
+    await sleep(300);
+  }
+
+  async function generate({ useAI }: { useAI: boolean }) {
+    const keep = keepCategory;
+    keepCategory = false;
+    const next = pickNextCategory(currentCategory, keep);
+    if (!keep) {
+      await animateSelection(next);
+    }
+    currentCategory = next;
+    rollingLabel = null;
+    return next.generate(generatorEngine, useAI);
+  }
+</script>
+
+<SEOGeneratorLayout
+  pageTitle="Surprise Me — Random RPG Idea Generator | Codex Cryptica"
+  metaDescription="Hit the button and get a random worldbuilding idea — a faction, kingdom, NPC, quest hook, or social hub. No account, no setup, just inspiration."
+  introTitle="Surprise Me"
+  eyebrow="Random Idea"
+  introText="Not sure what your world needs next? Spin the idea machine — it picks a random generator and rolls every input for you. Pure inspiration, zero decisions."
+  canonicalPath="/generators/random"
+  {generate}
+  initialDraft={null}
+  generateLabel="Surprise Me"
+  inputHint=""
+>
+  {#snippet formFields(trigger)}
+    <div
+      class="flex items-center gap-2 px-3 py-2.5 bg-theme-bg/60 border border-theme-border/60 rounded-lg text-xs text-theme-text"
+      aria-live="polite"
+    >
+      <span
+        class="icon-[lucide--dices] w-4 h-4 text-theme-primary flex-shrink-0 {rollingLabel
+          ? 'animate-spin'
+          : ''}"
+        aria-hidden="true"
+      ></span>
+      {#if rollingLabel}
+        <span class="text-theme-muted">Choosing an idea type…</span>
+        <span class="font-bold">{rollingLabel}</span>
+      {:else if currentCategory}
+        <span class="text-theme-muted">Idea type:</span>
+        <span class="font-bold">{currentCategory.label}</span>
+      {:else}
+        <span class="text-theme-muted">Rolling up something strange…</span>
+      {/if}
+    </div>
+
+    {#if currentCategory && !rollingLabel}
+      <button
+        type="button"
+        onclick={() => {
+          keepCategory = true;
+          trigger();
+        }}
+        class="w-full py-2.5 bg-theme-surface border border-theme-primary/40 text-theme-primary font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:bg-theme-primary/10 transition-all"
+        id="regenerate-category-btn"
+        title="Keep this idea type and roll a fresh one"
+      >
+        Another {currentCategory.label} Idea
+      </button>
+    {/if}
+  {/snippet}
+</SEOGeneratorLayout>

--- a/apps/web/src/routes/(marketing)/generators/random/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/random/+page.svelte
@@ -5,6 +5,7 @@
   import {
     randomIdeaCategories,
     pickNextCategory,
+    pickRandomIdeaTheme,
     type RandomIdeaCategory,
   } from "$lib/services/seo/random-idea";
   import type { GeneratorOutput } from "$lib/services/seo/generator-engine";
@@ -12,6 +13,10 @@
   let currentCategory = $state<RandomIdeaCategory | null>(null);
   let rollingLabel = $state<string | null>(null);
   let inFlight = $state(false);
+  // Linking a draft to the Session Hub locks the theme so follow-up rolls
+  // build a coherent set instead of hopping genres.
+  let lockedTheme = $state<string | null>(null);
+  let currentTheme: string | null = null;
   let keepCategory = false;
   let pending: Promise<GeneratorOutput> | null = null;
 
@@ -46,12 +51,14 @@
       const keep = keepCategory;
       keepCategory = false;
       const next = pickNextCategory(currentCategory, keep);
+      const theme = lockedTheme ?? pickRandomIdeaTheme();
       if (!keep) {
         await animateSelection(next);
       }
       currentCategory = next;
+      currentTheme = theme;
       rollingLabel = null;
-      return next.generate(generatorEngine, useAI);
+      return next.generate(generatorEngine, useAI, theme);
     })().finally(() => {
       pending = null;
       inFlight = false;
@@ -71,6 +78,9 @@
   initialDraft={null}
   generateLabel="Surprise Me"
   inputHint=""
+  onLinkToHub={() => {
+    lockedTheme = currentTheme;
+  }}
 >
   {#snippet formFields(trigger)}
     <div
@@ -93,6 +103,33 @@
         <span class="text-theme-muted">Rolling up something strange…</span>
       {/if}
     </div>
+
+    {#if lockedTheme}
+      <div
+        class="flex items-center justify-between gap-2 px-3 py-2 bg-theme-primary/5 border border-theme-primary/30 rounded-lg text-[10px]"
+      >
+        <span class="flex items-center gap-1.5 text-theme-text/80 min-w-0">
+          <span
+            class="icon-[lucide--lock] w-3.5 h-3.5 text-theme-primary flex-shrink-0"
+            aria-hidden="true"
+          ></span>
+          <span class="truncate">
+            Hub theme locked: <span class="font-bold">{lockedTheme}</span>
+          </span>
+        </span>
+        <button
+          type="button"
+          onclick={() => {
+            lockedTheme = null;
+          }}
+          class="font-bold uppercase tracking-wider text-theme-primary hover:brightness-110 flex-shrink-0"
+          id="unlock-theme-btn"
+          title="Let each roll pick a random theme again"
+        >
+          Unlock
+        </button>
+      </div>
+    {/if}
 
     {#if currentCategory && !rollingLabel}
       <button

--- a/apps/web/src/routes/(marketing)/generators/random/+page.ts
+++ b/apps/web/src/routes/(marketing)/generators/random/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -129,6 +129,13 @@
                 "Generate a political entity for any genre — fantasy empires, cyberpunk megacorp-states, sci-fi federations, and more.",
               icon: "icon-[lucide--globe]",
             },
+            {
+              href: "/generators/random",
+              label: "Surprise Me",
+              summary:
+                "Not sure what you need? Spin the idea machine — a random faction, realm, NPC, quest hook, or venue.",
+              icon: "icon-[lucide--dices]",
+            },
           ],
         },
       ],

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -102,6 +102,7 @@ export async function GET() {
     "names",
     "fantasy-names",
     "dnd-npc",
+    "random",
   ].map((slug) => ({
     path: `/generators/${slug}`,
     changefreq: "monthly",

--- a/apps/web/src/routes/sitemap.xml/sitemap.test.ts
+++ b/apps/web/src/routes/sitemap.xml/sitemap.test.ts
@@ -59,6 +59,7 @@ describe("Sitemap.xml API Endpoint", () => {
     expect(xml).toContain("https://codexcryptica.com/features/test-feat");
     expect(xml).toContain("https://codexcryptica.com/import/test-import");
     expect(xml).toContain("https://codexcryptica.com/generators/npc");
+    expect(xml).toContain("https://codexcryptica.com/generators/random");
     expect(xml).toContain("https://codexcryptica.com/blog/test-blog-post");
     // Responsible AI pillar page
     expect(xml).toContain(


### PR DESCRIPTION
Closes #1309

## What

Adds **/generators/random** — a standalone "Surprise Me" idea generator that rolls a random standalone generator and produces a worldbuilding idea with zero user input.

## Decisions (per issue triage)

- **No inputs, ever.** The user sees only a **Surprise Me** button. Every parameter (theme, genre, ancestry, tone, …) is rolled randomly and never shown — the engine already randomises any omitted option, so the pool entries just omit them (NPC/faction get a random theme explicitly since those default to Classic Fantasy).
- **AI-first.** The page uses the layout's default-on AI Lore Co-Author mode; the initial on-load example draft uses the fast local path like every other generator page.
- **No metadata registry.** Skipped the proposed `supportsRandomIdea`/`requiresVault` flag system — there is no generator registry today and no vault-aware generator to exclude. The pool is a small typed array in `random-idea.ts` behind a tested picker, as the issue's "isolated behind a small utility" alternative allows.
- **No route aliases.** Single canonical route; aliases would just add sitemap/canonical noise.
- **Rerolls:** the main button rerolls everything (never repeating the current category, so it always visibly changes); a secondary **Another [Category] Idea** button keeps the category and regenerates.
- **Animation:** a short text-cycle through the idea types ("Choosing an idea type… → Faction"), aria-live polite, skipped under `prefers-reduced-motion`. Deliberately modest, not casino-like.

## Implementation

- `random-idea.ts`: category pool (faction, kingdom/nation, NPC, quest hook, social hub) + `pickNextCategory` keep/exclude picker
- `generators/random/+page.svelte`: thin page reusing `SEOGeneratorLayout` (result rendering, save-to-Codex, session hub, SEO meta all come for free)
- `SEOGeneratorLayout`: two optional props (`generateLabel`, `inputHint`) so the page can show a bare Surprise Me button
- Surprise Me card on the generators index; `/generators/random` added to the sitemap

## Tests

- Pool composition (name/context generators excluded by construction)
- Engine dispatch per category incl. randomised hidden inputs and `useAI` forwarding
- Both reroll flows (keep-category, never-repeat-on-full-reroll)
- Sitemap inclusion
- Full suite: 247 files / 1958 tests green; svelte-check 0 errors; SSR smoke-tested the route (HTTP 200 with expected content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)