### PR TITLE
:lipstick: wrap entity explorer labels below long titles on mobile (#1311)

### DIFF
--- a/apps/web/src/lib/components/explorer/EntityListFilteringUI.test.ts
+++ b/apps/web/src/lib/components/explorer/EntityListFilteringUI.test.ts
@@ -194,4 +194,19 @@ describe("EntityList Filtering", () => {
       expect(screen.getByText("Merchant")).not.toBeNull();
     });
   });
+
+  it("renders label pills container with responsive styling classes for better mobile experience", () => {
+    render(EntityList);
+
+    const merchantPill = screen.getByText("MerchantLabel");
+    const container = merchantPill.parentElement;
+    expect(container).not.toBeNull();
+
+    // Verify responsive mobile layout classes exist
+    expect(container?.className).toContain("w-full");
+    expect(container?.className).toContain("order-last");
+    expect(container?.className).toContain("pl-9");
+    expect(container?.className).toContain("md:order-none");
+    expect(container?.className).toContain("md:w-auto");
+  });
 });

--- a/apps/web/src/lib/components/explorer/EntityListItem.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListItem.svelte
@@ -183,7 +183,7 @@
 
   {#if entity.labels && entity.labels.length > 0}
     <div
-      class="w-full md:w-auto order-last md:order-none pl-9 md:pl-0 flex gap-1 px-2 pb-2 md:pb-0 flex-nowrap justify-start md:justify-end max-w-full md:max-w-[45%] shrink-0"
+      class="w-full md:w-auto order-last md:order-none pl-9 pr-2 md:px-2 pb-2 md:pb-0 flex gap-1 flex-nowrap justify-start md:justify-end max-w-full md:max-w-[45%] shrink-0"
     >
       {#each entity.labels.slice(0, 2) as label, index (`${entity.id}-label-${index}`)}
         <button

--- a/apps/web/src/lib/components/explorer/EntityListItem.svelte
+++ b/apps/web/src/lib/components/explorer/EntityListItem.svelte
@@ -51,7 +51,7 @@
 </script>
 
 <div
-  class="[content-visibility:auto] [contain-intrinsic-size:0_56px] group relative flex items-center rounded-xl border transition-all {!isMatching
+  class="[content-visibility:auto] [contain-intrinsic-size:0_56px] group relative flex flex-wrap items-center rounded-xl border transition-all {!isMatching
     ? 'opacity-50'
     : ''} {entity.id === focusedEntityId
     ? 'border-theme-primary bg-theme-primary/10 ring-2 ring-theme-accent/20'
@@ -182,7 +182,9 @@
   </button>
 
   {#if entity.labels && entity.labels.length > 0}
-    <div class="flex gap-1 px-2 flex-nowrap justify-end max-w-[45%] shrink-0">
+    <div
+      class="w-full md:w-auto order-last md:order-none pl-9 md:pl-0 flex gap-1 px-2 pb-2 md:pb-0 flex-nowrap justify-start md:justify-end max-w-full md:max-w-[45%] shrink-0"
+    >
       {#each entity.labels.slice(0, 2) as label, index (`${entity.id}-label-${index}`)}
         <button
           type="button"

--- a/apps/web/tests/mobile-entity-explorer-1311.spec.ts
+++ b/apps/web/tests/mobile-entity-explorer-1311.spec.ts
@@ -30,8 +30,21 @@ test.describe("Mobile Entity Explorer (Issue 1311)", () => {
   }) => {
     await page.setViewportSize({ width: 375, height: 667 });
 
-    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
-      timeout: 15000,
+    await page.waitForFunction(
+      () => {
+        const v = (window as any).vault;
+        return v && v.isInitialized && v.status === "idle";
+      },
+      { timeout: 15000 },
+    );
+
+    // Dismiss any landing or world page overlays after vault is ready
+    await page.evaluate(() => {
+      const ui = (window as any).uiStore;
+      if (ui) {
+        ui.dismissedWorldPage = true;
+        ui.dismissedLandingPage = true;
+      }
     });
 
     // Create an entity with a long title and labels
@@ -44,11 +57,16 @@ test.describe("Mobile Entity Explorer (Issue 1311)", () => {
         "A Very Long Entity Name That Will Wrap On Mobile Screen Width",
         {
           content: "Content",
+          labels: ["Quest", "Secret"],
         },
       );
-      await vault.updateEntity(id, { labels: ["Quest", "Secret"] });
       return id;
     });
+
+    await page.waitForFunction((id) => {
+      const ent = (window as any).vault?.entities?.[id];
+      return ent && ent.labels && ent.labels.includes("Quest");
+    }, entityId);
 
     // Open the explorer sidebar directly via UI store state
     await page.evaluate(() => {
@@ -80,7 +98,9 @@ test.describe("Mobile Entity Explorer (Issue 1311)", () => {
     expect(titleRect).not.toBeNull();
     expect(labelRect).not.toBeNull();
 
-    // Label should be positioned vertically below the title (wrapping to second line)
-    expect(labelRect!.y).toBeGreaterThan(titleRect!.y);
+    // Label should be positioned vertically below the title block (wrapping to second line)
+    expect(labelRect!.y).toBeGreaterThanOrEqual(
+      titleRect!.y + titleRect!.height,
+    );
   });
 });

--- a/apps/web/tests/mobile-entity-explorer-1311.spec.ts
+++ b/apps/web/tests/mobile-entity-explorer-1311.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Mobile Entity Explorer (Issue 1311)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock init
+    await page.addInitScript(() => {
+      localStorage.setItem("codex_skip_landing", "true");
+      localStorage.setItem(
+        "codex-cryptica-help-state",
+        JSON.stringify({ completedTours: ["initial-onboarding"] }),
+      );
+    });
+    await page.goto("/");
+
+    // Wait for app load
+    await page.waitForSelector(".app-layout", { timeout: 10000 });
+
+    // Dismiss any landing or world page overlays on load
+    await page.evaluate(() => {
+      const ui = (window as any).uiStore;
+      if (ui) {
+        ui.dismissedWorldPage = true;
+        ui.dismissedLandingPage = true;
+      }
+    });
+  });
+
+  test("Entity explorer items with long titles should wrap labels below the text to prevent collision on mobile viewports", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
+      timeout: 15000,
+    });
+
+    // Create an entity with a long title and labels
+    const entityId = await page.evaluate(async () => {
+      const vault = (window as any).vault;
+      vault.isInitialized = true;
+      vault.rootHandle = {};
+      const id = await vault.createEntity(
+        "npc",
+        "A Very Long Entity Name That Will Wrap On Mobile Screen Width",
+        {
+          content: "Content",
+        },
+      );
+      await vault.updateEntity(id, { labels: ["Quest", "Secret"] });
+      return id;
+    });
+
+    // Open the explorer sidebar directly via UI store state
+    await page.evaluate(() => {
+      const layout = (window as any).layoutUIStore;
+      if (layout) {
+        layout.leftSidebarOpen = true;
+        layout.activeSidebarTool = "explorer";
+      }
+    });
+    const explorerPanel = page.getByTestId("entity-explorer-panel");
+    await expect(explorerPanel).toBeVisible();
+
+    // Find the entity list item
+    const entityItem = page.locator(`[data-entity-id="${entityId}"]`);
+    await expect(entityItem).toBeVisible();
+
+    // Verify title and label elements exist
+    const titleElement = entityItem.getByText(
+      "A Very Long Entity Name That Will Wrap On Mobile Screen Width",
+    );
+    const labelPill = entityItem.getByRole("button", { name: "Quest" });
+    await expect(titleElement).toBeVisible();
+    await expect(labelPill).toBeVisible();
+
+    // Check vertical coordinates to assert that labels are wrapped below the title
+    const titleRect = await titleElement.boundingBox();
+    const labelRect = await labelPill.boundingBox();
+
+    expect(titleRect).not.toBeNull();
+    expect(labelRect).not.toBeNull();
+
+    // Label should be positioned vertically below the title (wrapping to second line)
+    expect(labelRect!.y).toBeGreaterThan(titleRect!.y);
+  });
+});

--- a/apps/web/tests/mobile-ux-fixes.spec.ts
+++ b/apps/web/tests/mobile-ux-fixes.spec.ts
@@ -28,8 +28,21 @@ test.describe("Mobile UX Fixes", () => {
   test("Entity Detail Panel should have solid background and high z-index", async ({
     page,
   }) => {
-    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
-      timeout: 15000,
+    await page.waitForFunction(
+      () => {
+        const v = (window as any).vault;
+        return v && v.isInitialized && v.status === "idle";
+      },
+      { timeout: 15000 },
+    );
+
+    // Dismiss any landing or world page overlays after vault is ready
+    await page.evaluate(() => {
+      const ui = (window as any).uiStore;
+      if (ui) {
+        ui.dismissedWorldPage = true;
+        ui.dismissedLandingPage = true;
+      }
     });
 
     const entityId = await page.evaluate(async () => {
@@ -70,8 +83,21 @@ test.describe("Mobile UX Fixes", () => {
   }) => {
     await page.setViewportSize({ width: 375, height: 667 });
 
-    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
-      timeout: 15000,
+    await page.waitForFunction(
+      () => {
+        const v = (window as any).vault;
+        return v && v.isInitialized && v.status === "idle";
+      },
+      { timeout: 15000 },
+    );
+
+    // Dismiss any landing or world page overlays after vault is ready
+    await page.evaluate(() => {
+      const ui = (window as any).uiStore;
+      if (ui) {
+        ui.dismissedWorldPage = true;
+        ui.dismissedLandingPage = true;
+      }
     });
 
     const entityId = await page.evaluate(async () => {
@@ -84,6 +110,11 @@ test.describe("Mobile UX Fixes", () => {
         ),
       });
     });
+
+    await page.waitForFunction(
+      (id) => !!(window as any).vault?.entities?.[id],
+      entityId,
+    );
 
     await page.evaluate((id) => {
       const layout = (window as any).layoutUIStore;

--- a/apps/web/tests/mobile-ux-fixes.spec.ts
+++ b/apps/web/tests/mobile-ux-fixes.spec.ts
@@ -14,12 +14,23 @@ test.describe("Mobile UX Fixes", () => {
 
     // Wait for app load
     await page.waitForSelector(".app-layout", { timeout: 10000 });
+
+    // Dismiss any landing or world page overlays on load
+    await page.evaluate(() => {
+      const ui = (window as any).uiStore;
+      if (ui) {
+        ui.dismissedWorldPage = true;
+        ui.dismissedLandingPage = true;
+      }
+    });
   });
 
   test("Entity Detail Panel should have solid background and high z-index", async ({
     page,
   }) => {
-    await page.waitForFunction(() => (window as any).vault);
+    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
+      timeout: 15000,
+    });
 
     const entityId = await page.evaluate(async () => {
       const vault = (window as any).vault;
@@ -59,7 +70,9 @@ test.describe("Mobile UX Fixes", () => {
   }) => {
     await page.setViewportSize({ width: 375, height: 667 });
 
-    await page.waitForFunction(() => (window as any).vault);
+    await page.waitForFunction(() => (window as any).vault?.status === "idle", {
+      timeout: 15000,
+    });
 
     const entityId = await page.evaluate(async () => {
       const vault = (window as any).vault;
@@ -73,16 +86,19 @@ test.describe("Mobile UX Fixes", () => {
     });
 
     await page.evaluate((id) => {
-      const uiStore = (window as any).uiStore;
-      uiStore.focusEntity(id);
+      const layout = (window as any).layoutUIStore;
+      if (layout) {
+        layout.focusedEntityId = id;
+        layout.mainViewMode = "focus";
+      }
     }, entityId);
 
     await expect(page.getByTestId("embedded-entity-view")).toBeVisible({
-      timeout: 5000,
+      timeout: 15000,
     });
 
     const scrollShell = page.getByTestId("zen-mobile-scroll-container");
-    await expect(scrollShell).toBeVisible();
+    await expect(scrollShell).toBeVisible({ timeout: 15000 });
 
     const metrics = await scrollShell.evaluate((el) => {
       const style = window.getComputedStyle(el);


### PR DESCRIPTION
Closes #1311. Wraps entity explorer labels below long titles on mobile viewports for an improved responsive layout.