### PR TITLE
feat(seo): pantheon & deity generator landing pages with funnel flow

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # Codex-Cryptica Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-06-02
+Auto-generated from all feature plans. Last updated: 2026-06-11
 
 ## Active Technologies
 
@@ -207,8 +207,6 @@ TypeScript: Follow standard conventions
 - 129-seo-landing-pages: Added TypeScript 6.0.3 + Svelte 5 (Runes), SvelteKit, `@google/generative-ai` (Gemini SDK via `aiClientManager`), `@codex/vault-engine`
 
 - 129-seo-landing-pages: Added TypeScript 6.0.3 + Svelte 5 (Runes), SvelteKit, `@google/generative-ai` (Gemini SDK via `aiClientManager`), `@codex/vault-engine`
-
-- 128-guest-character-chat: Added TypeScript 6.0.3 + Svelte 5 Runes + `@google/generative-ai` (Gemini SDK), SvelteKit, Tailwind 4, Zod
 
 <!-- MANUAL ADDITIONS START -->
 

--- a/apps/web/src/lib/components/seo/PantheonFormFields.svelte
+++ b/apps/web/src/lib/components/seo/PantheonFormFields.svelte
@@ -146,7 +146,7 @@
     class="flex items-center gap-1.5 px-3 py-1.5 bg-theme-surface/60 border border-theme-border/60 rounded-lg text-[10px] font-bold uppercase tracking-wider text-theme-text hover:bg-theme-primary hover:text-theme-bg hover:border-theme-primary transition-all cursor-pointer"
     title="Randomize all options and generate a draft from the result"
   >
-    <span class="icon-[lucide--dices] w-3.5 h-3.5"></span>
+    <span class="icon-[lucide--dices] w-3.5 h-3.5" aria-hidden="true"></span>
     Surprise Me
   </button>
 </div>

--- a/apps/web/src/lib/components/seo/PantheonFormFields.svelte
+++ b/apps/web/src/lib/components/seo/PantheonFormFields.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { pantheonConfig, pickFrom } from "$lib/services/seo/generator-engine";
+
+  let {
+    mode = $bindable("single"),
+    genre = $bindable(pantheonConfig.genres[0]),
+    divineType = $bindable(pantheonConfig.divineTypes[0]),
+    domain = $bindable(pantheonConfig.domains[0]),
+    tone = $bindable(pantheonConfig.tones[0]),
+    worshippers = $bindable(pantheonConfig.worshippers[0]),
+    conflictTheme = $bindable(pantheonConfig.conflictThemes[0]),
+    campaignContext = $bindable(""),
+    onSurprise = undefined,
+  }: {
+    mode: "single" | "pantheon";
+    genre: string;
+    divineType: string;
+    domain: string;
+    tone: string;
+    worshippers: string;
+    conflictTheme: string;
+    campaignContext: string;
+    onSurprise?: () => void;
+  } = $props();
+
+  const selectClass =
+    "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
+  const labelClass =
+    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+</script>
+
+<div class="flex flex-col gap-1.5">
+  <label for="pantheon-mode-select" class={labelClass}>Generate target</label>
+  <select id="pantheon-mode-select" bind:value={mode} class={selectClass}>
+    <option value="single">Single Deity / Spirit</option>
+    <option value="pantheon">Small Pantheon (3-4 Deities)</option>
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="pantheon-genre-select" class={labelClass}>Genre / Theme</label>
+  <select id="pantheon-genre-select" bind:value={genre} class={selectClass}>
+    {#each pantheonConfig.genres as g (g)}
+      <option value={g}>{g}</option>
+    {/each}
+  </select>
+</div>
+
+{#if mode === "single"}
+  <div class="flex flex-col gap-1.5">
+    <label for="pantheon-type-select" class={labelClass}>Divine Type</label>
+    <select
+      id="pantheon-type-select"
+      bind:value={divineType}
+      class={selectClass}
+    >
+      {#each pantheonConfig.divineTypes as t (t)}
+        <option value={t}>{t}</option>
+      {/each}
+    </select>
+  </div>
+{/if}
+
+<div class="flex flex-col gap-1.5">
+  <label for="pantheon-domain-select" class={labelClass}>Primary Domain</label>
+  <select id="pantheon-domain-select" bind:value={domain} class={selectClass}>
+    {#each pantheonConfig.domains as d (d)}
+      <option value={d}>{d}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="pantheon-tone-select" class={labelClass}>Tone</label>
+  <select id="pantheon-tone-select" bind:value={tone} class={selectClass}>
+    {#each pantheonConfig.tones as t (t)}
+      <option value={t}>{t}</option>
+    {/each}
+  </select>
+</div>
+
+<div class="flex flex-col gap-1.5">
+  <label for="pantheon-worshippers-select" class={labelClass}>Worshippers</label
+  >
+  <select
+    id="pantheon-worshippers-select"
+    bind:value={worshippers}
+    class={selectClass}
+  >
+    {#each pantheonConfig.worshippers as w (w)}
+      <option value={w}>{w}</option>
+    {/each}
+  </select>
+</div>
+
+{#if mode === "pantheon"}
+  <div class="flex flex-col gap-1.5">
+    <label for="pantheon-conflict-select" class={labelClass}
+      >Conflict Theme</label
+    >
+    <select
+      id="pantheon-conflict-select"
+      bind:value={conflictTheme}
+      class={selectClass}
+    >
+      {#each pantheonConfig.conflictThemes as c (c)}
+        <option value={c}>{c}</option>
+      {/each}
+    </select>
+  </div>
+{/if}
+
+<div class="flex flex-col gap-1.5">
+  <label for="pantheon-context" class={labelClass}
+    >Campaign context (optional)</label
+  >
+  <textarea
+    id="pantheon-context"
+    bind:value={campaignContext}
+    maxlength="240"
+    rows="4"
+    aria-describedby="pantheon-context-help"
+    class="w-full min-h-24 bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-base md:text-xs text-theme-text focus:outline-none focus:border-theme-primary/60 resize-y"
+  ></textarea>
+  <p
+    id="pantheon-context-help"
+    class="text-[10px] text-theme-text/60 leading-relaxed"
+  >
+    Steer the generation with specific settings, e.g., "A dying sun world where
+    shadows hold physical weight."
+  </p>
+</div>
+
+<div class="pt-2 flex justify-end">
+  <button
+    type="button"
+    onclick={() => {
+      genre = pickFrom(pantheonConfig.genres);
+      divineType = pickFrom(pantheonConfig.divineTypes);
+      domain = pickFrom(pantheonConfig.domains);
+      tone = pickFrom(pantheonConfig.tones);
+      worshippers = pickFrom(pantheonConfig.worshippers);
+      conflictTheme = pickFrom(pantheonConfig.conflictThemes);
+      if (onSurprise) onSurprise();
+    }}
+    class="flex items-center gap-1.5 px-3 py-1.5 bg-theme-surface/60 border border-theme-border/60 rounded-lg text-[10px] font-bold uppercase tracking-wider text-theme-text hover:bg-theme-primary hover:text-theme-bg hover:border-theme-primary transition-all cursor-pointer"
+    title="Randomize all options and generate a draft from the result"
+  >
+    <span class="icon-[lucide--dices] w-3.5 h-3.5"></span>
+    Surprise Me
+  </button>
+</div>

--- a/apps/web/src/lib/components/seo/PantheonFormFields.svelte
+++ b/apps/web/src/lib/components/seo/PantheonFormFields.svelte
@@ -9,6 +9,7 @@
     tone = $bindable(pantheonConfig.tones[0]),
     worshippers = $bindable(pantheonConfig.worshippers[0]),
     conflictTheme = $bindable(pantheonConfig.conflictThemes[0]),
+    size = $bindable("small" as "small" | "medium" | "large"),
     campaignContext = $bindable(""),
     onSurprise = undefined,
   }: {
@@ -19,6 +20,7 @@
     tone: string;
     worshippers: string;
     conflictTheme: string;
+    size: "small" | "medium" | "large";
     campaignContext: string;
     onSurprise?: () => void;
   } = $props();
@@ -33,9 +35,20 @@
   <label for="pantheon-mode-select" class={labelClass}>Generate target</label>
   <select id="pantheon-mode-select" bind:value={mode} class={selectClass}>
     <option value="single">Single Deity / Spirit</option>
-    <option value="pantheon">Small Pantheon (3-4 Deities)</option>
+    <option value="pantheon">Pantheon</option>
   </select>
 </div>
+
+{#if mode === "pantheon"}
+  <div class="flex flex-col gap-1.5">
+    <label for="pantheon-size-select" class={labelClass}>Pantheon Size</label>
+    <select id="pantheon-size-select" bind:value={size} class={selectClass}>
+      {#each pantheonConfig.sizes as s (s.value)}
+        <option value={s.value}>{s.label}</option>
+      {/each}
+    </select>
+  </div>
+{/if}
 
 <div class="flex flex-col gap-1.5">
   <label for="pantheon-genre-select" class={labelClass}>Genre / Theme</label>

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -709,8 +709,7 @@
             </div>
 
             <div
-              role="group"
-              tabindex="-1"
+              role="none"
               class="seo-md text-sm leading-relaxed text-theme-text/90 flex-grow {variant ===
               'names'
                 ? 'md:columns-2 md:gap-x-8 [&_div]:break-inside-avoid [&_div]:mb-4'

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -276,8 +276,27 @@
     }
   }
 
-  const labelValueHtml = (label: string, value: string) =>
-    `<div class="flex flex-col mb-1"><span class="seo-label font-header font-bold uppercase tracking-widest text-xs text-theme-primary mb-0.5">${renderMd(label, { inline: true })}</span><span>${renderMd(value, { inline: true })}</span></div>\n`;
+  const labelValueHtml = (label: string, value: string) => {
+    if (variant === "names") {
+      const cleanLabel = label.replace(/\*\*/g, "").trim();
+      const escapedLabel = cleanLabel.replace(/"/g, "&quot;");
+      return `<div class="group relative flex flex-col p-4 bg-theme-surface/30 border border-theme-border/60 rounded-xl hover:border-theme-primary/30 hover:bg-theme-surface/50 transition-all duration-200 shadow-sm mb-3 break-inside-avoid">
+        <div class="flex items-start justify-between gap-3 mb-1">
+          <span class="font-header font-bold text-base md:text-lg text-theme-primary leading-tight select-all">${renderMd(cleanLabel, { inline: true })}</span>
+          <button 
+            type="button" 
+            class="opacity-100 md:opacity-0 md:group-hover:opacity-100 md:focus-within:opacity-100 p-1 hover:bg-theme-primary/10 text-theme-text/40 hover:text-theme-primary rounded transition-all duration-150 flex items-center justify-center cursor-pointer" 
+            data-copy-text="${escapedLabel}"
+            title="Copy name to clipboard"
+          >
+            <span class="icon-[lucide--copy] w-3.5 h-3.5"></span>
+          </button>
+        </div>
+        <span class="text-xs md:text-sm text-theme-text/80 leading-relaxed">${renderMd(value, { inline: true })}</span>
+      </div>\n`;
+    }
+    return `<div class="flex flex-col mb-1"><span class="seo-label font-header font-bold uppercase tracking-widest text-xs text-theme-primary mb-0.5">${renderMd(label, { inline: true })}</span><span>${renderMd(value, { inline: true })}</span></div>\n`;
+  };
 
   // Label/value pairs ("- **Key**: value") get a bespoke stacked layout
   // marked can't produce; everything else is delegated to marked.
@@ -428,6 +447,33 @@
       }, 2000);
     } catch (err) {
       console.error("Failed to copy markdown:", err);
+    }
+  }
+
+  function handleContainerClick(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    const copyBtn = target.closest("[data-copy-text]");
+    if (copyBtn) {
+      const textToCopy = copyBtn.getAttribute("data-copy-text");
+      if (textToCopy) {
+        navigator.clipboard
+          .writeText(textToCopy)
+          .then(() => {
+            const iconEl = copyBtn.querySelector("span");
+            if (iconEl) {
+              iconEl.className =
+                "icon-[lucide--check] w-3.5 h-3.5 text-green-500 animate-pulse";
+              setTimeout(() => {
+                if (iconEl) {
+                  iconEl.className = "icon-[lucide--copy] w-3.5 h-3.5";
+                }
+              }, 1500);
+            }
+          })
+          .catch((err) => {
+            console.error("Failed to copy text:", err);
+          });
+      }
     }
   }
 </script>
@@ -645,12 +691,15 @@
               </div>
             </div>
 
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
               class="seo-md text-sm leading-relaxed text-theme-text/90 flex-grow {variant ===
               'names'
                 ? 'md:columns-2 md:gap-x-8 [&_div]:break-inside-avoid [&_div]:mb-4'
                 : 'space-y-4'}"
               data-theme={worldTheme}
+              onclick={handleContainerClick}
             >
               {@html renderMarkdown(documentLayout.content)}
             </div>

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -69,8 +69,8 @@
   ]);
 
   let isGenerating = $state(false);
-  let generatedData = $state<GeneratorOutput | null>(initialDraft);
-  let isExampleDraft = $state(true);
+  let generatedData = $state<GeneratorOutput | null>(null);
+  let isExampleDraft = $state(false);
 
   $effect(() => {
     generatedData = initialDraft;
@@ -110,7 +110,12 @@
                 ? "settlements"
                 : eyebrow.toLowerCase().includes("item")
                   ? "magic items"
-                  : "RPG elements",
+                  : eyebrow.toLowerCase().includes("pantheon")
+                    ? "pantheons"
+                    : eyebrow.toLowerCase().includes("deity") ||
+                        eyebrow.toLowerCase().includes("god")
+                      ? "deities"
+                      : "RPG elements",
   );
 
   const generatedSingular = $derived(
@@ -120,7 +125,7 @@
   const documentLayout = $derived(getGeneratorDocumentLayout(generatedData));
 
   $effect(() => {
-    if (browser && isThemeCustomizable && activeThemeId) {
+    if (isThemeCustomizable && browser) {
       if (themeStore.worldThemeId !== activeThemeId) {
         void themeStore.setTheme(activeThemeId);
       }
@@ -134,6 +139,7 @@
   });
 
   async function handleGenerateOnMount() {
+    if (isGenerating || generatedData) return;
     isGenerating = true;
     errorMessage = null;
     try {
@@ -279,7 +285,12 @@
   const labelValueHtml = (label: string, value: string) => {
     if (variant === "names") {
       const cleanLabel = label.replace(/\*\*/g, "").trim();
-      const escapedLabel = cleanLabel.replace(/"/g, "&quot;");
+      const escapedLabel = cleanLabel
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
       return `<div class="group relative flex flex-col p-4 bg-theme-surface/30 border border-theme-border/60 rounded-xl hover:border-theme-primary/30 hover:bg-theme-surface/50 transition-all duration-200 shadow-sm mb-3 break-inside-avoid">
         <div class="flex items-start justify-between gap-3 mb-1">
           <span class="font-header font-bold text-base md:text-lg text-theme-primary leading-tight select-all">${renderMd(cleanLabel, { inline: true })}</span>
@@ -447,6 +458,12 @@
       }, 2000);
     } catch (err) {
       console.error("Failed to copy markdown:", err);
+    }
+  }
+
+  function handleContainerKeydown(event: KeyboardEvent) {
+    if (event.key === "Enter" || event.key === " ") {
+      handleContainerClick(event as unknown as MouseEvent);
     }
   }
 
@@ -691,15 +708,16 @@
               </div>
             </div>
 
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
+              role="group"
+              tabindex="-1"
               class="seo-md text-sm leading-relaxed text-theme-text/90 flex-grow {variant ===
               'names'
                 ? 'md:columns-2 md:gap-x-8 [&_div]:break-inside-avoid [&_div]:mb-4'
                 : 'space-y-4'}"
               data-theme={worldTheme}
               onclick={handleContainerClick}
+              onkeydown={handleContainerKeydown}
             >
               {@html renderMarkdown(documentLayout.content)}
             </div>

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.test.ts
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.test.ts
@@ -204,4 +204,48 @@ describe("SEOGeneratorLayout Theming Sync", () => {
       expect(personSchemaFound).toBe(true);
     });
   });
+
+  describe("Names variant rendering", () => {
+    it("renders names as beautiful cards with copy buttons when variant is 'names'", () => {
+      const mockGenerate = vi.fn().mockResolvedValue({});
+      const initialDraft = {
+        type: "character" as const,
+        title: "Test Names",
+        content: "- **Iridian Vespera**: A nomadic chronicler.",
+        lore: "",
+        labels: ["rpg-names"],
+        status: "draft" as const,
+      };
+
+      const { container } = render(SEOGeneratorLayout, {
+        props: {
+          pageTitle: "Names Generator",
+          metaDescription: "Generate names.",
+          canonicalPath: "/tools/fantasy-name-generator",
+          generate: mockGenerate,
+          formFields: noopSnippet,
+          initialDraft,
+          variant: "names",
+        },
+      });
+
+      // It should render a card div
+      const card = container.querySelector(".group.relative.flex.flex-col");
+      expect(card).toBeTruthy();
+
+      // The name should be rendered with font-header
+      const nameSpan = card?.querySelector(
+        ".font-header.font-bold.text-theme-primary",
+      );
+      expect(nameSpan).toBeTruthy();
+      expect(nameSpan?.textContent?.trim()).toBe("Iridian Vespera");
+
+      // The copy button should have copy icon and the data-copy-text attribute
+      const copyBtn = card?.querySelector(
+        "button[data-copy-text='Iridian Vespera']",
+      );
+      expect(copyBtn).toBeTruthy();
+      expect(copyBtn?.querySelector(".icon-\\[lucide--copy\\]")).toBeTruthy();
+    });
+  });
 });

--- a/apps/web/src/lib/components/seo/generator-document-layout.ts
+++ b/apps/web/src/lib/components/seo/generator-document-layout.ts
@@ -98,6 +98,26 @@ const LAYOUT_RULES: LayoutRule[] = [
       heading: "Secrets & Hooks",
     },
   },
+  {
+    label: "deity-generator",
+    railSections: new Set(["At a Glance", "Rituals & Taboos"]),
+    documentBullets: {
+      labels: new Set(["Secret", "Immediate Hook"]),
+      heading: "Secrets & Hooks",
+    },
+  },
+  {
+    label: "pantheon-generator",
+    railSections: new Set([
+      "At a Glance",
+      "Deities of the Pantheon",
+      "Entity Seeds",
+    ]),
+    documentBullets: {
+      labels: new Set(["Hidden Problem", "Immediate Hook"]),
+      heading: "Secrets & Hooks",
+    },
+  },
 ];
 
 interface MarkdownSection {

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -839,6 +839,114 @@ describe("DefaultGeneratorEngine", () => {
     }
   });
 
+  describe("generatePantheon", () => {
+    it("should generate single deity details locally when useAI is false", async () => {
+      const res = await engine.generatePantheon({
+        mode: "single",
+        genre: "Classic Fantasy",
+        divineType: "God",
+        domain: "Death",
+        useAI: false,
+      });
+
+      expect(res.type).toBe("character");
+      expect(res.title).toContain("Death");
+      expect(res.summary?.toLowerCase()).toContain("god");
+      expect(res.content).toContain("Deity Description");
+      expect(res.content.toLowerCase()).toContain("death");
+      expect(res.lore).toContain("At a Glance");
+      expect(res.labels).toContain("rpg-deity");
+      expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should generate pantheon details locally when useAI is false", async () => {
+      const res = await engine.generatePantheon({
+        mode: "pantheon",
+        genre: "Classic Fantasy",
+        conflictTheme: "Cosmic Balance",
+        useAI: false,
+      });
+
+      expect(res.type).toBe("faction");
+      expect(res.title).toContain("Pantheon");
+      expect(res.summary?.toLowerCase()).toContain("cosmic balance");
+      expect(res.content).toContain("Origin & Dogma");
+      expect(res.lore).toContain("At a Glance");
+      expect(res.labels).toContain("rpg-pantheon");
+      expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should call clientManager for single deity when useAI is true and succeed", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "Hel, Lady of Hela",
+                content: "AI Bio",
+                lore: "AI Lore",
+                labels: ["deity-custom"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generatePantheon({
+        mode: "single",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(res.type).toBe("character");
+      expect(res.title).toBe("Hel, Lady of Hela");
+      expect(res.content).toBe("AI Bio");
+      expect(res.lore).toBe("AI Lore");
+      expect(res.labels).toContain("deity-custom");
+    });
+
+    it("should call clientManager for pantheon when useAI is true and succeed", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "The Silent Maw",
+                content: "AI Bio",
+                lore: "AI Lore",
+                labels: ["pantheon-custom"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generatePantheon({
+        mode: "pantheon",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(res.type).toBe("faction");
+      expect(res.title).toBe("The Silent Maw");
+      expect(res.content).toBe("AI Bio");
+      expect(res.lore).toBe("AI Lore");
+      expect(res.labels).toContain("pantheon-custom");
+    });
+
+    it("should fall back to local tables if AI call fails", async () => {
+      mockClientManager.getModel.mockRejectedValue(new Error("Network Error"));
+
+      const res = await engine.generatePantheon({
+        mode: "single",
+        useAI: true,
+      });
+
+      expect(res.type).toBe("character");
+      expect(res.content).toContain("Deity Description");
+    });
+  });
+
   describe("session hub context", () => {
     const captureEngine = () => {
       const captured = { system: "", user: "" };

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -1,3 +1,4 @@
+/** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { DefaultGeneratorEngine } from "./generator-engine";
 import { BANNED_NAMES, NAME_BAN_PROMPT } from "./generators/banned-names";

--- a/apps/web/src/lib/services/seo/generator-engine.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.ts
@@ -19,6 +19,7 @@ export { magicItemConfig } from "./generators/magic-item";
 export { questConfig, themeToQuestGenre } from "./generators/quest";
 export { socialHubConfig } from "./generators/social-hub";
 export { nationConfig, kingdomConfig } from "./generators/kingdom-nation";
+export { pantheonConfig } from "./generators/pantheon";
 
 import { generateName as _generateName } from "./generators/base";
 import { generateNPC } from "./generators/npc";
@@ -29,6 +30,7 @@ import { generateQuestHook } from "./generators/quest";
 import { generateNames } from "./generators/names";
 import { generateSocialHub, generateTavern } from "./generators/social-hub";
 import { generateKingdom, generateNation } from "./generators/kingdom-nation";
+import { generatePantheon } from "./generators/pantheon";
 import type { GeneratorOutput } from "./generators/base";
 
 export class DefaultGeneratorEngine {
@@ -102,6 +104,12 @@ export class DefaultGeneratorEngine {
     options: Parameters<typeof generateNation>[1] = {},
   ): Promise<GeneratorOutput> {
     return generateNation(this.clientManager, options);
+  }
+
+  async generatePantheon(
+    options: Parameters<typeof generatePantheon>[1] = {},
+  ): Promise<GeneratorOutput> {
+    return generatePantheon(this.clientManager, options);
   }
 }
 

--- a/apps/web/src/lib/services/seo/generators/names.ts
+++ b/apps/web/src/lib/services/seo/generators/names.ts
@@ -90,11 +90,14 @@ Return only the JSON object. Do not include markdown code block formatting like 
     generated.push(prefix.charAt(0).toUpperCase() + prefix.slice(1) + suffix);
   }
 
-  const nameList = generated.map((n) => `- ${n}`).join("\n");
+  const nameList = generated
+    .map(
+      (n) =>
+        `- **${n}**: Traditional ${culture} style ${nameType.toLowerCase()} name.`,
+    )
+    .join("\n");
 
-  const content = `${culture} ${nameType.toLowerCase()} names in a ${gender.toLowerCase()} register.
-
-${nameList}`;
+  const content = `These names represent the traditional ${culture} style for ${nameType.toLowerCase()}s, filtered for a ${gender.toLowerCase()} register.\n\n${nameList}`;
 
   const lore = `### Generator Settings
 - **Culture**: ${culture}

--- a/apps/web/src/lib/services/seo/generators/pantheon.ts
+++ b/apps/web/src/lib/services/seo/generators/pantheon.ts
@@ -1,0 +1,298 @@
+import type { DefaultAIClientManager } from "$lib/services/ai/client-manager";
+import { NAME_BAN_PROMPT } from "./banned-names";
+import { getSessionContext } from "./session-context";
+import { type GeneratorOutput, generateName, pickFrom } from "./base";
+
+export const pantheonConfig = {
+  genres: [
+    "Classic Fantasy",
+    "Cyberpunk / Corporate",
+    "Vampire / Gothic Noir",
+    "Sci-Fi / Space Opera",
+    "Modern Conspiracy",
+    "Post-Apocalyptic",
+  ],
+  divineTypes: [
+    "God",
+    "Spirit",
+    "Saint",
+    "Demon",
+    "Ancestor",
+    "Abstract Force",
+  ],
+  domains: [
+    "War",
+    "Nature",
+    "Knowledge",
+    "Shadow",
+    "Death",
+    "Light",
+    "Arcana",
+    "Chaos",
+    "Harmony",
+  ],
+  tones: ["Mythic", "Dark / Grim", "Mystical", "Weird / Strange", "Heroic"],
+  worshippers: [
+    "Mystery Cult",
+    "State Religion",
+    "Secret Brotherhood",
+    "Nomadic Tribe",
+    "Folk Devotion",
+  ],
+  conflictThemes: [
+    "Succession War",
+    "Cosmic Balance",
+    "Betrayal",
+    "Forbidden Love",
+    "Forgotten Pact",
+  ],
+  symbols: [
+    "A weeping golden eye",
+    "A black iron key wrapped in thorns",
+    "An inverted silver crescent moon",
+    "A burning wheel with nine spokes",
+    "A skull holding a blossoming lily",
+    "A twin-headed serpent swallowing its tail",
+    "A cracked crystal mirror reflecting starlight",
+    "A bronze scale weighted with a raven feather",
+  ],
+  rituals: [
+    "Silent meditation under a starless night sky.",
+    "A feast of bread and salt where all weapons are left at the door.",
+    "Anointing the thresholds of homes with spring water at dawn.",
+    "Burning dried sage and leaving small copper coins at crossroads.",
+    "Tying silk ribbons of different colors to the branches of a hollow oak.",
+    "Whispering confessions to a flame before extinguishing it in oil.",
+  ],
+  myths: [
+    "The Great Eclipse: How the deity swallowed the sun to protect the realm from a cosmic terror.",
+    "The Iron Treaty: The day the deity descended to forge the boundaries between mortals and the divine.",
+    "The Shattered Mirror: How the deity split their own soul into seven pieces to populate the sky with stars.",
+    "The First Tear: The origin of the world's deepest ocean, wept when the deity's companion chose mortality.",
+  ],
+};
+
+export async function generatePantheon(
+  clientManager: DefaultAIClientManager,
+  options: {
+    mode?: "single" | "pantheon";
+    genre?: string;
+    divineType?: string;
+    domain?: string;
+    tone?: string;
+    worshippers?: string;
+    conflictTheme?: string;
+    campaignContext?: string;
+    useAI?: boolean;
+  } = {},
+): Promise<GeneratorOutput> {
+  const mode = options.mode || "single";
+  const genre = options.genre || "Classic Fantasy";
+  const divineType = options.divineType || pickFrom(pantheonConfig.divineTypes);
+  const domain = options.domain || pickFrom(pantheonConfig.domains);
+  const tone = options.tone || pickFrom(pantheonConfig.tones);
+  const worshipperType =
+    options.worshippers || pickFrom(pantheonConfig.worshippers);
+  const conflictTheme =
+    options.conflictTheme || pickFrom(pantheonConfig.conflictThemes);
+  const campaignContext = options.campaignContext?.trim() || "";
+
+  const randomSymbol = pickFrom(pantheonConfig.symbols);
+  const randomRitual = pickFrom(pantheonConfig.rituals);
+  const randomMyth = pickFrom(pantheonConfig.myths);
+
+  // Invent a base name for a deity
+  const generatedDeityName = generateName();
+
+  if (options.useAI !== false) {
+    try {
+      let prompt = "";
+      let systemInstruction = "";
+
+      if (mode === "single") {
+        systemInstruction =
+          "You are an expert RPG campaign writer. You generate detailed, table-ready single deities or divine spirits for tabletop GMs in JSON format.";
+        prompt = `Generate a detailed RPG Deity/Spirit in JSON format.
+Options:
+- Name suggestion: ${generatedDeityName}
+- Genre/Theme: ${genre}
+- Divine Type: ${divineType}
+- Primary Domain: ${domain}
+- Tone: ${tone}
+- Worshippers: ${worshipperType}
+${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
+
+You must return a valid JSON object matching the following structure exactly, no markdown fences:
+{
+  "title": "A majestic name for the deity (e.g. Solaris the Lightbringer, Xal'Koth the Devourer)",
+  "summary": "One-sentence overview of the deity's core nature.",
+  "content": "Markdown. Use exactly these section headers in order: '### Deity Description', '### Divine Portfolio', '### Worship & Cults'. Describe their appearance, symbols, dogmas, and temples.",
+  "lore": "Markdown. Use exactly this structure:\\n### At a Glance\\n- **Deity Type**: ${divineType}\\n- **Primary Domain**: ${domain}\\n- **Worshippers**: ${worshipperType}\\n- **Sacred Symbol**: description of symbol\\n- **Secret**: a dark truth or hidden vulnerability\\n- **Immediate Hook**: one-sentence GM hook\\n### Rituals & Taboos\\n- description of common ritual\\n- description of taboo\\n### Myths & Legends\\n- brief myth summary\\n### Adventure Hooks\\n- adventure hook 1\\n- adventure hook 2",
+  "labels": ["rpg-deity", "deity-generator", "imported-draft", "${genre.toLowerCase().replace(/[^a-z0-9]/g, "-")}"]
+}
+${NAME_BAN_PROMPT}
+${getSessionContext()}
+Return only the JSON object. Do not include markdown code block formatting.`;
+      } else {
+        systemInstruction =
+          "You are an expert RPG campaign writer. You generate cohesive, campaign-ready pantheons of deities and divine conflicts in JSON format.";
+        prompt = `Generate a detailed RPG Pantheon in JSON format.
+Options:
+- Genre/Theme: ${genre}
+- Tone: ${tone}
+- Primary Conflict Theme: ${conflictTheme}
+- Divine Domain focus: ${domain}
+- Worshippers: ${worshipperType}
+${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
+
+You must return a valid JSON object matching the following structure exactly, no markdown fences:
+{
+  "title": "A majestic name for the Pantheon (e.g. The Solar Conclave, The Seven Broken Shields)",
+  "summary": "One-sentence summary of the pantheon's main belief system.",
+  "content": "Markdown. Use exactly these section headers in order: '### Origin & Dogma', '### Pantheon Structure', '### Divine Alliances & Rivalries'. Describe how the deities relate to one another, referencing them by name.",
+  "lore": "Markdown. Use exactly this structure:\\n### At a Glance\\n- **Pantheon Name**: Name of pantheon\\n- **Conflict Theme**: ${conflictTheme}\\n- **Worshippers**: ${worshipperType}\\n- **Hidden Problem**: the underlying divine tension\\n- **Immediate Hook**: one-sentence GM hook\\n### Deities of the Pantheon\\nDetail 3-4 member deities. For each deity, provide:\\n- **Name**: title and short 1-line description\\n### Rumours & Legends\\n- short hook 1\\n- short hook 2\\n### Entity Seeds\\n- list of 4-5 Codex entity types (e.g. '**Character**: Deity A', '**Character**: Deity B', '**Faction**: Pantheon Cult')",
+  "labels": ["rpg-pantheon", "pantheon-generator", "imported-draft", "${genre.toLowerCase().replace(/[^a-z0-9]/g, "-")}"]
+}
+${NAME_BAN_PROMPT}
+${getSessionContext()}
+Return only the JSON object. Do not include markdown code block formatting.`;
+      }
+
+      const model = await clientManager.getModel(
+        "",
+        "gemini-3.1-flash-lite",
+        systemInstruction,
+      );
+      const response = await model.generateContent(prompt);
+      const text = response.response.text().trim();
+      const cleanText = text
+        .replace(/^```json\s*/i, "")
+        .replace(/```$/, "")
+        .trim();
+      const data = JSON.parse(cleanText);
+
+      return {
+        type: mode === "single" ? "character" : "faction",
+        title:
+          data.title ||
+          (mode === "single" ? generatedDeityName : "The Divine Assembly"),
+        summary: data.summary || "",
+        content: data.content || "",
+        lore: data.lore || "",
+        labels: Array.isArray(data.labels)
+          ? data.labels
+          : mode === "single"
+            ? ["rpg-deity", "deity-generator", "imported-draft"]
+            : ["rpg-pantheon", "pantheon-generator", "imported-draft"],
+        status: "active",
+      };
+    } catch (err) {
+      console.warn("AI generation failed, falling back to local tables:", err);
+    }
+  }
+
+  // Fallback Generation Logic
+  if (mode === "single") {
+    const title = `${generatedDeityName}, the ${tone} ${divineType} of ${domain}`;
+    const summary = `A powerful ${divineType.toLowerCase()} governing the forces of ${domain.toLowerCase()} with a ${tone.toLowerCase()} outlook.`;
+
+    let content = `### Deity Description
+The deity ${generatedDeityName} manifests as a striking presence aligned with ${domain.toLowerCase()}. Commonly depicted carrying ${randomSymbol.toLowerCase()}, their sacred icons can be found carved in old shrines.
+
+### Divine Portfolio
+Followers look to ${generatedDeityName} for guidance in matters of ${domain.toLowerCase()}. The deity's tenets demand adhering to the laws of ${tone.toLowerCase()} harmony and resisting the temptations of rival entities.
+
+### Worship & Cults
+The worship of this ${divineType.toLowerCase()} is usually organized as a ${worshipperType.toLowerCase()}. Temples range from modest roadside altars to grand cathedrals built in urban centers.`;
+
+    if (campaignContext) {
+      content += `\n\n### Influence of Campaign Context\nIn this campaign setting (${campaignContext}), the deity's worshippers have adapted to these circumstances, altering their rites accordingly.`;
+    }
+
+    const lore = `### At a Glance
+- **Deity Type**: ${divineType}
+- **Primary Domain**: ${domain}
+- **Worshippers**: ${worshipperType}
+- **Sacred Symbol**: ${randomSymbol}
+- **Secret**: Holds a secret fear of their own power being forgotten by mortal hearts.
+- **Immediate Hook**: A lost tomb dedicated to this deity has been uncovered, containing a relic that has begun to glow.
+
+### Rituals & Taboos
+- **Ritual**: ${randomRitual}
+- **Taboo**: Damaging or defacing sacred symbols of ${domain.toLowerCase()} is believed to bring immediate bad fortune.
+
+### Myths & Legends
+- **The Tale of Creation**: ${randomMyth}
+
+### Adventure Hooks
+- A high priest of the local ${worshipperType.toLowerCase()} hires the adventurers to recover a stolen relic.
+- A heretical sect has arisen, claiming the deity demands a dark and forbidden sacrifice.`;
+
+    return {
+      type: "character",
+      title,
+      summary,
+      content,
+      lore,
+      labels: ["rpg-deity", "deity-generator", "imported-draft"],
+      status: "active",
+    };
+  } else {
+    // Pantheon fallback logic
+    const pantheonTitle = `The ${generatedDeityName} Pantheon`;
+    const summary = `A collection of deities bound by the theme of ${conflictTheme.toLowerCase()} in a ${genre.toLowerCase()} world.`;
+
+    const deityNameA = generateName();
+    const deityNameB = generateName();
+    const deityNameC = generateName();
+
+    let content = `### Origin & Dogma
+According to legend, the deities of this pantheon were born from a single cosmic event. Under the theme of ${conflictTheme.toLowerCase()}, they divide the control of the cosmos between their spheres of influence.
+
+### Pantheon Structure
+The pantheon consists of three major figures:
+1. **${deityNameA}**: Represents the domain of ${domain}.
+2. **${deityNameB}**: Controls the opposite forces of the cosmos.
+3. **${deityNameC}**: A neutral arbiter holding the balance.
+
+### Divine Alliances & Rivalries
+- **[[${deityNameA}]]** is allied with **[[${deityNameC}]]**, but stands in direct opposition to **[[${deityNameB}]]**.
+- **[[${deityNameB}]]** seeks to overthrow the established order of the other deities.`;
+
+    if (campaignContext) {
+      content += `\n\n### Influence of Campaign Context\nIn this campaign setting (${campaignContext}), the struggles of the pantheon are reflected in the shifting boundaries of the mortal kingdoms.`;
+    }
+
+    const lore = `### At a Glance
+- **Pantheon Name**: ${pantheonTitle}
+- **Conflict Theme**: ${conflictTheme}
+- **Worshippers**: ${worshipperType}
+- **Hidden Problem**: An ancient prophecy predicts that one of the deities will fall, destabilizing the entire celestial hierarchy.
+- **Immediate Hook**: Omens of celestial alignment have sent local cults into a frenzy of preparations.
+
+### Deities of the Pantheon
+- **[[${deityNameA}]]**: The deity of ${domain}, depicted as a warrior.
+- **[[${deityNameB}]]**: A mysterious spirit of chaos and shadows.
+- **[[${deityNameC}]]**: An ancient ancestor guarding the gates of death.
+
+### Rumours & Legends
+- A forgotten temple of the pantheon lies submerged under the local lake.
+- The high priests of the three deities are secretly meeting to avert a holy war.
+
+### Entity Seeds
+- **Character**: [[${deityNameA}]]
+- **Character**: [[${deityNameB}]]
+- **Character**: [[${deityNameC}]]
+- **Faction**: ${worshipperType}`;
+
+    return {
+      type: "faction",
+      title: pantheonTitle,
+      summary,
+      content,
+      lore,
+      labels: ["rpg-pantheon", "pantheon-generator", "imported-draft"],
+      status: "active",
+    };
+  }
+}

--- a/apps/web/src/lib/services/seo/generators/pantheon.ts
+++ b/apps/web/src/lib/services/seo/generators/pantheon.ts
@@ -46,6 +46,16 @@ export const pantheonConfig = {
     "Forbidden Love",
     "Forgotten Pact",
   ],
+  sizes: [
+    { label: "Small (3–4 deities)", value: "small", min: 3, max: 4 },
+    { label: "Medium (5–7 deities)", value: "medium", min: 5, max: 7 },
+    { label: "Large (8–12 deities)", value: "large", min: 8, max: 12 },
+  ] as {
+    label: string;
+    value: "small" | "medium" | "large";
+    min: number;
+    max: number;
+  }[],
   symbols: [
     "A weeping golden eye",
     "A black iron key wrapped in thorns",
@@ -76,6 +86,7 @@ export async function generatePantheon(
   clientManager: DefaultAIClientManager,
   options: {
     mode?: "single" | "pantheon";
+    size?: "small" | "medium" | "large";
     genre?: string;
     divineType?: string;
     domain?: string;
@@ -87,6 +98,9 @@ export async function generatePantheon(
   } = {},
 ): Promise<GeneratorOutput> {
   const mode = options.mode || "single";
+  const sizeCfg =
+    pantheonConfig.sizes.find((s) => s.value === options.size) ??
+    pantheonConfig.sizes[0];
   const genre = options.genre || "Classic Fantasy";
   const divineType = options.divineType || pickFrom(pantheonConfig.divineTypes);
   const domain = options.domain || pickFrom(pantheonConfig.domains);
@@ -143,6 +157,7 @@ Options:
 - Primary Conflict Theme: ${conflictTheme}
 - Divine Domain focus: ${domain}
 - Worshippers: ${worshipperType}
+- Pantheon Size: ${sizeCfg.min}–${sizeCfg.max} deities
 ${campaignContext ? `- Campaign Context: ${campaignContext}` : ""}
 
 You must return a valid JSON object matching the following structure exactly, no markdown fences:
@@ -150,7 +165,7 @@ You must return a valid JSON object matching the following structure exactly, no
   "title": "A majestic name for the Pantheon (e.g. The Solar Conclave, The Seven Broken Shields)",
   "summary": "One-sentence summary of the pantheon's main belief system.",
   "content": "Markdown. Use exactly these section headers in order: '### Origin & Dogma', '### Pantheon Structure', '### Divine Alliances & Rivalries'. Describe how the deities relate to one another, referencing them by name.",
-  "lore": "Markdown. Use exactly this structure:\\n### At a Glance\\n- **Pantheon Name**: Name of pantheon\\n- **Conflict Theme**: ${conflictTheme}\\n- **Worshippers**: ${worshipperType}\\n- **Hidden Problem**: the underlying divine tension\\n- **Immediate Hook**: one-sentence GM hook\\n### Deities of the Pantheon\\nDetail 3-4 member deities. For each deity, provide:\\n- **Name**: title and short 1-line description\\n### Rumours & Legends\\n- short hook 1\\n- short hook 2\\n### Entity Seeds\\n- list of 4-5 Codex entity types (e.g. '**Character**: Deity A', '**Character**: Deity B', '**Faction**: Pantheon Cult')",
+  "lore": "Markdown. Use exactly this structure:\\n### At a Glance\\n- **Pantheon Name**: Name of pantheon\\n- **Conflict Theme**: ${conflictTheme}\\n- **Worshippers**: ${worshipperType}\\n- **Hidden Problem**: the underlying divine tension\\n- **Immediate Hook**: one-sentence GM hook\\n### Deities of the Pantheon\\nDetail ${sizeCfg.min}-${sizeCfg.max} member deities. For each deity, provide:\\n- **Name**: title and short 1-line description\\n### Rumours & Legends\\n- short hook 1\\n- short hook 2\\n### Entity Seeds\\n- list of Codex entity types for each deity plus one cult faction (e.g. '**Character**: Deity A', '**Faction**: Pantheon Cult')",
   "labels": ["rpg-pantheon", "pantheon-generator", "imported-draft", "${genre.toLowerCase().replace(/[^a-z0-9]/g, "-")}"]
 }
 ${NAME_BAN_PROMPT}
@@ -242,22 +257,19 @@ The worship of this ${divineType.toLowerCase()} is usually organized as a ${wors
     const pantheonTitle = `The ${generatedDeityName} Pantheon`;
     const summary = `A collection of deities bound by the theme of ${conflictTheme.toLowerCase()} in a ${genre.toLowerCase()} world.`;
 
-    const deityNameA = generateName();
-    const deityNameB = generateName();
-    const deityNameC = generateName();
+    const deityCount = sizeCfg.min;
+    const deityNames = Array.from({ length: deityCount }, () => generateName());
 
     let content = `### Origin & Dogma
 According to legend, the deities of this pantheon were born from a single cosmic event. Under the theme of ${conflictTheme.toLowerCase()}, they divide the control of the cosmos between their spheres of influence.
 
 ### Pantheon Structure
-The pantheon consists of three major figures:
-1. **${deityNameA}**: Represents the domain of ${domain}.
-2. **${deityNameB}**: Controls the opposite forces of the cosmos.
-3. **${deityNameC}**: A neutral arbiter holding the balance.
+The pantheon consists of ${deityCount} deities:
+${deityNames.map((n, i) => `${i + 1}. **${n}**: ${i === 0 ? `Represents the domain of ${domain}.` : i === deityCount - 1 ? "A neutral arbiter holding the balance." : "Controls opposing forces of the cosmos."}`).join("\n")}
 
 ### Divine Alliances & Rivalries
-- **[[${deityNameA}]]** is allied with **[[${deityNameC}]]**, but stands in direct opposition to **[[${deityNameB}]]**.
-- **[[${deityNameB}]]** seeks to overthrow the established order of the other deities.`;
+- **[[${deityNames[0]}]]** is allied with **[[${deityNames[deityNames.length - 1]}]]**, but stands in direct opposition to **[[${deityNames[1]}]]**.
+- **[[${deityNames[1]}]]** seeks to overthrow the established order of the other deities.`;
 
     if (campaignContext) {
       content += `\n\n### Influence of Campaign Context\nIn this campaign setting (${campaignContext}), the struggles of the pantheon are reflected in the shifting boundaries of the mortal kingdoms.`;
@@ -271,18 +283,14 @@ The pantheon consists of three major figures:
 - **Immediate Hook**: Omens of celestial alignment have sent local cults into a frenzy of preparations.
 
 ### Deities of the Pantheon
-- **[[${deityNameA}]]**: The deity of ${domain}, depicted as a warrior.
-- **[[${deityNameB}]]**: A mysterious spirit of chaos and shadows.
-- **[[${deityNameC}]]**: An ancient ancestor guarding the gates of death.
+${deityNames.map((n, i) => `- **[[${n}]]**: ${i === 0 ? `The deity of ${domain}, depicted as a warrior.` : i === 1 ? "A mysterious spirit of chaos and shadows." : "An ancient ancestor guarding the gates of death."}`).join("\n")}
 
 ### Rumours & Legends
 - A forgotten temple of the pantheon lies submerged under the local lake.
-- The high priests of the three deities are secretly meeting to avert a holy war.
+- The high priests of the deities are secretly meeting to avert a holy war.
 
 ### Entity Seeds
-- **Character**: [[${deityNameA}]]
-- **Character**: [[${deityNameB}]]
-- **Character**: [[${deityNameC}]]
+${deityNames.map((n) => `- **Character**: [[${n}]]`).join("\n")}
 - **Faction**: ${worshipperType}`;
 
     return {

--- a/apps/web/src/lib/services/seo/random-idea.test.ts
+++ b/apps/web/src/lib/services/seo/random-idea.test.ts
@@ -15,9 +15,11 @@ import { nationConfig } from "./generators/kingdom-nation";
 describe("randomIdeaCategories", () => {
   it("contains exactly the standalone generator pool", () => {
     expect(randomIdeaCategories.map((c) => c.key).sort()).toEqual([
+      "deity",
       "faction",
       "nation",
       "npc",
+      "pantheon",
       "quest",
       "social-hub",
     ]);
@@ -37,6 +39,7 @@ describe("randomIdeaCategories", () => {
       generateNPC: vi.fn().mockResolvedValue("npc-result"),
       generateQuestHook: vi.fn().mockResolvedValue("quest-result"),
       generateSocialHub: vi.fn().mockResolvedValue("social-hub-result"),
+      generatePantheon: vi.fn().mockResolvedValue("pantheon-result"),
     } as unknown as DefaultGeneratorEngine;
     const theme = "Cyberpunk / Corporate";
 
@@ -68,6 +71,16 @@ describe("randomIdeaCategories", () => {
     expect(engine.generateSocialHub).toHaveBeenCalledWith({
       useAI: true,
       genre: "Cyberpunk",
+    });
+    expect(engine.generatePantheon).toHaveBeenCalledWith({
+      useAI: true,
+      genre: theme,
+      mode: "pantheon",
+    });
+    expect(engine.generatePantheon).toHaveBeenCalledWith({
+      useAI: true,
+      genre: theme,
+      mode: "single",
     });
   });
 

--- a/apps/web/src/lib/services/seo/random-idea.ts
+++ b/apps/web/src/lib/services/seo/random-idea.ts
@@ -5,7 +5,14 @@ import { npcThemeConfig } from "./generators/npc";
 import { themeToQuestGenre } from "./generators/quest";
 
 export interface RandomIdeaCategory {
-  key: "faction" | "nation" | "npc" | "quest" | "social-hub";
+  key:
+    | "faction"
+    | "nation"
+    | "npc"
+    | "quest"
+    | "social-hub"
+    | "pantheon"
+    | "deity";
   label: string;
   generate: (
     engine: DefaultGeneratorEngine,
@@ -74,6 +81,18 @@ export const randomIdeaCategories: RandomIdeaCategory[] = [
     label: "Social Hub",
     generate: (engine, useAI, theme) =>
       engine.generateSocialHub({ genre: themeToHubGenre[theme], useAI }),
+  },
+  {
+    key: "pantheon",
+    label: "Pantheon",
+    generate: (engine, useAI, theme) =>
+      engine.generatePantheon({ genre: theme, mode: "pantheon", useAI }),
+  },
+  {
+    key: "deity",
+    label: "Deity",
+    generate: (engine, useAI, theme) =>
+      engine.generatePantheon({ genre: theme, mode: "single", useAI }),
   },
 ];
 

--- a/apps/web/src/routes/(marketing)/generators/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/+page.svelte
@@ -58,6 +58,25 @@
       ],
     },
     {
+      group: "Divine & Mythology",
+      items: [
+        {
+          href: "/generators/pantheon-generator",
+          label: "Pantheon Generator",
+          summary:
+            "Build a small pantheon with alliances, rivalries, cosmic conflicts, and member deities.",
+          icon: "icon-[lucide--sun]",
+        },
+        {
+          href: "/generators/god-generator",
+          label: "God & Deity Generator",
+          summary:
+            "Design a single deity, spirit, or abstract force with domains, taboos, symbols, and hooks.",
+          icon: "icon-[lucide--star]",
+        },
+      ],
+    },
+    {
       group: "Adventure & Worldbuilding",
       items: [
         {
@@ -113,7 +132,7 @@
           href: "/generators/random",
           label: "Surprise Me",
           summary:
-            "Not sure what you need? Spin the idea machine — a random faction, realm, NPC, quest hook, or venue.",
+            "Not sure what you need? Spin the idea machine — a random faction, realm, NPC, quest hook, deity, or venue.",
           icon: "icon-[lucide--dices]",
         },
       ],

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -382,6 +382,7 @@
     mode: (data.slug === "pantheon-generator" ? "pantheon" : "single") as
       | "single"
       | "pantheon",
+    size: "small" as "small" | "medium" | "large",
     genre: pantheonConfig.genres[0],
     divineType: pantheonConfig.divineTypes[0],
     domain: pantheonConfig.domains[0],
@@ -849,6 +850,7 @@
         bind:tone={pantheon.tone}
         bind:worshippers={pantheon.worshippers}
         bind:conflictTheme={pantheon.conflictTheme}
+        bind:size={pantheon.size}
         bind:campaignContext={pantheon.campaignContext}
         onSurprise={trigger}
       />

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -313,7 +313,9 @@
   });
 
   let pantheon = $state({
-    mode: "single" as "single" | "pantheon",
+    mode: (data.slug === "pantheon-generator" ? "pantheon" : "single") as
+      | "single"
+      | "pantheon",
     genre: pantheonConfig.genres[0],
     divineType: pantheonConfig.divineTypes[0],
     domain: pantheonConfig.domains[0],

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -11,6 +11,7 @@
   import VampireFormFields from "$lib/components/seo/VampireFormFields.svelte";
   import NameFormFields from "$lib/components/seo/NameFormFields.svelte";
   import NPCFormFields from "$lib/components/seo/NPCFormFields.svelte";
+  import PantheonFormFields from "$lib/components/seo/PantheonFormFields.svelte";
   import {
     generatorEngine,
     npcConfig,
@@ -24,6 +25,7 @@
     nationConfig,
     vampireConfig,
     nameGeneratorConfig,
+    pantheonConfig,
     themeIdToLabel,
     themeToQuestGenre,
     type GeneratorOutput,
@@ -187,6 +189,28 @@
         "Create a fantasy NPC with ancestry, role, personality traits, a hidden secret, and a table-ready GM hook. Works without login, then imports into your local vault.",
       canonicalPath: "/generators/dnd-npc",
     },
+    "pantheon-generator": {
+      pageTitle:
+        "RPG Pantheon Generator | Free Deity & Divine Assembly Tool | Codex Cryptica",
+      metaDescription:
+        "Generate detailed RPG pantheons with alliances, rivalries, myths, and hooks. Save drafts directly to your Codex campaign vault.",
+      introTitle: "RPG Pantheon Generator",
+      eyebrow: "Pantheon Generator",
+      introText:
+        "Create a campaign-ready pantheon with alliances, cosmic conflicts, and detailed member deities. Works without login, then imports into your local vault.",
+      canonicalPath: "/generators/pantheon-generator",
+    },
+    "god-generator": {
+      pageTitle:
+        "RPG God & Deity Generator | Free Tabletop Worldbuilding Tool | Codex Cryptica",
+      metaDescription:
+        "Generate fantasy RPG deities, saints, spirits, and demons with domains, taboos, symbols, and hooks. Save drafts directly to your campaign vault.",
+      introTitle: "RPG God & Deity Generator",
+      eyebrow: "Deity Generator",
+      introText:
+        "Design detailed single deities, ancestors, or abstract forces with portfolio, rituals, and myths. Works without login, then imports into your local vault.",
+      canonicalPath: "/generators/god-generator",
+    },
   } as const;
 
   const meta = $derived(slugMeta[data.slug]);
@@ -288,6 +312,17 @@
     campaignContext: "",
   });
 
+  let pantheon = $state({
+    mode: "single" as "single" | "pantheon",
+    genre: pantheonConfig.genres[0],
+    divineType: pantheonConfig.divineTypes[0],
+    domain: pantheonConfig.domains[0],
+    tone: pantheonConfig.tones[0],
+    worshippers: pantheonConfig.worshippers[0],
+    conflictTheme: pantheonConfig.conflictThemes[0],
+    campaignContext: "",
+  });
+
   const socialHubGenreToTheme: Record<string, string> = {
     Fantasy: "Classic Fantasy",
     "Dark Fantasy": "Vampire / Gothic Noir",
@@ -312,6 +347,11 @@
       activeTheme = socialHubGenreToTheme[socialHub.genre] ?? "Classic Fantasy";
     else if (data.slug === "nation")
       activeTheme = socialHubGenreToTheme[nation.genre] ?? "Classic Fantasy";
+    else if (
+      data.slug === "pantheon-generator" ||
+      data.slug === "god-generator"
+    )
+      activeTheme = pantheon.genre;
   });
 
   onMount(() => {
@@ -326,6 +366,10 @@
     }
     if (data.slug === "vampire-clan") {
       activeTheme = "Vampire / Gothic Noir";
+      return;
+    }
+    if (data.slug === "pantheon-generator" || data.slug === "god-generator") {
+      activeTheme = pantheon.genre;
       return;
     }
     if (
@@ -378,6 +422,11 @@
       });
     } else if (data.slug === "dnd-npc") {
       return generatorEngine.generateNPC({ ...dndNpc, useAI });
+    } else if (
+      data.slug === "pantheon-generator" ||
+      data.slug === "god-generator"
+    ) {
+      return generatorEngine.generatePantheon({ ...pantheon, useAI });
     } else {
       throw new Error(`No generator implemented for slug: ${data.slug}`);
     }
@@ -503,11 +552,31 @@
     "dnd-npc": {
       type: "character",
       title: "Elowen Ashford",
-      summary: "A half-elf rogue with a hidden past and a talent for leverage.",
+      summary: "A half-elf rogue with a talent for leverage.",
       content:
         "### Description\nElowen moves through taverns and guild halls with the easy confidence of someone who knows where the exits are. Her smile is genuine — mostly.\n\n### Secret\nShe carries a stolen signet ring that proves a local noble's son committed a crime the family has paid to bury.",
       lore: "",
       labels: ["rpg-npc", "Rogue", "Half-Elf"],
+      status: "draft",
+    },
+    "pantheon-generator": {
+      type: "faction",
+      title: "The Silent Maw",
+      summary: "A small pantheon of forgotten deities.",
+      content:
+        "### Origin & Dogma\nThe Silent Maw is a collection of ancient entities who hold sway over the dark and forgotten corners of the world.\n\n### Divine Portfolio\nTheir tenets demand absolute silence and devotion to secrets.",
+      lore: "### At a Glance\n- **Pantheon Name**: The Silent Maw\n- **Conflict Theme**: Cosmic Balance\n- **Worshippers**: Mystery Cult",
+      labels: ["rpg-pantheon", "pantheon-generator", "imported-draft"],
+      status: "draft",
+    },
+    "god-generator": {
+      type: "character",
+      title: "Oros, the Light of Dawn",
+      summary: "A deity of the rising sun and new beginnings.",
+      content:
+        "### Deity Description\nOros is depicted as a radiant figure carrying a shield of polished bronze. Their altars face the east.",
+      lore: "### At a Glance\n- **Deity Type**: God\n- **Primary Domain**: Light\n- **Worshippers**: State Religion",
+      labels: ["rpg-deity", "deity-generator", "imported-draft"],
       status: "draft",
     },
   };
@@ -699,6 +768,18 @@
         bind:role={dndNpc.role}
         bind:alignment={dndNpc.alignment}
         bind:campaignContext={dndNpc.campaignContext}
+        onSurprise={trigger}
+      />
+    {:else if data.slug === "pantheon-generator" || data.slug === "god-generator"}
+      <PantheonFormFields
+        bind:mode={pantheon.mode}
+        bind:genre={pantheon.genre}
+        bind:divineType={pantheon.divineType}
+        bind:domain={pantheon.domain}
+        bind:tone={pantheon.tone}
+        bind:worshippers={pantheon.worshippers}
+        bind:conflictTheme={pantheon.conflictTheme}
+        bind:campaignContext={pantheon.campaignContext}
         onSurprise={trigger}
       />
     {/if}

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -33,8 +33,19 @@
 
   let { data } = $props();
 
+  type SlugMetaEntry = {
+    pageTitle: string;
+    metaDescription: string;
+    introTitle: string;
+    eyebrow: string;
+    introText: string;
+    canonicalPath: string;
+    faqs?: { question: string; answer: string }[];
+    relatedLinks?: { href: string; label: string }[];
+  };
+
   // Per-slug SEO metadata (#1)
-  const slugMeta = {
+  const slugMeta: Record<typeof data.slug, SlugMetaEntry> = {
     npc: {
       pageTitle:
         "RPG NPC Generator | Fantasy, Cyberpunk, Gothic & Sci-Fi Characters | Codex Cryptica",
@@ -45,6 +56,35 @@
       introText:
         "Create NPCs across any genre with secrets, faction ties, and table-ready hooks. Works without login, then imports into your local Codex vault.",
       canonicalPath: "/generators/npc",
+      faqs: [
+        {
+          question: "Does the D&D NPC generator require an account?",
+          answer:
+            "No. Generate and copy NPC notes on this page without logging in. Save the draft directly into a browser-local Codex Cryptica vault — no sign-up required.",
+        },
+        {
+          question: "What does the RPG NPC generator create?",
+          answer:
+            "It generates a complete NPC with a name, ancestry, role, personality traits, a hidden secret, motivation, faction connection, and a table-ready GM hook — structured for immediate use.",
+        },
+        {
+          question: "Can I use it outside D&D?",
+          answer:
+            "Yes. The output works for D&D, Pathfinder, OSR games, cyberpunk, and any genre. The generator is system-agnostic.",
+        },
+        {
+          question: "How does saving a generated NPC work?",
+          answer:
+            "Clicking 'Save to Codex' stores the NPC draft in your browser's local storage. Open Codex Cryptica and it imports automatically as a Character entity, ready to link to factions, locations, and campaign notes.",
+        },
+      ],
+      relatedLinks: [
+        { href: "/solutions/ai-gm-assistant", label: "AI GM assistant" },
+        {
+          href: "/free-rpg-campaign-manager",
+          label: "Free RPG campaign manager",
+        },
+      ],
     },
     settlement: {
       pageTitle:
@@ -78,6 +118,32 @@
       introText:
         "Forge campaign-ready organizations across any genre. Use it as a fantasy guild generator, cyberpunk megacorp creator, sci-fi empire builder, or gothic vampire clan generator with distinct agendas, conflicts, and NPCs.",
       canonicalPath: "/generators/faction",
+      faqs: [
+        {
+          question: "What does the faction generator create?",
+          answer:
+            "It generates a complete RPG faction across any genre — fantasy guilds, cyberpunk megacorps, vampire covens, space federations, and more. Each result includes a name, agenda, internal conflict, rival faction, notable NPCs, and a ready-to-use GM hook.",
+        },
+        {
+          question: "Can I use it without an account?",
+          answer:
+            "Yes. Generate and copy faction notes on this page without logging in. When you're ready, save the draft directly into a browser-local Codex Cryptica vault — no sign-up required.",
+        },
+        {
+          question: "Can I aim the faction at my current campaign?",
+          answer:
+            "Yes. Add optional campaign context — a location, villain, ongoing conflict, or political tension — and the generator will fit the faction to your table rather than producing a generic result.",
+        },
+        {
+          question: "How does saving a generated faction work?",
+          answer:
+            "Clicking 'Save to Codex' stores the faction draft in your browser's local storage. Open Codex Cryptica and it imports automatically as a Faction entity, ready to link to NPCs, locations, and campaign notes.",
+        },
+      ],
+      relatedLinks: [
+        { href: "/tools/dnd-npc-generator", label: "D&D NPC Generator" },
+        { href: "/solutions/worldbuilding-tool", label: "Worldbuilding tool" },
+      ],
     },
     quest: {
       pageTitle:
@@ -211,7 +277,7 @@
         "Design detailed single deities, ancestors, or abstract forces with portfolio, rituals, and myths. Works without login, then imports into your local vault.",
       canonicalPath: "/generators/god-generator",
     },
-  } as const;
+  };
 
   const meta = $derived(slugMeta[data.slug]);
 
@@ -598,6 +664,8 @@
   eyebrow={meta.eyebrow}
   introText={meta.introText}
   canonicalPath={meta.canonicalPath}
+  faqs={meta.faqs ?? []}
+  relatedLinks={meta.relatedLinks ?? []}
   bind:theme={activeTheme}
   isThemeCustomizable={data.slug === "faction" ||
     data.slug === "npc" ||

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.ts
@@ -18,6 +18,8 @@ const validSlugs = new Set([
   "names",
   "fantasy-names",
   "dnd-npc",
+  "pantheon-generator",
+  "god-generator",
 ]);
 
 export const load: PageLoad = ({ params }) => {
@@ -39,7 +41,9 @@ export const load: PageLoad = ({ params }) => {
       | "vampire-clan"
       | "names"
       | "fantasy-names"
-      | "dnd-npc",
+      | "dnd-npc"
+      | "pantheon-generator"
+      | "god-generator",
   };
 };
 
@@ -59,5 +63,7 @@ export const entries: EntryGenerator = () => {
     { slug: "names" },
     { slug: "fantasy-names" },
     { slug: "dnd-npc" },
+    { slug: "pantheon-generator" },
+    { slug: "god-generator" },
   ];
 };

--- a/apps/web/src/routes/(marketing)/generators/[slug]/generators.test.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/generators.test.ts
@@ -35,6 +35,8 @@ describe("Generators SvelteKit Route", () => {
         { slug: "names" },
         { slug: "fantasy-names" },
         { slug: "dnd-npc" },
+        { slug: "pantheon-generator" },
+        { slug: "god-generator" },
       ]);
     });
   });

--- a/apps/web/src/routes/(marketing)/tools/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/+page.svelte
@@ -78,6 +78,25 @@
           ],
         },
         {
+          title: "Divine & Mythology",
+          links: [
+            {
+              href: "/generators/pantheon-generator",
+              label: "Pantheon Generator",
+              summary:
+                "Build a small pantheon with alliances, rivalries, cosmic conflicts, and member deities.",
+              icon: "icon-[lucide--sun]",
+            },
+            {
+              href: "/generators/god-generator",
+              label: "God & Deity Generator",
+              summary:
+                "Design a single deity, spirit, or abstract force with domains, taboos, symbols, and hooks.",
+              icon: "icon-[lucide--star]",
+            },
+          ],
+        },
+        {
           title: "Adventure & Worldbuilding",
           links: [
             {

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -102,6 +102,8 @@ export async function GET() {
     "names",
     "fantasy-names",
     "dnd-npc",
+    "pantheon-generator",
+    "god-generator",
     "random",
   ].map((slug) => ({
     path: `/generators/${slug}`,

--- a/apps/web/tests/seo.spec.ts
+++ b/apps/web/tests/seo.spec.ts
@@ -47,20 +47,31 @@ test.describe("SEO and Prerendering", () => {
     page,
   }) => {
     await page.goto("/");
-    await expect(page).toHaveTitle("Codex Cryptica | AI RPG Campaign Manager");
-    await expect(page.getByText(/Build Your World/i)).toBeVisible();
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    await page.reload();
+    await expect(page).toHaveTitle("Codex Cryptica | AI RPG Campaign Manager", {
+      timeout: 15000,
+    });
+    await expect(page.getByText(/Private RPG Lore Vault/i)).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test("non-prerendered routes fallback to SPA shell", async ({ page }) => {
     // Navigate to a route that isn't prerendered but exists in the app
     await page.goto("/oracle");
 
-    // It should still have the layout title from +layout.svelte
-    await expect(page).toHaveTitle(/Codex Cryptica/);
+    // It should still have the layout title from +layout.svelte, wait for compile/hydration
+    await expect(page).toHaveTitle(/Lore Oracle | Codex Cryptica/, {
+      timeout: 15000,
+    });
 
     // It should show the loading state or the oracle interface
     const oracleIndicator = page.getByText(/Lore Oracle/i).first();
-    await expect(oracleIndicator).toBeVisible();
+    await expect(oracleIndicator).toBeVisible({ timeout: 15000 });
   });
 
   test("llms.txt standard files exist and are discoverable", async ({
@@ -136,8 +147,9 @@ test.describe("SEO and Prerendering", () => {
       const response = await request.get("/tools/dnd-npc-generator");
       expect(response.ok()).toBe(true);
       const html = await response.text();
-      expect(html).toContain("D&amp;D NPC Generator");
-      expect(html).toContain("What does each generated NPC include?");
+      // Since tools redirects, html is generators/npc
+      expect(html).toContain("RPG NPC Generator");
+      expect(html).toContain("Create NPCs across any genre");
       expect(html).toContain("/solutions/ai-gm-assistant");
       expect(html).toContain("/free-rpg-campaign-manager");
       const jsonLdScripts = [
@@ -158,9 +170,9 @@ test.describe("SEO and Prerendering", () => {
       // 1. Navigate to generator
       await page.goto("/tools/dnd-npc-generator");
       await expect(page.locator("#generator-title")).toContainText(
-        "D&D NPC Generator",
+        "RPG NPC Generator",
       );
-      await expect(page.getByLabel("Optional Campaign Context")).toBeVisible();
+      await expect(page.getByLabel("Add campaign context")).toBeVisible();
       await expect(
         page.getByRole("link", { name: /AI GM assistant/i }),
       ).toHaveAttribute("href", "/solutions/ai-gm-assistant");
@@ -171,7 +183,7 @@ test.describe("SEO and Prerendering", () => {
         await aiToggle.uncheck();
       }
       await page
-        .getByLabel("Optional Campaign Context")
+        .getByLabel("Add campaign context")
         .fill("a haunted border city under siege");
 
       // 3. Trigger generate
@@ -180,10 +192,10 @@ test.describe("SEO and Prerendering", () => {
       // 4. Wait for generated element to show up
       await expect(page.locator("#save-to-codex-btn")).toBeVisible();
       await expect(
-        page.getByRole("heading", { name: "Faction Connection" }),
+        page.getByRole("heading", { name: "Who they are" }),
       ).toBeVisible();
       await expect(
-        page.getByRole("heading", { name: "Plot Hook" }),
+        page.getByRole("heading", { name: "What they want" }),
       ).toBeVisible();
       const generatedTitle = page.locator("h2").first();
       await expect(generatedTitle).not.toContainText("No Draft Generated"); // Check that a title is populated
@@ -193,15 +205,15 @@ test.describe("SEO and Prerendering", () => {
 
       // 5. Click Save to Codex
       await page.click("#save-to-codex-btn");
+      await page.click("button:has-text('Open Codex')");
 
       // 6. Verify redirection to workspace app root
       await expect(page).toHaveURL(/\/$/);
 
       // 7. Verify the new vault is active and the entity is loaded/selected
-      // Since it's local-first OPFS or fallback, wait for the imported entity detail panel to open or show up in sidebar
       await expect(
         page.getByRole("heading", { name: generatedName!.trim(), level: 2 }),
-      ).toBeVisible();
+      ).toBeVisible({ timeout: 15000 });
     });
 
     test("faction generator page and import conversion funnel flow", async ({
@@ -211,9 +223,10 @@ test.describe("SEO and Prerendering", () => {
       const response = await request.get("/tools/faction-generator");
       expect(response.ok()).toBe(true);
       const html = await response.text();
-      expect(html).toContain("Faction Generator");
-      expect(html).toContain("What does the faction generator create?");
-      expect(html).toContain("/tools/dnd-npc-generator");
+      // Since tools redirects, html is generators/faction
+      expect(html).toContain("RPG Faction Generator");
+      expect(html).toContain("Forge campaign-ready organizations");
+      expect(html).toContain("tools/dnd-npc-generator");
       expect(html).toContain("/solutions/worldbuilding-tool");
       const jsonLdScripts = [
         ...html.matchAll(
@@ -233,10 +246,10 @@ test.describe("SEO and Prerendering", () => {
       await expect(page.locator("#generator-title")).toContainText(
         "Faction Generator",
       );
-      await expect(page.getByLabel("Faction Type")).toBeVisible();
-      await expect(page.getByLabel("Operating Scope")).toBeVisible();
-      await expect(page.getByLabel("Moral Posture")).toBeVisible();
-      await expect(page.getByLabel("Optional Campaign Context")).toBeVisible();
+      await expect(page.getByLabel("Choose what they are")).toBeVisible();
+      await expect(page.getByLabel("Choose their scale")).toBeVisible();
+      await expect(page.getByLabel("Choose their morality")).toBeVisible();
+      await expect(page.getByLabel("Add campaign context")).toBeVisible();
       await expect(
         page.getByRole("link", { name: /Worldbuilding tool/i }),
       ).toHaveAttribute("href", "/solutions/worldbuilding-tool");
@@ -245,20 +258,22 @@ test.describe("SEO and Prerendering", () => {
       if (await aiToggle.isChecked()) {
         await aiToggle.uncheck();
       }
-      await page.getByLabel("Faction Type").selectOption("Merchant Guild");
-      await page.getByLabel("Operating Scope").selectOption("Single city");
       await page
-        .getByLabel("Optional Campaign Context")
+        .getByLabel("Choose what they are")
+        .selectOption("Merchant Guild");
+      await page.getByLabel("Choose their scale").selectOption("Single city");
+      await page
+        .getByLabel("Add campaign context")
         .fill("a canal city split by old guild rivalries");
 
       await page.click("#generate-button");
 
       await expect(page.locator("#save-to-codex-btn")).toBeVisible();
       await expect(
-        page.getByRole("heading", { name: "Internal Conflict" }),
+        page.getByRole("heading", { name: "What they control" }),
       ).toBeVisible();
       await expect(
-        page.getByRole("heading", { name: "Adventure Hook" }),
+        page.getByRole("heading", { name: "What they want" }),
       ).toBeVisible();
       const generatedTitle = page.locator("h2").first();
       await expect(generatedTitle).not.toContainText("No Draft Generated");
@@ -266,10 +281,89 @@ test.describe("SEO and Prerendering", () => {
       expect(generatedName).toBeTruthy();
 
       await page.click("#save-to-codex-btn");
+      await page.click("button:has-text('Open Codex')");
       await expect(page).toHaveURL(/\/$/);
       await expect(
         page.getByRole("heading", { name: generatedName!.trim(), level: 2 }),
-      ).toBeVisible();
+      ).toBeVisible({ timeout: 15000 });
+    });
+
+    test("pantheon and god generator page funnel flows", async ({
+      page,
+      request,
+    }) => {
+      // 1. Check Pantheon Generator static HTML & SEO elements
+      const response = await request.get("/generators/pantheon-generator");
+      expect(response.ok()).toBe(true);
+      const html = await response.text();
+      expect(html).toContain("RPG Pantheon Generator");
+
+      // 2. Navigate to Pantheon Generator E2E page
+      await page.goto("/generators/pantheon-generator");
+      await expect(page.locator("#generator-title")).toContainText(
+        "RPG Pantheon Generator",
+      );
+
+      // Toggle AI off
+      const aiToggle = page.locator("#ai-toggle");
+      if (await aiToggle.isChecked()) {
+        await aiToggle.uncheck();
+      }
+
+      // Check default target mode (should be pantheon)
+      await expect(page.locator("#pantheon-mode-select")).toHaveValue(
+        "pantheon",
+      );
+
+      // Generate
+      await page.click("#generate-button");
+
+      // Verify generated content and saving
+      await expect(page.locator("#save-to-codex-btn")).toBeVisible();
+      const generatedTitle = page.locator("h2").first();
+      await expect(generatedTitle).not.toContainText("No Draft Generated");
+      const generatedName = await generatedTitle.textContent();
+      expect(generatedName).toBeTruthy();
+
+      await page.click("#save-to-codex-btn");
+      await page.click("button:has-text('Open Codex')");
+      await expect(page).toHaveURL(/\/$/);
+      await expect(
+        page.getByRole("heading", { name: generatedName!.trim(), level: 2 }),
+      ).toBeVisible({ timeout: 15000 });
+
+      // 3. Navigate to Deity Generator E2E page
+      await page.goto("/generators/god-generator");
+      await expect(page.locator("#generator-title")).toContainText(
+        "RPG God & Deity Generator",
+      );
+
+      // Toggle AI off
+      const aiToggleGod = page.locator("#ai-toggle");
+      if (await aiToggleGod.isChecked()) {
+        await aiToggleGod.uncheck();
+      }
+
+      // Check default target mode (should be single)
+      await expect(page.locator("#pantheon-mode-select")).toHaveValue("single");
+
+      // Generate
+      await page.click("#generate-button");
+
+      // Verify generated content and saving
+      await expect(page.locator("#save-to-codex-btn")).toBeVisible();
+      const generatedGodTitle = page.locator("h2").first();
+      await expect(generatedGodTitle).not.toContainText("No Draft Generated");
+      const generatedGodName = await generatedGodTitle.textContent();
+      expect(generatedGodName).toBeTruthy();
+
+      await page.click("#save-to-codex-btn");
+      await page.click("button:has-text('Open Codex')");
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(/\/$/);
+      await expect(
+        page.getByRole("heading", { name: generatedGodName!.trim(), level: 2 }),
+      ).toBeVisible({ timeout: 20000 });
     });
   });
 });

--- a/specs/1255-pantheon-generator/checklists/requirements.md
+++ b/specs/1255-pantheon-generator/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: 1255-pantheon-generator
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-11
+**Feature**: [spec.md](file:///home/espen/proj/remotecodexarcana/specs/1255-pantheon-generator/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items checked and passed validation on first iteration.

--- a/specs/1255-pantheon-generator/data-model.md
+++ b/specs/1255-pantheon-generator/data-model.md
@@ -1,0 +1,135 @@
+# Phase 1 Data Model: Pantheon / God Generator
+
+**Branch**: `1255-pantheon-generator` | **Date**: 2026-06-11
+**Feature**: [spec.md](file:///home/espen/proj/remotecodexarcana/specs/1255-pantheon-generator/spec.md)
+
+## Generator Input Configuration
+
+The inputs passed from Svelte UI to the generator engine:
+
+```typescript
+export interface PantheonGeneratorOptions {
+  mode: "single" | "pantheon";
+  genre?: string;
+  divineType?: string;
+  domain?: string;
+  tone?: string;
+  worshippers?: string;
+  conflictTheme?: string;
+  campaignContext?: string;
+  useAI?: boolean;
+}
+```
+
+## AI Schema & Prompt Outputs
+
+### 1. Single Deity JSON Format
+
+When `mode` is `"single"`, the AI is prompted to return a single deity JSON:
+
+```json
+{
+  "title": "Name of Deity/Spirit",
+  "type": "God / Spirit / Saint / Demon / Ancestor / Abstract Force",
+  "summary": "One-sentence defining concept.",
+  "content": "Markdown description including appearance, symbols, rituals, taboos, and sacred spaces.",
+  "lore": "Markdown GM info detailing myths, divine connections, and adventure hooks.",
+  "labels": [
+    "rpg-deity",
+    "deity-generator",
+    "imported-draft",
+    "classic-fantasy"
+  ]
+}
+```
+
+### 2. Small Pantheon JSON Format
+
+When `mode` is `"pantheon"`, the AI is prompted to return a pantheon JSON:
+
+```json
+{
+  "title": "Name of the Pantheon (e.g. The Silent Maw, The Solar Conclave)",
+  "summary": "One-sentence summary of the pantheon's main belief system.",
+  "content": "Markdown description of the pantheon's origin myth, shared dogmas, and primary conflicts.",
+  "deities": [
+    {
+      "title": "Name of Deity A",
+      "type": "God",
+      "domains": "War & Fury",
+      "summary": "Brief summary.",
+      "content": "Markdown description details.",
+      "lore": "Markdown GM info."
+    },
+    {
+      "title": "Name of Deity B",
+      "type": "Spirit",
+      "domains": "Nature & Growth",
+      "summary": "Brief summary.",
+      "content": "Markdown description details.",
+      "lore": "Markdown GM info."
+    },
+    {
+      "title": "Name of Deity C",
+      "type": "Ancestor",
+      "domains": "Secrets & Shadows",
+      "summary": "Brief summary.",
+      "content": "Markdown description details.",
+      "lore": "Markdown GM info."
+    }
+  ],
+  "relationships": "Markdown description of alliances, rivalries, and conflicts between the deities (using [[Wiki Links]] for deity titles)."
+}
+```
+
+## Local Storage Import Format
+
+The generator parses the output of the generator engine and converts it to a pending import payload structure stored in `localStorage` under `__codex_pending_import`:
+
+### For Single Deity:
+
+A single `ImportDraft` object:
+
+```json
+{
+  "type": "character",
+  "title": "Solaris the Lightbringer",
+  "content": "### Description\n...",
+  "lore": "### GM Reference\n...",
+  "labels": ["rpg-deity", "deity-generator", "imported-draft"],
+  "status": "active"
+}
+```
+
+### For Small Pantheon:
+
+An array of `ImportDraft` objects:
+
+```json
+[
+  {
+    "type": "faction",
+    "title": "The Solar Conclave",
+    "content": "### Dogmas & Origin\n...\n### Deities & Conflicts\n- [[Solaris the Lightbringer]] is in conflict with [[Nyx the Shadow Weaver]].",
+    "lore": "### GM Reference\n...",
+    "labels": ["rpg-pantheon", "pantheon-generator", "imported-draft"],
+    "status": "active"
+  },
+  {
+    "type": "character",
+    "title": "Solaris the Lightbringer",
+    "content": "### Description\n...",
+    "lore": "### GM Reference\n...",
+    "labels": ["rpg-deity", "pantheon-generator", "imported-draft"],
+    "status": "active"
+  },
+  {
+    "type": "character",
+    "title": "Nyx the Shadow Weaver",
+    "content": "### Description\n...",
+    "lore": "### GM Reference\n...",
+    "labels": ["rpg-deity", "pantheon-generator", "imported-draft"],
+    "status": "active"
+  }
+]
+```

--- a/specs/1255-pantheon-generator/plan.md
+++ b/specs/1255-pantheon-generator/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Pantheon / God Generator Landing Tool
+
+**Branch**: `1255-pantheon-generator` | **Date**: 2026-06-11 | **Spec**: [spec.md](file:///home/espen/proj/remotecodexarcana/specs/1255-pantheon-generator/spec.md)
+**Input**: Feature specification from `/specs/1255-pantheon-generator/spec.md`
+
+## Summary
+
+We will implement a public Pantheon / God Generator tool inside the web application at the route `/generators/pantheon-generator` (and `/generators/god-generator` as a valid slug pointing to the same page or alias).
+The implementation will follow the design of existing SEO generators in the repository:
+
+1. Define the generator configuration and generation functions in `apps/web/src/lib/services/seo/generators/pantheon.ts`.
+2. Register the `pantheon` generator in the central `generator-engine.ts` and `+page.ts` route loader.
+3. Create a visual form fields component `apps/web/src/lib/components/seo/PantheonFormFields.svelte` to configure options (Divine Type, Domains, Worshippers, Conflict Themes, etc.).
+4. Add the Svelte route layout configuration in `apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte` to map inputs, call the engine, and show the results.
+5. Save generated deities as `character` entities and pantheons as `faction` entities with connections, integrating with the app's standard local import workflow.
+
+## Technical Context
+
+- **Language/Version**: TypeScript 6.0.3, Svelte 5 Runes, SvelteKit
+- **Primary Dependencies**: `@google/generative-ai` (Gemini SDK via `aiClientManager`), `zod`, SvelteKit pre-rendering
+- **Storage**: Browser `sessionStorage` (transient drafts) and `localStorage` (transient transfer for IndexedDB/OPFS imports)
+- **Testing**: Vitest (`apps/web/src/lib/services/seo/generator-engine.test.ts`), Playwright E2E tests
+- **Target Platform**: Desktop and mobile web browsers (Chrome, Safari, Firefox)
+- **Project Type**: Web Application
+- **Performance Goals**: Under 5s generation time under normal API response; immediate fallback to local table generation.
+- **Constraints**: Offline-capable local tables, SEO compliance (indexable, sitemap included, clean semantic structure).
+- **Scale/Scope**: 1 new generator type, 2 new routes, 1 new Svelte form fields component, unit tests.
+
+## Constitution Check
+
+| Principle                      | Check                                                                                                                          | Status |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------- | :----- |
+| **I. Library-First**           | Reuses the existing generator layout and engine architecture inside `apps/web` as this is specific to public marketing routes. | Pass   |
+| **II. TDD**                    | Add comprehensive unit tests covering single deity generation, pantheon generation, option mapping, and fallback logic.        | Pass   |
+| **III. Simplicity & YAGNI**    | Leverages the existing `SEOGeneratorLayout` component, avoiding creation of new layout components or custom Markdown parsers.  | Pass   |
+| **IV. AI-First Extraction**    | Feeds clean parameters to Gemini and parses structured JSON deity details and connection mappings.                             | Pass   |
+| **V. Privacy**                 | All campaign context is processed locally; no server-side database storage is used.                                            | Pass   |
+| **VI. Clean Implementation**   | Strict Svelte 5 runes, Tailwind 4 theme tokens, and lint validation will be executed.                                          | Pass   |
+| **VII. User Documentation**    | The generator is self-contained with built-in descriptive copy and SEO intro text.                                             | Pass   |
+| **VIII. Dependency Injection** | Reuses `aiClientManager` singleton injected into the generator service.                                                        | Pass   |
+| **IX. Natural Language**       | Simple, clear, non-jargon copy for options and description fields.                                                             | Pass   |
+| **X. Quality & Coverage**      | Maintain test coverage of the generator engine package above the 70% floor.                                                    | Pass   |
+| **XII. Labels Over Tags**      | Metadata and taxonomy strictly use the term "Labels" instead of "Tags".                                                        | Pass   |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/1255-pantheon-generator/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── checklists/
+│   └── requirements.md  # Quality checklist
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 data model definitions
+└── quickstart.md        # Phase 1 quickstart documentation
+```
+
+### Source Code
+
+```text
+apps/web/
+├── src/
+│   ├── components/
+│   │   └── seo/
+│   │       └── PantheonFormFields.svelte   # New form inputs component
+│   ├── lib/
+│   │   └── services/
+│   │       └── seo/
+│   │           ├── generator-engine.ts     # Register pantheon generator
+│   │           └── generators/
+│   │               └── pantheon.ts         # Deity/Pantheon generation logic & local tables
+│   └── routes/
+│       └── (marketing)/
+│           └── generators/
+│               └── [slug]/
+│                   ├── +page.svelte        # Add layout mapping for pantheon
+│                   └── +page.ts            # Register "pantheon" and "god-generator" in validSlugs
+```
+
+**Structure Decision**: Standard SvelteKit layout. Form fields and business logic are integrated directly into the `apps/web/src/lib/services/seo/` subfolders to match existing generators.

--- a/specs/1255-pantheon-generator/quickstart.md
+++ b/specs/1255-pantheon-generator/quickstart.md
@@ -1,0 +1,50 @@
+# Developer Quickstart: Pantheon / God Generator
+
+**Branch**: `1255-pantheon-generator` | **Date**: 2026-06-11
+**Feature**: [spec.md](file:///home/espen/proj/remotecodexarcana/specs/1255-pantheon-generator/spec.md)
+
+## Implementation Steps
+
+### 1. Business Logic
+
+Create `apps/web/src/lib/services/seo/generators/pantheon.ts` and define:
+
+- `pantheonConfig` with values for genres, types, domains, tones, worshippers, and conflict themes.
+- Local fallback logic generating names and content arrays.
+- `generatePantheon` (which handles both single deity and small pantheon generation).
+
+Register it in:
+
+- `apps/web/src/lib/services/seo/generator-engine.ts`
+
+### 2. Svelte Components & Routing
+
+Create `apps/web/src/lib/components/seo/PantheonFormFields.svelte` with:
+
+- Toggles between "Single Deity" and "Small Pantheon".
+- Interactive dropdown selects mapping to configuration parameters.
+- Textarea for optional campaign context.
+- "Surprise Me" randomization button.
+
+Update `apps/web/src/routes/(marketing)/generators/[slug]/+page.ts` to include:
+
+- `"pantheon-generator"` and `"god-generator"` in `validSlugs` and entries.
+
+Update `apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte` to:
+
+- Bind state variables for the new form fields.
+- Map the layouts and generate handler functions.
+
+### 3. Verification
+
+Run unit tests:
+
+```bash
+bun test generator-engine.test.ts
+```
+
+Run linter:
+
+```bash
+bun run lint
+```

--- a/specs/1255-pantheon-generator/research.md
+++ b/specs/1255-pantheon-generator/research.md
@@ -1,0 +1,27 @@
+# Phase 0 Research: Pantheon / God Generator Landing Tool
+
+**Branch**: `1255-pantheon-generator` | **Date**: 2026-06-11
+**Feature**: [spec.md](file:///home/espen/proj/remotecodexarcana/specs/1255-pantheon-generator/spec.md)
+
+## Decisions
+
+### 1. Route Slug Mapping
+
+- **Decision**: Register both `"pantheon-generator"` and `"god-generator"` in `validSlugs` in `apps/web/src/routes/(marketing)/generators/[slug]/+page.ts`.
+- **Rationale**: The user could search for either a "pantheon generator" or "god generator". Mapping both slugs ensures we capture both search intents and serve the most appropriate SEO page titles/meta descriptions for each keyword group, while keeping the visual component and generation logic unified.
+- **Alternatives Considered**: Directing all requests to `/pantheon-generator` with a redirect on `/god-generator`. Rejected because having distinct static routes for each keyword maximizes SEO relevance.
+
+### 2. Multi-Entity Import Mapping
+
+- **Decision**: When generating a "Small Pantheon", return a structured array of `ImportDraft` objects from the generator engine instead of a single merged text.
+  - The pantheon itself will be returned as a `faction` entity draft.
+  - Each individual deity/spirit will be returned as a `character` entity draft.
+  - Relationships will be expressed in the Markdown text using `[[Wiki Links]]` (e.g. `[[Deity A]]` is allied with `[[Deity B]]`).
+- **Rationale**: The `SeoImportService` in `apps/web/src/lib/services/seo/import-handler.ts` naturally handles array payloads of `ImportDraft[]` and automatically constructs bidirectional connections for all `[[Wiki Links]]` it finds in the content. This leverages existing codebase functionality with zero modification to the importer.
+- **Alternatives Considered**: Returning a single giant `faction` containing all the deities in one note. Rejected because it violates the "Lore as structured entities" goal of Codex Cryptica, which makes individual gods separate cards.
+
+### 3. Local Roll Table Fallback
+
+- **Decision**: Define a robust local fallback generator in `pantheon.ts` using predefined arrays of names, suffixes, domains, rituals, and myths.
+- **Rationale**: Ensures the tool remains functional offline, when the user disables AI, or if the Gemini API is rate-limited or fails.
+- **Alternatives Considered**: None; this is a mandatory project requirement.

--- a/specs/1255-pantheon-generator/spec.md
+++ b/specs/1255-pantheon-generator/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: Pantheon / God Generator Landing Tool
+
+**Feature Branch**: `1255-pantheon-generator`  
+**Created**: 2026-06-11  
+**Status**: Draft  
+**Input**: User description: "Create a public, indexable Pantheon / God Generator that acts as both a useful worldbuilding tool and a discovery entry point into Codex Cryptica."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Generate a Single Deity or Spirit (Priority: P1)
+
+An RPG GM or worldbuilder visits the public generator without logging in and wants to generate a single divine entity (god, spirit, ancestor, etc.) to fit their campaign setting. They select options like divine type, domain, and culture inspiration, click "Generate," and immediately see a structured markdown preview of the entity's lore. They can copy the output or click "Save to Codex" to import it.
+
+**Why this priority**: This forms the core Minimum Viable Product (MVP). It provides immediate value to fantasy worldbuilders and establishes the conversion funnel into Codex Cryptica.
+
+**Independent Test**: Can be tested by filling out the single deity options, clicking generate, verifying that a named deity is rendered with all expected sections (Name, Type, Domains, Symbols, Worshippers, Temples, Rituals, Myths, Adventure Hooks), and verifying that copying to clipboard or clicking the Save button functions correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the Pantheon/God Generator page, **When** they choose "Single Deity", select "Classic Fantasy" genre, "God" type, and "Death" domain, and click "Generate", **Then** the page displays a generated deity with a death-themed name and corresponding deity details in Markdown format.
+2. **Given** a generated deity is displayed, **When** the user clicks "Save to Codex", **Then** the deity draft is stored in local storage and the user is prompted with a modal redirecting them to the main app dashboard for importing.
+3. **Given** a generated deity is displayed, **When** the user clicks "Copy Markdown", **Then** the structured Markdown text representing the deity is copied to their clipboard.
+
+---
+
+### User Story 2 - Generate a Small Pantheon with Relationships (Priority: P2)
+
+A worldbuilder wants to create a cohesive pantheon of deities rather than a single god. They select "Small Pantheon" (3-4 deities) and choose a conflict theme (e.g., succession, cosmic balance). The generator outputs a list of deities along with defined relationship connections and divine conflicts between them.
+
+**Why this priority**: A pantheon provides richer worldbuilding depth than single entities and demonstrates the multi-entity and connection-mapping capabilities of Codex Cryptica.
+
+**Independent Test**: Can be tested by choosing the "Small Pantheon" option, generating a response, and confirming that the UI displays a structured set of multiple deities, details their relationships/conflicts, and allows saving them as a bundle.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user selects "Small Pantheon", **When** they choose "Cosmic Balance" conflict theme and click "Generate", **Then** the system outputs a pantheon containing 3 to 4 deities, each with distinct domains, along with a "Divine Conflicts & Alliances" section detailing how they relate to one another.
+2. **Given** a generated pantheon, **When** the user clicks "Save to Codex", **Then** the system packages the pantheon as a Faction entity, each deity as a Character entity, and creates connections between them, saving all of them to local storage for importing into the app.
+
+---
+
+### User Story 3 - Steer Generation with Campaign Context (Priority: P3)
+
+A GM wants the generated divine lore to fit an ongoing campaign. They type a brief description in the "Campaign Context" box (e.g., "The sun is dying and the moon has shattered"). The generator incorporates this context to steer the name, myths, and hooks of the deity or pantheon.
+
+**Why this priority**: Custom context makes the generator feel tailored, increasing user satisfaction and the likelihood of saving the draft.
+
+**Independent Test**: Can be tested by adding specific text in the Campaign Context box, clicking generate, and verifying that the generated deity's name, myths, or hooks reference or align with the provided context.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user enters "The sky is permanently covered in ash" in the Campaign Context box, **When** they generate a deity, **Then** the output incorporates ash, darkness, or the blocked sky into the deity's description or lore.
+
+---
+
+### Edge Cases
+
+- **AI Failure / Rate Limiting**: If the AI model fails or is rate-limited, the system must gracefully fall back to generating a fully formatted deity using pre-defined local roll tables, displaying a warning notice but presenting valid content.
+- **Malformed AI JSON Response**: If the AI returns malformed JSON, the parser must recover by creating a default title and placing the raw text into the content block, avoiding page crashes.
+- **Empty / Junk Campaign Context**: If the user enters only spaces or emojis in the context box, the generator should ignore the context and proceed with standard generation without error.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The Pantheon / God Generator MUST be hosted on a public page `/generators/pantheon-generator` or `/generators/god-generator`, accessible without user login.
+- **FR-002**: The page MUST be indexable by search engines, with a unique meta title and description, and be listed in the app's sitemap.
+- **FR-003**: The UI MUST provide a toggle/selector to switch between generating a "Single Deity" and a "Small Pantheon".
+- **FR-004**: The generator MUST accept the following user inputs:
+  - **Genre/Theme**: Selectable (Classic Fantasy, Cyberpunk, Gothic Noir, Sci-Fi, Modern Conspiracy, Post-Apocalyptic).
+  - **Divine Type**: Selectable (God, Spirit, Saint, Demon, Ancestor, Abstract Force).
+  - **Divine Domain**: Selectable (War, Nature, Knowledge, Shadow, Death, Light, Arcana, Chaos, Harmony).
+  - **Tone**: Selectable (Mythic, Dark, Mystical, Weird, Heroic).
+  - **Worshippers**: Selectable (Mystery Cult, State Religion, Secret Brotherhood, Nomadic Tribe, Folk Devotion).
+  - **Conflict Theme** (Pantheon only): Selectable (Succession, Cosmic Balance, Betrayal, Forbidden Love, Forgotten Pact).
+  - **Campaign Context**: Optional free-text textarea (max 240 characters).
+- **FR-005**: The single deity generator output MUST include the following structured fields:
+  - Name
+  - Type
+  - Domains
+  - Symbols & Icons
+  - Worshippers & Cults
+  - Temples & Sacred Places
+  - Rituals & Taboos
+  - Myths & Legends
+  - Adventure Hooks
+- **FR-006**: The pantheon generator output MUST include 3 to 4 deities (each with names and brief descriptions) and a list of relationships/conflicts linking them.
+- **FR-007**: The generator MUST output a structured payload that can be saved to `localStorage` under the key `__codex_pending_import` as a single draft (Single Deity) or an array of drafts (Pantheon) with appropriate type categories (`character` for deities, `faction` for the pantheon).
+- **FR-008**: The generator page MUST have a "Copy Markdown" button that copies the structured markdown output to the user's clipboard.
+- **FR-009**: The generator page MUST feature links to other generator pages in the ecosystem to drive engagement.
+
+### Key Entities
+
+- **Deity**: A character-type entity representing a single god or spirit. Attributes: Name, Type, Domains, Symbols, Worshippers, Temples, Rituals, Myths, Hooks. Maps to a Codex `character` entity with appropriate tags.
+- **Pantheon**: A faction-type entity representing the divine organization. Attributes: Name, Description, Member Deities, Conflict Theme. Maps to a Codex `faction` entity.
+- **Divine Connection**: A connection-type entity representing a relationship between deities (e.g. Ally, Rival, Parent, Child). Maps to Codex `connection` definitions.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A user can generate a deity or pantheon in under 5 seconds when the AI model responds normally.
+- **SC-002**: Generated drafts saved via the "Save to Codex" CTA must successfully load into the user's campaign vault upon redirect to the main app dashboard.
+- **SC-003**: The page must pass standard lighthouse/SEO checks for page titles, headings, and semantic structure.
+- **SC-004**: The page is fully responsive, looking polished and usable on mobile screens down to 360px wide.

--- a/specs/1255-pantheon-generator/tasks.md
+++ b/specs/1255-pantheon-generator/tasks.md
@@ -1,0 +1,44 @@
+# Task List: Pantheon / God Generator
+
+**Branch**: `1255-pantheon-generator` | **Date**: 2026-06-11
+**Spec**: [spec.md](file:///home/espen/proj/remotecodexarcana/specs/1255-pantheon-generator/spec.md)
+**Plan**: [plan.md](file:///home/espen/proj/remotecodexarcana/specs/1255-pantheon-generator/plan.md)
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T001[T001: Branch Setup] --> T002[T002: Create pantheon.ts & Local Fallback]
+    T002 --> T003[T003: Register Pantheon in Engine]
+    T003 --> T004[T004: Create PantheonFormFields Component]
+    T004 --> T005[T005: Register Slugs & Page Routing]
+    T005 --> T006[T006: Add Svelte Layout Mapping]
+    T006 --> T007[T007: Register in sitemap.xml]
+    T007 --> T008[T008: Add Unit & Integration Tests]
+    T008 --> T009[T009: Verification, Lint & Build]
+```
+
+## Phase 1: Setup & Initialization
+
+- [x] T001 Verify active branch is `1255-pantheon-generator` and the working tree is clean.
+
+## Phase 2: Foundational Engine Work
+
+- [x] T002 Create the generator file at `apps/web/src/lib/services/seo/generators/pantheon.ts` containing the `pantheonConfig` data structure and the `generatePantheon` function with local fallback tables.
+- [x] T003 Register the `generatePantheon` function and configurations in the central engine `apps/web/src/lib/services/seo/generator-engine.ts`.
+
+## Phase 3: Single Deity Generator [US1]
+
+- [x] T004 Create Svelte component `apps/web/src/lib/components/seo/PantheonFormFields.svelte` implementing options (Divine Type, Domains, Tones, Worshippers, Conflict Themes, etc.) and a "Surprise Me" randomization button.
+- [x] T005 Update SvelteKit page loader in `apps/web/src/routes/(marketing)/generators/[slug]/+page.ts` to include `"pantheon-generator"` and `"god-generator"` in `validSlugs` and entries.
+- [x] T006 Integrate `PantheonFormFields` and config mappings inside the dynamic page `apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte`.
+- [x] T007 Register `"pantheon-generator"` and `"god-generator"` in `apps/web/src/routes/sitemap.xml/+server.ts` to expose them to search engines.
+
+## Phase 4: Small Pantheon Generator [US2] & Campaign Context [US3]
+
+- [x] T008 Add unit tests in `apps/web/src/lib/services/seo/generator-engine.test.ts` to verify Single Deity and Small Pantheon generation, local fallback generation, option binding, and UTM link campaigns.
+- [x] T009 Run verification tests, style linter, and static builds to ensure no typescript errors exist.
+
+```bash
+bun test generator-engine.test.ts && bun run lint
+```


### PR DESCRIPTION
## Summary

- Adds public prerendered landing pages for `/generators/pantheon-generator` and `/generators/god-generator`
- New `PantheonFormFields` component with mode toggle (single deity vs pantheon), genre, domain, tone, worshippers, and conflict theme fields
- `SEOGeneratorLayout`: copy-by-click names variant with event delegation, `generatedNoun` extended for pantheon/deity
- Fixes from codex-review: HTML-entity XSS escape on `data-copy-text`, `isExampleDraft` initial state, removed `$effect` that overwrote user `pantheon.mode`, keyboard a11y on copy delegate container
- E2E tests for both pantheon and deity funnel flows

## Test plan

- [ ] `/generators/pantheon-generator` renders static HTML with correct title and SEO meta
- [ ] Pantheon generator defaults to `pantheon` mode, generates, saves to Codex
- [ ] `/generators/god-generator` defaults to `single` mode, generates, saves to Codex
- [ ] Copy button in names variant works via keyboard (Enter/Space) and mouse
- [ ] No Svelte a11y warnings introduced

🤖 Generated with [Claude Code](https://claude.ai/code)