### PR TITLE
Feat/seo category icons all generators

### DIFF
--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -278,6 +278,15 @@ describe("DefaultGeneratorEngine", () => {
       expect(mockModel.generateContent).toHaveBeenCalledWith(
         expect.stringContaining("an ancient cathedral ruin"),
       );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **👤 Sire Name**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **👤 Thrall Name**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **👥 Rival Name**"),
+      );
       expect(res.type).toBe("faction");
       expect(res.title).toBe("House Karnstein");
       expect(res.content).toBe("AI Generated Vampire Clan");
@@ -389,6 +398,45 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.lore).toContain("- **📍");
       expect(res.lore).toContain("- **👥");
       expect(res.labels).toContain("imported-draft");
+    });
+
+    it("should include settlement icon sections in the AI prompt", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "Stonebridge",
+                content: "AI settlement description",
+                lore: "AI settlement lore",
+                labels: ["rpg-location", "imported-draft"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      const res = await engine.generateSettlement({
+        size: "Village",
+        economy: "Trade Hub",
+        useAI: true,
+      });
+
+      expect(mockClientManager.getModel).toHaveBeenCalled();
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("### Points of Interest"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **📍 Location Name**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("### Controlling Factions"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **👥 Faction Name**"),
+      );
+      expect(res.title).toBe("Stonebridge");
+      expect(res.lore).toBe("AI settlement lore");
     });
   });
 
@@ -915,6 +963,12 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.content).toContain("Deity Description");
       expect(res.content.toLowerCase()).toContain("death");
       expect(res.lore).toContain("At a Glance");
+      expect(res.lore).toContain("- **👤 Deity Type**");
+      expect(res.lore).toContain("- **✨ Primary Domain**");
+      expect(res.lore).toContain("- **👥 Worshippers**");
+      expect(res.lore).toContain("- **📍 Sacred Symbol**");
+      expect(res.lore).toContain("- **📅 Secret**");
+      expect(res.lore).toContain("- **⚔ Immediate Hook**");
       expect(res.labels).toContain("rpg-deity");
       expect(res.labels).toContain("imported-draft");
     });
@@ -982,6 +1036,51 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.content).toBe("AI Bio");
       expect(res.lore).toBe("AI Lore");
       expect(res.labels).toContain("deity-custom");
+    });
+
+    it("should include deity icon sections in the AI prompt", async () => {
+      const mockModel = {
+        generateContent: vi.fn().mockResolvedValue({
+          response: {
+            text: () =>
+              JSON.stringify({
+                title: "Hel, Lady of Hela",
+                content: "AI Bio",
+                lore: "AI Lore",
+                labels: ["deity-custom"],
+              }),
+          },
+        }),
+      };
+      mockClientManager.getModel.mockResolvedValue(mockModel);
+
+      await engine.generatePantheon({
+        mode: "single",
+        genre: "Classic Fantasy",
+        divineType: "God",
+        domain: "Death",
+        worshippers: "State Religion",
+        useAI: true,
+      });
+
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **👤 Deity Type**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **✨ Primary Domain**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **👥 Worshippers**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **📍 Sacred Symbol**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **📅 Secret**"),
+      );
+      expect(mockModel.generateContent).toHaveBeenCalledWith(
+        expect.stringContaining("- **⚔ Immediate Hook**"),
+      );
     });
 
     it("should call clientManager for pantheon when useAI is true and succeed", async () => {

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -131,6 +131,9 @@ describe("DefaultGeneratorEngine", () => {
       );
       expect(res.lore).toContain("Internal Conflict");
       expect(res.lore).toContain("At the Table");
+      expect(res.lore).toContain("- **📍 Base**");
+      expect(res.lore).toContain("- **👤");
+      expect(res.lore).toContain("- **👥");
       expect(res.labels).toContain("faction-generator");
       expect(res.labels).toContain("imported-draft");
     });
@@ -237,6 +240,9 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.lore).toContain("Clan Weakness");
       expect(res.lore).toContain("Internal Conflict");
       expect(res.lore).toContain("Adventure Hook");
+      expect(res.lore).toContain("- **👤 Sire");
+      expect(res.lore).toContain("- **👤 Thrall");
+      expect(res.lore).toContain("- **👥");
       expect(res.labels).toContain("vampire-clan");
       expect(res.labels).toContain("imported-draft");
     });
@@ -380,6 +386,8 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.title).toBeDefined();
       expect(res.content).toContain("mining");
       expect(res.lore).toContain("Town");
+      expect(res.lore).toContain("- **📍");
+      expect(res.lore).toContain("- **👥");
       expect(res.labels).toContain("imported-draft");
     });
   });
@@ -396,6 +404,30 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.title).toBeDefined();
       expect(res.lore).toContain("Weapon");
       expect(res.lore).toContain("Legendary");
+      expect(res.labels).toContain("imported-draft");
+    });
+  });
+
+  describe("generateQuestHook", () => {
+    it("should generate quest hook details locally when useAI is false", async () => {
+      const res = await engine.generateQuestHook({
+        genre: "Classic Fantasy",
+        tone: "Heroic",
+        scope: "Local / Village",
+        locationType: "Dungeon",
+        threat: "Goblins",
+        twist: "The goblins were protecting a sacred egg",
+        reward: "A pouch of silver coins",
+        useAI: false,
+      });
+
+      expect(res.type).toBe("event");
+      expect(res.title).toBeDefined();
+      expect(res.content).toContain("### The Hook");
+      expect(res.lore).toContain("### Core Fields");
+      expect(res.lore).toContain("- **📍 Setting**");
+      expect(res.lore).toContain("- **📅 Threat**");
+      expect(res.lore).toContain("- **👤");
       expect(res.labels).toContain("imported-draft");
     });
   });

--- a/apps/web/src/lib/services/seo/generators/faction.ts
+++ b/apps/web/src/lib/services/seo/generators/faction.ts
@@ -416,7 +416,7 @@ OUTPUT FORMAT — return ONLY a valid JSON object, no markdown fences:
   "title": "Faction name (follow the naming directive in the user message)",
   "summary": "One sentence: what this faction is and what makes them interesting (e.g. 'A sanitation cult-technocracy that controls clean water in a poisoned city.').",
   "content": "Markdown. Use exactly these four section headers in order: '### What they control', '### What they want', '### Why they are dangerous', '### How to use them at the table'. Each section: 2-4 tight sentences. Include campaign context if provided.",
-  "lore": "Markdown. Use EXACTLY this structure with ### headers and '- **Label**: Value' list items:\\n### At the Table\\n- **Base**: specific named location\\n- **Resource**: what they control that others need\\n- **Symbol**: identifying mark or emblem\\n- **Secret**: hidden truth that would destroy them\\n- **Immediate Hook**: one-sentence GM hook\\n### Notable NPCs\\n- **Name**: one-line description (2-3 NPCs)\\n### Internal Conflict\\none paragraph\\n### Rival Faction\\n- **Name**: one-line rivalry",
+  "lore": "Markdown. Use EXACTLY this structure with ### headers and '- **Label**: Value' list items:\\n### At the Table\\n- **📍 Base**: specific named location\\n- **Resource**: what they control that others need\\n- **Symbol**: identifying mark or emblem\\n- **Secret**: hidden truth that would destroy them\\n- **Immediate Hook**: one-sentence GM hook\\n### Notable NPCs\\n- **👤 Name**: one-line description (2-3 NPCs)\\n### Internal Conflict\\none paragraph\\n### Rival Faction\\n- **👥 Name**: one-line rivalry",
   "labels": ["2-5 lowercase tags for the faction's theme and activities, plus 'rpg-faction', 'faction-generator', 'imported-draft'"]
 }
 
@@ -491,21 +491,21 @@ ${conflict} Beyond their internal tensions, they will negotiate before striking 
 Bring ${name} into play when the party needs leverage, pressure, a sponsor, or a rival who can operate in daylight. They reward players who deal in favors and punish those who make public enemies.`;
 
   const lore = `### At the Table
-- **Base**: ${factionBase(factionType)}
+- **📍 Base**: ${factionBase(factionType)}
 - **Resource**: ${factionResource(factionType)}
 - **Symbol**: ${name.split(" ")[0]} iconography worn by inner-circle members
 - **Secret**: ${conflict}
 - **Immediate Hook**: ${hook}
 
 ### Notable NPCs
-- **${leader}**: Public face who insists every deal serves the common good.
-- **${agent}**: Field operative who knows where the faction buries its failures.
+- **👤 ${leader}**: Public face who insists every deal serves the common good.
+- **👤 ${agent}**: Field operative who knows where the faction buries its failures.
 
 ### Internal Conflict
 ${conflict}
 
 ### Rival Faction
-${rival} is pursuing the same influence, relic, or route — and will reach it first if the party does nothing.`;
+- **👥 ${rival}**: Pursuing the same influence, relic, or route — and will reach it first if the party does nothing.`;
 
   return {
     type: "faction",
@@ -670,11 +670,11 @@ ${goal}
 ${conflict}
 
 ### Notable NPCs
-- **Sire ${sire}**: The ancient leader of the clan who has survived centuries of inquisitions and power struggles.
-- **Thrall ${thrall}**: A high-ranking mortal puppet who manages the clan's daytime assets and legal matters.
+- **👤 Sire ${sire}**: The ancient leader of the clan who has survived centuries of inquisitions and power struggles.
+- **👤 Thrall ${thrall}**: A high-ranking mortal puppet who manages the clan's daytime assets and legal matters.
 
 ### Rival Faction
-The ${rival} seeks to expose, purge, or take control of the secrets and assets held by ${name}.
+- **👥 The ${rival}**: Seeks to expose, purge, or take control of the secrets and assets held by ${name}.
 
 ### Adventure Hook
 ${hook}`;

--- a/apps/web/src/lib/services/seo/generators/faction.ts
+++ b/apps/web/src/lib/services/seo/generators/faction.ts
@@ -597,7 +597,7 @@ You must return a valid JSON object matching the following structure exactly:
 {
   "title": "A single string for the vampire clan/house name",
   "content": "A detailed multi-paragraph overview (markdown formatted) describing its history, public facade in mortal society, dark haven, and how it fits the campaign context if provided.",
-  "lore": "Structured GM details (markdown formatted) with sections for core fields, bloodline traits, feeding habits, weakness, dark agenda, internal conflict, notable NPCs, rival faction, and adventure hook.",
+  "lore": "Structured GM details (markdown formatted). Use EXACTLY this structure with ### headers and '- **Label**: Value' list items:\n### GM Reference Information\n- **Faction Type**: Vampire Clan (archetype)\n- **Bloodline**: bloodline summary\n- **Scope**: scope of influence\n- **Moral Posture**: moral posture\n- **Feeding Habit**: feeding habit\n- **Clan Weakness**: weakness\n- **Entity Type**: Faction\n\n### Dark Agenda\none paragraph\n\n### Internal Conflict\none paragraph\n\n### Notable NPCs\n- **👤 Sire Name**: one-line description\n- **👤 Thrall Name**: one-line description\n\n### Rival Faction\n- **👥 Rival Name**: one-line rivalry summary\n\n### Adventure Hook\none paragraph",
   "labels": ["rpg-faction", "vampire-clan", "imported-draft"]
 }
 ${NAME_BAN_PROMPT}

--- a/apps/web/src/lib/services/seo/generators/pantheon.ts
+++ b/apps/web/src/lib/services/seo/generators/pantheon.ts
@@ -151,7 +151,7 @@ You must return a valid JSON object matching the following structure exactly, no
   "title": "A majestic name for the deity (e.g. Solaris the Lightbringer, Xal'Koth the Devourer)",
   "summary": "One-sentence overview of the deity's core nature.",
   "content": "Markdown. Use exactly these section headers in order: '### Deity Description', '### Divine Portfolio', '### Worship & Cults'. Describe their appearance, symbols, dogmas, and temples.",
-  "lore": "Markdown. Use exactly this structure:\\n### At a Glance\\n- **Deity Type**: ${divineType}\\n- **Primary Domain**: ${domain}\\n- **Worshippers**: ${worshipperType}\\n- **Sacred Symbol**: description of symbol\\n- **Secret**: a dark truth or hidden vulnerability\\n- **Immediate Hook**: one-sentence GM hook\\n### Rituals & Taboos\\n- description of common ritual\\n- description of taboo\\n### Myths & Legends\\n- brief myth summary\\n### Adventure Hooks\\n- adventure hook 1\\n- adventure hook 2",
+  "lore": "Markdown. Use exactly this structure:\\n### At a Glance\\n- **👤 Deity Type**: ${divineType}\\n- **✨ Primary Domain**: ${domain}\\n- **👥 Worshippers**: ${worshipperType}\\n- **📍 Sacred Symbol**: description of symbol\\n- **📅 Secret**: a dark truth or hidden vulnerability\\n- **⚔ Immediate Hook**: one-sentence GM hook\\n### Rituals & Taboos\\n- description of common ritual\\n- description of taboo\\n### Myths & Legends\\n- brief myth summary\\n### Adventure Hooks\\n- adventure hook 1\\n- adventure hook 2",
   "labels": ["rpg-deity", "deity-generator", "imported-draft", "${genre.toLowerCase().replace(/[^a-z0-9]/g, "-")}"]
 }
 ${NAME_BAN_PROMPT}
@@ -398,12 +398,12 @@ The worship of this ${divineType.toLowerCase()} is usually organized as a ${wors
     }
 
     const lore = `### At a Glance
-- **Deity Type**: ${divineType}
-- **Primary Domain**: ${domain}
-- **Worshippers**: ${worshipperType}
-- **Sacred Symbol**: ${randomSymbol}
-- **Secret**: Holds a secret fear of their own power being forgotten by mortal hearts.
-- **Immediate Hook**: A lost tomb dedicated to this deity has been uncovered, containing a relic that has begun to glow.
+- **👤 Deity Type**: ${divineType}
+- **✨ Primary Domain**: ${domain}
+- **👥 Worshippers**: ${worshipperType}
+- **📍 Sacred Symbol**: ${randomSymbol}
+- **📅 Secret**: Holds a secret fear of their own power being forgotten by mortal hearts.
+- **⚔ Immediate Hook**: A lost tomb dedicated to this deity has been uncovered, containing a relic that has begun to glow.
 
 ### Rituals & Taboos
 - **Ritual**: ${randomHighlightRitual}

--- a/apps/web/src/lib/services/seo/generators/quest.ts
+++ b/apps/web/src/lib/services/seo/generators/quest.ts
@@ -343,7 +343,7 @@ You must return a valid JSON object matching the following structure exactly:
 {
   "title": "A single evocative quest name (3-6 words)",
   "content": "A detailed multi-paragraph quest hook (markdown formatted) describing the situation, what the party is asked to do, the location, the key NPC involved, and how it fits the campaign context if provided.",
-  "lore": "GM-only details (markdown formatted) with these sections: '### Core Fields' (bullet list with **Setting** and **Threat**, each a vivid one-sentence description with proper nouns), '### Complication' (a concrete mechanical or narrative pressure), '### Key NPC' (bullet with **Name**: motivation and secret), '### The Twist' (a paragraph revealing the hidden truth, ideally tying back to the party's past or the campaign context), '### Reward' (a paragraph describing what is gained and why it matters to the larger campaign).",
+  "lore": "GM-only details (markdown formatted) with these sections: '### Core Fields' (bullet list with '**📍 Setting**' and '**📅 Threat**', each a vivid one-sentence description with proper nouns), '### Complication' (a concrete mechanical or narrative pressure), '### Key NPC' (bullet with '**👤 Name**': motivation and secret), '### The Twist' (a paragraph revealing the hidden truth, ideally tying back to the party's past or the campaign context), '### Reward' (a paragraph describing what is gained and why it matters to the larger campaign).",
   "labels": ["rpg-quest", "quest-generator", "imported-draft"]
 }
 ${NAME_BAN_PROMPT}
@@ -400,14 +400,14 @@ ${locationName} serves as the primary setting — a ${locationType.toLowerCase()
 The central danger is a ${threat.toLowerCase()}. It has been active long enough to leave evidence, earn fear, and create a power vacuum that others are already trying to fill.`;
 
   const lore = `### Core Fields
-- **Setting**: ${locationName}, a ${locationType.toLowerCase()} shaped by ${genre.toLowerCase()} conventions and a ${tone.toLowerCase()} atmosphere.
-- **Threat**: A ${threat.toLowerCase()}, active long enough to leave evidence, earn fear, and create a power vacuum.
+- **📍 Setting**: ${locationName}, a ${locationType.toLowerCase()} shaped by ${genre.toLowerCase()} conventions and a ${tone.toLowerCase()} atmosphere.
+- **📅 Threat**: A ${threat.toLowerCase()}, active long enough to leave evidence, earn fear, and create a power vacuum.
 
 ### Complication
 ${complication}
 
 ### Key NPC
-- **${npcName}**: The immediate contact, patron, or obstacle. Their stated reason for involving the party is credible, but their personal stake runs deeper than they admit.
+- **👤 ${npcName}**: The immediate contact, patron, or obstacle. Their stated reason for involving the party is credible, but their personal stake runs deeper than they admit.
 
 ### The Twist
 ${twist}. Reveal this only once the party is committed — it should recast earlier scenes in a new light.

--- a/apps/web/src/lib/services/seo/generators/settlement.ts
+++ b/apps/web/src/lib/services/seo/generators/settlement.ts
@@ -102,7 +102,7 @@ You must return a valid JSON object matching the following structure exactly:
 {
   "title": "A single string for the settlement name",
   "content": "A detailed multi-paragraph description (markdown formatted) describing the settlement's atmosphere, layout, and geography.",
-  "lore": "Structured GM details (markdown formatted) detailing its size, government, notable locations, active factions, and current rumors.",
+  "lore": "Structured GM details (markdown formatted). Use EXACTLY this structure with ### headers and '- **Label**: Value' list items:\n### GM Reference Information\n- **Size**: size with population\n- **Primary Economy**: economy summary\n- **Government**: government type\n\n### Points of Interest\n- **📍 Location Name**: one-line purpose or detail (1-4 items)\n\n### Controlling Factions\n- **👥 Faction Name**: one-line influence summary",
   "labels": ["rpg-location", "imported-draft"]
 }
 ${NAME_BAN_PROMPT}

--- a/apps/web/src/lib/services/seo/generators/settlement.ts
+++ b/apps/web/src/lib/services/seo/generators/settlement.ts
@@ -162,10 +162,10 @@ The air is filled with the smells of local industries, and visitors are greeted 
 - **Government**: ${government}
 
 ### Points of Interest
-${locs.map((l) => `- **${l}**: A crucial hub of local activity.`).join("\n")}
+${locs.map((l) => `- **📍 ${l}**: A crucial hub of local activity.`).join("\n")}
 
 ### Controlling Factions
-- **${faction}**: Maintains significant influence over the local district's rules and affairs.`;
+- **👥 ${faction}**: Maintains significant influence over the local district's rules and affairs.`;
 
   return {
     type: "location",

--- a/apps/web/tests/seo.spec.ts
+++ b/apps/web/tests/seo.spec.ts
@@ -115,9 +115,10 @@ test.describe("SEO and Prerendering", () => {
     test.beforeEach(async ({ page }) => {
       await page.addInitScript(() => {
         localStorage.setItem(
-          "help_state",
+          "codex-cryptica-help-state",
           JSON.stringify({ completedTours: ["initial-onboarding"] }),
         );
+        localStorage.setItem("codex_dismissed_landing", "true");
       });
     });
 

--- a/apps/web/tests/seo.spec.ts
+++ b/apps/web/tests/seo.spec.ts
@@ -112,6 +112,15 @@ test.describe("SEO and Prerendering", () => {
   });
 
   test.describe("SEO Landing Pages and Generator Funnel", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript(() => {
+        localStorage.setItem(
+          "help_state",
+          JSON.stringify({ completedTours: ["initial-onboarding"] }),
+        );
+      });
+    });
+
     test("solutions and comparison pages prerender correctly", async ({
       request,
     }) => {


### PR DESCRIPTION
## 🎯 Purpose

Align the SEO generator lore format around category-icon entity references and close the review gaps between local fallback output, AI prompt contracts, and generator E2E setup.

## 🛠️ Changes

- adds icon-prefixed lore/entity references across the SEO generators touched by this branch
- aligns AI prompt contracts with local fallback formatting for settlement and vampire clan generation
- extends the deity generator so single-deity output now uses the same icon-labeled `At a Glance` structure
- fixes the SEO Playwright setup to use the app's real persisted help/onboarding keys
- adds prompt-level test coverage to prevent AI/local format drift

## 🚦 Target Branch Reminder

> [!IMPORTANT]
> **This PR must target the `staging` branch.**
> All features and fixes must be verified on staging before being promoted to `main`.

## 🧪 Testing

- `bun run test src/lib/services/seo/generator-engine.test.ts` in `apps/web`
- `bun run test:e2e tests/seo.spec.ts` in `apps/web`
- `bun run lint`
- `git push` pre-push hook (`bun run --filter '*' lint -- --cache --cache-strategy content` and `bun run --filter '*' test -- --changed`)

Note: a full root `bun run test` in this repo still reports pre-existing `web` Vitest teardown errors unrelated to this PR's files.

## 🏷️ Release Labeling

- likely `minor` if the generator output format change is being treated as user-facing
- otherwise no label if this is being treated as a fix/consistency pass
