### PR TITLE
[codex] Polish generator layout and DnD NPC stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This file is the Codex-facing instruction layer for this repository.
 - **User-Facing Changelogs**: Keep all entries in the changelog (`apps/web/src/lib/content/changelog/releases.json`) strictly focused on high-impact, user-facing features. Do not list under-the-hood technical refactors, code optimization, or architectural decomposition updates in the changelog highlights.
 - Create a new branch for code changes, fixes, or refactors.
 - Prefer the GitHub app/MCP tools for structured GitHub work such as PR metadata, comments, labels, reviews, file patches, and PR edits.
+- Create regular ready-for-review pull requests by default; never create draft PRs unless the user explicitly asks for a draft.
 - Prefer `gh` for CI and Actions debugging, raw check/log inspection, or other terminal-native GitHub workflows.
 - Use `gh` as the fallback when the connector does not expose the needed GitHub action cleanly.
 

--- a/apps/web/src/lib/components/seo/FactionFormFields.svelte
+++ b/apps/web/src/lib/components/seo/FactionFormFields.svelte
@@ -20,7 +20,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 
   const thematicTypes: Record<string, string[]> = {
     "Classic Fantasy": [

--- a/apps/web/src/lib/components/seo/KingdomFormFields.svelte
+++ b/apps/web/src/lib/components/seo/KingdomFormFields.svelte
@@ -24,7 +24,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 </script>
 
 <div class="flex flex-col gap-1.5">

--- a/apps/web/src/lib/components/seo/NPCFormFields.svelte
+++ b/apps/web/src/lib/components/seo/NPCFormFields.svelte
@@ -18,7 +18,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 </script>
 
 <div class="flex flex-col gap-1.5">

--- a/apps/web/src/lib/components/seo/NameFormFields.svelte
+++ b/apps/web/src/lib/components/seo/NameFormFields.svelte
@@ -23,7 +23,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 
   const activeCultures = $derived(
     showTheme

--- a/apps/web/src/lib/components/seo/NationFormFields.svelte
+++ b/apps/web/src/lib/components/seo/NationFormFields.svelte
@@ -24,7 +24,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 
   let polityTypes = $derived(
     nationConfig.polityTypesByGenre[genre] ??

--- a/apps/web/src/lib/components/seo/PantheonFormFields.svelte
+++ b/apps/web/src/lib/components/seo/PantheonFormFields.svelte
@@ -30,7 +30,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 </script>
 
 <div class="flex flex-col gap-1.5">

--- a/apps/web/src/lib/components/seo/RPGNPCFormFields.svelte
+++ b/apps/web/src/lib/components/seo/RPGNPCFormFields.svelte
@@ -24,7 +24,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 
   const availableAncestries = $derived(
     npcThemeConfig.ancestries[theme] ?? npcConfig.races,

--- a/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOGeneratorLayout.svelte
@@ -11,6 +11,7 @@
   import { renderMarkdown as renderMd } from "$lib/utils/markdown";
   import { SESSION_DRAFTS_KEY } from "$lib/services/seo/generators/session-context";
   import { getGeneratorDocumentLayout } from "$lib/components/seo/generator-document-layout";
+  import { splitMarkdownForCopy } from "$lib/components/seo/markdown-sections";
 
   let {
     canonicalPath,
@@ -81,6 +82,7 @@
   let outputCard = $state<HTMLElement | null>(null);
   let errorMessage = $state<string | null>(null);
   let copied = $state(false);
+  let copiedSectionId = $state<string | null>(null);
   let useAI = $state(true);
   let showSaveModal = $state(false);
   let redirectUrl = $state(`${cleanBase}/`);
@@ -124,6 +126,9 @@
   );
 
   const documentLayout = $derived(getGeneratorDocumentLayout(generatedData));
+  const documentSections = $derived(
+    variant === "names" ? [] : splitMarkdownForCopy(documentLayout.content),
+  );
 
   $effect(() => {
     if (isThemeCustomizable && browser) {
@@ -500,6 +505,18 @@
     }
   }
 
+  async function handleCopySection(sectionId: string, markdown: string) {
+    try {
+      await navigator.clipboard.writeText(markdown.trim());
+      copiedSectionId = sectionId;
+      setTimeout(() => {
+        if (copiedSectionId === sectionId) copiedSectionId = null;
+      }, 1600);
+    } catch (err) {
+      console.error("Failed to copy section markdown:", err);
+    }
+  }
+
   function handleContainerKeydown(event: KeyboardEvent) {
     if (event.key === "Enter" || event.key === " ") {
       handleContainerClick(event as unknown as MouseEvent);
@@ -634,15 +651,17 @@
   </header>
 
   <!-- Compact Explainer Strip — no duplicate generate CTA (#1274) -->
-  <div
-    class="w-full border-b border-theme-border/30 bg-theme-surface/10 py-4 px-6"
-  >
-    <div class="max-w-6xl mx-auto">
+  <div class="w-full border-b border-theme-border/30 bg-theme-surface/10 px-6">
+    <div class="max-w-6xl mx-auto py-4 flex items-center justify-between gap-4">
       <p
-        class="text-xs font-bold text-theme-muted uppercase tracking-widest font-header"
+        class="text-xs font-bold text-theme-text/75 uppercase tracking-widest font-header"
       >
         Generate campaign-ready {generatedNoun} in seconds — no account required.
       </p>
+      <span
+        class="hidden md:inline-flex h-px flex-1 bg-gradient-to-r from-theme-primary/35 via-theme-border/30 to-transparent"
+        aria-hidden="true"
+      ></span>
     </div>
   </div>
 
@@ -716,12 +735,15 @@
                     </span>
                   {/each}
                 </div>
-                <div class="flex gap-2 flex-wrap items-center flex-shrink-0">
+                <div
+                  class="flex flex-wrap items-center overflow-hidden rounded-lg border border-theme-primary/25 bg-theme-bg/35 shadow-sm"
+                  aria-label="Draft actions"
+                >
                   {#if variant !== "names"}
                     <button
                       type="button"
                       onclick={handleSaveToCodex}
-                      class="px-4 py-2 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:brightness-110 shadow-sm transition-all"
+                      class="px-4 py-2 bg-theme-primary text-theme-bg font-bold uppercase font-header tracking-wider text-[10px] hover:brightness-110 transition-all"
                       id="save-to-codex-btn"
                       title="Import this draft into your local Codex Cryptica vault"
                     >
@@ -730,22 +752,28 @@
                     <button
                       type="button"
                       onclick={addToSessionHub}
-                      class="px-4 py-2 bg-theme-surface border border-theme-primary/40 text-theme-primary font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:bg-theme-primary/10 transition-all flex items-center gap-1.5"
+                      class="px-4 py-2 border-l border-theme-primary/25 bg-theme-surface/45 text-theme-primary font-bold uppercase font-header tracking-wider text-[10px] hover:bg-theme-primary/10 transition-all flex items-center gap-1.5"
                       id="add-to-hub-btn"
                       title="Add this draft to the Session Hub to bundle several drafts before exporting"
                     >
-                      <span class="icon-[lucide--link] w-3.5 h-3.5"></span>
+                      <span
+                        class="icon-[lucide--link] w-3.5 h-3.5"
+                        aria-hidden="true"
+                      ></span>
                       Link to Hub
                     </button>
                   {/if}
                   <button
                     type="button"
                     onclick={handleCopyMarkdown}
-                    class="px-4 py-2 bg-theme-surface border border-theme-border/80 text-theme-text font-bold uppercase font-header tracking-wider text-[10px] rounded-lg hover:border-theme-primary/60 transition-all flex items-center gap-1.5"
+                    class="px-4 py-2 border-l border-theme-primary/25 bg-theme-surface/35 text-theme-text/85 font-bold uppercase font-header tracking-wider text-[10px] hover:bg-theme-surface/70 hover:text-theme-primary transition-all flex items-center gap-1.5"
                     id="copy-markdown-btn"
                     title="Copy this draft as markdown to your clipboard"
                   >
-                    <span class="icon-[lucide--copy] w-3.5 h-3.5"></span>
+                    <span
+                      class="icon-[lucide--copy] w-3.5 h-3.5"
+                      aria-hidden="true"
+                    ></span>
                     {copied ? "Copied!" : "Copy"}
                   </button>
                 </div>
@@ -762,7 +790,51 @@
               onclick={handleContainerClick}
               onkeydown={handleContainerKeydown}
             >
-              {@html renderMarkdown(documentLayout.content)}
+              {#if variant === "names"}
+                {@html renderMarkdown(documentLayout.content)}
+              {:else}
+                {#each documentSections as section (section.id)}
+                  <article
+                    class="group/section rounded-xl border border-transparent transition-colors hover:border-theme-border/35 hover:bg-theme-surface/10"
+                  >
+                    {#if section.heading}
+                      <div
+                        class="mb-2 flex items-center justify-between gap-3 border-b border-theme-border/35 pb-2"
+                      >
+                        <h3
+                          class="font-header text-base font-bold text-[color:color-mix(in_srgb,var(--color-primary)_65%,var(--color-text))]"
+                        >
+                          {section.heading}
+                        </h3>
+                        <button
+                          type="button"
+                          onclick={() =>
+                            void handleCopySection(
+                              section.id,
+                              section.markdown,
+                            )}
+                          class="inline-flex items-center gap-1.5 rounded-full border border-theme-border/60 bg-theme-surface/45 px-2.5 py-1 text-[9px] font-bold uppercase tracking-wider text-theme-text/65 opacity-100 transition-all hover:border-theme-primary/60 hover:text-theme-primary md:opacity-0 md:group-hover/section:opacity-100 md:focus-visible:opacity-100"
+                          aria-label="Copy {section.heading} as Markdown"
+                          title="Copy this section as Markdown"
+                        >
+                          <span
+                            class={copiedSectionId === section.id
+                              ? "icon-[lucide--check] h-3.5 w-3.5"
+                              : "icon-[lucide--copy] h-3.5 w-3.5"}
+                            aria-hidden="true"
+                          ></span>
+                          {copiedSectionId === section.id
+                            ? "Copied"
+                            : "Copy MD"}
+                        </button>
+                      </div>
+                    {/if}
+                    <div>
+                      {@html renderMarkdown(section.body)}
+                    </div>
+                  </article>
+                {/each}
+              {/if}
             </div>
           </div>
         {:else}
@@ -797,12 +869,12 @@
       </p>
       <div class="sticky top-24 flex flex-col gap-6">
         <div
-          class="p-5 bg-theme-surface/45 border border-theme-border/40 rounded-2xl shadow-sm backdrop-blur-sm"
+          class="p-5 bg-theme-surface/50 border border-theme-border/50 rounded-2xl shadow-sm backdrop-blur-sm"
         >
           {#if generatedData}
             <div
               in:fade={{ duration: 250 }}
-              class="seo-rail seo-md text-sm leading-relaxed text-theme-text/80"
+              class="seo-rail seo-md text-sm leading-relaxed text-theme-text/85"
             >
               {@html renderLore(documentLayout.lore)}
             </div>
@@ -939,7 +1011,7 @@
         </p>
         {#if inputHint}
           <p
-            class="text-[9px] text-theme-text/45 uppercase tracking-widest font-header mb-4 flex items-center gap-1.5"
+            class="text-[9px] text-theme-text/45 uppercase tracking-widest font-header mb-5 flex items-center gap-1.5"
           >
             <span class="icon-[lucide--arrow-right] w-3 h-3"></span>
             {inputHint}
@@ -1192,7 +1264,7 @@
   }
   /* Rail stat block — compact heading scale, muted palette (#1276) */
   .seo-rail.seo-md :global(.seo-label) {
-    color: color-mix(in srgb, var(--color-text) 60%, transparent);
+    color: color-mix(in srgb, var(--color-primary) 42%, var(--color-text));
     text-shadow: none;
     filter: none;
   }
@@ -1200,7 +1272,7 @@
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: color-mix(in srgb, var(--color-text) 65%, transparent);
+    color: color-mix(in srgb, var(--color-text) 82%, transparent);
     margin: 0.875rem 0 0.375rem;
     border-bottom: none;
   }
@@ -1209,9 +1281,9 @@
     border-bottom: 1px solid
       color-mix(in srgb, var(--color-border) 30%, transparent);
     margin: 1rem 0 0.5rem;
-    color: color-mix(in srgb, var(--color-text) 75%, transparent);
+    color: color-mix(in srgb, var(--color-text) 88%, transparent);
   }
   .seo-rail.seo-md :global(strong) {
-    color: color-mix(in srgb, var(--color-text) 80%, transparent);
+    color: color-mix(in srgb, var(--color-text) 92%, transparent);
   }
 </style>

--- a/apps/web/src/lib/components/seo/markdown-sections.test.ts
+++ b/apps/web/src/lib/components/seo/markdown-sections.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { splitMarkdownForCopy } from "./markdown-sections";
+
+describe("splitMarkdownForCopy", () => {
+  it("splits level-three markdown sections and keeps copy source intact", () => {
+    const sections = splitMarkdownForCopy(`### Origin & Dogma
+Mortals remember the wrong creation myth.
+
+### Divine Alliances & Rivalries
+- **Aster**: Betrayed the throne.`);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0]).toMatchObject({
+      heading: "Origin & Dogma",
+      body: "Mortals remember the wrong creation myth.",
+      markdown: "### Origin & Dogma\nMortals remember the wrong creation myth.",
+    });
+    expect(sections[1].markdown).toContain("### Divine Alliances & Rivalries");
+    expect(sections[1].markdown).toContain("**Aster**");
+  });
+
+  it("preserves preamble content before the first heading", () => {
+    const sections = splitMarkdownForCopy(`Opening note.
+
+### Details
+More text.`);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0]).toEqual({
+      id: "section-preamble",
+      heading: "",
+      body: "Opening note.",
+      markdown: "Opening note.",
+    });
+    expect(sections[1].heading).toBe("Details");
+  });
+
+  it("returns a single copyable section for plain markdown", () => {
+    expect(splitMarkdownForCopy("Plain text.")).toEqual([
+      {
+        id: "section-1",
+        heading: "",
+        body: "Plain text.",
+        markdown: "Plain text.",
+      },
+    ]);
+  });
+
+  it("returns no sections for empty markdown", () => {
+    expect(splitMarkdownForCopy("   \n")).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/components/seo/markdown-sections.ts
+++ b/apps/web/src/lib/components/seo/markdown-sections.ts
@@ -1,0 +1,67 @@
+export interface MarkdownSectionForCopy {
+  id: string;
+  heading: string;
+  body: string;
+  markdown: string;
+}
+
+function slugify(value: string, fallback: string) {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || fallback;
+}
+
+export function splitMarkdownForCopy(
+  markdown: string,
+): MarkdownSectionForCopy[] {
+  const normalized = markdown.trim();
+  if (!normalized) return [];
+
+  const matches = Array.from(normalized.matchAll(/^###\s+(.+)$/gm));
+  if (matches.length === 0) {
+    return [
+      {
+        id: "section-1",
+        heading: "",
+        body: normalized,
+        markdown: normalized,
+      },
+    ];
+  }
+
+  const sections: MarkdownSectionForCopy[] = [];
+  const preamble = normalized.slice(0, matches[0].index ?? 0).trim();
+
+  if (preamble) {
+    sections.push({
+      id: "section-preamble",
+      heading: "",
+      body: preamble,
+      markdown: preamble,
+    });
+  }
+
+  for (const [index, match] of matches.entries()) {
+    const heading = match[1]?.trim() ?? "";
+    const start = match.index ?? 0;
+    const headingEnd = start + match[0].length;
+    const end =
+      index + 1 < matches.length
+        ? (matches[index + 1].index ?? normalized.length)
+        : normalized.length;
+    const body = normalized.slice(headingEnd, end).trim();
+    const fallback = `section-${sections.length + 1}`;
+
+    sections.push({
+      id: `${slugify(heading, fallback)}-${index}`,
+      heading,
+      body,
+      markdown: normalized.slice(start, end).trim(),
+    });
+  }
+
+  return sections;
+}

--- a/apps/web/src/lib/services/seo/generator-engine.test.ts
+++ b/apps/web/src/lib/services/seo/generator-engine.test.ts
@@ -43,6 +43,25 @@ describe("DefaultGeneratorEngine", () => {
       expect(res.lore).toContain("Faction Connection");
       expect(res.labels).toContain("npc-generator");
       expect(res.labels).toContain("imported-draft");
+      expect(res.lore).not.toContain("Class / Archetype");
+      expect(res.lore).not.toContain("Table Rating");
+    });
+
+    it("should include D&D quick stats when requested", async () => {
+      const res = await engine.generateNPC({
+        race: "Human",
+        role: "Priest",
+        alignment: "Lawful Good",
+        includeDndQuickStats: true,
+        useAI: false,
+      });
+
+      expect(res.lore).toContain("### At a Glance");
+      expect(res.lore).toContain("**Class / Archetype**: Cleric / Level 5");
+      expect(res.lore).toContain("**Table Rating**: CR 3");
+      expect(res.lore.indexOf("Class / Archetype")).toBeLessThan(
+        res.lore.indexOf("Ancestry"),
+      );
     });
 
     it("should include optional campaign context in local NPC output", async () => {
@@ -79,6 +98,7 @@ describe("DefaultGeneratorEngine", () => {
         role: "Mage",
         alignment: "Neutral Good",
         campaignContext: "a ruined elven academy",
+        includeDndQuickStats: true,
         useAI: true,
       });
 
@@ -89,7 +109,9 @@ describe("DefaultGeneratorEngine", () => {
       );
       expect(res.title).toBe("Aelwen The Wise");
       expect(res.content).toBe("AI Generated Bio");
-      expect(res.lore).toBe("AI Generated Stats");
+      expect(res.lore).toContain("AI Generated Stats");
+      expect(res.lore).toContain("**Class / Archetype**: Wizard / Level 5");
+      expect(res.lore).toContain("**Table Rating**: CR 3");
       expect(res.labels).toContain("custom-label");
     });
 

--- a/apps/web/src/lib/services/seo/generators/npc.ts
+++ b/apps/web/src/lib/services/seo/generators/npc.ts
@@ -426,6 +426,52 @@ export const npcThemeConfig = {
   >,
 };
 
+const dndNpcQuickStatsByRole: Record<
+  string,
+  { archetype: string; tableRating: string }
+> = {
+  Mage: { archetype: "Wizard / Level 5", tableRating: "CR 3" },
+  Warrior: { archetype: "Fighter / Level 4", tableRating: "CR 2" },
+  Rogue: { archetype: "Rogue / Level 4", tableRating: "CR 2" },
+  Priest: { archetype: "Cleric / Level 5", tableRating: "CR 3" },
+  Merchant: { archetype: "Commoner-Expert / Level 2", tableRating: "CR 1/2" },
+  Scholar: { archetype: "Sage / Level 3", tableRating: "CR 1" },
+  Blacksmith: { archetype: "Artisan / Level 3", tableRating: "CR 1" },
+  Guard: { archetype: "Guard Veteran / Level 3", tableRating: "CR 1" },
+  Noble: { archetype: "Noble / Level 3", tableRating: "CR 1" },
+  Innkeeper: { archetype: "Commoner-Expert / Level 2", tableRating: "CR 1/2" },
+};
+
+function getDndNpcQuickStats(role: string) {
+  return (
+    dndNpcQuickStatsByRole[role] ?? {
+      archetype: `${role} / Level 3`,
+      tableRating: "CR 1",
+    }
+  );
+}
+
+function injectDndNpcQuickStats(lore: string, role: string) {
+  const { archetype, tableRating } = getDndNpcQuickStats(role);
+  const quickStats = `- **Class / Archetype**: ${archetype}
+- **Table Rating**: ${tableRating}`;
+
+  if (lore.includes("- **Class / Archetype**:")) return lore;
+
+  if (!lore.includes("### At a Glance")) {
+    return `### At a Glance
+${quickStats}
+
+${lore}`.trim();
+  }
+
+  return lore.replace(
+    /(### At a Glance\s*)/,
+    `$1${quickStats}
+`,
+  );
+}
+
 export async function generateNPC(
   clientManager: DefaultAIClientManager,
   options: {
@@ -435,6 +481,7 @@ export async function generateNPC(
     alignment?: string;
     campaignContext?: string;
     theme?: string;
+    includeDndQuickStats?: boolean;
     useAI?: boolean;
   } = {},
 ): Promise<GeneratorOutput> {
@@ -537,7 +584,9 @@ ${theme ? `- Genre/Theme: ${theme}` : ""}
           data.summary ||
           `A ${(moralityAnchor?.label ?? alignment).toLowerCase()} ${race.toLowerCase()} ${role.toLowerCase()} with something to hide.`,
         content: data.content || "",
-        lore: data.lore || "",
+        lore: options.includeDndQuickStats
+          ? injectDndNpcQuickStats(data.lore || "", role)
+          : data.lore || "",
         labels: Array.isArray(data.labels)
           ? data.labels
           : ["rpg-character", "npc-generator", "imported-draft"],
@@ -596,7 +645,9 @@ ${faction}`;
     title: name,
     summary,
     content,
-    lore,
+    lore: options.includeDndQuickStats
+      ? injectDndNpcQuickStats(lore, role)
+      : lore,
     labels: ["rpg-character", "npc-generator", "imported-draft"],
     status: "active",
   };

--- a/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/+page.svelte
@@ -12,6 +12,7 @@
   import NameFormFields from "$lib/components/seo/NameFormFields.svelte";
   import NPCFormFields from "$lib/components/seo/NPCFormFields.svelte";
   import PantheonFormFields from "$lib/components/seo/PantheonFormFields.svelte";
+  import { shouldSyncGeneratorTheme } from "./generator-theme";
   import {
     generatorEngine,
     npcConfig,
@@ -500,7 +501,11 @@
         useAI,
       });
     } else if (data.slug === "dnd-npc") {
-      return generatorEngine.generateNPC({ ...dndNpc, useAI });
+      return generatorEngine.generateNPC({
+        ...dndNpc,
+        includeDndQuickStats: true,
+        useAI,
+      });
     } else if (
       data.slug === "pantheon-generator" ||
       data.slug === "god-generator"
@@ -665,7 +670,7 @@
   const selectClass =
     "w-full bg-theme-bg/60 border border-theme-border/60 rounded-lg px-3 py-2 text-xs text-theme-text focus:outline-none focus:border-theme-primary/60";
   const labelClass =
-    "text-[10px] font-bold uppercase tracking-wider text-theme-muted";
+    "text-[10px] font-bold uppercase tracking-wider text-theme-text/80";
 </script>
 
 <SEOGeneratorLayout
@@ -678,16 +683,7 @@
   faqs={meta.faqs ?? []}
   relatedLinks={meta.relatedLinks ?? []}
   bind:theme={activeTheme}
-  isThemeCustomizable={data.slug === "faction" ||
-    data.slug === "npc" ||
-    data.slug === "social-hub" ||
-    data.slug === "nation" ||
-    data.slug === "vampire-clan" ||
-    data.slug === "dnd-npc" ||
-    data.slug === "quest" ||
-    data.slug === "names" ||
-    data.slug === "fantasy-names" ||
-    data.slug === "tavern"}
+  isThemeCustomizable={shouldSyncGeneratorTheme(data.slug)}
   {generate}
   {initialDraft}
   variant={data.slug === "names" || data.slug === "fantasy-names"

--- a/apps/web/src/routes/(marketing)/generators/[slug]/generator-theme.test.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/generator-theme.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { shouldSyncGeneratorTheme } from "./generator-theme";
+
+describe("shouldSyncGeneratorTheme", () => {
+  it("syncs every generator route into the CFF theme store", () => {
+    const slugs = [
+      "npc",
+      "settlement",
+      "magic-item",
+      "faction",
+      "quest",
+      "item",
+      "tavern",
+      "social-hub",
+      "kingdom",
+      "nation",
+      "vampire-clan",
+      "names",
+      "fantasy-names",
+      "dnd-npc",
+      "pantheon-generator",
+      "god-generator",
+    ];
+
+    for (const slug of slugs) {
+      expect(shouldSyncGeneratorTheme(slug)).toBe(true);
+    }
+  });
+
+  it("does not sync unknown slugs", () => {
+    expect(shouldSyncGeneratorTheme("not-a-generator")).toBe(false);
+  });
+});

--- a/apps/web/src/routes/(marketing)/generators/[slug]/generator-theme.ts
+++ b/apps/web/src/routes/(marketing)/generators/[slug]/generator-theme.ts
@@ -1,0 +1,22 @@
+const GENERATOR_SLUGS = new Set([
+  "npc",
+  "settlement",
+  "magic-item",
+  "faction",
+  "quest",
+  "item",
+  "tavern",
+  "social-hub",
+  "kingdom",
+  "nation",
+  "vampire-clan",
+  "names",
+  "fantasy-names",
+  "dnd-npc",
+  "pantheon-generator",
+  "god-generator",
+]);
+
+export function shouldSyncGeneratorTheme(slug: string) {
+  return GENERATOR_SLUGS.has(slug);
+}

--- a/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
+++ b/apps/web/src/routes/(marketing)/tools/dnd-npc-generator/+page.svelte
@@ -17,6 +17,7 @@
       role,
       alignment,
       campaignContext,
+      includeDndQuickStats: true,
       useAI,
     });
   }


### PR DESCRIPTION
## Summary

Polishes the public generator layout based on review feedback and adds D&D-specific quick reference stats for generated NPCs.

## Changes

- Improves generator form label contrast and right-rail reference hierarchy.
- Refines the generator explainer strip, action button group, and left-column spacing.
- Adds per-section `Copy MD` actions for generated narrative sections.
- Syncs CFF/world theme behavior across all generator routes, including pantheon/god generators.
- Adds D&D NPC quick stats in `At a Glance`, including `Class / Archetype` and `Table Rating`.

## Root Cause

The pantheon/god generator updated its local genre value but was not included in the shared theme sync gate, so CFF theme state did not update. The D&D NPC generator also reused the generic NPC output without table-facing quick reference stats.

## Validation

- `bun run --filter web test -- src/lib/services/seo/generator-engine.test.ts`
- `bun run --filter web test -- src/routes/(marketing)/generators/[slug]/generator-theme.test.ts src/routes/(marketing)/generators/[slug]/generators.test.ts src/lib/components/seo/SEOGeneratorLayout.test.ts`
- `bun run --filter web lint -- ...touched files`
- `bun run --filter web lint:types` (passes with existing repo warnings)
- Pre-push hooks: workspace lint and changed-file tests passed