### PR TITLE
:sparkles: Preserve graph viewport on safe updates with stable layout

### DIFF
--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -279,12 +279,33 @@ export class GraphViewController {
     }
   };
 
+  /**
+   * Decides whether a layout pass may move the camera. With stable layout on,
+   * safe updates (edge churn from content edits, plain window resizes) keep
+   * the user's pan/zoom; structural changes (new/removed nodes), mode
+   * changes, explicit Fit/Redraw, and orientation changes still fit.
+   */
+  private resolveViewportPolicy = (
+    isInitial: boolean,
+    caller: string,
+    randomizeForced: boolean,
+    hasNewNodes: boolean,
+    hasRemovedNodes: boolean,
+  ): "preserve" | "fit" => {
+    if (isInitial || !this.deps.graph.stableLayout) return "fit";
+    if (caller === "Window Resize" && !randomizeForced) return "preserve";
+    if (caller === "Elements Update" && !hasNewNodes && !hasRemovedNodes)
+      return "preserve";
+    return "fit";
+  };
+
   applyCurrentLayout = async (
     isInitial = false,
     isForced = false,
     caller = "unknown",
     randomizeForced = false,
     hasNewNodes = false,
+    hasRemovedNodes = false,
   ) => {
     if (!this.layoutManager) return;
 
@@ -298,6 +319,13 @@ export class GraphViewController {
         stableLayout: this.deps.graph.stableLayout,
         isGuest: this.deps.vault.isGuest,
         isMobile: this.deps.layoutUIStore.isMobile,
+        viewportPolicy: this.resolveViewportPolicy(
+          isInitial,
+          caller,
+          randomizeForced,
+          hasNewNodes,
+          hasRemovedNodes,
+        ),
         onLayoutStart: () => {
           this.isLayoutRunning = true;
         },
@@ -380,13 +408,20 @@ export class GraphViewController {
           this.initialLoaded = true;
           this.graphVisible = true;
         },
-        onLayoutUpdate: (isInitial, isForced, caller, hasNewNodes) => {
+        onLayoutUpdate: (
+          isInitial,
+          isForced,
+          caller,
+          hasNewNodes,
+          hasRemovedNodes,
+        ) => {
           this.applyCurrentLayout(
             isInitial,
             isForced,
             caller,
             false,
             hasNewNodes,
+            hasRemovedNodes,
           );
         },
       });

--- a/apps/web/src/lib/components/graph/graph-view-controller.test.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.test.ts
@@ -185,4 +185,93 @@ describe("GraphViewController", () => {
     expect(controller.didFinalizeLoad).toBe(true);
     expect(applySpy).toHaveBeenCalledWith(true, true, "Load Finalized");
   });
+
+  describe("viewport policy", () => {
+    const lastPolicy = () => {
+      const apply = (controller.layoutManager as any).apply;
+      const calls = apply.mock.calls;
+      return calls[calls.length - 1][0].viewportPolicy;
+    };
+
+    beforeEach(async () => {
+      const container = document.createElement("div");
+      await controller.init(container, {});
+    });
+
+    it("preserves the camera for edge-only element updates with stable layout", async () => {
+      await controller.applyCurrentLayout(
+        false,
+        true,
+        "Elements Update",
+        false,
+        false,
+        false,
+      );
+      expect(lastPolicy()).toBe("preserve");
+    });
+
+    it("fits when new nodes are added", async () => {
+      await controller.applyCurrentLayout(
+        false,
+        false,
+        "Elements Update",
+        false,
+        true,
+        false,
+      );
+      expect(lastPolicy()).toBe("fit");
+    });
+
+    it("fits when nodes are removed", async () => {
+      await controller.applyCurrentLayout(
+        false,
+        true,
+        "Elements Update",
+        false,
+        false,
+        true,
+      );
+      expect(lastPolicy()).toBe("fit");
+    });
+
+    it("preserves the camera for plain window resizes", async () => {
+      await controller.applyCurrentLayout(false, false, "Window Resize", false);
+      expect(lastPolicy()).toBe("preserve");
+    });
+
+    it("fits on orientation-change resizes", async () => {
+      await controller.applyCurrentLayout(false, true, "Window Resize", true);
+      expect(lastPolicy()).toBe("fit");
+    });
+
+    it("fits when stable layout is off", async () => {
+      deps.graph.stableLayout = false;
+      await controller.applyCurrentLayout(
+        false,
+        true,
+        "Elements Update",
+        false,
+        false,
+        false,
+      );
+      expect(lastPolicy()).toBe("fit");
+    });
+
+    it("fits on initial layout", async () => {
+      await controller.applyCurrentLayout(true, true, "Load Finalized");
+      expect(lastPolicy()).toBe("fit");
+    });
+
+    it("fits on mode changes and manual redraw", async () => {
+      await controller.applyCurrentLayout(false, true, "Mode Change Effect");
+      expect(lastPolicy()).toBe("fit");
+      await controller.applyCurrentLayout(
+        false,
+        true,
+        "UI Redraw Button",
+        true,
+      );
+      expect(lastPolicy()).toBe("fit");
+    });
+  });
 });

--- a/docs/GRAPH_STABILITY.md
+++ b/docs/GRAPH_STABILITY.md
@@ -11,6 +11,7 @@ The **Stable Layout** toggle (represented by a pin icon in the Graph Toolbar) co
 - **Manual Persistence:** Any nodes you drag will stay at their new coordinates. These positions are saved directly into the entity's markdown frontmatter under `metadata.coordinates`.
 - **No Auto-Redraw:** Adding new connections or entities will _not_ trigger a full graph re-simulation. New nodes will be placed at a stable default position, and existing nodes will not move.
 - **Performance:** This mode is highly recommended for large vaults (100+ nodes) as it prevents expensive force-directed calculations on every change.
+- **Camera Stability:** Safe updates also keep your current pan/zoom. Editing titles, lore, labels, categories, or dates — including content edits that add or remove connections — and plain window resizes will not move the camera. The viewport only re-fits for structural changes (new or deleted entities), mode changes (timeline/orbit), orientation changes, and explicit **Fit** or **Redraw** actions.
 
 ### When OFF (Unpinned)
 

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -122,6 +122,7 @@ describe("LayoutManager", () => {
       width: vi.fn().mockReturnValue(1000),
       height: vi.fn().mockReturnValue(800),
       fit: vi.fn(),
+      stop: vi.fn(),
       animate: vi.fn((animationOptions?: { complete?: () => void }) => {
         animationOptions?.complete?.();
       }),
@@ -231,10 +232,12 @@ describe("LayoutManager", () => {
       "Elements Update",
     );
 
-    // fit-only path with preserve policy: no worker, no fit animation
+    // fit-only path with preserve policy: no worker, no fit animation, and
+    // any in-flight viewport animation is halted
     expect(capturedPostMessage).toBeNull();
     expect(mockCy.animate).not.toHaveBeenCalled();
     expect(mockCy.fit).not.toHaveBeenCalled();
+    expect(mockCy.stop).toHaveBeenCalled();
     expect(onLayoutStop).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/graph-engine/src/LayoutManager.test.ts
+++ b/packages/graph-engine/src/LayoutManager.test.ts
@@ -211,6 +211,53 @@ describe("LayoutManager", () => {
     expect(mockCy.animate).toHaveBeenCalled();
   });
 
+  it("should keep the camera still for preserve-policy stable updates", async () => {
+    const onLayoutStop = vi.fn();
+
+    await layoutManager.apply(
+      {
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: true,
+        isGuest: false,
+        viewportPolicy: "preserve",
+        onLayoutStop,
+      },
+      false,
+      true,
+      "Elements Update",
+    );
+
+    // fit-only path with preserve policy: no worker, no fit animation
+    expect(capturedPostMessage).toBeNull();
+    expect(mockCy.animate).not.toHaveBeenCalled();
+    expect(mockCy.fit).not.toHaveBeenCalled();
+    expect(onLayoutStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("should still fit when viewportPolicy is fit on the stable path", async () => {
+    await layoutManager.apply(
+      {
+        timelineMode: false,
+        timelineAxis: "x",
+        timelineScale: 1,
+        orbitMode: false,
+        centralNodeId: null,
+        stableLayout: true,
+        isGuest: false,
+        viewportPolicy: "fit",
+      },
+      false,
+      false,
+      "Elements Update",
+    );
+
+    expect(mockCy.animate).toHaveBeenCalled();
+  });
+
   it("should use lower gravity in landscape view", async () => {
     mockCy.width.mockReturnValue(1200);
     mockCy.height.mockReturnValue(800); // AR = 1.5 (Landscape)

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -17,6 +17,13 @@ export interface LayoutOptions {
   stableLayout: boolean;
   isGuest: boolean;
   isMobile?: boolean;
+  /**
+   * Camera behavior for this layout pass. "fit" (default) may animate the
+   * viewport to fit all elements; "preserve" keeps the user's current
+   * pan/zoom. Only honored on the stable fit-only path — full layout solves
+   * always fit because node positions may change wholesale.
+   */
+  viewportPolicy?: "preserve" | "fit";
   onLayoutStart?: () => void;
   onLayoutStop?: () => void;
   onLayoutComputed?: (durationMs: number) => void;
@@ -505,7 +512,11 @@ export class LayoutManager {
         options.onPositionsUpdated?.(updates);
       }
 
-      this.animateFitAndStop(options, "ease-out-cubic");
+      if (options.viewportPolicy === "preserve") {
+        options.onLayoutStop?.();
+      } else {
+        this.animateFitAndStop(options, "ease-out-cubic");
+      }
       return;
     }
 

--- a/packages/graph-engine/src/LayoutManager.ts
+++ b/packages/graph-engine/src/LayoutManager.ts
@@ -513,6 +513,10 @@ export class LayoutManager {
       }
 
       if (options.viewportPolicy === "preserve") {
+        // Halt any in-flight fit animation from a previous layout pass —
+        // otherwise it would keep moving the camera after this update
+        // promised to preserve the viewport.
+        this.cy.stop();
         options.onLayoutStop?.();
       } else {
         this.animateFitAndStop(options, "ease-out-cubic");

--- a/packages/graph-engine/src/sync/useGraphSync.ts
+++ b/packages/graph-engine/src/sync/useGraphSync.ts
@@ -21,6 +21,7 @@ export interface SyncOptions {
     isForced: boolean,
     caller: string,
     hasNewNodes?: boolean,
+    hasRemovedNodes?: boolean,
   ) => void;
 }
 
@@ -298,7 +299,16 @@ export function syncGraphElements(cy: Core, options: SyncOptions) {
         // Preserve current positions for edge-only updates. This avoids a second
         // relayout when AI discovery adds connections right after creating a node.
         const force = hasDeletions;
-        options.onLayoutUpdate?.(false, force, "Elements Update", hasNewNodes);
+        // Edge churn (e.g. lore edits rewriting wiki-links) removes elements
+        // without removing nodes — callers use this to keep the camera still.
+        const hasRemovedNodes = elementsToRemove.some((el) => el.isNode());
+        options.onLayoutUpdate?.(
+          false,
+          force,
+          "Elements Update",
+          hasNewNodes,
+          hasRemovedNodes,
+        );
       }
     }
   } catch (err) {

--- a/packages/graph-engine/src/sync/useGraphSync.ts.test.ts
+++ b/packages/graph-engine/src/sync/useGraphSync.ts.test.ts
@@ -5,11 +5,26 @@ import type { Core } from "cytoscape";
 function createMockNode(id: string, labels?: string[]) {
   return {
     id: vi.fn().mockReturnValue(id),
+    isNode: vi.fn().mockReturnValue(true),
     hasClass: vi.fn().mockReturnValue(false),
     data: vi.fn().mockReturnValue({ labels }),
+    removeData: vi.fn(),
     addClass: vi.fn(),
     removeClass: vi.fn(),
     connectedEdges: vi.fn().mockReturnValue([]),
+  };
+}
+
+function createMockEdge(id: string, source: string, target: string) {
+  return {
+    id: vi.fn().mockReturnValue(id),
+    isNode: vi.fn().mockReturnValue(false),
+    hasClass: vi.fn().mockReturnValue(false),
+    data: vi.fn().mockReturnValue({ id, source, target }),
+    addClass: vi.fn(),
+    removeClass: vi.fn(),
+    source: vi.fn(),
+    target: vi.fn(),
   };
 }
 
@@ -267,6 +282,34 @@ describe("syncGraphElements", () => {
       true,
       "Elements Update",
       false,
+      true,
+    );
+  });
+
+  it("should report edge-only removals with hasRemovedNodes=false", () => {
+    const onLayoutUpdate = vi.fn();
+    const nodeA = createMockNode("node-a");
+    const nodeB = createMockNode("node-b");
+    const staleEdge = createMockEdge("node-a-node-b-ally", "node-a", "node-b");
+    mockCy.elements.mockReturnValue([nodeA, nodeB, staleEdge]);
+
+    syncGraphElements(mockCy as unknown as Core, {
+      elements: [
+        { group: "nodes", data: { id: "node-a" } },
+        { group: "nodes", data: { id: "node-b" } },
+      ] as any[],
+      vaultStatus: "idle",
+      initialLoaded: true,
+      isTemporalMetadataEqual: (a, b) => a === b,
+      onLayoutUpdate,
+    });
+
+    expect(onLayoutUpdate).toHaveBeenCalledWith(
+      false,
+      true,
+      "Elements Update",
+      false,
+      false,
     );
   });
 
@@ -287,6 +330,7 @@ describe("syncGraphElements", () => {
       false,
       "Elements Update",
       true,
+      false,
     );
   });
 


### PR DESCRIPTION
## Summary

Slice 1 of the #932 graph polish epic (closes #1323): with **Stable Layout** on, safe graph updates no longer move the camera.

Previously, the stable-layout "fit-only" path preserved node coordinates but always ran `animateFitAndStop`, so the viewport re-fit the whole graph after:
- edge churn from content edits (edge IDs are `source-target-type`, so rewriting a wiki-link or changing a connection type removes + re-adds edges)
- plain window resizes

## Changes

- **`LayoutManager`**: new `viewportPolicy: "preserve" | "fit"` option (default `fit`, fully backward compatible). `preserve` is honored only on the stable fit-only path — full layout solves always fit since positions can change wholesale.
- **`syncGraphElements`**: reports `hasRemovedNodes` separately from generic deletions, so edge-only removals can be distinguished from entity deletions.
- **`GraphViewController`**: resolves the policy per layout pass — preserve for edge-only element updates and plain resizes (stable layout only); fit for initial load, new/removed nodes, mode changes, orientation changes, and explicit Fit/Redraw.
- **Docs**: `GRAPH_STABILITY.md` now documents the camera guarantee.

## Tests

- `LayoutManager`: preserve policy skips the fit animation and still calls `onLayoutStop`; fit policy unchanged.
- `useGraphSync`: edge-only removal vs node removal reporting.
- `graph-view-controller`: 8 policy-resolution cases.
- `bun run --filter web lint:types` clean; graph-engine suite 107 pass; web graph suites 59 pass.

## Runtime verification

Drove the real app headless (Playwright against the dev server, fresh vault): all 6 camera-preserve cases held (edge churn, connection delete, title/lore edit, bulk label, filter toggle, plain resize) and all 6 fit cases still fit (new/deleted entity, Fit, Redraw, timeline toggle, orientation change). Legacy behavior with stable layout OFF probed and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)