### PR TITLE
:sparkles: Add saved graph view presets per vault

### DIFF
--- a/apps/web/src/lib/components/graph/GraphToolbar.svelte
+++ b/apps/web/src/lib/components/graph/GraphToolbar.svelte
@@ -5,6 +5,7 @@
   import { vault } from "$lib/stores/vault.svelte";
   import { guestStore } from "$lib/stores/guest.svelte";
   import Minimap from "./Minimap.svelte";
+  import GraphViewPresets from "./GraphViewPresets.svelte";
   import TimelineControls from "./TimelineControls.svelte";
   import { layoutUIStore } from "$lib/stores/ui/layout-ui.svelte";
   import { connectionModeStore } from "$lib/stores/ui/connection-mode.svelte";
@@ -88,6 +89,7 @@
     >
       <span class="icon-[lucide--map] w-4 h-4"></span>
     </button>
+    <GraphViewPresets {cy} />
     <div class="h-6 w-px bg-theme-border/30 mx-1 flex-shrink-0"></div>
   {/if}
   <TimelineControls

--- a/apps/web/src/lib/components/graph/GraphViewPresets.svelte
+++ b/apps/web/src/lib/components/graph/GraphViewPresets.svelte
@@ -9,6 +9,8 @@
   let newPresetName = $state("");
   let editingId = $state<string | null>(null);
   let editingName = $state("");
+  let isSaving = $state(false);
+  let isRenaming = $state(false);
 
   const close = () => {
     isOpen = false;
@@ -16,10 +18,17 @@
   };
 
   const saveCurrent = async () => {
-    if (!newPresetName.trim()) return;
-    const viewport = cy ? { pan: { ...cy.pan() }, zoom: cy.zoom() } : undefined;
-    await graph.saveViewPreset(newPresetName, viewport);
-    newPresetName = "";
+    if (!newPresetName.trim() || isSaving) return;
+    isSaving = true;
+    try {
+      const viewport = cy
+        ? { pan: { ...cy.pan() }, zoom: cy.zoom() }
+        : undefined;
+      await graph.saveViewPreset(newPresetName, viewport);
+      newPresetName = "";
+    } finally {
+      isSaving = false;
+    }
   };
 
   const applyPreset = (id: string) => {
@@ -52,8 +61,14 @@
   };
 
   const commitRename = async () => {
+    if (isRenaming) return;
     if (editingId && editingName.trim()) {
-      await graph.renameViewPreset(editingId, editingName);
+      isRenaming = true;
+      try {
+        await graph.renameViewPreset(editingId, editingName);
+      } finally {
+        isRenaming = false;
+      }
     }
     editingId = null;
   };
@@ -61,6 +76,7 @@
 
 <div class="relative">
   <button
+    type="button"
     class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {isOpen
       ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
       : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
@@ -93,6 +109,7 @@
         <div class="space-y-1 max-h-48 overflow-y-auto pr-1 mb-2">
           <div class="flex items-center gap-1">
             <button
+              type="button"
               class="flex-1 min-w-0 text-left truncate px-2 py-1 rounded hover:bg-theme-muted/15 hover:text-theme-muted transition text-theme-muted/70 italic"
               onclick={() => {
                 graph.resetView();
@@ -116,6 +133,7 @@
                   aria-label="Preset name"
                 />
                 <button
+                  type="button"
                   class="w-6 h-6 flex items-center justify-center text-theme-primary hover:bg-theme-primary/20 rounded"
                   onclick={() => void commitRename()}
                   title="Save name"
@@ -125,6 +143,7 @@
                 >
               {:else}
                 <button
+                  type="button"
                   class="flex-1 min-w-0 text-left truncate px-2 py-1 rounded hover:bg-theme-primary/15 hover:text-theme-primary transition"
                   onclick={() => applyPreset(preset.id)}
                   title={`Apply "${preset.name}"`}
@@ -132,6 +151,7 @@
                   {preset.name}
                 </button>
                 <button
+                  type="button"
                   class="w-6 h-6 flex items-center justify-center text-theme-muted hover:text-theme-primary opacity-0 group-hover:opacity-100 transition"
                   onclick={() => startRename(preset.id, preset.name)}
                   title="Rename"
@@ -139,6 +159,7 @@
                   ><span class="icon-[lucide--pencil] w-3 h-3"></span></button
                 >
                 <button
+                  type="button"
                   class="w-6 h-6 flex items-center justify-center text-theme-muted hover:text-red-400 opacity-0 group-hover:opacity-100 transition"
                   onclick={() => void graph.deleteViewPreset(preset.id)}
                   title="Delete"
@@ -163,9 +184,10 @@
           data-testid="view-preset-name-input"
         />
         <button
+          type="button"
           class="h-7 px-2 flex items-center justify-center border border-theme-primary/50 text-theme-primary hover:bg-theme-primary/20 rounded transition disabled:opacity-40 disabled:cursor-not-allowed"
           onclick={() => void saveCurrent()}
-          disabled={!newPresetName.trim()}
+          disabled={!newPresetName.trim() || isSaving}
           title="Save current view"
           aria-label="Save current view"
           data-testid="view-preset-save"

--- a/apps/web/src/lib/components/graph/GraphViewPresets.svelte
+++ b/apps/web/src/lib/components/graph/GraphViewPresets.svelte
@@ -91,6 +91,18 @@
         </p>
       {:else}
         <div class="space-y-1 max-h-48 overflow-y-auto pr-1 mb-2">
+          <div class="flex items-center gap-1">
+            <button
+              class="flex-1 min-w-0 text-left truncate px-2 py-1 rounded hover:bg-theme-muted/15 hover:text-theme-muted transition text-theme-muted/70 italic"
+              onclick={() => {
+                graph.resetView();
+                close();
+              }}
+              title="Clear all filters and modes"
+            >
+              Reset to default
+            </button>
+          </div>
           {#each graph.viewPresets as preset (preset.id)}
             <div class="flex items-center gap-1 group">
               {#if editingId === preset.id}

--- a/apps/web/src/lib/components/graph/GraphViewPresets.svelte
+++ b/apps/web/src/lib/components/graph/GraphViewPresets.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  import { fade } from "svelte/transition";
+  import type { Core } from "cytoscape";
+  import { graph } from "$lib/stores/graph.svelte";
+
+  let { cy } = $props<{ cy: Core | undefined }>();
+
+  let isOpen = $state(false);
+  let newPresetName = $state("");
+  let editingId = $state<string | null>(null);
+  let editingName = $state("");
+
+  const close = () => {
+    isOpen = false;
+    editingId = null;
+  };
+
+  const saveCurrent = async () => {
+    if (!newPresetName.trim()) return;
+    const viewport = cy ? { pan: { ...cy.pan() }, zoom: cy.zoom() } : undefined;
+    await graph.saveViewPreset(newPresetName, viewport);
+    newPresetName = "";
+  };
+
+  const applyPreset = (id: string) => {
+    const result = graph.applyViewPreset(id);
+    if (!result) return;
+    const { preset, modeChanged } = result;
+    const vp = preset.state.viewport;
+    // Mode layouts (timeline/orbit) run their own fit — only restore the
+    // stored camera when no mode layout will fight it.
+    if (
+      cy &&
+      vp &&
+      !modeChanged &&
+      !preset.state.timelineMode &&
+      !preset.state.orbitMode
+    ) {
+      cy.animate({
+        pan: { ...vp.pan },
+        zoom: vp.zoom,
+        duration: 500,
+        easing: "ease-out-cubic",
+      });
+    }
+    close();
+  };
+
+  const startRename = (id: string, name: string) => {
+    editingId = id;
+    editingName = name;
+  };
+
+  const commitRename = async () => {
+    if (editingId && editingName.trim()) {
+      await graph.renameViewPreset(editingId, editingName);
+    }
+    editingId = null;
+  };
+</script>
+
+<div class="relative">
+  <button
+    class="w-8 h-8 flex-shrink-0 flex items-center justify-center border transition {isOpen
+      ? 'border-theme-primary bg-theme-primary/20 text-theme-primary'
+      : 'border-theme-border bg-theme-surface/80 text-theme-muted hover:text-theme-primary'}"
+    onclick={() => (isOpen = !isOpen)}
+    title="Saved Views"
+    aria-label="Saved Views"
+    aria-pressed={isOpen}
+    data-testid="view-presets-toggle"
+    ><span class="icon-[lucide--bookmark] w-4 h-4"></span></button
+  >
+
+  {#if isOpen}
+    <div
+      class="absolute bottom-full mb-2 left-0 w-64 rounded-lg border border-theme-border bg-theme-surface/95 p-2 text-xs text-theme-text shadow-xl backdrop-blur z-30"
+      data-testid="view-presets-panel"
+      transition:fade={{ duration: 100 }}
+    >
+      <div
+        class="flex items-center gap-2 text-theme-primary uppercase tracking-[0.2em] font-mono text-[11px] mb-2"
+      >
+        <span class="icon-[lucide--bookmark] w-3 h-3"></span>
+        Saved Views
+      </div>
+
+      {#if graph.viewPresets.length === 0}
+        <p class="text-theme-muted px-1 pb-2">
+          Save the current filters, modes, and camera as a reusable view.
+        </p>
+      {:else}
+        <div class="space-y-1 max-h-48 overflow-y-auto pr-1 mb-2">
+          {#each graph.viewPresets as preset (preset.id)}
+            <div class="flex items-center gap-1 group">
+              {#if editingId === preset.id}
+                <input
+                  class="flex-1 min-w-0 bg-theme-bg/60 border border-theme-primary/50 rounded px-2 py-1 text-theme-text focus:outline-none"
+                  bind:value={editingName}
+                  onkeydown={(e) => {
+                    if (e.key === "Enter") void commitRename();
+                    if (e.key === "Escape") editingId = null;
+                  }}
+                  aria-label="Preset name"
+                />
+                <button
+                  class="w-6 h-6 flex items-center justify-center text-theme-primary hover:bg-theme-primary/20 rounded"
+                  onclick={() => void commitRename()}
+                  title="Save name"
+                  aria-label="Save name"
+                  ><span class="icon-[lucide--check] w-3.5 h-3.5"
+                  ></span></button
+                >
+              {:else}
+                <button
+                  class="flex-1 min-w-0 text-left truncate px-2 py-1 rounded hover:bg-theme-primary/15 hover:text-theme-primary transition"
+                  onclick={() => applyPreset(preset.id)}
+                  title={`Apply "${preset.name}"`}
+                >
+                  {preset.name}
+                </button>
+                <button
+                  class="w-6 h-6 flex items-center justify-center text-theme-muted hover:text-theme-primary opacity-0 group-hover:opacity-100 transition"
+                  onclick={() => startRename(preset.id, preset.name)}
+                  title="Rename"
+                  aria-label={`Rename "${preset.name}"`}
+                  ><span class="icon-[lucide--pencil] w-3 h-3"></span></button
+                >
+                <button
+                  class="w-6 h-6 flex items-center justify-center text-theme-muted hover:text-red-400 opacity-0 group-hover:opacity-100 transition"
+                  onclick={() => void graph.deleteViewPreset(preset.id)}
+                  title="Delete"
+                  aria-label={`Delete "${preset.name}"`}
+                  ><span class="icon-[lucide--trash-2] w-3 h-3"></span></button
+                >
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="flex items-center gap-1 border-t border-theme-border/40 pt-2">
+        <input
+          class="flex-1 min-w-0 bg-theme-bg/60 border border-theme-border rounded px-2 py-1 text-theme-text placeholder:text-theme-muted focus:border-theme-primary focus:outline-none"
+          placeholder="Name this view..."
+          bind:value={newPresetName}
+          onkeydown={(e) => {
+            if (e.key === "Enter") void saveCurrent();
+          }}
+          aria-label="New preset name"
+          data-testid="view-preset-name-input"
+        />
+        <button
+          class="h-7 px-2 flex items-center justify-center border border-theme-primary/50 text-theme-primary hover:bg-theme-primary/20 rounded transition disabled:opacity-40 disabled:cursor-not-allowed"
+          onclick={() => void saveCurrent()}
+          disabled={!newPresetName.trim()}
+          title="Save current view"
+          aria-label="Save current view"
+          data-testid="view-preset-save"
+          ><span class="icon-[lucide--plus] w-3.5 h-3.5"></span></button
+        >
+      </div>
+    </div>
+  {/if}
+</div>

--- a/apps/web/src/lib/stores/graph-presets.test.ts
+++ b/apps/web/src/lib/stores/graph-presets.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { parsePresets, presetsSettingsKey } from "./graph-presets";
+
+const validState = {
+  activeLabels: ["quest-arc"],
+  labelFilterMode: "AND",
+  activeCategories: ["person"],
+  showLabels: true,
+  showImages: false,
+  stableLayout: true,
+  timelineMode: false,
+  timelineAxis: "x",
+  timelineRange: { start: null, end: null },
+  timelineScale: 100,
+  orbitMode: false,
+  centralNodeId: null,
+  viewport: { pan: { x: 10, y: -20 }, zoom: 1.5 },
+};
+
+const validPreset = {
+  id: "p1",
+  name: "Quest Arc",
+  createdAt: 1000,
+  updatedAt: 2000,
+  state: validState,
+};
+
+describe("presetsSettingsKey", () => {
+  it("scopes the settings key per vault", () => {
+    expect(presetsSettingsKey("vault-a")).toBe("graphViewPresets:vault-a");
+  });
+});
+
+describe("parsePresets", () => {
+  it("round-trips a valid preset", () => {
+    const [p] = parsePresets([validPreset]);
+    expect(p).toEqual(validPreset);
+  });
+
+  it("returns empty for non-array input", () => {
+    expect(parsePresets(undefined)).toEqual([]);
+    expect(parsePresets(null)).toEqual([]);
+    expect(parsePresets("junk")).toEqual([]);
+    expect(parsePresets({})).toEqual([]);
+  });
+
+  it("drops malformed entries but keeps valid ones", () => {
+    const parsed = parsePresets([
+      null,
+      "garbage",
+      { id: "", name: "no id", state: validState },
+      { id: "p2", name: "   ", state: validState },
+      { id: "p3", name: "no state" },
+      {
+        id: "p4",
+        name: "bad labels",
+        state: { ...validState, activeLabels: "x" },
+      },
+      validPreset,
+    ]);
+    expect(parsed.map((p) => p.id)).toEqual(["p1"]);
+  });
+
+  it("normalizes invalid enum and numeric fields to safe defaults", () => {
+    const [p] = parsePresets([
+      {
+        id: "p5",
+        name: "odd",
+        state: {
+          ...validState,
+          labelFilterMode: "XOR",
+          timelineAxis: "z",
+          timelineScale: "wide",
+          timelineRange: { start: "then", end: 50 },
+          centralNodeId: 42,
+        },
+      },
+    ]);
+    expect(p.state.labelFilterMode).toBe("OR");
+    expect(p.state.timelineAxis).toBe("x");
+    expect(p.state.timelineScale).toBe(100);
+    expect(p.state.timelineRange).toEqual({ start: null, end: 50 });
+    expect(p.state.centralNodeId).toBeNull();
+  });
+
+  it("drops a corrupt viewport instead of the whole preset", () => {
+    const [p] = parsePresets([
+      {
+        ...validPreset,
+        state: { ...validState, viewport: { pan: { x: NaN, y: 0 }, zoom: 1 } },
+      },
+    ]);
+    expect(p.state.viewport).toBeUndefined();
+  });
+
+  it("fills missing timestamps", () => {
+    const [p] = parsePresets([{ id: "p6", name: "old", state: validState }]);
+    expect(p.createdAt).toBeGreaterThan(0);
+    expect(p.updatedAt).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/stores/graph-presets.test.ts
+++ b/apps/web/src/lib/stores/graph-presets.test.ts
@@ -98,4 +98,23 @@ describe("parsePresets", () => {
     expect(p.createdAt).toBeGreaterThan(0);
     expect(p.updatedAt).toBeGreaterThan(0);
   });
+
+  it("keeps createdAt <= updatedAt when only one timestamp is present", () => {
+    const [a] = parsePresets([
+      { id: "p7", name: "a", updatedAt: 5000, state: validState },
+    ]);
+    expect(a.createdAt).toBe(5000);
+    expect(a.updatedAt).toBe(5000);
+
+    const [b] = parsePresets([
+      { id: "p8", name: "b", createdAt: 3000, state: validState },
+    ]);
+    expect(b.createdAt).toBe(3000);
+    expect(b.updatedAt).toBe(3000);
+  });
+
+  it("trims whitespace from persisted names", () => {
+    const [p] = parsePresets([{ ...validPreset, name: "  Padded Name  " }]);
+    expect(p.name).toBe("Padded Name");
+  });
 });

--- a/apps/web/src/lib/stores/graph-presets.ts
+++ b/apps/web/src/lib/stores/graph-presets.ts
@@ -1,0 +1,111 @@
+/**
+ * Saved graph view presets: named visual states (filters, modes, display
+ * toggles, optional camera) scoped per vault. Presets never contain entity
+ * data or node coordinates — coordinates live in entity metadata.
+ */
+
+export interface GraphViewPresetState {
+  activeLabels: string[];
+  labelFilterMode: "AND" | "OR";
+  activeCategories: string[];
+  showLabels: boolean;
+  showImages: boolean;
+  stableLayout: boolean;
+  timelineMode: boolean;
+  timelineAxis: "x" | "y";
+  timelineRange: { start: number | null; end: number | null };
+  timelineScale: number;
+  orbitMode: boolean;
+  centralNodeId: string | null;
+  viewport?: { pan: { x: number; y: number }; zoom: number };
+}
+
+export interface GraphViewPreset {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  state: GraphViewPresetState;
+}
+
+export const GRAPH_VIEW_PRESETS_KEY_PREFIX = "graphViewPresets:";
+
+export function presetsSettingsKey(vaultId: string) {
+  return `${GRAPH_VIEW_PRESETS_KEY_PREFIX}${vaultId}`;
+}
+
+const isStringArray = (v: unknown): v is string[] =>
+  Array.isArray(v) && v.every((s) => typeof s === "string");
+
+const isFiniteNumber = (v: unknown): v is number =>
+  typeof v === "number" && Number.isFinite(v);
+
+function parseViewport(
+  raw: unknown,
+): GraphViewPresetState["viewport"] | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const v = raw as Record<string, any>;
+  if (
+    !isFiniteNumber(v.zoom) ||
+    typeof v.pan !== "object" ||
+    v.pan === null ||
+    !isFiniteNumber(v.pan.x) ||
+    !isFiniteNumber(v.pan.y)
+  ) {
+    return undefined;
+  }
+  return { pan: { x: v.pan.x, y: v.pan.y }, zoom: v.zoom };
+}
+
+function parsePresetState(raw: unknown): GraphViewPresetState | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const s = raw as Record<string, any>;
+  if (!isStringArray(s.activeLabels) || !isStringArray(s.activeCategories)) {
+    return null;
+  }
+  return {
+    activeLabels: s.activeLabels,
+    labelFilterMode: s.labelFilterMode === "AND" ? "AND" : "OR",
+    activeCategories: s.activeCategories,
+    showLabels: s.showLabels !== false,
+    showImages: s.showImages !== false,
+    stableLayout: s.stableLayout !== false,
+    timelineMode: s.timelineMode === true,
+    timelineAxis: s.timelineAxis === "y" ? "y" : "x",
+    timelineRange: {
+      start: isFiniteNumber(s.timelineRange?.start)
+        ? s.timelineRange.start
+        : null,
+      end: isFiniteNumber(s.timelineRange?.end) ? s.timelineRange.end : null,
+    },
+    timelineScale: isFiniteNumber(s.timelineScale) ? s.timelineScale : 100,
+    orbitMode: s.orbitMode === true,
+    centralNodeId: typeof s.centralNodeId === "string" ? s.centralNodeId : null,
+    viewport: parseViewport(s.viewport),
+  };
+}
+
+/**
+ * Parses a persisted preset list, silently dropping malformed entries so one
+ * corrupt record never breaks preset loading for the vault.
+ */
+export function parsePresets(raw: unknown): GraphViewPreset[] {
+  if (!Array.isArray(raw)) return [];
+  const presets: GraphViewPreset[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const p = entry as Record<string, any>;
+    if (typeof p.id !== "string" || p.id.length === 0) continue;
+    if (typeof p.name !== "string" || p.name.trim().length === 0) continue;
+    const state = parsePresetState(p.state);
+    if (!state) continue;
+    presets.push({
+      id: p.id,
+      name: p.name,
+      createdAt: isFiniteNumber(p.createdAt) ? p.createdAt : Date.now(),
+      updatedAt: isFiniteNumber(p.updatedAt) ? p.updatedAt : Date.now(),
+      state,
+    });
+  }
+  return presets;
+}

--- a/apps/web/src/lib/stores/graph-presets.ts
+++ b/apps/web/src/lib/stores/graph-presets.ts
@@ -96,16 +96,19 @@ export function parsePresets(raw: unknown): GraphViewPreset[] {
     if (typeof entry !== "object" || entry === null) continue;
     const p = entry as Record<string, any>;
     if (typeof p.id !== "string" || p.id.length === 0) continue;
-    if (typeof p.name !== "string" || p.name.trim().length === 0) continue;
+    const name = typeof p.name === "string" ? p.name.trim() : "";
+    if (name.length === 0) continue;
     const state = parsePresetState(p.state);
     if (!state) continue;
-    presets.push({
-      id: p.id,
-      name: p.name,
-      createdAt: isFiniteNumber(p.createdAt) ? p.createdAt : Date.now(),
-      updatedAt: isFiniteNumber(p.updatedAt) ? p.updatedAt : Date.now(),
-      state,
-    });
+    // Derive a missing timestamp from its sibling so createdAt <= updatedAt
+    // holds even for partial records.
+    const createdAt = isFiniteNumber(p.createdAt)
+      ? p.createdAt
+      : isFiniteNumber(p.updatedAt)
+        ? p.updatedAt
+        : Date.now();
+    const updatedAt = isFiniteNumber(p.updatedAt) ? p.updatedAt : createdAt;
+    presets.push({ id: p.id, name, createdAt, updatedAt, state });
   }
   return presets;
 }

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -2,6 +2,12 @@ import { vault as defaultVault } from "./vault.svelte";
 import { GraphTransformer } from "graph-engine";
 import { isEntityVisible, type Era, type Entity } from "schema";
 import { getDB } from "../utils/idb";
+import {
+  parsePresets,
+  presetsSettingsKey,
+  type GraphViewPreset,
+  type GraphViewPresetState,
+} from "./graph-presets";
 import { explorerUIStore } from "$lib/stores/ui/explorer-ui.svelte";
 import { sessionModeStore } from "$lib/stores/ui/session-mode.svelte";
 import { connectionModeStore } from "$lib/stores/ui/connection-mode.svelte";
@@ -93,6 +99,9 @@ export class GraphStore {
 
   eras = $state<Era[]>([]);
 
+  // Saved view presets for the active vault
+  viewPresets = $state<GraphViewPreset[]>([]);
+
   stats = $derived.by(() => {
     // OPTIMIZATION: Use imperative loop instead of multiple .filter() calls
     // to avoid intermediate array allocations and reduce GC pressure.
@@ -158,6 +167,8 @@ export class GraphStore {
       this.labelFilterMode = savedLabelFilterMode;
     }
 
+    await this.loadViewPresets();
+
     if (typeof window !== "undefined") {
       window.addEventListener("vault-switched", () => {
         this.clearLabelFilters();
@@ -165,8 +176,156 @@ export class GraphStore {
         this.orbitMode = false;
         this.centralNodeId = null;
         // Keep timelineMode as it's a global preference usually
+        void this.loadViewPresets();
       });
     }
+  }
+
+  // ── View presets ────────────────────────────────────────────────────────
+
+  private get viewPresetsKey() {
+    return presetsSettingsKey(this.vault.activeVaultId ?? "default");
+  }
+
+  async loadViewPresets() {
+    try {
+      const db = await getDB();
+      const raw = await db.get("settings", this.viewPresetsKey);
+      this.viewPresets = parsePresets(raw);
+    } catch (error) {
+      console.error("[GraphStore] Failed to load graph view presets:", error);
+      this.viewPresets = [];
+    }
+  }
+
+  private async persistViewPresets() {
+    try {
+      const db = await getDB();
+      await db.put(
+        "settings",
+        $state.snapshot(this.viewPresets),
+        this.viewPresetsKey,
+      );
+    } catch (error) {
+      console.error(
+        "[GraphStore] Failed to persist graph view presets:",
+        error,
+      );
+    }
+  }
+
+  captureViewState(viewport?: {
+    pan: { x: number; y: number };
+    zoom: number;
+  }): GraphViewPresetState {
+    return {
+      activeLabels: Array.from(this.activeLabels),
+      labelFilterMode: this.labelFilterMode,
+      activeCategories: Array.from(this.activeCategories),
+      showLabels: this.showLabels,
+      showImages: this.showImages,
+      stableLayout: this.stableLayout,
+      timelineMode: this.timelineMode,
+      timelineAxis: this.timelineAxis,
+      timelineRange: { ...this.timelineRange },
+      timelineScale: this.timelineScale,
+      orbitMode: this.orbitMode,
+      centralNodeId: this.centralNodeId,
+      viewport,
+    };
+  }
+
+  async saveViewPreset(
+    name: string,
+    viewport?: { pan: { x: number; y: number }; zoom: number },
+  ): Promise<GraphViewPreset | null> {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    const now = Date.now();
+    const preset: GraphViewPreset = {
+      id:
+        typeof crypto !== "undefined" && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `preset-${now}-${Math.random().toString(36).slice(2, 8)}`,
+      name: trimmed,
+      createdAt: now,
+      updatedAt: now,
+      state: this.captureViewState(viewport),
+    };
+    this.viewPresets = [...this.viewPresets, preset];
+    await this.persistViewPresets();
+    return preset;
+  }
+
+  /**
+   * Restores a preset's visual state. Filters that reference labels,
+   * categories, or orbit centers that no longer exist in the vault are
+   * skipped instead of failing (preset drift).
+   *
+   * Returns the preset and whether a mode (timeline/orbit) flipped — callers
+   * use that to decide if restoring the stored viewport is safe or whether
+   * the mode layout's own fit should win.
+   */
+  applyViewPreset(
+    id: string,
+  ): { preset: GraphViewPreset; modeChanged: boolean } | null {
+    const preset = this.viewPresets.find((p) => p.id === id);
+    if (!preset) return null;
+    const s = preset.state;
+
+    const entities = this.vault.allEntities;
+    let labels = s.activeLabels;
+    let categories = s.activeCategories;
+    let centralNodeId = s.centralNodeId;
+    if (entities.length > 0) {
+      const existingLabels = new Set<string>();
+      const existingCategories = new Set<string>();
+      const existingIds = new Set<string>();
+      for (const e of entities) {
+        existingIds.add(e.id);
+        if (e.type) existingCategories.add(e.type);
+        for (const l of e.labels ?? []) existingLabels.add(l.toLowerCase());
+      }
+      labels = labels.filter((l) => existingLabels.has(l.toLowerCase()));
+      categories = categories.filter((c) => existingCategories.has(c));
+      if (centralNodeId && !existingIds.has(centralNodeId)) {
+        centralNodeId = null;
+      }
+    }
+
+    const wasTimeline = this.timelineMode;
+    const wasOrbit = this.orbitMode;
+
+    this.activeLabels = new Set(labels);
+    this.labelFilterMode = s.labelFilterMode;
+    this.activeCategories = new Set(categories);
+    this.showLabels = s.showLabels;
+    this.showImages = s.showImages;
+    this.stableLayout = s.stableLayout;
+    this.timelineAxis = s.timelineAxis;
+    this.timelineRange = { ...s.timelineRange };
+    this.timelineScale = s.timelineScale;
+    this.timelineMode = s.timelineMode;
+    this.centralNodeId = centralNodeId;
+    this.orbitMode = s.orbitMode && centralNodeId !== null;
+
+    const modeChanged =
+      wasTimeline !== this.timelineMode || wasOrbit !== this.orbitMode;
+    return { preset, modeChanged };
+  }
+
+  async renameViewPreset(id: string, name: string) {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    this.viewPresets = this.viewPresets.map((p) =>
+      p.id === id ? { ...p, name: trimmed, updatedAt: Date.now() } : p,
+    );
+    await this.persistViewPresets();
+  }
+
+  async deleteViewPreset(id: string) {
+    this.viewPresets = this.viewPresets.filter((p) => p.id !== id);
+    await this.persistViewPresets();
   }
 
   async saveEras() {

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -328,6 +328,17 @@ export class GraphStore {
     await this.persistViewPresets();
   }
 
+  resetView() {
+    this.activeLabels = new Set();
+    this.activeCategories = new Set();
+    this.labelFilterMode = "OR";
+    this.showLabels = true;
+    this.showImages = true;
+    this.timelineMode = false;
+    this.orbitMode = false;
+    this.centralNodeId = null;
+  }
+
   async saveEras() {
     const db = await getDB();
     const tx = db.transaction("world_eras", "readwrite");

--- a/apps/web/src/lib/stores/graph.svelte.ts
+++ b/apps/web/src/lib/stores/graph.svelte.ts
@@ -19,6 +19,7 @@ export class GraphStore {
   private sessionModeStore: typeof sessionModeStore;
   private connectionModeStore: typeof connectionModeStore;
   private _initPromise: Promise<void> | null = null;
+  private _vaultSwitchHandler: (() => void) | null = null;
 
   private get vault() {
     return this._vault ?? defaultVault;
@@ -170,14 +171,18 @@ export class GraphStore {
     await this.loadViewPresets();
 
     if (typeof window !== "undefined") {
-      window.addEventListener("vault-switched", () => {
+      if (this._vaultSwitchHandler) {
+        window.removeEventListener("vault-switched", this._vaultSwitchHandler);
+      }
+      this._vaultSwitchHandler = () => {
         this.clearLabelFilters();
         this.clearCategoryFilters();
         this.orbitMode = false;
         this.centralNodeId = null;
         // Keep timelineMode as it's a global preference usually
         void this.loadViewPresets();
-      });
+      };
+      window.addEventListener("vault-switched", this._vaultSwitchHandler);
     }
   }
 
@@ -334,6 +339,7 @@ export class GraphStore {
     this.labelFilterMode = "OR";
     this.showLabels = true;
     this.showImages = true;
+    this.stableLayout = true;
     this.timelineMode = false;
     this.orbitMode = false;
     this.centralNodeId = null;

--- a/apps/web/src/lib/stores/graph.test.ts
+++ b/apps/web/src/lib/stores/graph.test.ts
@@ -79,6 +79,8 @@ describe("GraphStore", () => {
     // Reset mocks
     (vault as any).allEntities = [];
     (vault as any).isGuest = false;
+    (vault as any).activeVaultId = "vault-1";
+    graph.viewPresets = [];
     sessionModeStore.sharedMode = false;
     explorerUIStore.labelFilters = new Set();
   });
@@ -176,7 +178,8 @@ describe("GraphStore", () => {
     await graph.init();
 
     expect(getAllSpy).toHaveBeenCalledTimes(1);
-    expect(getSpy).toHaveBeenCalledTimes(5);
+    // 5 global graph settings + 1 vault-scoped view presets key
+    expect(getSpy).toHaveBeenCalledTimes(6);
     expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
 
     addEventListenerSpy.mockRestore();
@@ -301,6 +304,138 @@ describe("GraphStore", () => {
     graph.toggleOrbit();
     expect(graph.orbitMode).toBe(false);
     expect(graph.centralNodeId).toBe(null);
+  });
+
+  describe("view presets", () => {
+    it("should save a preset capturing current state and persist it", async () => {
+      graph.activeLabels = new Set(["arc"]);
+      graph.labelFilterMode = "AND";
+      graph.activeCategories = new Set(["person"]);
+      graph.showImages = false;
+
+      const preset = await graph.saveViewPreset("Quest Arc", {
+        pan: { x: 5, y: 6 },
+        zoom: 2,
+      });
+
+      expect(preset).not.toBeNull();
+      expect(preset!.name).toBe("Quest Arc");
+      expect(preset!.state.activeLabels).toEqual(["arc"]);
+      expect(preset!.state.labelFilterMode).toBe("AND");
+      expect(preset!.state.activeCategories).toEqual(["person"]);
+      expect(preset!.state.showImages).toBe(false);
+      expect(preset!.state.viewport).toEqual({ pan: { x: 5, y: 6 }, zoom: 2 });
+      expect(graph.viewPresets).toHaveLength(1);
+
+      const db = await getDB();
+      expect(db.put).toHaveBeenCalledWith(
+        "settings",
+        expect.arrayContaining([
+          expect.objectContaining({ name: "Quest Arc" }),
+        ]),
+        "graphViewPresets:vault-1",
+      );
+    });
+
+    it("should reject empty preset names", async () => {
+      expect(await graph.saveViewPreset("   ")).toBeNull();
+      expect(graph.viewPresets).toHaveLength(0);
+    });
+
+    it("should apply a preset and report mode changes", async () => {
+      (vault as any).allEntities = [
+        { id: "e1", type: "person", labels: ["Arc"] },
+      ];
+      const preset = await graph.saveViewPreset("base");
+      graph.activeLabels = new Set();
+      graph.timelineMode = true;
+
+      const result = graph.applyViewPreset(preset!.id);
+
+      expect(result).not.toBeNull();
+      expect(result!.modeChanged).toBe(true); // timeline true -> false
+      expect(graph.timelineMode).toBe(false);
+    });
+
+    it("should skip filters and orbit centers that no longer exist", async () => {
+      graph.activeLabels = new Set(["arc", "gone-label"]);
+      graph.activeCategories = new Set(["person", "gone-type"]);
+      graph.setCentralNode("deleted-node");
+      const preset = await graph.saveViewPreset("drifted");
+
+      (vault as any).allEntities = [
+        { id: "e1", type: "person", labels: ["Arc"] },
+      ];
+      graph.activeLabels = new Set();
+      graph.activeCategories = new Set();
+      graph.orbitMode = false;
+      graph.centralNodeId = null;
+
+      graph.applyViewPreset(preset!.id);
+
+      expect(Array.from(graph.activeLabels)).toEqual(["arc"]);
+      expect(Array.from(graph.activeCategories)).toEqual(["person"]);
+      expect(graph.centralNodeId).toBeNull();
+      expect(graph.orbitMode).toBe(false);
+    });
+
+    it("should return null when applying an unknown preset", () => {
+      expect(graph.applyViewPreset("nope")).toBeNull();
+    });
+
+    it("should rename and delete presets with persistence", async () => {
+      const preset = await graph.saveViewPreset("old name");
+      await graph.renameViewPreset(preset!.id, "new name");
+      expect(graph.viewPresets[0].name).toBe("new name");
+
+      await graph.deleteViewPreset(preset!.id);
+      expect(graph.viewPresets).toHaveLength(0);
+
+      const db = await getDB();
+      expect(db.put).toHaveBeenLastCalledWith(
+        "settings",
+        [],
+        "graphViewPresets:vault-1",
+      );
+    });
+
+    it("should ignore malformed persisted preset data on load", async () => {
+      const db = await getDB();
+      (db.get as any).mockResolvedValue([
+        { id: "bad" },
+        "junk",
+        {
+          id: "ok",
+          name: "Valid",
+          state: {
+            activeLabels: [],
+            activeCategories: [],
+          },
+        },
+      ]);
+
+      await graph.loadViewPresets();
+
+      expect(graph.viewPresets).toHaveLength(1);
+      expect(graph.viewPresets[0].name).toBe("Valid");
+    });
+
+    it("should recover with empty presets when loading fails", async () => {
+      const db = await getDB();
+      (db.get as any).mockRejectedValue(new Error("IDB Error"));
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      graph.viewPresets = [{ id: "stale" } as any];
+      await graph.loadViewPresets();
+
+      expect(graph.viewPresets).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load graph view presets"),
+        expect.anything(),
+      );
+    });
   });
 
   it("should handle IDB errors gracefully in toggle methods", async () => {


### PR DESCRIPTION
## Summary

Slice 2 of the #932 graph polish epic (closes #1324): named graph views that can be saved and restored per vault — reusable campaign lenses like "current quest arc" or "villain network" without rebuilding filters each session.

## Changes

- **`graph-presets.ts`** (new): `GraphViewPreset` model — filters, filter mode, display toggles, timeline/orbit state, optional viewport. No entity data, no node coordinates. `parsePresets` validates persisted data, silently dropping malformed entries.
- **`GraphStore`**: `viewPresets` state with save/apply/rename/delete + persistence in IndexedDB under `graphViewPresets:<vaultId>`. Presets reload on `vault-switched`. Applying a preset skips labels, categories, and orbit centers that no longer exist (preset drift), and reports whether a mode flipped so callers know if the stored viewport is safe to restore.
- **`GraphViewPresets.svelte`** (new): compact bookmark popover in the graph toolbar (desktop) — save current view (captures camera from `cy`), apply, inline rename, delete. Camera restore is skipped when a timeline/orbit mode layout would fight it.

## Tests

- `graph-presets.test.ts`: parse round-trip, malformed entries dropped, enum/numeric normalization, corrupt viewport dropped without losing the preset.
- `graph.test.ts`: save/apply/rename/delete with persistence, empty-name rejection, drift skipping, mode-change reporting, malformed-load recovery, IDB failure recovery.
- `bun run --filter web lint:types` clean (0 errors).

## Runtime verification

Drove the real app headless (Playwright, fresh vault): saved a preset through the toolbar popover with an active label filter and a custom camera (zoom 1.7, pan 333/111), cleared all state, applied the preset from the list — filter and camera restored exactly — and confirmed the preset survived a full page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)