### PR TITLE
Graph focus handoff polish (#1325)

### DIFF
--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -360,6 +360,14 @@
     }
   });
 
+  // When focus mode takes over from outside the graph, clear stale graph
+  // selection and dimming so both views don't claim ownership simultaneously.
+  $effect(() => {
+    if (layoutUIStore.mainViewMode === "focus" && controller.selectedId) {
+      controller.clearGraphSelection();
+    }
+  });
+
   // Connect Mode Visual Cleanup
   $effect(() => {
     if (!connectionModeStore.isConnecting && controller.cy) {

--- a/apps/web/src/lib/components/GraphView.svelte
+++ b/apps/web/src/lib/components/GraphView.svelte
@@ -363,8 +363,12 @@
   // When focus mode takes over from outside the graph, clear stale graph
   // selection and dimming so both views don't claim ownership simultaneously.
   $effect(() => {
-    if (layoutUIStore.mainViewMode === "focus" && controller.selectedId) {
-      controller.clearGraphSelection();
+    if (layoutUIStore.mainViewMode === "focus") {
+      untrack(() => {
+        if (controller.selectedId) {
+          controller.clearGraphSelection();
+        }
+      });
     }
   });
 

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -162,7 +162,7 @@ export class GraphViewController {
             }, this.NODE_SELECT_DELAY_MS);
           }
         },
-        onNodeDoubleTap: (id) => {
+        onNodeDoubleTap: (id, _node) => {
           this.clearGraphSelection();
           this.deps.modalUIStore.openZenMode(id);
         },
@@ -460,8 +460,8 @@ export class GraphViewController {
     this.clearNodeSelectTimer();
     if (this.cy) {
       this.cy.$("node:selected").unselect();
+      this.applyFocus(null);
     }
-    this.applyFocus(null);
   };
 
   applyFocus = (id: string | null) => {

--- a/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.svelte.ts
@@ -151,10 +151,8 @@ export class GraphViewController {
             }
           } else {
             if (this.deps.layoutUIStore.isMobile) {
-              this.clearNodeSelectTimer();
+              this.clearGraphSelection();
               this.deps.modalUIStore.openZenMode(id);
-              this.selectedId = null;
-              node.unselect();
               return;
             }
             this.clearNodeSelectTimer();
@@ -164,11 +162,9 @@ export class GraphViewController {
             }, this.NODE_SELECT_DELAY_MS);
           }
         },
-        onNodeDoubleTap: (id, node) => {
-          this.clearNodeSelectTimer();
+        onNodeDoubleTap: (id) => {
+          this.clearGraphSelection();
           this.deps.modalUIStore.openZenMode(id);
-          this.selectedId = null;
-          node.unselect();
         },
         onEdgeTap: (data) => {
           if (this.deps.vault.isGuest) return;
@@ -180,8 +176,7 @@ export class GraphViewController {
           };
         },
         onBackgroundTap: () => {
-          this.clearNodeSelectTimer();
-          this.selectedId = null;
+          this.clearGraphSelection();
           if (this.deps.connectionModeStore.isConnecting)
             this.deps.connectionModeStore.toggleConnectMode();
         },
@@ -453,6 +448,20 @@ export class GraphViewController {
         });
       });
     }
+  };
+
+  /**
+   * Clears graph-side selection: deselects all nodes, nulls selectedId, and
+   * removes neighbourhood dimming. Call this whenever focus ownership moves
+   * away from the graph (focus mode takeover, double-tap Zen, background tap).
+   */
+  clearGraphSelection = () => {
+    this.selectedId = null;
+    this.clearNodeSelectTimer();
+    if (this.cy) {
+      this.cy.$("node:selected").unselect();
+    }
+    this.applyFocus(null);
   };
 
   applyFocus = (id: string | null) => {

--- a/apps/web/src/lib/components/graph/graph-view-controller.test.ts
+++ b/apps/web/src/lib/components/graph/graph-view-controller.test.ts
@@ -186,6 +186,46 @@ describe("GraphViewController", () => {
     expect(applySpy).toHaveBeenCalledWith(true, true, "Load Finalized");
   });
 
+  describe("focus handoff", () => {
+    beforeEach(async () => {
+      const container = document.createElement("div");
+      await controller.init(container, {});
+    });
+
+    it("clearGraphSelection nulls selectedId and calls applyFocus(null)", () => {
+      controller.selectedId = "node-1";
+      const batchSpy = vi.spyOn(controller, "applyFocus");
+
+      controller.clearGraphSelection();
+
+      expect(controller.selectedId).toBeNull();
+      expect(batchSpy).toHaveBeenCalledWith(null);
+    });
+
+    it("clearGraphSelection unselects all nodes in cytoscape", () => {
+      controller.selectedId = "node-1";
+      const unselectSpy = vi.fn();
+      (controller.cy as any).$ = vi
+        .fn()
+        .mockReturnValue({ unselect: unselectSpy });
+
+      controller.clearGraphSelection();
+
+      expect(unselectSpy).toHaveBeenCalled();
+    });
+
+    it("clearGraphSelection cancels any pending node select timer", () => {
+      const clearSpy = vi.spyOn(global, "clearTimeout");
+      // Force a timer into place by inspecting private state via any cast
+      (controller as any).nodeSelectTimer = 999;
+
+      controller.clearGraphSelection();
+
+      expect(clearSpy).toHaveBeenCalledWith(999);
+      expect((controller as any).nodeSelectTimer).toBeNull();
+    });
+  });
+
   describe("viewport policy", () => {
     const lastPolicy = () => {
       const apply = (controller.layoutManager as any).apply;

--- a/apps/web/src/lib/stores/ui/navigation.test.ts
+++ b/apps/web/src/lib/stores/ui/navigation.test.ts
@@ -6,6 +6,47 @@ import { LayoutUIStore } from "./layout-ui.svelte";
 import { focusEntity } from "./navigation";
 import { UIPersistence } from "./persistence";
 
+describe("focusEntity — ownership rules", () => {
+  it("clears vault selectedEntityId when focus mode takes over", () => {
+    const layout = new LayoutUIStore(new UIPersistence(), null);
+    const vault = { selectedEntityId: "graph-selected" };
+
+    focusEntity(layout, "e1", vault);
+
+    expect(layout.mainViewMode).toBe("focus");
+    expect(layout.focusedEntityId).toBe("e1");
+    // graph-side selection must be cleared so both don't claim ownership
+    expect(vault.selectedEntityId).toBeNull();
+  });
+
+  it("is a no-op when already focused on the same entity", () => {
+    const layout = new LayoutUIStore(new UIPersistence(), null);
+    const vault = { selectedEntityId: null as string | null };
+    layout.mainViewMode = "focus";
+    layout.focusedEntityId = "e1";
+
+    focusEntity(layout, "e1", vault);
+
+    // Should return early without changing vault
+    expect(vault.selectedEntityId).toBeNull();
+    expect(layout.focusedEntityId).toBe("e1");
+  });
+
+  it("restores vault selection on exit only when was in focus mode", () => {
+    const layout = new LayoutUIStore(new UIPersistence(), null);
+    const vault = { selectedEntityId: null as string | null };
+
+    // Not in focus mode — exit call should be a no-op
+    focusEntity(layout, null, vault);
+    expect(vault.selectedEntityId).toBeNull();
+
+    // Enter focus mode, then exit
+    focusEntity(layout, "e2", vault);
+    focusEntity(layout, null, vault);
+    expect(vault.selectedEntityId).toBe("e2");
+  });
+});
+
 describe("focusEntity", () => {
   it("focuses an entity, closes mobile sidebar, and clears vault selection", () => {
     const layout = new LayoutUIStore(new UIPersistence(), null);

--- a/apps/web/tests/graph-focus.spec.ts
+++ b/apps/web/tests/graph-focus.spec.ts
@@ -82,6 +82,125 @@ test.describe("Graph Focus Mode", () => {
     expect(selected).toBeNull();
   });
 
+  // Helpers shared by handoff tests
+  async function clickNode(page: any, nodeId: string) {
+    const canvasBox = await page.getByTestId("graph-canvas").boundingBox();
+    const pos = await page.evaluate(
+      (id: string) => (window as any).cy.$id(id).renderedPosition(),
+      nodeId,
+    );
+    await page.mouse.click(canvasBox!.x + pos.x, canvasBox!.y + pos.y);
+  }
+
+  async function dblclickNode(page: any, nodeId: string) {
+    const canvasBox = await page.getByTestId("graph-canvas").boundingBox();
+    const pos = await page.evaluate(
+      (id: string) => (window as any).cy.$id(id).renderedPosition(),
+      nodeId,
+    );
+    await page.mouse.dblclick(canvasBox!.x + pos.x, canvasBox!.y + pos.y);
+  }
+
+  async function clickBackground(page: any) {
+    const canvasBox = await page.getByTestId("graph-canvas").boundingBox();
+    // Click a corner of the canvas well away from any node
+    await page.mouse.click(canvasBox!.x + 10, canvasBox!.y + 10);
+  }
+
+  async function dimmedNodeIds(page: any): Promise<string[]> {
+    return page.evaluate(() =>
+      (window as any).cy.nodes(".dimmed").map((n: any) => n.id()),
+    );
+  }
+
+  test("clicking a node dims others; clicking background clears all dimming", async ({
+    page,
+  }) => {
+    // Click node-1 — node-2 is a direct neighbour, node-3 and island are not
+    await clickNode(page, "node-1");
+
+    // Wait for selection to register
+    await page.waitForFunction(
+      () => (window as any).vault?.selectedEntityId !== null,
+      { timeout: 5000 },
+    );
+
+    const dimmedAfterClick = await dimmedNodeIds(page);
+    expect(dimmedAfterClick.length).toBeGreaterThan(0);
+    // node-1 and node-2 are in the neighbourhood — should NOT be dimmed
+    expect(dimmedAfterClick).not.toContain("node-1");
+    expect(dimmedAfterClick).not.toContain("node-2");
+
+    // Click background — all dimming must clear
+    await clickBackground(page);
+    await page.waitForFunction(
+      () => (window as any).cy.nodes(".dimmed").length === 0,
+      { timeout: 3000 },
+    );
+    const dimmedAfterBackground = await dimmedNodeIds(page);
+    expect(dimmedAfterBackground).toHaveLength(0);
+  });
+
+  test("double-clicking a node opens Zen mode and clears dimming", async ({
+    page,
+  }) => {
+    // First single-click to establish dimming
+    await clickNode(page, "node-1");
+    await page.waitForFunction(
+      () => (window as any).cy.nodes(".dimmed").length > 0,
+      { timeout: 5000 },
+    );
+
+    // Double-click the same node
+    await dblclickNode(page, "node-1");
+
+    // Zen mode must open
+    await expect(page.getByTestId("zen-mode-modal")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Dimming must be cleared (no .dimmed nodes)
+    const dimmed = await dimmedNodeIds(page);
+    expect(dimmed).toHaveLength(0);
+
+    // vault selection must be null
+    const selectedId = await page.evaluate(
+      () => (window as any).vault?.selectedEntityId,
+    );
+    expect(selectedId).toBeNull();
+  });
+
+  test("focusEntity from outside graph clears graph selection and dimming", async ({
+    page,
+  }) => {
+    // Click a node to establish selection and dimming on the graph side
+    await clickNode(page, "node-1");
+    await page.waitForFunction(
+      () => (window as any).vault?.selectedEntityId === "node-1",
+      { timeout: 5000 },
+    );
+
+    // Trigger focus mode externally (as Oracle/ZenView/EmbeddedEntity would)
+    // window.uiStore is the proxy over layoutUIStore exposed in dev/test mode
+    await page.evaluate(() => {
+      const uiStore = (window as any).uiStore;
+      if (uiStore) {
+        uiStore.focusedEntityId = "node-2";
+        uiStore.mainViewMode = "focus";
+      }
+    });
+
+    // The $effect watching mainViewMode should clear graph selection
+    await page.waitForFunction(
+      () => (window as any).vault?.selectedEntityId === null,
+      { timeout: 3000 },
+    );
+
+    // No dimmed nodes should remain
+    const dimmed = await dimmedNodeIds(page);
+    expect(dimmed).toHaveLength(0);
+  });
+
   test("should give medium opacity to 2-hop neighbors", async ({ page }) => {
     await page.evaluate(() => {
       (window as any).vault.addConnection("node-2", "node-3", "related");


### PR DESCRIPTION
## Summary

- Adds `clearGraphSelection()` to `GraphViewController` — single method that nulls `selectedId`, cancels pending select timer, unselects Cytoscape nodes, and clears neighbourhood dimming
- Fixes `onBackgroundTap`, `onNodeDoubleTap`, and mobile tap to use `clearGraphSelection()` — all previously left dimming styles stale on the graph
- Adds a `$effect` in `GraphView.svelte` that clears graph selection when `layoutUIStore.mainViewMode` enters `"focus"`, preventing split ownership between `controller.selectedId` and `layoutUIStore.focusedEntityId`

## Test plan

- [ ] Click a node — neighbourhood dims; click background — dimming clears cleanly
- [ ] Double-click a node — Zen mode opens, dimming clears, no stale selected node
- [ ] Open focus mode from Oracle activity log or embedded entity view while graph has a selected node — graph selection and dimming clear automatically
- [ ] Switch back from focus mode to graph — `vault.selectedEntityId` is restored correctly
- [ ] Mobile: tap a node — Zen mode opens, no stale dimming
- Unit tests: 23/23 pass (`graph-view-controller.test.ts`, `navigation.test.ts`)

Closes #1325
Part of #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)