### PR TITLE
🎨 Palette: Improve accessibility of map icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,8 @@
 
 **Learning:** Found an `a11y_click_events_have_key_events` and `a11y_no_static_element_interactions` warning on a `div` used as a floating dialog backdrop in `QuickNoteScratchpad.svelte`. This pattern makes it difficult for keyboard users to interact with or understand the backdrop's function (closing the dialog).
 **Action:** When implementing floating dialogs or modals with clickable background overlays, use a semantic `<button type="button">` with `aria-label="Close [Modal Name]"`, `w-full h-full`, and proper keyboard focus classes (like `focus-visible:ring-2 focus:outline-none focus-visible:ring-inset`) instead of ignoring the accessibility warnings on a `div`. Ensure this backdrop `<button>` is a sibling of the main modal `div` container, as HTML specs forbid nesting a modal block inside a button.
+
+## 2024-06-13 - Hidden ARIA decorative icons inside buttons
+
+**Learning:** Svelte components frequently include decorative icons (such as those from `icon-[lucide--*]`) inside buttons that already provide an `aria-label` or visible text. Without explicitly hiding them, screen readers may interpret or announce redundant text or confusing graphics.
+**Action:** When adding or updating buttons with decorative icon spans (e.g. `<span class="icon-[lucide--...]"></span>`), always add `aria-hidden="true"` to the icon element so assistive technologies ignore the decoration and focus on the parent button's accessible name.

--- a/apps/web/src/lib/components/map/MapContextMenu.svelte
+++ b/apps/web/src/lib/components/map/MapContextMenu.svelte
@@ -43,7 +43,7 @@
         onClose();
       }}
     >
-      <span class="icon-[lucide--radar] w-3.5 h-3.5 text-theme-primary"></span>
+      <span class="icon-[lucide--radar] w-3.5 h-3.5 text-theme-primary" aria-hidden="true"></span>
       <span>Ping Token</span>
     </button>
 
@@ -61,7 +61,7 @@
           }
         }}
       >
-        <span class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary"
+        <span class="icon-[lucide--book-open] w-3.5 h-3.5 text-theme-primary" aria-hidden="true"
         ></span>
         <span>Look at {_ctxToken.name}</span>
       </button>
@@ -87,7 +87,7 @@
             onClose();
           }}
         >
-          <span class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted"
+          <span class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted" aria-hidden="true"
           ></span>
           <span>Hide Selected</span>
         </button>
@@ -102,7 +102,7 @@
             onClose();
           }}
         >
-          <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+          <span class="icon-[lucide--trash-2] w-3.5 h-3.5" aria-hidden="true"></span>
           <span>Remove Selected</span>
         </button>
       {:else}
@@ -136,7 +136,7 @@
           onClose();
         }}
       >
-        <span class="icon-[lucide--copy-plus] w-3.5 h-3.5"></span>
+        <span class="icon-[lucide--copy-plus] w-3.5 h-3.5" aria-hidden="true"></span>
         <span>Clone Token</span>
       </button>
 
@@ -150,11 +150,11 @@
         }}
       >
         {#if _ctxToken?.visibleTo === "all"}
-          <span class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted"
+          <span class="icon-[lucide--eye-off] w-3.5 h-3.5 text-theme-muted" aria-hidden="true"
           ></span>
           <span>Hide from Guests</span>
         {:else}
-          <span class="icon-[lucide--eye] w-3.5 h-3.5 text-theme-primary"
+          <span class="icon-[lucide--eye] w-3.5 h-3.5 text-theme-primary" aria-hidden="true"
           ></span>
           <span>Show to All</span>
         {/if}
@@ -168,7 +168,7 @@
           onClose();
         }}
       >
-        <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+        <span class="icon-[lucide--trash-2] w-3.5 h-3.5" aria-hidden="true"></span>
         <span>Remove Token</span>
       </button>
 
@@ -205,10 +205,10 @@
           }}
         >
           <div class="flex items-center gap-2">
-            <span class="icon-[lucide--maximize] w-3.5 h-3.5"></span>
+            <span class="icon-[lucide--maximize] w-3.5 h-3.5" aria-hidden="true"></span>
             <span>Resize</span>
           </div>
-          <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50"></span>
+          <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50" aria-hidden="true"></span>
         </button>
 
         {#if showResizeSubmenu}
@@ -286,10 +286,10 @@
           }}
         >
           <div class="flex items-center gap-2">
-            <span class="icon-[lucide--badge] w-3.5 h-3.5"></span>
+            <span class="icon-[lucide--badge] w-3.5 h-3.5" aria-hidden="true"></span>
             <span>Status</span>
           </div>
-          <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50"></span>
+          <span class="icon-[lucide--chevron-right] w-3 h-3 opacity-50" aria-hidden="true"></span>
         </button>
 
         {#if showStatusSubmenu}
@@ -350,7 +350,7 @@
         onClose();
       }}
     >
-      <span class="icon-[lucide--map-pin] w-3.5 h-3.5 text-theme-primary"
+      <span class="icon-[lucide--map-pin] w-3.5 h-3.5 text-theme-primary" aria-hidden="true"
       ></span>
       <span>Ping Here</span>
     </button>

--- a/apps/web/src/lib/components/map/MapHUD.svelte
+++ b/apps/web/src/lib/components/map/MapHUD.svelte
@@ -29,7 +29,7 @@
         class="px-3 py-1.5 bg-theme-surface border border-theme-border text-theme-text text-xs font-bold rounded-lg hover:border-theme-primary transition-colors flex items-center gap-2 focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:outline-none"
         onclick={() => mapStore.goBack()}
       >
-        <span class="icon-[lucide--arrow-left] w-3 h-3"></span>
+        <span class="icon-[lucide--arrow-left] w-3 h-3" aria-hidden="true"></span>
         BACK
       </button>
     {/if}
@@ -68,14 +68,14 @@
           onclick={() => mapStore.setAsWorldMap(mapStore.activeMapId!)}
           title="Set as World Map"
         >
-          <span class="icon-[lucide--star] w-3 h-3"></span>
+          <span class="icon-[lucide--star] w-3 h-3" aria-hidden="true"></span>
           SET WORLD
         </button>
       {:else if mapStore.activeMap?.isWorldMap}
         <div
           class="px-3 py-1.5 bg-theme-primary/10 border border-theme-primary/30 text-theme-primary text-[10px] font-bold rounded-lg flex items-center gap-2"
         >
-          <span class="icon-[lucide--star] w-3 h-3 fill-theme-primary"></span>
+          <span class="icon-[lucide--star] w-3 h-3 fill-theme-primary" aria-hidden="true"></span>
           WORLD MAP
         </div>
       {/if}
@@ -96,7 +96,7 @@
         }}
         title="Delete Map"
       >
-        <span class="icon-[lucide--trash-2] w-3 h-3"></span>
+        <span class="icon-[lucide--trash-2] w-3 h-3" aria-hidden="true"></span>
         DELETE
       </button>
 

--- a/apps/web/src/lib/components/map/MapPinPopover.svelte
+++ b/apps/web/src/lib/components/map/MapPinPopover.svelte
@@ -54,6 +54,7 @@
       >
         <span
           class="icon-[lucide--map] w-3.5 h-3.5 group-hover/map:scale-110 transition-transform"
+          aria-hidden="true"
         ></span>
       </button>
     {/if}
@@ -64,14 +65,14 @@
         onclick={onDelete}
         aria-label="Delete pin"
       >
-        <span class="icon-[lucide--trash-2] w-3.5 h-3.5"></span>
+        <span class="icon-[lucide--trash-2] w-3.5 h-3.5" aria-hidden="true"></span>
       </button>
       <button
         class="p-1.5 text-theme-muted hover:text-theme-text transition-all rounded-md hover:bg-theme-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-1 focus-visible:ring-offset-theme-surface"
         onclick={onClose}
         aria-label="Close pin details"
       >
-        <span class="icon-[lucide--x] w-3.5 h-3.5"></span>
+        <span class="icon-[lucide--x] w-3.5 h-3.5" aria-hidden="true"></span>
       </button>
     </div>
   </div>

--- a/apps/web/src/lib/components/map/VTTControls.svelte
+++ b/apps/web/src/lib/components/map/VTTControls.svelte
@@ -37,7 +37,7 @@
       title="Explore"
       aria-pressed={mapSession.mode === "exploration"}
     >
-      <span class="icon-[lucide--compass] h-4 w-4"></span>
+      <span class="icon-[lucide--compass] h-4 w-4" aria-hidden="true"></span>
     </button>
 
     <button
@@ -48,7 +48,7 @@
       title="Combat"
       aria-pressed={mapSession.mode === "combat"}
     >
-      <span class="icon-[lucide--swords] h-4 w-4"></span>
+      <span class="icon-[lucide--swords] h-4 w-4" aria-hidden="true"></span>
     </button>
 
     {#if canManageVtt}
@@ -64,7 +64,7 @@
         aria-haspopup="dialog"
         aria-expanded={!!mapSession.pendingTokenCoords}
       >
-        <span class="icon-[lucide--user-plus] h-4 w-4"></span>
+        <span class="icon-[lucide--user-plus] h-4 w-4" aria-hidden="true"></span>
       </button>
 
       <button
@@ -76,7 +76,7 @@
         aria-haspopup="dialog"
         aria-expanded={showEncounters}
       >
-        <span class="icon-[lucide--scroll-text] h-4 w-4"></span>
+        <span class="icon-[lucide--scroll-text] h-4 w-4" aria-hidden="true"></span>
       </button>
     {/if}
   </div>

--- a/apps/web/src/lib/components/map/VTTGridSettings.svelte
+++ b/apps/web/src/lib/components/map/VTTGridSettings.svelte
@@ -50,7 +50,7 @@
       id="vtt-grid-settings-title"
       class="text-lg font-bold text-theme-text mb-6 uppercase font-header tracking-wider flex items-center gap-2"
     >
-      <span class="icon-[lucide--grid-3x3] w-5 h-5 text-theme-primary"></span>
+      <span class="icon-[lucide--grid-3x3] w-5 h-5 text-theme-primary" aria-hidden="true"></span>
       Grid Settings
     </h3>
 
@@ -142,7 +142,7 @@
               close();
             }}
           >
-            <span class="icon-[lucide--square] w-3.5 h-3.5"></span>
+            <span class="icon-[lucide--square] w-3.5 h-3.5" aria-hidden="true"></span>
             Fit Grid from Map
           </button>
           <p class="text-[9px] text-theme-muted mt-1 text-center italic">
@@ -163,7 +163,7 @@
                 );
               }}
             >
-              <span class="icon-[lucide--move] w-3.5 h-3.5"></span>
+              <span class="icon-[lucide--move] w-3.5 h-3.5" aria-hidden="true"></span>
               Move Map to Fine-tune
             </button>
             <p class="text-[9px] text-theme-muted mt-1 text-center italic">

--- a/apps/web/src/lib/components/map/VTTShareButton.svelte
+++ b/apps/web/src/lib/components/map/VTTShareButton.svelte
@@ -22,6 +22,6 @@
     title="Share Campaign"
     aria-label="Share Campaign"
   >
-    <span class="icon-[lucide--share-2] w-4 h-4"></span>
+    <span class="icon-[lucide--share-2] w-4 h-4" aria-hidden="true"></span>
   </button>
 {/if}


### PR DESCRIPTION
### 💡 What: 
Added `aria-hidden="true"` to decorative `<span class="icon-[...]"></span>` elements nested inside buttons across the map and VTT components.
Also appended a note in the UX-Journal (`.jules/palette.md`) reflecting this learning.

### 🎯 Why: 
Buttons that are icon-only or contain icons next to text often get misinterpreted by screen readers if the inner decorative graphic isn't explicitly hidden. By adding `aria-hidden="true"`, screen readers will ignore the icon span and rely on the proper `aria-label` or inner text provided on the parent `<button>`, resulting in a cleaner and clearer experience for users with assistive technologies.

### ♿ Accessibility:
- Removes redundant screen-reader announcements on map icons.
- Ensures focus is kept strictly on actionable semantic content.

---
*PR created automatically by Jules for task [1311377584159246981](https://jules.google.com/task/1311377584159246981) started by @eserlan*