### PR TITLE
feat: phase 1 homepage dual-authority SEO (#1332)

### DIFF
--- a/apps/web/src/lib/config/index.test.ts
+++ b/apps/web/src/lib/config/index.test.ts
@@ -55,8 +55,8 @@ describe("shared schema.org metadata", () => {
     expect(software).toMatchObject({
       "@type": "SoftwareApplication",
       name: "Codex Cryptica",
-      applicationCategory: "GameApplication",
-      applicationSubCategory: "RPG campaign manager",
+      applicationCategory: ["GameApplication", "UtilitiesApplication"],
+      applicationSubCategory: ["RPG campaign manager", "worldbuilding tool"],
       operatingSystem: "Web browser",
       isAccessibleForFree: true,
       image: "https://codexcryptica.com/og-image.png",

--- a/apps/web/src/lib/config/index.ts
+++ b/apps/web/src/lib/config/index.ts
@@ -31,8 +31,8 @@ export const SCHEMA_ORG = {
       name: APP_NAME,
       description:
         "A free, local-first RPG campaign manager and worldbuilding workspace for private Markdown vaults, offline prep, spatial lore maps, timelines, and optional AI assistance.",
-      applicationCategory: "GameApplication",
-      applicationSubCategory: "RPG campaign manager",
+      applicationCategory: ["GameApplication", "UtilitiesApplication"],
+      applicationSubCategory: ["RPG campaign manager", "worldbuilding tool"],
       operatingSystem: "Web browser",
       url: "https://codexcryptica.com/",
       browserRequirements:

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -232,6 +232,14 @@
 
 <svelte:head>
   {#if !isGuestMode && onboardingStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
+    <title
+      >Codex Cryptica — Local-First RPG Campaign Manager & Worldbuilding Tool</title
+    >
+    <meta
+      name="description"
+      content="Codex Cryptica is a free, local-first RPG campaign manager and worldbuilding tool for GMs: private Markdown notes, visual lore graphs, timelines, offline prep, and optional AI — all in your browser."
+    />
+    <link rel="canonical" href="https://codexcryptica.com/" />
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html `<scr` +
       `ipt type="application/ld+json">${schemaOrgString}</scr` +
@@ -356,6 +364,11 @@
             >
               Private RPG Lore Vault
             </h1>
+            <p
+              class="text-xs sm:text-sm font-mono uppercase tracking-widest text-theme-primary/60 mb-3"
+            >
+              RPG Campaign Manager &amp; Worldbuilding Tool
+            </p>
             <p
               class="text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl text-theme-muted max-w-3xl mx-auto leading-relaxed mb-5 md:mb-6 font-body font-light"
             >

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -231,7 +231,7 @@
 </script>
 
 <svelte:head>
-  {#if !isGuestMode && onboardingStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
+  {#if !isGuestMode && (building || !page.url.searchParams.has("demo"))}
     <title
       >Codex Cryptica — Local-First RPG Campaign Manager & Worldbuilding Tool</title
     >
@@ -240,6 +240,8 @@
       content="Codex Cryptica is a free, local-first RPG campaign manager and worldbuilding tool for GMs: private Markdown notes, visual lore graphs, timelines, offline prep, and optional AI — all in your browser."
     />
     <link rel="canonical" href="https://codexcryptica.com/" />
+  {/if}
+  {#if !isGuestMode && onboardingStore.isLandingPageVisible && (building || !page.url.searchParams.has("demo"))}
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html `<scr` +
       `ipt type="application/ld+json">${schemaOrgString}</scr` +
@@ -364,11 +366,11 @@
             >
               Private RPG Lore Vault
             </h1>
-            <p
+            <h2
               class="text-xs sm:text-sm font-mono uppercase tracking-widest text-theme-primary/60 mb-3"
             >
               RPG Campaign Manager &amp; Worldbuilding Tool
-            </p>
+            </h2>
             <p
               class="text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl text-theme-muted max-w-3xl mx-auto leading-relaxed mb-5 md:mb-6 font-body font-light"
             >

--- a/docs/seo/head-term-cluster-plan.md
+++ b/docs/seo/head-term-cluster-plan.md
@@ -1,0 +1,106 @@
+# Head-Term SEO/LLM Plan: "RPG Campaign Manager" + "Worldbuilding Tool"
+
+Refines and extends [#1156](https://github.com/eserlan/Codex-Cryptica/issues/1156)
+("Create campaign manager and worldbuilding SEO topic clusters").
+
+## Strategy
+
+The **homepage (`/`)** is the authority target for both bare head terms —
+"RPG campaign manager" and "worldbuilding tool" — winning them via authority,
+on-page signals, and inbound anchor text. Every cluster page becomes a
+**differentiated spoke** that:
+
+1. Targets a distinct _modifier_ intent (free / ai / offline / local-first / graph).
+2. Links **up** to `/` with exact head-term anchor text.
+3. Is unique vs its siblings (no thin duplicates).
+
+### Why this matters now (diagnosis)
+
+- **Cannibalization:** `/solutions/campaign-manager` ("Best Free RPG Campaign
+  Manager") and `/free-rpg-campaign-manager` ("Free RPG Campaign Manager") fight
+  for the same intent. No page cleanly owns the bare term.
+- **Homepage gaps:** title targets the _AI_ variant only
+  (`+layout.svelte:10`), H1 is "Private RPG Lore Vault" (contains neither head
+  term), no `<link rel="canonical">`, schema doesn't assert both categories.
+- **Weak authority links:** clusters are only linked from tools/generators
+  pages, not from homepage/nav/footer with head-term anchor text.
+
+Infra is already in place: `SoftwareApplication` + `FAQPage` JSON-LD and
+canonical handling in `SEOPageLayout.svelte`, sitemap exposure, and
+`llms.txt` / `llms-full.txt`.
+
+---
+
+## Phase 1 — Homepage dual-authority targeting (highest leverage)
+
+Smallest, lowest-risk change; ~80% of the head-term win. Do first, standalone.
+
+- [ ] Update title/meta to lead with both categories, e.g. _"Codex Cryptica —
+      Local-First RPG Campaign Manager & Worldbuilding Tool"_ (`+layout.svelte:10-12`,
+      or an explicit homepage `<title>` in `(app)/+page.svelte` `<svelte:head>`).
+- [ ] Add a keyword **subhead/H2** + quotable first sentence containing both
+      exact phrases. Keep the brand H1 ("Private RPG Lore Vault") — do **not**
+      keyword-stuff the H1 (UX/brand tension).
+- [ ] Add `<link rel="canonical" href="https://codexcryptica.com/">`.
+- [ ] Extend homepage `SoftwareApplication` JSON-LD to name both
+      `applicationCategory` angles; optionally add a small `FAQPage`
+      ("What is an RPG campaign manager?" / "...worldbuilding tool?").
+- [ ] Curl-smoke `/` to confirm title, subhead, canonical, and schema render
+      server-side.
+
+## Phase 2 — De-cannibalize & differentiate the campaign manager cluster
+
+Pages: `/solutions/campaign-manager`, `/free-rpg-campaign-manager`,
+`/ai-rpg-campaign-manager`, `/solutions/offline-rpg-campaign-manager`,
+`/solutions/local-first-rpg-campaign-manager`.
+
+- [ ] Retitle `/solutions/campaign-manager` off "Best Free…" → features/how-to
+      solution angle (stops fighting homepage + `/free-`).
+- [ ] Lock intents: `/free-` = no-account/privacy, `/ai-` = AI prep/generation,
+      `/solutions/offline-` = offline, `/solutions/local-first-rpg-campaign-manager`
+      = data ownership.
+- [ ] Ensure each has unique title, meta, H1, body copy, examples, FAQ, CTA.
+- [ ] Each spoke links up to `/` with "RPG campaign manager" anchor text.
+- [ ] Cross-link to relevant blog posts, comparison pages, and generator pages.
+
+## Phase 3 — De-cannibalize & differentiate the worldbuilding tool cluster
+
+Pages: `/worldbuilding-tool`, `/solutions/worldbuilding-tool`,
+`/solutions/ai-worldbuilding-tool`, `/solutions/local-first-worldbuilding-tool`,
+`/solutions/rpg-knowledge-graph`.
+
+- [ ] Lock intents: `/worldbuilding-tool` = broad entry,
+      `/solutions/worldbuilding-tool` = structured use-case,
+      `/solutions/ai-worldbuilding-tool` = AI lore generation/refinement,
+      `/solutions/local-first-worldbuilding-tool` = privacy/local vault,
+      `/solutions/rpg-knowledge-graph` = graph/entity relationships.
+- [ ] Ensure each has unique title, meta, H1, body copy, examples, FAQ, CTA.
+- [ ] Each spoke links up to `/` with "worldbuilding tool" anchor text.
+- [ ] Cross-link to graph, Oracle, canvas, templates, and generator content.
+
+## Phase 4 — Authority internal links
+
+- [ ] Add homepage / nav / footer links into both hubs with exact-phrase anchor
+      text.
+- [ ] Add links from the `vs` comparison pages into the relevant cluster pages.
+
+## Phase 5 — GEO / LLM polish
+
+- [ ] Update `static/llms.txt` so `/` is the clear primary entry for both
+      categories.
+- [ ] Make every FAQ answer self-contained / quotable (answer-engine friendly).
+- [ ] Align each page's `relatedLinks` with the hub-and-spoke graph.
+
+## Phase 6 — Verify & close #1156
+
+- [ ] Manual crawler smoke test (curl static HTML) confirms definition sentence + FAQ + schema on every URL.
+- [ ] Tick off all #1156 acceptance criteria for both clusters.
+
+---
+
+## Sequencing
+
+1. **Phase 1** alone (fast, high-leverage).
+2. **Phases 2–3** (bulk content work across 10 pages).
+3. **Phases 4–5** (quick once the page set is settled).
+4. **Phase 6** (verification gate before closing #1156).


### PR DESCRIPTION
## Summary

- Adds homepage-specific `<title>`, `<meta name="description">`, and `<link rel="canonical">` targeting both head terms: "RPG campaign manager" and "worldbuilding tool"
- Adds keyword subhead "RPG Campaign Manager & Worldbuilding Tool" below the H1 on the landing overlay
- Extends `SCHEMA_ORG` `applicationSubCategory` array to include both head terms

Closes #1332
Part of #1156

## Test plan

- [ ] Curl `/` and confirm title, subhead, canonical, and JSON-LD render server-side
- [ ] Verify no TypeScript/lint errors
- [ ] Visually confirm subhead looks correct on the landing page overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)