### PR TITLE
:sparkles: phase 4: add authority internal links into hubs

### DIFF
--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -184,11 +184,13 @@
       >
         <a
           href="{cleanBase}/free-rpg-campaign-manager"
-          class="hover:text-theme-primary transition-colors">Campaign Manager</a
+          class="hover:text-theme-primary transition-colors"
+          >Free RPG campaign manager</a
         >
         <a
           href="{cleanBase}/worldbuilding-tool"
-          class="hover:text-theme-primary transition-colors">Worldbuilder</a
+          class="hover:text-theme-primary transition-colors"
+          >worldbuilding tool</a
         >
         <a
           href="{cleanBase}/features"
@@ -639,7 +641,7 @@
         <a
           href="{cleanBase}/free-rpg-campaign-manager"
           class="hover:text-theme-primary transition-colors"
-          >RPG campaign manager</a
+          >Free RPG campaign manager</a
         >
         <a
           href="{cleanBase}/worldbuilding-tool"

--- a/apps/web/src/lib/components/seo/SEOPageLayout.svelte
+++ b/apps/web/src/lib/components/seo/SEOPageLayout.svelte
@@ -183,6 +183,14 @@
         class="hidden md:flex items-center gap-6 text-xs font-bold uppercase tracking-widest font-header text-theme-muted"
       >
         <a
+          href="{cleanBase}/free-rpg-campaign-manager"
+          class="hover:text-theme-primary transition-colors">Campaign Manager</a
+        >
+        <a
+          href="{cleanBase}/worldbuilding-tool"
+          class="hover:text-theme-primary transition-colors">Worldbuilder</a
+        >
+        <a
           href="{cleanBase}/features"
           class="hover:text-theme-primary transition-colors">Features</a
         >
@@ -628,6 +636,16 @@
     >
       <div>© 2026 Codex Cryptica. All rights reserved.</div>
       <div class="flex gap-6">
+        <a
+          href="{cleanBase}/free-rpg-campaign-manager"
+          class="hover:text-theme-primary transition-colors"
+          >RPG campaign manager</a
+        >
+        <a
+          href="{cleanBase}/worldbuilding-tool"
+          class="hover:text-theme-primary transition-colors"
+          >worldbuilding tool</a
+        >
         <a
           href="{cleanBase}/terms"
           class="hover:text-theme-primary transition-colors">Terms</a

--- a/apps/web/src/lib/config/seo-pages.ts
+++ b/apps/web/src/lib/config/seo-pages.ts
@@ -689,9 +689,10 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       { href: "/import/obsidian-vault", label: "Import Obsidian vault" },
       { href: "/vs/world-anvil", label: "vs World Anvil" },
       {
-        href: "/solutions/local-first-worldbuilding-tool",
-        label: "Local-first worldbuilding",
+        href: "/free-rpg-campaign-manager",
+        label: "Free RPG campaign manager",
       },
+      { href: "/worldbuilding-tool", label: "worldbuilding tool" },
     ],
   },
   "world-anvil": {
@@ -802,9 +803,10 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     relatedLinks: [
       { href: "/vs/obsidian", label: "vs Obsidian" },
       { href: "/vs/kanka-alternative", label: "vs Kanka" },
+      { href: "/worldbuilding-tool", label: "worldbuilding tool" },
       {
-        href: "/solutions/local-first-worldbuilding-tool",
-        label: "Local-first worldbuilding",
+        href: "/free-rpg-campaign-manager",
+        label: "Free RPG campaign manager",
       },
     ],
     aiTrustSection: true,
@@ -897,9 +899,10 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
       },
       { href: "/vs/world-anvil", label: "vs World Anvil" },
       { href: "/vs/obsidian", label: "vs Obsidian" },
+      { href: "/worldbuilding-tool", label: "worldbuilding tool" },
       {
-        href: "/solutions/offline-rpg-campaign-manager",
-        label: "Offline campaign manager",
+        href: "/free-rpg-campaign-manager",
+        label: "Free RPG campaign manager",
       },
     ],
   },
@@ -985,8 +988,11 @@ export const comparisons: Record<string, SEOComparisonPageData> = {
     relatedLinks: [
       { href: "/import/kanka-json", label: "Import Kanka export" },
       { href: "/vs/world-anvil", label: "vs World Anvil" },
-      { href: "/vs/obsidian", label: "vs Obsidian" },
-      { href: "/solutions/local-first-rpg", label: "Local-first RPG" },
+      {
+        href: "/free-rpg-campaign-manager",
+        label: "Free RPG campaign manager",
+      },
+      { href: "/worldbuilding-tool", label: "worldbuilding tool" },
     ],
     faq: [
       {

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -751,28 +751,32 @@
               href="{base}/free-rpg-campaign-manager"
               class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
             >
-              <span class="icon-[lucide--castle] w-3 h-3"></span>
-              RPG Campaign Manager
+              <span class="icon-[lucide--castle] w-3 h-3" aria-hidden="true"
+              ></span>
+              Free RPG campaign manager
             </a>
             <a
               href="{base}/worldbuilding-tool"
               class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
             >
-              <span class="icon-[lucide--globe] w-3 h-3"></span>
-              Worldbuilding Tool
+              <span class="icon-[lucide--globe] w-3 h-3" aria-hidden="true"
+              ></span>
+              worldbuilding tool
             </a>
             <a
               href="{base}/features"
               class="inline-flex items-center gap-2 text-theme-primary/60 hover:text-theme-primary font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
             >
-              <span class="icon-[lucide--zap] w-3 h-3"></span>
+              <span class="icon-[lucide--zap] w-3 h-3" aria-hidden="true"
+              ></span>
               Features
             </a>
             <a
               href="{base}/changelog"
               class="inline-flex items-center gap-2 text-theme-primary/60 hover:text-theme-primary font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
             >
-              <span class="icon-[lucide--history] w-3 h-3"></span>
+              <span class="icon-[lucide--history] w-3 h-3" aria-hidden="true"
+              ></span>
               Changelog
             </a>
           </div>

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -746,21 +746,34 @@
 
         <!-- Footer actions & settings -->
         <footer class="flex flex-col items-center gap-4 w-full">
-          <div class="flex flex-col sm:flex-row items-center gap-4">
+          <div class="flex flex-wrap items-center justify-center gap-6">
             <a
-              href="{base}/features"
+              href="{base}/free-rpg-campaign-manager"
               class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
             >
-              <span class="icon-[lucide--zap] w-3 h-3"></span>
-              View Features Overview
+              <span class="icon-[lucide--castle] w-3 h-3"></span>
+              RPG Campaign Manager
             </a>
-
+            <a
+              href="{base}/worldbuilding-tool"
+              class="inline-flex items-center gap-2 text-theme-primary hover:text-theme-primary/80 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
+            >
+              <span class="icon-[lucide--globe] w-3 h-3"></span>
+              Worldbuilding Tool
+            </a>
+            <a
+              href="{base}/features"
+              class="inline-flex items-center gap-2 text-theme-primary/60 hover:text-theme-primary font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
+            >
+              <span class="icon-[lucide--zap] w-3 h-3"></span>
+              Features
+            </a>
             <a
               href="{base}/changelog"
               class="inline-flex items-center gap-2 text-theme-primary/60 hover:text-theme-primary font-mono text-[10px] uppercase tracking-[0.2em] transition-colors"
             >
               <span class="icon-[lucide--history] w-3 h-3"></span>
-              View Full Changelog
+              Changelog
             </a>
           </div>
 

--- a/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
+++ b/apps/web/src/routes/(marketing)/free-rpg-campaign-manager/+page.svelte
@@ -402,7 +402,7 @@
         <a
           href="{base}/worldbuilding-tool"
           class="hover:text-theme-primary transition-colors"
-          >Free Worldbuilding Tool</a
+          >worldbuilding tool</a
         >
         <a
           href="{base}/ai-rpg-campaign-manager"

--- a/docs/seo/head-term-cluster-plan.md
+++ b/docs/seo/head-term-cluster-plan.md
@@ -80,9 +80,9 @@ Pages: `/worldbuilding-tool`, `/solutions/worldbuilding-tool`,
 
 ## Phase 4 — Authority internal links
 
-- [ ] Add homepage / nav / footer links into both hubs with exact-phrase anchor
+- [x] Add homepage / nav / footer links into both hubs with exact-phrase anchor
       text.
-- [ ] Add links from the `vs` comparison pages into the relevant cluster pages.
+- [x] Add links from the `vs` comparison pages into the relevant cluster pages.
 
 ## Phase 5 — GEO / LLM polish
 


### PR DESCRIPTION
Implements Phase 4 of the head-term SEO plan:
- Adds links pointing to both the Campaign Manager and Worldbuilder hubs into the app workspace landing overlay's footer.
- Incorporates direct hub links to '/free-rpg-campaign-manager' and '/worldbuilding-tool' in the general SEO layout header and footer.
- Updates relatedLinks for Obsidian, World Anvil, LegendKeeper, and Kanka comparisons to link to the two main hubs using exact anchor text.
- Standardizes the free campaign manager footer links.