### PR TITLE
:bug: fix: resolve remaining E2E test failures

### DIFF
--- a/apps/web/tests/fp-screenshot.spec.ts
+++ b/apps/web/tests/fp-screenshot.spec.ts
@@ -8,7 +8,7 @@ test("screenshot front page", async ({ page }) => {
       JSON.stringify({ completedTours: ["initial-onboarding"] }),
     );
   });
-  await page.goto("http://localhost:5174");
+  await page.goto("/");
   await page.waitForLoadState("networkidle");
 
   await page

--- a/apps/web/tests/guest-mode.spec.ts
+++ b/apps/web/tests/guest-mode.spec.ts
@@ -133,7 +133,7 @@ test.describe("Guest Mode (P2P Share)", () => {
         Object.keys((window as any).vault?.entities || {}).length > 0,
     );
 
-    // 2. Verify shared data is loaded — wait for the count to stabilise
+    // 2. Verify shared data is loaded — wait until the expected entity count is reached
     // after any async P2P GRAPH_SYNC processing finishes.
     await page.waitForFunction(
       () => Object.keys((window as any).vault.entities).length === 2,

--- a/apps/web/tests/guest-mode.spec.ts
+++ b/apps/web/tests/guest-mode.spec.ts
@@ -133,7 +133,12 @@ test.describe("Guest Mode (P2P Share)", () => {
         Object.keys((window as any).vault?.entities || {}).length > 0,
     );
 
-    // 2. Verify shared data is loaded
+    // 2. Verify shared data is loaded — wait for the count to stabilise
+    // after any async P2P GRAPH_SYNC processing finishes.
+    await page.waitForFunction(
+      () => Object.keys((window as any).vault.entities).length === 2,
+      { timeout: 5000 },
+    );
     const entitiesCount = await page.evaluate(
       () => Object.keys((window as any).vault.entities).length,
     );

--- a/apps/web/tests/importer-e2e.spec.ts
+++ b/apps/web/tests/importer-e2e.spec.ts
@@ -158,6 +158,14 @@ test.describe("Intelligent Importer E2E", () => {
                           lore: "Trained in the shadow isles since she was five.",
                           frontmatter: { labels: ["Assassin"] },
                         },
+                        {
+                          title: "Silent Blade",
+                          type: "Faction",
+                          chronicle:
+                            "An elite guild of assassins operating in the shadows.",
+                          lore: "Founded centuries ago to serve the highest bidder.",
+                          frontmatter: { labels: ["Guild"] },
+                        },
                       ]),
                     },
                   ],

--- a/apps/web/tests/oracle-clear.spec.ts
+++ b/apps/web/tests/oracle-clear.spec.ts
@@ -57,7 +57,9 @@ test.describe("Oracle Clear Chat", () => {
 
     // 6. Messages should be gone and the empty state restored.
     await expect(page.getByText("Hello Oracle")).not.toBeVisible();
-    await expect(page.getByText("The Archives are Open")).toBeVisible();
+    await expect(page.getByText("The Archives are Open")).toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test("should show clear chat button and clear history on standalone page", async ({

--- a/apps/web/tests/oracle-parsing.spec.ts
+++ b/apps/web/tests/oracle-parsing.spec.ts
@@ -104,6 +104,11 @@ test.describe("Oracle Response Parsing & Smart Apply", () => {
       ]);
     });
 
+    // Abort Gemini API calls so background AI generation can't overwrite Smart Apply results.
+    await page.route(/.*\/v1beta\/models\/.*:generateContent.*/, (route) =>
+      route.abort(),
+    );
+
     // 3. Select a dummy node to enable 'Apply'
     await page.evaluate(async () => {
       const vault = (window as any).vault;


### PR DESCRIPTION
## Summary

- **fp-screenshot**: replaced hardcoded `localhost:5174` with `/` so it uses the configured `baseURL` (port 5173 in CI)
- **guest-mode**: added a `waitForFunction` that waits for entity count to stabilise at 2 before asserting, eliminating the flaky race with the async P2P GRAPH_SYNC handler
- **importer-e2e**: added "Silent Blade" faction to the mock Gemini response so both entities the test expects are actually returned
- **oracle-clear**: increased empty-state `"The Archives are Open"` visibility timeout from default 5s to 10s
- **oracle-parsing**: added `page.route()` to abort all Gemini API calls before `createEntity`, preventing background AI generation from overwriting the Smart Apply result

## Test plan

- [ ] Verify CI E2E run passes for `fp-screenshot`, `guest-mode`, `importer-e2e`, `oracle-clear`, and `oracle-parsing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)